### PR TITLE
feat(hf-space): Docker HF Space wrapper + auto-sync workflow

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -1,0 +1,70 @@
+name: Sync HF Space
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/hf-space/**"
+      - "packages/mcp-core/**"
+      - "packages/data-adapters/**"
+      - ".github/workflows/sync-hf-space.yml"
+  workflow_dispatch:
+
+# Single source of truth = this repo. The HF Space repo is treated as a mirror;
+# any direct commit there will be overwritten on the next sync.
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      # Override via repo Variables → Actions if you renamed the Space.
+      HF_SPACE_ID: ${{ vars.HF_SPACE_ID || 'qdonnars/openwind-mcp' }}
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Assemble Space build context
+        run: |
+          set -euo pipefail
+          BUILD_DIR=/tmp/hf-build
+          rm -rf "$BUILD_DIR"
+          mkdir -p "$BUILD_DIR/vendor"
+          cp -R packages/hf-space/. "$BUILD_DIR/"
+          cp -R packages/data-adapters "$BUILD_DIR/vendor/data-adapters"
+          cp -R packages/mcp-core      "$BUILD_DIR/vendor/mcp-core"
+          # Strip artefacts that don't belong on the Space.
+          find "$BUILD_DIR/vendor" -type d \( -name __pycache__ -o -name .pytest_cache -o -name .ruff_cache -o -name tests \) -prune -exec rm -rf {} +
+          find "$BUILD_DIR/vendor" -type f -name "*.pyc" -delete
+          rm -f "$BUILD_DIR/.gitignore"
+          ls -la "$BUILD_DIR"
+          ls -la "$BUILD_DIR/vendor"
+
+      - name: Push to HF Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GIT_USER_NAME: openwind-ci
+          GIT_USER_EMAIL: ci@openwind.fr
+        run: |
+          set -euo pipefail
+          if [ -z "${HF_TOKEN:-}" ]; then
+            echo "::error::HF_TOKEN secret is not set"
+            exit 1
+          fi
+          BUILD_DIR=/tmp/hf-build
+          SPACE_DIR=/tmp/hf-space
+          rm -rf "$SPACE_DIR"
+          git clone --depth 1 "https://oauth2:${HF_TOKEN}@huggingface.co/spaces/${HF_SPACE_ID}" "$SPACE_DIR"
+          cd "$SPACE_DIR"
+          # Replace contents wholesale (preserve .git).
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp -R "$BUILD_DIR/." ./
+          git lfs install --local || true
+          git config user.name  "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to push."
+            exit 0
+          fi
+          SHA="${GITHUB_SHA::7}"
+          git commit -m "sync: github ${SHA}"
+          git push

--- a/packages/hf-space/.gitignore
+++ b/packages/hf-space/.gitignore
@@ -1,0 +1,2 @@
+# vendored copies populated by the sync workflow at deploy time
+vendor/

--- a/packages/hf-space/Dockerfile
+++ b/packages/hf-space/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Vendored copies of the two local packages, populated by the sync workflow
+# before push (see .github/workflows/sync-hf-space.yml). On HF, these are the
+# code shipped to the Space repo — there is no monorepo context.
+COPY vendor/data-adapters /app/data-adapters
+COPY vendor/mcp-core /app/mcp-core
+
+RUN pip install /app/data-adapters /app/mcp-core
+
+COPY app.py /app/app.py
+
+EXPOSE 7860
+
+CMD ["python", "/app/app.py"]

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -1,0 +1,51 @@
+---
+title: OpenWind MCP
+emoji: ⛵
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 7860
+pinned: false
+license: mit
+short_description: Mediterranean sailing planner — MCP server (FastMCP, HTTP).
+---
+
+# OpenWind MCP
+
+FastMCP server exposing 4 tools for Mediterranean sailing passage planning:
+
+- `list_boat_archetypes` — descriptive list of 5 boat archetypes
+- `get_marine_forecast` — wind + sea around a point/window (Open-Meteo, keyless)
+- `estimate_passage` — per-segment timing along a polyline of waypoints
+- `score_complexity` — 1-5 difficulty score from wind (and optional Hs)
+
+## Connect from an MCP client
+
+This Space serves MCP over **streamable HTTP** at the Space URL (or
+`mcp.openwind.fr` once the custom domain is wired). Add it to any MCP-capable
+client that accepts an HTTP MCP endpoint.
+
+> ⚠️ This Space uses the **Docker SDK** (not Gradio). It does **not** carry
+> the HF MCP badge and is not listed in `huggingface.co/spaces?filter=mcp-server`.
+> See [openwind.fr](https://openwind.fr) for setup instructions.
+
+## Source
+
+Single source of truth: <https://github.com/qdonnars/openwind>. This Space is a
+mirror auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Do
+not commit directly to the Space repo — changes will be overwritten.
+
+## Architecture
+
+The Space wrapper is intentionally minimal (`app.py`, ~10 lines). All logic
+lives upstream in `openwind-mcp-core` and `openwind-data` — re-deployable on
+Fly/Modal/VPS by writing a different wrapper.
+
+## Cold-start
+
+Free CPU-basic hardware sleeps after 48 h of inactivity. First request after
+sleep takes ~5 s to wake. Acceptable for V1 (cf. plan decision #4).
+
+## License
+
+MIT.

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -1,0 +1,32 @@
+"""HF Space entry point — serves the OpenWind FastMCP server over HTTP.
+
+This wrapper is intentionally thin. All tools live in ``openwind_mcp_core``
+(which itself imports ``openwind_data``). Re-deploying on Fly/Modal/VPS = a
+different Dockerfile that runs the same ``build_server()`` factory.
+
+Transport: ``streamable-http`` on port 7860 (HF Spaces default). Clients
+connect to ``https://mcp.openwind.fr/mcp`` (custom domain) or to the
+default ``qdonnars-openwind-mcp.hf.space`` URL.
+
+Trade-off explicitly accepted (cf. ``plan/04-backlog.md``): HF Docker SDK
+Spaces do not get the ``MCP`` badge or the one-click connector flow that
+Gradio ``mcp_server=True`` Spaces get. Discoverability is via the project
+website, not via the HF catalog. Re-evaluate if traffic plateaus.
+"""
+
+from __future__ import annotations
+
+from openwind_mcp_core import build_server
+
+PORT = 7860
+
+
+def main() -> None:
+    server = build_server()
+    server.settings.host = "0.0.0.0"
+    server.settings.port = PORT
+    server.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Thin Docker-based HF Space wrapper (`packages/hf-space/`) that runs `build_server()` over streamable-http on port 7860. mcp-core stays the single source of truth.
- GitHub Action that vendors `data-adapters` + `mcp-core` into a build context and force-pushes to the HF Space repo on every push to `main` touching the relevant paths.
- Backlog entry for the future Gradio-based refacto (would gain the HF MCP badge + one-click connector flow at the cost of duplicating the tool surface).

## Design call (logged in `plan/04-backlog.md`)
Docker over Gradio for V1: keeps mcp-core cloud-agnostic, preserves the local stdio dev path, no tool-surface duplication. Trade-off accepted: no HF MCP badge, no listing in `huggingface.co/spaces?filter=mcp-server`. Discovery is via openwind.fr.

## Manual steps still required outside this PR
1. Create the HF Space `qdonnars/openwind-mcp` (SDK = Docker, hardware = CPU basic).
2. Add `HF_TOKEN` (write-scope) as a GitHub repo secret.
3. (Optional) wire `mcp.openwind.fr` → HF Custom Domain + Gandi CNAME `mcp` → `hf.space`.

## Test plan
- [x] `uv run pytest -q` in both packages — 92 tests green
- [x] `uv run ruff check . && ruff format --check .` clean in both
- [x] `build_server()` exposes `streamable_http_app` and accepts `settings.host/port` overrides
- [ ] First push to `main` triggers the sync workflow and lands a deploy on the HF Space (verified post-merge)
- [ ] Live MCP smoke from a remote client against the deployed Space (post-merge, when DNS is wired)

## Notes
- Pre-PR routine step 2 (live MCP smoke via subagent) skipped: this PR doesn't change the LLM-facing tool surface, only the deployment wrapper.
- Sprint 5 cache work (persistent SQLite at `/data/cache.db`) requires attaching HF persistent storage later — no Dockerfile changes needed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)