### PR TITLE
fix(hf-space): allow Space hostname in FastMCP DNS-rebinding protection

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -17,20 +17,41 @@ website, not via the HF catalog. Re-evaluate if traffic plateaus.
 
 from __future__ import annotations
 
+import os
+
 import uvicorn
+from mcp.server.transport_security import TransportSecuritySettings
 from openwind_mcp_core import build_server
 
 PORT = 7860
 
+# FastMCP's streamable-http transport ships DNS-rebinding protection that
+# rejects any Host header outside ``localhost`` by default — on HF that
+# manifests as 421 "Invalid Host header" with the Space hostname. The Space
+# is fronted by HF's TLS proxy which we already authorize via
+# ``proxy_headers``, so we extend the allowed-hosts list to include the
+# Space hostname (overridable via env for future custom domains / migrations).
+DEFAULT_ALLOWED_HOSTS = [
+    "qdonnars-openwind-mcp.hf.space",
+]
+ALLOWED_HOSTS = [
+    h.strip()
+    for h in os.environ.get("OPENWIND_ALLOWED_HOSTS", ",".join(DEFAULT_ALLOWED_HOSTS)).split(",")
+    if h.strip()
+]
+
 
 def main() -> None:
+    server = build_server()
+    server.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=ALLOWED_HOSTS,
+    )
     # Run uvicorn explicitly (rather than ``server.run(transport=...)``) so we
-    # can enable ``proxy_headers``/``forwarded_allow_ips``. HF Spaces front
-    # the container with a TLS-terminating reverse proxy; without these flags
-    # FastMCP's ASGI app sees ``http`` + the internal Host header and emits
-    # broken 307 redirects (``http://...:443/mcp/``) that the edge then
-    # answers with 421 Misdirected Request.
-    app = build_server().streamable_http_app()
+    # can enable ``proxy_headers``/``forwarded_allow_ips``. HF terminates TLS
+    # at the edge; without these flags ASGI sees ``http`` + the internal Host
+    # and emits broken redirects.
+    app = server.streamable_http_app()
     uvicorn.run(
         app,
         host="0.0.0.0",


### PR DESCRIPTION
## Root cause (from HF logs)

\`\`\`
WARNING  Invalid Host header:       transport_security.py:64
         qdonnars-openwind-mcp.hf.space
INFO:    \"POST /mcp HTTP/1.1\" 421 Misdirected Request
\`\`\`

Not a uvicorn issue — it's FastMCP's built-in DNS-rebinding protection. \`TransportSecuritySettings.allowed_hosts\` defaults to empty and the middleware only lets localhost through, so the Space's public hostname was rejected.

## Fix

In \`app.py\`, after \`build_server()\`, set \`server.settings.transport_security\` with the Space hostname allowed. Configurable via \`OPENWIND_ALLOWED_HOSTS\` env var (comma-separated) so future custom domains / Fly migrations don't need a code change.

Previous fix (uvicorn \`proxy_headers\`) is still correct and stays — necessary for HF's TLS termination.

## Test plan
- [ ] Merge → workflow redeploys → re-run live smoke against \`https://qdonnars-openwind-mcp.hf.space/mcp\`
- [ ] Verify Claude.ai connector accepts the URL with no \"Couldn't reach\" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)