### PR TITLE
feat(adapters): pace HTTP + bump default segment to 10 nm

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -43,6 +44,13 @@ FETCH_HORIZON_DAYS = 7
 # Cap entries per adapter instance — adapter may live across many MCP tool
 # calls; without a cap, each new (lat, lon, models) tuple grows the dict.
 CACHE_MAX_ENTRIES = 64
+# Minimum spacing between consecutive HTTP request *starts* on a single adapter.
+# A passage routes 12+ sub-segments through `asyncio.gather`, each fetching wind
+# + sea; without pacing, that's 24 simultaneous requests on the HF Space's
+# shared egress IP, which Open-Meteo rate-limits. The lock serialises starts
+# (cache hits stay free); 0.1 s ≈ 10 req/s, well under the public-API quota.
+# Disable in tests with `http_min_interval_s=0`.
+DEFAULT_HTTP_MIN_INTERVAL_S = 0.1
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,10 +87,28 @@ class OpenMeteoAdapter:
         client: httpx.AsyncClient | None = None,
         *,
         timeout: float = 10.0,
+        http_min_interval_s: float = DEFAULT_HTTP_MIN_INTERVAL_S,
     ) -> None:
         self._client = client
         self._timeout = timeout
         self._cache: dict[_CacheKey, _CacheEntry] = {}
+        self._http_min_interval_s = http_min_interval_s
+        self._http_lock = asyncio.Lock()
+        self._last_http_at: float = 0.0
+
+    async def _pace_http(self) -> None:
+        """Block until ≥ ``http_min_interval_s`` has elapsed since the last
+        HTTP start on this adapter. Cache hits never reach this — they stay
+        free.
+        """
+        if self._http_min_interval_s <= 0:
+            return
+        async with self._http_lock:
+            elapsed = time.monotonic() - self._last_http_at
+            wait = self._http_min_interval_s - elapsed
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_http_at = time.monotonic()
 
     async def fetch(
         self,
@@ -170,6 +196,7 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
+        await self._pace_http()
         resp = await client.get(FORECAST_URL, params=params)
         resp.raise_for_status()
         return _parse_wind(resp.json(), model, start, end)
@@ -190,6 +217,7 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
+        await self._pace_http()
         resp = await client.get(MARINE_URL, params=params)
         resp.raise_for_status()
         return _parse_sea(resp.json(), start, end)

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -119,7 +119,7 @@ async def estimate_passage(
     boat_archetype: str,
     *,
     efficiency: float = 0.75,
-    segment_length_nm: float = 5.0,
+    segment_length_nm: float = 10.0,
     adapter: MarineDataAdapter | None = None,
     model: str = DEFAULT_MODEL,
     heuristic_speed_kn: float = HEURISTIC_SPEED_KN,
@@ -136,7 +136,10 @@ async def estimate_passage(
             - ``0.75`` cruising (default — sail trim, comfort margins, helm)
             - ``0.65`` loaded family cruising (water/fuel/gear, fouled hull)
             - ``0.55`` heavy seas, neglected hull, short-handed
-        segment_length_nm: target sub-segment length in NM.
+        segment_length_nm: target sub-segment length in NM. Default 10 nm
+            balances precision and Open-Meteo request budget — Med wind
+            gradients <10 nm are rare offshore. Drop to 5 for tight coastal
+            work; raise to 20 for long offshore legs.
         adapter: any `MarineDataAdapter` (defaults to a fresh `OpenMeteoAdapter`).
         model: wind model name. Pass ``"auto"`` to try AROME → ICON → GFS in
             order and use the first one whose horizon covers the passage.

--- a/packages/data-adapters/tests/test_openmeteo.py
+++ b/packages/data-adapters/tests/test_openmeteo.py
@@ -31,7 +31,7 @@ async def test_fetch_returns_bundle_with_default_model(
         return_value=httpx.Response(200, json=marine_porquerolles)
     )
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     bundle = await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
 
@@ -63,7 +63,7 @@ async def test_fetch_passes_arome_as_default_model_param(
     )
     respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
 
@@ -82,7 +82,7 @@ async def test_cache_hits_within_ttl(forecast_marseille_arome, marine_porqueroll
         return_value=httpx.Response(200, json=marine_porquerolles)
     )
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
     await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
@@ -103,7 +103,7 @@ async def test_cache_serves_subwindow_without_refetch(
         return_value=httpx.Response(200, json=marine_porquerolles)
     )
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
     # Sub-window inside the original day — must be served from cache.
@@ -128,7 +128,7 @@ async def test_cache_dedupes_close_lat_lon_within_grid_cell(
     )
     respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     await adapter.fetch(lat=43.301, lon=5.351, start=start, end=end)
     await adapter.fetch(lat=43.304, lon=5.348, start=start, end=end)  # same 2dp cell
@@ -143,7 +143,7 @@ async def test_multi_model_runs_parallel_requests(forecast_marseille_arome, mari
     )
     respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     bundle = await adapter.fetch(
         lat=43.30,
@@ -162,7 +162,7 @@ async def test_multi_model_runs_parallel_requests(forecast_marseille_arome, mari
 
 
 async def test_naive_datetime_raises():
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     with pytest.raises(ValueError, match="timezone-aware"):
         await adapter.fetch(
             lat=43.0,
@@ -173,7 +173,7 @@ async def test_naive_datetime_raises():
 
 
 async def test_end_before_start_raises():
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     end = datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
     start = datetime(2026, 4, 26, 23, 0, tzinfo=UTC)
     with pytest.raises(ValueError, match="after start"):
@@ -185,7 +185,62 @@ async def test_http_error_propagates(marine_porquerolles):
     respx.get(FORECAST_URL).mock(return_value=httpx.Response(500))
     respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
 
-    adapter = OpenMeteoAdapter()
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
     start, end = _start_end()
     with pytest.raises(httpx.HTTPStatusError):
         await adapter.fetch(lat=43.0, lon=5.0, start=start, end=end)
+
+
+@respx.mock
+async def test_http_pacing_serializes_concurrent_starts(
+    forecast_marseille_arome, marine_porquerolles
+):
+    # A passage routes ~12 sub-segments through asyncio.gather; without pacing
+    # that's a 24-request burst on Open-Meteo's free tier. The lock should
+    # space starts by ≥http_min_interval_s. Use distinct lat/lon so the cache
+    # never short-circuits the HTTP path.
+    import asyncio
+    import time
+
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0.05)
+    start, end = _start_end()
+    coords = [(43.30, 5.30), (43.40, 5.30), (43.50, 5.30), (43.60, 5.30)]
+
+    t0 = time.monotonic()
+    await asyncio.gather(
+        *[adapter.fetch(lat=lat, lon=lon, start=start, end=end) for lat, lon in coords]
+    )
+    elapsed = time.monotonic() - t0
+
+    # 4 fetches x 2 endpoints = 8 HTTP starts; serialized at 50ms each => >=350ms
+    # for the spaces between starts (8 starts means 7 inter-start gaps). Be
+    # generous on the upper bound to keep the test stable on slow CI.
+    assert elapsed >= 0.35, f"pacing not enforced (elapsed={elapsed:.3f}s)"
+
+
+async def test_http_pacing_disabled_when_zero(forecast_marseille_arome, marine_porquerolles):
+    # http_min_interval_s=0 must skip the lock entirely (cheap path for tests
+    # and for callers who already rate-limit upstream).
+    import asyncio
+    import time
+
+    with respx.mock(assert_all_called=False) as r:
+        r.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+        r.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+        adapter = OpenMeteoAdapter(http_min_interval_s=0)
+        start, end = _start_end()
+        coords = [(43.30, 5.30), (43.40, 5.30), (43.50, 5.30), (43.60, 5.30)]
+
+        t0 = time.monotonic()
+        await asyncio.gather(
+            *[adapter.fetch(lat=lat, lon=lon, start=start, end=end) for lat, lon in coords]
+        )
+        elapsed = time.monotonic() - t0
+
+    # No artificial wait: 4 mocked fetches in parallel should finish in well
+    # under 100ms on any sane runner.
+    assert elapsed < 0.1, f"unexpected slowdown with pacing off (elapsed={elapsed:.3f}s)"

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -152,7 +152,7 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         departure: str,
         archetype: str,
         efficiency: float = 0.75,
-        segment_length_nm: float = 5.0,
+        segment_length_nm: float = 10.0,
         model: str = AUTO_MODEL,
     ) -> dict[str, Any]:
         """Estimate passage timing along a polyline.
@@ -166,7 +166,10 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
             efficiency: multiplier on polar speed. Reference values:
                 ``0.85`` racing trim, ``0.75`` cruising (default), ``0.65``
                 loaded family cruising, ``0.55`` heavy seas / fouled hull.
-            segment_length_nm: target sub-segment length.
+            segment_length_nm: target sub-segment length. Default 10 nm
+                balances precision against Open-Meteo request budget; drop
+                to 5 for tight coastal work, raise to 20 for long offshore
+                legs.
             model: wind model. Default ``"auto"`` tries AROME (≤48 h) →
                 ICON-EU (≤5 d) → GFS (≤16 d). The actually-chosen model is
                 returned in ``model``. Pass an explicit name to bypass.
@@ -194,7 +197,7 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         archetype: str,
         max_hs_m: float | None = None,
         efficiency: float = 0.75,
-        segment_length_nm: float = 5.0,
+        segment_length_nm: float = 10.0,
         model: str = AUTO_MODEL,
     ) -> dict[str, Any]:
         """Score a passage on a 1-5 difficulty scale (wind + optional sea).


### PR DESCRIPTION
## Summary

Two coordinated knobs to halve the Open-Meteo request burst that earlier hit rate limits on the HF Space (shared egress IP):

- **HTTP pacing in `OpenMeteoAdapter`** — `asyncio.Lock` enforces ≥100 ms between consecutive HTTP request starts on a single adapter instance. Cache hits stay free (lock not engaged). New `http_min_interval_s` constructor param (default 0.1; pass 0 to disable).
- **`segment_length_nm` default 5 → 10 nm** — in both `openwind_data.routing.estimate_passage` and the two MCP tools that expose it. Sub-segment count halves on typical Med passages; precision stays acceptable since wind gradients <10 nm are rare offshore.

## Effect on the Marseille → Porquerolles 6-waypoint plan

Before: 12 sub-segments × 2 endpoints = **24 simultaneous HTTP requests** in `asyncio.gather`.

After: **12 HTTP requests, spaced ≥100 ms apart at the start** → wall time ~1.2 s for the burst alone, well under the public-API quota even on HF's shared IP.

## Test plan

- [x] `uv run pytest -x -q` — `data-adapters`: 89 passed (+2 new pacing tests). `mcp-core`: 10 passed.
- [x] `uv run ruff check .` + `format --check .` — clean.
- [ ] Live smoke against deployed HF Space once merged + redeployed: replay the 6-waypoint Marseille → Porquerolles plan, verify it returns without rate-limit errors.

## Tradeoffs

- Wall time on a cold-cache passage goes up by ~1.2 s (was a parallel burst, now staggered). Acceptable — the burst was the rate-limit risk.
- The lock is per-adapter-instance. If we ever spawn multiple adapters per process, we'd want to lift it to a class-level lock or a shared rate limiter. Single adapter today; not urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)