### PR TITLE
fix(hf-space): trim short_description to <60 chars

### DIFF
--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -7,7 +7,7 @@ sdk: docker
 app_port: 7860
 pinned: false
 license: mit
-short_description: Mediterranean sailing planner — talk to your LLM, cast off with confidence.
+short_description: Mediterranean sailing planner for any MCP client.
 ---
 
 # OpenWind MCP ⛵


### PR DESCRIPTION
## Summary

Hotfix for [HF sync run 24959840354](https://github.com/qdonnars/openwind/actions/runs/24959840354) which failed with:

\`\`\`
Error: \"short_description\" length must be less than or equal to 60 characters long
\`\`\`

PR #14's README rewrite pushed the short_description to 90+ chars; HF Spaces enforce a 60-char cap via pre-receive hook. Trim to 49 chars (\`Mediterranean sailing planner for any MCP client.\`) — keeps the value prop, unblocks the sync.

## Test plan

- [x] \`awk\` confirms 49 chars
- [ ] Merge → re-trigger \`Sync HF Space\` workflow → verify it succeeds → verify the new landing renders at https://qdonnars-openwind-mcp.hf.space/

🤖 Generated with [Claude Code](https://claude.com/claude-code)