### PR TITLE
fix(hf-space): proxy_headers + uvicorn dep — fixes 421 on deployed Space

### DIFF
--- a/packages/hf-space/Dockerfile
+++ b/packages/hf-space/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY vendor/data-adapters /app/data-adapters
 COPY vendor/mcp-core /app/mcp-core
 
-RUN pip install /app/data-adapters /app/mcp-core
+RUN pip install /app/data-adapters /app/mcp-core "uvicorn[standard]>=0.30"
 
 COPY app.py /app/app.py
 

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -21,9 +21,9 @@ FastMCP server exposing 4 tools for Mediterranean sailing passage planning:
 
 ## Connect from an MCP client
 
-This Space serves MCP over **streamable HTTP** at the Space URL (or
-`mcp.openwind.fr` once the custom domain is wired). Add it to any MCP-capable
-client that accepts an HTTP MCP endpoint.
+This Space serves MCP over **streamable HTTP** at
+`https://qdonnars-openwind-mcp.hf.space`. Add it to any MCP-capable client
+that accepts an HTTP MCP endpoint.
 
 > ⚠️ This Space uses the **Docker SDK** (not Gradio). It does **not** carry
 > the HF MCP badge and is not listed in `huggingface.co/spaces?filter=mcp-server`.

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -17,16 +17,27 @@ website, not via the HF catalog. Re-evaluate if traffic plateaus.
 
 from __future__ import annotations
 
+import uvicorn
 from openwind_mcp_core import build_server
 
 PORT = 7860
 
 
 def main() -> None:
-    server = build_server()
-    server.settings.host = "0.0.0.0"
-    server.settings.port = PORT
-    server.run(transport="streamable-http")
+    # Run uvicorn explicitly (rather than ``server.run(transport=...)``) so we
+    # can enable ``proxy_headers``/``forwarded_allow_ips``. HF Spaces front
+    # the container with a TLS-terminating reverse proxy; without these flags
+    # FastMCP's ASGI app sees ``http`` + the internal Host header and emits
+    # broken 307 redirects (``http://...:443/mcp/``) that the edge then
+    # answers with 421 Misdirected Request.
+    app = build_server().streamable_http_app()
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=PORT,
+        proxy_headers=True,
+        forwarded_allow_ips="*",
+    )
 
 
 if __name__ == "__main__":

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -5,8 +5,9 @@ This wrapper is intentionally thin. All tools live in ``openwind_mcp_core``
 different Dockerfile that runs the same ``build_server()`` factory.
 
 Transport: ``streamable-http`` on port 7860 (HF Spaces default). Clients
-connect to ``https://mcp.openwind.fr/mcp`` (custom domain) or to the
-default ``qdonnars-openwind-mcp.hf.space`` URL.
+connect to ``https://qdonnars-openwind-mcp.hf.space``. (Custom domain
+``mcp.openwind.fr`` deferred — HF gates custom domains behind PRO; see
+``plan/04-backlog.md``.)
 
 Trade-off explicitly accepted (cf. ``plan/04-backlog.md``): HF Docker SDK
 Spaces do not get the ``MCP`` badge or the one-click connector flow that


### PR DESCRIPTION
## Summary
Live smoke test against the deployed Space surfaced HTTP 421 on every MCP request. Root cause: FastMCP's \`server.run(transport='streamable-http')\` doesn't expose uvicorn's proxy flags, so behind HF's TLS-terminating proxy the app saw \`http\` + internal Host and emitted broken redirects (\`http://...:443/mcp/\`) that the edge answered with 421.

Fix: run uvicorn directly with \`proxy_headers=True\` + \`forwarded_allow_ips='*'\` so \`X-Forwarded-Proto\`/Host from HF are honored. Also add \`uvicorn[standard]\` to the Dockerfile install — it's not a transitive dep of \`mcp\`.

Also includes a doc/backlog cleanup commit (no \`mcp.openwind.fr\` until HF PRO or migration off HF — logged in \`plan/04-backlog.md\` with reactivation paths).

## Test plan
- [ ] Merge → workflow redeploys Space → re-run live smoke (Marseille → Porquerolles, real Open-Meteo, auto-model + horizon-error checks)
- [ ] Verify \`https://qdonnars-openwind-mcp.hf.space/mcp\` accepts MCP \`initialize\` with no 421

🤖 Generated with [Claude Code](https://claude.com/claude-code)