### PR TITLE
docs: vendeur rewrite — root README, HF Space README, Starlette landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,108 @@
-# OpenWind
+# OpenWind ⛵
 
-**[Live App](https://openwind.fr)**
+> **Talk to your LLM. Cast off with confidence.**
+>
+> OpenWind turns any MCP-capable assistant — Claude, Le Chat, Cursor, Goose,
+> Zed, Continue — into a Mediterranean passage planner. Ask in plain
+> language. Get a per-leg ETA, a 1‑5 complexity score, and a deep-link to
+> the full plan. Free, keyless, open source.
 
-Free wind forecast. Compare wind predictions from multiple weather models side by side for any spot.
+[**openwind.fr**](https://openwind.fr) · [`mcp.openwind.fr`](https://qdonnars-openwind-mcp.hf.space/) · MIT
 
-## Features
+![OpenWind passage plan rendered in the web app](docs/screenshots/widget-preview.png)
 
-- **Multi-model comparison** — ECMWF, GFS, ICON, AROME displayed in a compact hourly table with Beaufort color scale
-- **Interactive map** — Dark CARTO basemap with clickable spots and wind direction arrows per model
-- **Time selection** — Tap any hour in the table to display wind arrows on the map for all models
-- **Spot search** — Autocomplete geocoding via Open-Meteo API
-- **Custom spots** — Save your own spots to localStorage, no account needed
-- **Mobile-first** — Designed for phone screens with horizontal scroll on the forecast table
+---
 
-## Tech Stack
+## Try it in 30 seconds
 
-- React + TypeScript + Vite
-- Tailwind CSS v4
-- Leaflet (map)
-- Open-Meteo API (free, no API key, no backend)
+**1.** Open your MCP client and add the endpoint:
 
-## Weather Models
-
-| Model | Resolution | Horizon |
-|-------|-----------|---------|
-| ECMWF IFS | 9 km | 10 days |
-| GFS | 13-22 km | 16 days |
-| ICON | 13 km | 7 days |
-| AROME | 1.25 km | 2 days |
-
-## Development
-
-```bash
-npm install
-npm run dev
+```
+https://qdonnars-openwind-mcp.hf.space/mcp
 ```
 
-## Deployment
+**2.** Ask, in your own words:
 
-Deployed automatically to GitHub Pages on push to `main` via GitHub Actions.
+> *"Demain matin, Marseille → Porquerolles, sur un Sun Odyssey 36. Bonne
+> idée ? Combien de temps et c'est tendu comment ?"*
 
-## Privacy
+**3.** Your assistant calls four tools, renders an inline preview card, and
+hands you a deep-link to the full plan on [openwind.fr](https://openwind.fr).
+That's it. No account. No API key. No credit card.
 
-OpenWind is a **100% client-side application**. No server, no backend, no analytics.
+> **First time with MCP?** It takes 2 minutes. Pick your client on
+> [modelcontextprotocol.io/clients](https://modelcontextprotocol.io/clients),
+> then follow the
+> [remote-server quickstart](https://modelcontextprotocol.io/docs/develop/connect-remote-servers).
+> Claude Desktop users can start with the
+> [user quickstart](https://modelcontextprotocol.io/quickstart/user).
 
-- **No data is stored on any server.** All your spots and preferences are saved in your browser's `localStorage` only.
-- **No account, no tracking, no cookies.** The app runs entirely in your browser.
-- **External API calls are made directly from your browser:**
-  - [Open-Meteo.com](https://open-meteo.com/) — weather forecasts (coordinates of your spots)
-  - [Nominatim / OpenStreetMap](https://nominatim.openstreetmap.org/) — reverse geocoding to name a spot when you long-press the map (coordinates of the point you selected, not your location)
-  - [CARTO](https://carto.com/) — map tiles
-- **We do not collect, store, or transmit any personal information.**
+## Why OpenWind
+
+|                              |                                                                                              |
+|------------------------------|----------------------------------------------------------------------------------------------|
+| 🆓 **Free, keyless**         | Wind & sea via [Open-Meteo](https://open-meteo.com) (CC BY 4.0). No account, no API key.     |
+| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km — catches thermals, mistral, tramontane. Falls back to ICON-EU/GFS. |
+| ⛵ **Boat-aware**             | Five archetypes from racer-cruiser to bluewater, real polars, an `efficiency` knob.          |
+| 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
+| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, your VPS — `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
+
+## What the LLM sees
+
+Five MCP tools, all async, all keyless:
+
+| Tool                      | What it does                                                              |
+|---------------------------|---------------------------------------------------------------------------|
+| `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
+| `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
+| `estimate_passage`        | Per-segment timing along a polyline of waypoints.                         |
+| `score_complexity`        | 1–5 difficulty score from wind (and optional max wave height).            |
+| `read_me`                 | Hands the client a self-contained HTML widget for inline rendering.       |
+
+The widget switches palette via `prefers-color-scheme` — looks right in light
+and dark hosts, no Claude-specific CSS variables, no vendor lock-in.
+
+## Architecture
+
+```
+packages/
+├── data-adapters/   # pure domain logic (forecast adapters, polars, routing, complexity)
+├── mcp-core/        # FastMCP server (cloud-agnostic, no Gradio, no HF deps)
+└── hf-space/        # ~20-line Docker wrapper for Hugging Face Spaces
+```
+
+`mcp-core` stays deployment-agnostic. Re-deploying on Fly, Modal, or a VPS is
+a different `Dockerfile` calling the same `build_server()`. See
+[docs/architecture.md](docs/architecture.md).
+
+## Run locally
+
+```bash
+# Tests + lint (data-adapters & mcp-core, Python via uv)
+cd packages/mcp-core
+uv sync --all-extras
+uv run pytest -x -q
+uv run ruff check .
+
+# Local HTTP MCP smoke
+cd packages/hf-space
+uv run python app.py   # serves :7860 — point any MCP client at /mcp
+```
+
+## V1 scope
+
+Wind, sea (`Hs` max), per-leg ETA, 1–5 complexity. Tides and currents ignored
+on the Med (negligible). No automatic routing optimisation — the LLM and the
+human stay in the loop. Roadmap and scope decisions live in
+[`plan/`](plan/) (local).
 
 ## Credits
 
-Weather data: [Open-Meteo.com](https://open-meteo.com/) (CC BY 4.0)
-Map tiles: [CARTO](https://carto.com/) / [OpenStreetMap](https://www.openstreetmap.org/copyright)
+Wind & sea: [Open-Meteo](https://open-meteo.com/) (CC BY 4.0). Hosting:
+[Hugging Face Spaces](https://huggingface.co/spaces). Map tiles on
+[openwind.fr](https://openwind.fr): [CARTO](https://carto.com/) /
+[OpenStreetMap](https://www.openstreetmap.org/copyright).
+
+## License
+
+[MIT](LICENSE).

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,14 @@
+# Screenshots
+
+Drop README hero assets in this folder. The READMEs reference:
+
+- `widget-preview.png` — the OpenWind passage widget rendered inline in an
+  MCP client (Claude Desktop, Le Chat, …). Used as the hero image in the
+  root README, the HF Space README, and the Starlette landing of the Space.
+  Replace by a `widget-preview.gif` (animated demo) later — update the
+  `<img src="…">` in [packages/hf-space/app.py](../../packages/hf-space/app.py)
+  and the markdown references in the two READMEs.
+
+Both READMEs and the Starlette landing reference the file via the GitHub raw
+URL on `main` so the image resolves on huggingface.co and from the live HF
+Space without extra plumbing.

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -7,44 +7,83 @@ sdk: docker
 app_port: 7860
 pinned: false
 license: mit
-short_description: Mediterranean sailing planner — MCP server (FastMCP, HTTP).
+short_description: Mediterranean sailing planner — talk to your LLM, cast off with confidence.
 ---
 
-# OpenWind MCP
+# OpenWind MCP ⛵
 
-FastMCP server exposing 4 tools for Mediterranean sailing passage planning:
+> **Talk to your LLM. Cast off with confidence.**
+>
+> Turns any MCP-capable assistant into a Mediterranean passage planner.
+> Free, keyless, open source.
 
-- `list_boat_archetypes` — descriptive list of 5 boat archetypes
-- `get_marine_forecast` — wind + sea around a point/window (Open-Meteo, keyless)
-- `estimate_passage` — per-segment timing along a polyline of waypoints
-- `score_complexity` — 1-5 difficulty score from wind (and optional Hs)
+![OpenWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/openwind/main/docs/screenshots/widget-preview.png)
 
-## Connect from an MCP client
+---
 
-This Space serves MCP over **streamable HTTP** at
-`https://qdonnars-openwind-mcp.hf.space`. Add it to any MCP-capable client
-that accepts an HTTP MCP endpoint.
+## Try it in 30 seconds
+
+**1.** In your MCP client, add the endpoint:
+
+```
+https://qdonnars-openwind-mcp.hf.space/mcp
+```
+
+**2.** Ask, in your own words:
+
+> *"I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey
+> 36. How long is the passage and how tricky is it?"*
+
+**3.** Your assistant calls the OpenWind tools, renders an inline preview
+card, and hands you a deep-link to the full plan on
+[openwind.fr](https://openwind.fr). No account. No API key. No credit card.
+
+> **First time with MCP?** Pick your client on
+> [modelcontextprotocol.io/clients](https://modelcontextprotocol.io/clients),
+> then follow the
+> [remote-server quickstart](https://modelcontextprotocol.io/docs/develop/connect-remote-servers).
+> Works with Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, and any
+> other MCP-compatible host.
+
+## Why OpenWind
+
+- **Free & keyless** — wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
+- **Mediterranean-tuned** — AROME 1.3 km by default, catches thermals & mistral. ICON-EU / GFS for longer reach.
+- **Boat-aware** — 5 archetypes, real polars, `efficiency` knob for trim and crew level.
+- **Client-agnostic** — one HTTP MCP endpoint, no vendor lock-in.
+- **Open source, MIT** — self-host on Fly, Modal, your VPS in minutes.
+
+## Five tools
+
+| Tool                      | What it does                                                              |
+|---------------------------|---------------------------------------------------------------------------|
+| `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft`. |
+| `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
+| `estimate_passage`        | Per-segment timing along a polyline of waypoints.                         |
+| `score_complexity`        | 1–5 difficulty score from wind (and optional max wave height).            |
+| `read_me`                 | Hands the client a self-contained HTML widget for inline rendering.       |
+
+## About this Space
 
 > ⚠️ This Space uses the **Docker SDK** (not Gradio). It does **not** carry
-> the HF MCP badge and is not listed in `huggingface.co/spaces?filter=mcp-server`.
-> See [openwind.fr](https://openwind.fr) for setup instructions.
+> the HF MCP badge and isn't listed in
+> `huggingface.co/spaces?filter=mcp-server`. Discoverability lives at
+> [openwind.fr](https://openwind.fr) instead.
 
-## Source
+**Source of truth:** <https://github.com/qdonnars/openwind>. This Space is
+auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Don't
+commit directly to the Space repo — your changes will be overwritten at the
+next push.
 
-Single source of truth: <https://github.com/qdonnars/openwind>. This Space is a
-mirror auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Do
-not commit directly to the Space repo — changes will be overwritten.
-
-## Architecture
-
-The Space wrapper is intentionally minimal (`app.py`, ~10 lines). All logic
-lives upstream in `openwind-mcp-core` and `openwind-data` — re-deployable on
-Fly/Modal/VPS by writing a different wrapper.
+The Space wrapper is intentionally minimal (~20 lines in `app.py`). All logic
+lives in `openwind-mcp-core` and `openwind-data` upstream — re-deployable on
+Fly, Modal, or a VPS by writing a different wrapper.
 
 ## Cold-start
 
 Free CPU-basic hardware sleeps after 48 h of inactivity. First request after
-sleep takes ~5 s to wake. Acceptable for V1 (cf. plan decision #4).
+sleep takes ~5 s to wake. Acceptable for V1 (cf.
+[plan decision #4](https://github.com/qdonnars/openwind/blob/main/plan/04-backlog.md)).
 
 ## License
 

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -49,52 +49,125 @@ LANDING_HTML = """<!doctype html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>OpenWind MCP</title>
+  <title>OpenWind MCP — talk to your LLM, cast off with confidence</title>
   <style>
-    :root { color-scheme: light dark; }
-    body { font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-           max-width: 42rem; margin: 3rem auto; padding: 0 1.25rem; }
-    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
-    .tag { color: #666; font-size: 0.95rem; margin-top: 0; }
-    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em; }
-    pre { background: rgba(127,127,127,0.12); padding: 0.85rem 1rem; border-radius: 8px; overflow-x: auto; }
-    a { color: #1a6dff; }
-    ul { padding-left: 1.25rem; }
-    .badge { display: inline-block; padding: 0.1rem 0.55rem; border-radius: 999px;
-             background: rgba(34,139,230,0.12); color: #228be6; font-size: 0.78rem;
-             font-weight: 600; letter-spacing: 0.02em; vertical-align: middle; }
+    :root {
+      color-scheme: light dark;
+      --bg: #FAF7EE;
+      --card: #FFFFFF;
+      --text: #1A1A1A;
+      --muted: #4A4A4A;
+      --faint: #777169;
+      --border: #E2DDCD;
+      --accent: #1D9E75;
+      --soft: #F1ECDF;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #15140F;
+        --card: rgba(255,255,255,0.04);
+        --text: #F2F2F2;
+        --muted: #B8B5AC;
+        --faint: #888780;
+        --border: rgba(255,255,255,0.10);
+        --accent: #2BBE93;
+        --soft: rgba(255,255,255,0.06);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      max-width: 44rem; margin: 0 auto; padding: 3rem 1.25rem 4rem;
+      background: var(--bg); color: var(--text);
+    }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+    .lede { font-size: 1.15rem; color: var(--muted); margin: 0 0 2rem; line-height: 1.45; }
+    h2 { font-size: 1.15rem; margin: 2.25rem 0 0.75rem; letter-spacing: -0.005em; }
+    p { margin: 0.6rem 0; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    code { font-size: 0.92em; background: var(--soft); padding: 0.1rem 0.35rem; border-radius: 4px; }
+    pre { background: var(--card); border: 1px solid var(--border); padding: 0.85rem 1rem;
+          border-radius: 10px; overflow-x: auto; margin: 0.75rem 0; }
+    pre code { background: none; padding: 0; font-size: 0.95em; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .hero {
+      display: block; width: 100%; max-width: 100%; height: auto;
+      border-radius: 12px; border: 1px solid var(--border);
+      margin: 1rem 0 2rem; box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    }
+    .badge {
+      display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px;
+      background: var(--soft); color: var(--accent); font-size: 0.75rem;
+      font-weight: 600; letter-spacing: 0.04em; vertical-align: middle;
+      text-transform: uppercase;
+    }
+    blockquote {
+      margin: 0.75rem 0; padding: 0.75rem 1rem; border-left: 3px solid var(--accent);
+      background: var(--soft); border-radius: 0 8px 8px 0; color: var(--muted);
+      font-style: italic;
+    }
+    ol { padding-left: 1.25rem; line-height: 1.7; }
+    ol li { margin: 0.4rem 0; }
+    .perks { display: grid; grid-template-columns: 1fr; gap: 0.5rem; margin: 1rem 0; padding: 0; list-style: none; }
+    .perks li { padding: 0.65rem 0.9rem; background: var(--card); border: 1px solid var(--border);
+                border-radius: 8px; font-size: 0.95rem; }
+    .perks strong { color: var(--text); }
+    .footnote { color: var(--faint); font-size: 0.85rem; margin-top: 2.5rem; }
   </style>
 </head>
 <body>
-  <h1>⛵ OpenWind MCP <span class="badge">running</span></h1>
-  <p class="tag">Mediterranean sailing planner — Model Context Protocol server.</p>
+  <h1>OpenWind MCP <span class="badge">running</span></h1>
+  <p class="lede">Talk to your LLM. Cast off with confidence.<br>
+    A free, keyless, open-source Mediterranean passage planner — exposed as an
+    MCP server, so any compatible assistant can use it.</p>
 
-  <p>Four tools for an LLM client to plan a coastal passage:
-    <code>list_boat_archetypes</code>, <code>get_marine_forecast</code>,
-    <code>estimate_passage</code>, <code>score_complexity</code>.
-    Wind &amp; sea data via <a href="https://open-meteo.com">Open-Meteo</a> (keyless).</p>
+  <img class="hero" src="https://raw.githubusercontent.com/qdonnars/openwind/main/docs/screenshots/widget-preview.png"
+       alt="OpenWind passage plan: 5 waypoints, 48.6 nm, ETA 21:24, complexity 3 of 5.">
 
-  <h2>Connect from an MCP client</h2>
-  <p>Add this URL to any client that accepts an HTTP MCP endpoint
-    (Claude Desktop, ChatGPT, Mistral Le Chat, Goose, Continue, Zed, …):</p>
-  <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre>
+  <h2>Try it in 30 seconds</h2>
+  <ol>
+    <li>In your MCP client, add the endpoint:
+      <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
+    <li>Ask, in your own words:
+      <blockquote>I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey 36.
+        How long is the passage and how tricky is it?</blockquote></li>
+    <li>Your assistant calls the OpenWind tools, renders an inline preview card,
+      and hands you a deep-link to the full plan on
+      <a href="https://openwind.fr">openwind.fr</a>. No account. No API key.</li>
+  </ol>
 
-  <h2>Try it</h2>
-  <p>Once connected, ask your LLM something like:</p>
-  <blockquote>
-    <em>I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey 36.
-    Good idea? How long is the passage and how tricky is it?</em>
-  </blockquote>
+  <h2>New to MCP?</h2>
+  <p>It takes 2 minutes. Pick your client on
+    <a href="https://modelcontextprotocol.io/clients">modelcontextprotocol.io/clients</a>,
+    then follow the
+    <a href="https://modelcontextprotocol.io/docs/develop/connect-remote-servers">remote-server quickstart</a>.
+    Works with Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, and any
+    other MCP-compatible host.</p>
 
-  <h2>Source &amp; docs</h2>
-  <ul>
-    <li>Project site: <a href="https://openwind.fr">openwind.fr</a></li>
-    <li>GitHub: <a href="https://github.com/qdonnars/openwind">qdonnars/openwind</a> (MIT)</li>
+  <h2>Why OpenWind</h2>
+  <ul class="perks">
+    <li><strong>Free &amp; keyless.</strong> Wind + sea via
+      <a href="https://open-meteo.com">Open-Meteo</a> (CC BY 4.0).</li>
+    <li><strong>Mediterranean-tuned.</strong> AROME 1.3 km by default — catches thermals &amp; mistral.</li>
+    <li><strong>Boat-aware.</strong> Five archetypes, real polars, an <code>efficiency</code> knob.</li>
+    <li><strong>Client-agnostic.</strong> One HTTP MCP endpoint. No vendor lock-in.</li>
+    <li><strong>Open source, MIT.</strong> Self-host on Fly, Modal, your VPS.</li>
   </ul>
 
-  <p style="color: #888; font-size: 0.85rem; margin-top: 2.5rem;">
-    First request after inactivity may take a few seconds (HF Spaces cold-start).
-  </p>
+  <h2>Five tools</h2>
+  <p><code>list_boat_archetypes</code>, <code>get_marine_forecast</code>,
+    <code>estimate_passage</code>, <code>score_complexity</code>,
+    <code>read_me</code> — the last one hands the client a self-contained
+    HTML widget for inline rendering of the result.</p>
+
+  <h2>Source</h2>
+  <p>Project site: <a href="https://openwind.fr">openwind.fr</a> &middot;
+    GitHub: <a href="https://github.com/qdonnars/openwind">qdonnars/openwind</a>
+    (MIT).</p>
+
+  <p class="footnote">First request after inactivity may take a few seconds
+    (HF Spaces cold-start).</p>
 </body>
 </html>
 """


### PR DESCRIPTION
## Summary

- Root README rewritten from scratch (was still describing the obsolete pre-pivot React app). Hero shot + 30-second onboarding + perks table + five-tool reference + MCP quickstart links.
- HF Space README mirrors the same pitch with Front Matter intact, so the page on huggingface.co tells the same story as the GitHub repo.
- Starlette landing in `packages/hf-space/app.py` (served at `qdonnars-openwind-mcp.hf.space/`) gets a matching palette, the same hero, the same flow.

## Image

All three surfaces reference `docs/screenshots/widget-preview.png` — the root README via relative path, the HF README + Starlette landing via the GitHub raw URL on `main` so it resolves on huggingface.co and inside the live HF Space. Drop the screenshot at that path (the OpenWind app passage shot you sent works great; a GIF can replace it later — same path, same name, no other changes needed).

## Provider links

Stable URLs only: `modelcontextprotocol.io/clients` (canonical client list), `modelcontextprotocol.io/docs/develop/connect-remote-servers` (HTTP/remote setup), `modelcontextprotocol.io/quickstart/user` (Claude Desktop). Cursor / Goose / Le Chat / Zed / Continue / ChatGPT named in copy but not linked — their docs URLs move too often to embed safely. Users find their own client via `modelcontextprotocol.io/clients`.

## Test plan

- [x] `python -c "import ast; ast.parse(open('packages/hf-space/app.py').read())"` — syntax OK
- [ ] Drop `docs/screenshots/widget-preview.png` and visually inspect: root README on github.com, HF Space README on huggingface.co, Starlette landing at `qdonnars-openwind-mcp.hf.space/` (after merge → auto-deploy)
- [ ] Sanity-check both light & dark mode on the Starlette landing (mobile + desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)