### PR TITLE
feat(adapters): range-aware cache + grid coalescing

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -34,15 +34,27 @@ _WIND_VARS = "wind_speed_10m,wind_direction_10m,wind_gusts_10m"
 _MARINE_VARS = "wave_height,wave_period,wave_direction,wind_wave_height,swell_wave_height"
 
 CACHE_TTL = timedelta(minutes=30)
+# Lat/lon rounding for cache key — 2dp ≈ 1.1 km, matches AROME native grid (~1.3 km).
+# Two waypoints in the same AROME cell share a cache entry.
+GRID_DECIMALS = 2
+# When fetching uncached, prefetch this many days from the start so that subsequent
+# calls with later `departure` windows in the same forecast issue still hit cache.
+FETCH_HORIZON_DAYS = 7
 
 
 @dataclass(frozen=True, slots=True)
 class _CacheKey:
     lat_round: float
     lon_round: float
-    start: datetime
-    end: datetime
     models: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _CacheEntry:
+    fetched_at: datetime
+    fetch_start: datetime
+    fetch_end: datetime
+    bundle: ForecastBundle
 
 
 class OpenMeteoAdapter:
@@ -51,9 +63,14 @@ class OpenMeteoAdapter:
     All inputs and outputs are in UTC. Caller is responsible for any local-timezone
     rendering downstream.
 
-    Cache: 30 min in-memory keyed on rounded lat/lon (4 decimals), the time range,
-    and the sorted set of models requested. Default model is AROME (per the
-    Mediterranean focus and high resolution capture of thermal/local winds).
+    Cache: 30 min in-memory keyed on rounded lat/lon (2 decimals, ~1.1 km, matches
+    AROME native grid) and the sorted set of models. The cache stores the widest
+    [start, end] ever requested for a given key and slices on read; subsequent
+    requests that fall inside a cached window are served without an HTTP call,
+    even if the requested time window differs from the original.
+
+    Default model is AROME (Mediterranean focus, high-resolution capture of thermal
+    and local winds).
     """
 
     def __init__(
@@ -64,7 +81,7 @@ class OpenMeteoAdapter:
     ) -> None:
         self._client = client
         self._timeout = timeout
-        self._cache: dict[_CacheKey, tuple[datetime, ForecastBundle]] = {}
+        self._cache: dict[_CacheKey, _CacheEntry] = {}
 
     async def fetch(
         self,
@@ -83,22 +100,35 @@ class OpenMeteoAdapter:
 
         models = models or [DEFAULT_MODEL]
         key = _CacheKey(
-            lat_round=round(lat, 4),
-            lon_round=round(lon, 4),
-            start=start_utc,
-            end=end_utc,
+            lat_round=round(lat, GRID_DECIMALS),
+            lon_round=round(lon, GRID_DECIMALS),
             models=tuple(sorted(models)),
         )
         now = datetime.now(UTC)
         cached = self._cache.get(key)
-        if cached is not None and (now - cached[0]) < CACHE_TTL:
-            return cached[1]
+        if (
+            cached is not None
+            and (now - cached.fetched_at) < CACHE_TTL
+            and cached.fetch_start <= start_utc
+            and cached.fetch_end >= end_utc
+        ):
+            return _slice_bundle(cached.bundle, start_utc, end_utc, now)
+
+        # Fetch a wide window so future calls with later `departure` can be served
+        # from cache. If a stale-but-narrower entry exists, widen to cover both.
+        fetch_start = start_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        fetch_end = max(end_utc, start_utc + timedelta(days=FETCH_HORIZON_DAYS))
+        if cached is not None:
+            fetch_start = min(fetch_start, cached.fetch_start)
+            fetch_end = max(fetch_end, cached.fetch_end)
 
         owns_client = self._client is None
         client = self._client or httpx.AsyncClient(timeout=self._timeout)
         try:
-            wind_tasks = [self._fetch_wind(client, lat, lon, start_utc, end_utc, m) for m in models]
-            sea_task = self._fetch_sea(client, lat, lon, start_utc, end_utc)
+            wind_tasks = [
+                self._fetch_wind(client, lat, lon, fetch_start, fetch_end, m) for m in models
+            ]
+            sea_task = self._fetch_sea(client, lat, lon, fetch_start, fetch_end)
             results = await asyncio.gather(*wind_tasks, sea_task)
         finally:
             if owns_client:
@@ -106,17 +136,22 @@ class OpenMeteoAdapter:
 
         wind_series_list: list[WindSeries] = list(results[:-1])
         sea_series: SeaSeries = results[-1]
-        bundle = ForecastBundle(
+        full_bundle = ForecastBundle(
             lat=lat,
             lon=lon,
-            start=start_utc,
-            end=end_utc,
+            start=fetch_start,
+            end=fetch_end,
             wind_by_model={w.model: w for w in wind_series_list},
             sea=sea_series,
             requested_at=now,
         )
-        self._cache[key] = (now, bundle)
-        return bundle
+        self._cache[key] = _CacheEntry(
+            fetched_at=now,
+            fetch_start=fetch_start,
+            fetch_end=fetch_end,
+            bundle=full_bundle,
+        )
+        return _slice_bundle(full_bundle, start_utc, end_utc, now)
 
     async def _fetch_wind(
         self,
@@ -160,6 +195,29 @@ class OpenMeteoAdapter:
         resp = await client.get(MARINE_URL, params=params)
         resp.raise_for_status()
         return _parse_sea(resp.json(), start, end)
+
+
+def _slice_bundle(
+    bundle: ForecastBundle, start: datetime, end: datetime, requested_at: datetime
+) -> ForecastBundle:
+    """Return a view of ``bundle`` restricted to [start, end]."""
+    sliced_winds = {
+        model: WindSeries(
+            model=series.model,
+            points=tuple(p for p in series.points if start <= p.time <= end),
+        )
+        for model, series in bundle.wind_by_model.items()
+    }
+    sliced_sea = SeaSeries(points=tuple(p for p in bundle.sea.points if start <= p.time <= end))
+    return ForecastBundle(
+        lat=bundle.lat,
+        lon=bundle.lon,
+        start=start,
+        end=end,
+        wind_by_model=sliced_winds,
+        sea=sliced_sea,
+        requested_at=requested_at,
+    )
 
 
 def _parse_wind(data: dict[str, Any], model: str, start: datetime, end: datetime) -> WindSeries:

--- a/packages/data-adapters/tests/test_openmeteo.py
+++ b/packages/data-adapters/tests/test_openmeteo.py
@@ -92,6 +92,51 @@ async def test_cache_hits_within_ttl(forecast_marseille_arome, marine_porqueroll
 
 
 @respx.mock
+async def test_cache_serves_subwindow_without_refetch(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """A second fetch with a narrower [start, end] inside the cached window must hit cache."""
+    forecast_route = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=forecast_marseille_arome)
+    )
+    marine_route = respx.get(MARINE_URL).mock(
+        return_value=httpx.Response(200, json=marine_porquerolles)
+    )
+
+    adapter = OpenMeteoAdapter()
+    start, end = _start_end()
+    await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
+    # Sub-window inside the original day — must be served from cache.
+    sub_start = datetime(2026, 4, 26, 6, 0, tzinfo=UTC)
+    sub_end = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    bundle = await adapter.fetch(lat=43.30, lon=5.35, start=sub_start, end=sub_end)
+
+    assert forecast_route.call_count == 1
+    assert marine_route.call_count == 1
+    wind = bundle.wind_by_model[DEFAULT_MODEL]
+    assert all(sub_start <= p.time <= sub_end for p in wind.points)
+    assert len(wind.points) == 7  # 06:00..12:00 inclusive
+
+
+@respx.mock
+async def test_cache_dedupes_close_lat_lon_within_grid_cell(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """Two waypoints within the AROME grid cell (~1.1 km) share a cache entry."""
+    forecast_route = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=forecast_marseille_arome)
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter()
+    start, end = _start_end()
+    await adapter.fetch(lat=43.301, lon=5.351, start=start, end=end)
+    await adapter.fetch(lat=43.304, lon=5.348, start=start, end=end)  # same 2dp cell
+
+    assert forecast_route.call_count == 1
+
+
+@respx.mock
 async def test_multi_model_runs_parallel_requests(forecast_marseille_arome, marine_porquerolles):
     forecast_route = respx.get(FORECAST_URL).mock(
         return_value=httpx.Response(200, json=forecast_marseille_arome)

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -82,8 +82,8 @@ LANDING_HTML = """<!doctype html>
   <h2>Try it</h2>
   <p>Once connected, ask your LLM something like:</p>
   <blockquote>
-    <em>Je pars demain matin de Marseille pour Porquerolles avec un Sun Odyssey 36.
-    Bonne idée&nbsp;? Tu as combien de temps de route et quelle complexité&nbsp;?</em>
+    <em>I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey 36.
+    Good idea? How long is the passage and how tricky is it?</em>
   </blockquote>
 
   <h2>Source &amp; docs</h2>


### PR DESCRIPTION
## Summary

Sprint 5 rate-limit mitigation. Open-Meteo cache rework so that re-running `estimate_passage` with a different `departure` (within the same forecast issue) is served from cache instead of refetching.

- **Cache key** drops `start`/`end`, rounds lat/lon to 2 decimals (~1.1 km, matches AROME native grid). Two close waypoints share an entry.
- **On miss**, prefetch a 7-day window from the requested start. On hit, slice the cached bundle. Sub-windows inside a cached range no longer hit the network.
- **Landing page** example is now English (matches the global audience).

Behavioural surface unchanged — `OpenMeteoAdapter.fetch(start, end, models=...)` returns a bundle restricted to `[start, end]` exactly as before.

## Test plan

- [x] `pytest packages/data-adapters` — 87 pass (2 new: sub-window cache hit, grid-cell dedup)
- [x] `pytest packages/mcp-core` — 7 pass
- [x] `ruff check` + `ruff format --check`
- [ ] Post-deploy smoke against live HF Space after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)