### PR TITLE
feat(mcp-core): add render_passage_widget tool

### DIFF
--- a/packages/mcp-core/src/openwind_mcp_core/render.py
+++ b/packages/mcp-core/src/openwind_mcp_core/render.py
@@ -1,0 +1,256 @@
+"""Server-side rendering of OpenWind widgets to final HTML.
+
+Companion to ``widget.py`` (which holds the static template + rendering
+instructions returned by ``read_me``). Where ``read_me`` lets the LLM do the
+substitution itself, this module performs the same substitution in Python and
+hands back ready-to-display HTML — no placeholders left.
+
+Why two paths:
+- ``read_me`` stays the fallback for clients that want to customise rendering
+  or for debugging. Cross-client by definition (LLM emits HTML).
+- ``render_passage`` is the fast path: deterministic Python substitution moves
+  the work off the LLM's slow output stream. The LLM passes the structured
+  output of ``estimate_passage`` (+ optionally ``score_complexity``) and gets
+  back a self-contained HTML string it can either relay verbatim or hand to
+  the host client's artifact / show_widget capability.
+
+Both paths share the same underlying ``PASSAGE_WIDGET_HTML`` template — single
+source of visual truth. Only the substitution mechanism differs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+from .widget import PASSAGE_WIDGET_HTML
+
+_CX_COLORS: dict[int, str] = {
+    1: "#1D9E75",
+    2: "#1D9E75",
+    3: "#EF9F27",
+    4: "#D85A30",
+    5: "#E24B4A",
+}
+
+_FR_DAYS = ("Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim")
+_FR_MONTHS = (
+    "janv.",
+    "févr.",
+    "mars",
+    "avr.",
+    "mai",
+    "juin",
+    "juil.",
+    "août",
+    "sept.",
+    "oct.",
+    "nov.",
+    "déc.",
+)
+_EN_DAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+_EN_MONTHS = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+_LABEL_FR: dict[str, str] = {
+    ">DEPARTURE<": ">DÉPART<",
+    ">Distance<": ">Distance<",
+    ">Duration<": ">Durée<",
+    ">ETA<": ">ETA<",
+    ">Complexity<": ">Complexité<",
+    ">Open in OpenWind &rarr;<": ">Ouvrir dans OpenWind &rarr;<",
+}
+
+_LEG_TEMPLATE = (
+    '<div class="ow-leg">'
+    '<div class="ow-leg-num" style="background:{color}">{index}</div>'
+    '<div class="ow-leg-info">'
+    '<div class="ow-leg-title">{title}</div>'
+    '<div class="ow-leg-meta">'
+    "<span>{distance} nm</span>"
+    "<span>TWS {tws}kn</span>"
+    "<span>TWA {twa}&deg;</span>"
+    "<span>VMG {vmg}kn</span>"
+    "</div></div>"
+    '<div class="ow-leg-eta">{eta}</div>'
+    "</div>"
+)
+
+_CX_BAR_FILLED = '<span class="ow-cx-bar" style="background:{color}"></span>'
+_CX_BAR_EMPTY = '<span class="ow-cx-bar"></span>'
+
+SUPPORTED_LOCALES = ("fr", "en")
+
+
+def _format_date(dt: datetime, locale: str) -> str:
+    if locale == "fr":
+        return f"{_FR_DAYS[dt.weekday()]} {dt.day} {_FR_MONTHS[dt.month - 1]} {dt.year}"
+    return f"{_EN_DAYS[dt.weekday()]} {dt.day} {_EN_MONTHS[dt.month - 1]} {dt.year}"
+
+
+def _archetype_display(archetype: str) -> str:
+    """``cruiser_30ft`` -> ``Cruiser 30ft``."""
+    return " ".join(p.capitalize() for p in archetype.split("_"))
+
+
+def _build_url(
+    waypoints: list[dict[str, float]],
+    departure_iso: str,
+    archetype: str,
+) -> str:
+    wpts = ";".join(f"{w['lat']:.3f},{w['lon']:.3f}" for w in waypoints)
+    dep = quote(departure_iso, safe="")
+    return f"https://openwind.fr/plan?wpts={wpts}&departure={dep}&archetype={archetype}"
+
+
+def _waypoints_from_segments(segments: list[dict[str, Any]]) -> list[dict[str, float]]:
+    """Reconstruct user-supplied waypoints from sub-segments — start of seg[0] +
+    end of every seg.
+
+    Note: segments are sub-segments after polyline splitting, so this returns
+    *sub-segment* boundaries, not the original user waypoints. Caller should
+    pass `waypoints` explicitly when the original ones are known — this is a
+    last-resort fallback for the deep-link URL.
+    """
+    if not segments:
+        return []
+    out: list[dict[str, float]] = [
+        {"lat": segments[0]["start"]["lat"], "lon": segments[0]["start"]["lon"]}
+    ]
+    out.extend({"lat": s["end"]["lat"], "lon": s["end"]["lon"]} for s in segments)
+    return out
+
+
+def _localize_labels(html: str, locale: str) -> str:
+    if locale == "fr":
+        for old, new in _LABEL_FR.items():
+            html = html.replace(old, new)
+    return html
+
+
+def render_passage(
+    passage: dict[str, Any],
+    complexity: dict[str, Any] | None = None,
+    *,
+    waypoints: list[dict[str, float]] | None = None,
+    boat_name: str | None = None,
+    leg_titles: list[str] | None = None,
+    locale: str = "fr",
+    timezone: str = "Europe/Paris",
+) -> str:
+    """Render the passage widget to final, self-contained HTML.
+
+    Args:
+        passage: dict shaped like the output of ``estimate_passage``
+            (ISO datetimes, segments[], etc.).
+        complexity: dict shaped like the output of ``score_complexity``.
+            If ``None``, the complexity bars render empty and the score shows ``-``.
+        waypoints: original user waypoints for the deep-link URL. If ``None``,
+            inferred from segment endpoints (less accurate).
+        boat_name: optional commercial name (e.g. ``"OTAGO III"``); prepended to
+            the boat line.
+        leg_titles: optional human-friendly per-leg titles (e.g.
+            ``["Sortie rade", "Cap Sicié → Grand Ribaud"]``). Falls back to
+            ``"Leg N · wpN → wpN+1"`` for missing entries.
+        locale: ``"fr"`` (default) or ``"en"``. Drives label text and date format.
+        timezone: IANA tz for time display. Default ``Europe/Paris`` (the
+            project's primary cruising area).
+    """
+    if locale not in SUPPORTED_LOCALES:
+        raise ValueError(f"locale must be one of {SUPPORTED_LOCALES}, got {locale!r}")
+
+    tz = ZoneInfo(timezone)
+
+    dep_iso = passage["departure_time"]
+    arr_iso = passage["arrival_time"]
+    dep_dt = datetime.fromisoformat(dep_iso).astimezone(tz)
+    arr_dt = datetime.fromisoformat(arr_iso).astimezone(tz)
+
+    duration_total_min = round(passage["duration_h"] * 60)
+    duration_hours = duration_total_min // 60
+    duration_minutes = duration_total_min % 60
+
+    archetype = passage["archetype"]
+    archetype_line = _archetype_display(archetype)
+    if boat_name:
+        archetype_line = f"{boat_name} &middot; {archetype_line}"
+
+    segments = passage["segments"]
+    if waypoints is None:
+        waypoints = _waypoints_from_segments(segments)
+
+    if complexity is not None:
+        cx_level = complexity["level"]
+        cx_color = _CX_COLORS[cx_level]
+        complexity_score = str(cx_level)
+        bars = [
+            _CX_BAR_FILLED.format(color=cx_color) if i <= cx_level else _CX_BAR_EMPTY
+            for i in range(1, 6)
+        ]
+    else:
+        cx_level = 0
+        cx_color = _CX_COLORS[1]
+        complexity_score = "-"
+        bars = [_CX_BAR_EMPTY] * 5
+    complexity_bars = "".join(bars)
+
+    leg_blocks: list[str] = []
+    for i, seg in enumerate(segments):
+        idx = i + 1
+        if leg_titles and i < len(leg_titles):
+            title = leg_titles[i]
+        else:
+            title = f"Leg {idx} &middot; wp{idx} &rarr; wp{idx + 1}"
+        end_dt = datetime.fromisoformat(seg["end_time"]).astimezone(tz)
+        # "VMG" here is speed-made-good toward the next waypoint. Segments
+        # follow the rhumb line, so this equals boat_speed_kn directly — more
+        # useful for passage planning than the racing VMG-to-wind.
+        leg_blocks.append(
+            _LEG_TEMPLATE.format(
+                color=cx_color,
+                index=idx,
+                title=title,
+                distance=f"{seg['distance_nm']:.1f}",
+                tws=f"{seg['tws_kn']:.1f}",
+                twa=round(seg["twa_deg"]),
+                vmg=f"{seg['boat_speed_kn']:.1f}",
+                eta=end_dt.strftime("%H:%M"),
+            )
+        )
+
+    substitutions: dict[str, str] = {
+        "{{departure_time}}": dep_dt.strftime("%H:%M"),
+        "{{departure_date_display}}": _format_date(dep_dt, locale),
+        "{{timezone}}": dep_dt.tzname() or "",
+        "{{num_waypoints}}": str(len(waypoints)),
+        "{{total_distance}}": f"{passage['distance_nm']:.1f}",
+        "{{archetype_display}}": archetype_line,
+        "{{efficiency}}": f"{passage['efficiency']:.2f}",
+        "{{duration_hours}}": str(duration_hours),
+        "{{duration_minutes}}": str(duration_minutes),
+        "{{eta_time}}": arr_dt.strftime("%H:%M"),
+        "{{complexity_score}}": complexity_score,
+        "{{complexity_bars}}": complexity_bars,
+        "{{legs}}": "".join(leg_blocks),
+        "{{openwind_url}}": _build_url(waypoints, dep_iso, archetype),
+    }
+
+    html = PASSAGE_WIDGET_HTML
+    for placeholder, value in substitutions.items():
+        html = html.replace(placeholder, value)
+
+    return _localize_labels(html, locale)

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -12,9 +12,13 @@ Tools exposed (V1):
 3. ``estimate_passage`` — per-segment timing along a polyline for a given
    archetype + departure time.
 4. ``score_complexity`` — 1-5 difficulty score from a passage + optional Hs max.
-5. ``read_me`` — returns the HTML template + rendering instructions the client
-   should use to display passage results inline. Client-agnostic (no Claude
-   CSS-variable coupling — palette switches via ``prefers-color-scheme``).
+5. ``render_passage_widget`` — server-side render of the passage widget to
+   final HTML. Fast path: substitution happens in Python, the LLM doesn't
+   regenerate ~5 KB of markup token by token.
+6. ``read_me`` — returns the HTML template + rendering instructions for
+   clients/LLMs that want to substitute placeholders themselves (fallback,
+   debugging, customisation). Client-agnostic (no Claude CSS-variable
+   coupling — palette switches via ``prefers-color-scheme``).
 
 Typical orchestration pattern (LLM perspective):
 
@@ -51,6 +55,7 @@ from openwind_data.routing import (
     score_complexity as _score_complexity,
 )
 
+from .render import render_passage
 from .widget import PASSAGE_WIDGET_INSTRUCTIONS
 
 
@@ -223,15 +228,61 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         return asdict(score)
 
     @server.tool()
+    def render_passage_widget(
+        passage: dict[str, Any],
+        complexity: dict[str, Any] | None = None,
+        waypoints: list[dict[str, float]] | None = None,
+        boat_name: str | None = None,
+        leg_titles: list[str] | None = None,
+        locale: str = "fr",
+        timezone: str = "Europe/Paris",
+    ) -> str:
+        """Render the passage widget to final, self-contained HTML.
+
+        Pass the dicts returned by ``estimate_passage`` and (optionally)
+        ``score_complexity``. The server substitutes every placeholder, picks
+        complexity colours, formats dates/durations, and returns ~5 KB of
+        ready-to-display HTML. The LLM either relays the string verbatim or
+        hands it to the host client's artifact / show_widget capability.
+
+        Prefer this over manually substituting the ``read_me`` template —
+        deterministic, ~10x faster, no formatting mistakes.
+
+        Args:
+            passage: dict from ``estimate_passage``.
+            complexity: dict from ``score_complexity``. If omitted, the
+                complexity card renders empty (score "-", bars unfilled).
+            waypoints: original user waypoints for the deep-link URL. If
+                omitted, derived from segment endpoints (less accurate when
+                segments were sub-divided).
+            boat_name: optional commercial name (e.g. ``"OTAGO III"``);
+                prepended to the boat line.
+            leg_titles: optional human-friendly per-leg titles (e.g.
+                ``["Sortie rade", "Cap Sicié → Grand Ribaud"]``). Falls back to
+                ``"Leg N · wpN → wpN+1"`` for missing entries.
+            locale: ``"fr"`` (default) or ``"en"`` — drives label text and
+                date format.
+            timezone: IANA tz for time display (default ``"Europe/Paris"``).
+        """
+        return render_passage(
+            passage,
+            complexity,
+            waypoints=waypoints,
+            boat_name=boat_name,
+            leg_titles=leg_titles,
+            locale=locale,
+            timezone=timezone,
+        )
+
+    @server.tool()
     def read_me() -> str:
         """Return the OpenWind passage-widget rendering instructions.
 
-        Call this **once** per conversation, before rendering passage results
-        to the user. The returned text contains a self-contained HTML template
-        and a data-mapping guide; substitute the ``{{placeholders}}`` with
-        values from ``estimate_passage`` + ``score_complexity`` and surface
-        the result inline (e.g. via the host client's ``show_widget`` /
-        artifact / fenced-HTML capability).
+        Fallback for clients/LLMs that want to substitute placeholders
+        themselves (e.g. to customise the rendering, or for debugging).
+        For the standard flow, prefer ``render_passage_widget`` — it does the
+        substitution server-side and returns final HTML directly, avoiding
+        ~3 minutes of token-by-token regeneration.
 
         The template adapts to light / dark mode automatically via
         ``prefers-color-scheme`` — no client-specific CSS variables.

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -61,6 +61,7 @@ class TestBuildServer:
             "get_marine_forecast",
             "estimate_passage",
             "score_complexity",
+            "render_passage_widget",
             "read_me",
         }
 
@@ -142,6 +143,126 @@ class TestScoreComplexityTool:
             },
         )
         assert out["sea_level"] == 4
+
+
+class TestRenderPassageWidgetTool:
+    """The fast path — server-side rendering of final HTML.
+
+    Anchors the contract: *no placeholders* in the output, the deep-link URL
+    points at openwind.fr, FR/EN labels swap, and the segment data drives the
+    leg blocks.
+    """
+
+    @staticmethod
+    async def _build_passage(server: FastMCP) -> dict:
+        out = await _call(
+            server,
+            "estimate_passage",
+            {
+                "waypoints": [{"lat": 43.30, "lon": 5.35}, {"lat": 43.00, "lon": 6.20}],
+                "departure": datetime(2026, 5, 1, 6, 0, tzinfo=UTC).isoformat(),
+                "archetype": "cruiser_40ft",
+                "segment_length_nm": 10.0,
+            },
+        )
+        return out
+
+    @staticmethod
+    async def _build_complexity(server: FastMCP) -> dict:
+        return await _call(
+            server,
+            "score_complexity",
+            {
+                "waypoints": [{"lat": 43.30, "lon": 5.35}, {"lat": 43.00, "lon": 6.20}],
+                "departure": datetime(2026, 5, 1, 6, 0, tzinfo=UTC).isoformat(),
+                "archetype": "cruiser_40ft",
+            },
+        )
+
+    @staticmethod
+    async def _render(server: FastMCP, args: dict) -> str:
+        out = await _call(server, "render_passage_widget", args)
+        body = out["result"] if isinstance(out, dict) and "result" in out else out
+        assert isinstance(body, str)
+        return body
+
+    async def test_returns_final_html_with_no_placeholders(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        complexity = await self._build_complexity(server)
+
+        body = await self._render(server, {"passage": passage, "complexity": complexity})
+        # The whole point: substitution happened server-side. Any leftover
+        # mustache-style placeholder is a bug — the LLM would render it raw.
+        assert "{{" not in body
+        assert "}}" not in body
+
+    async def test_renders_one_leg_block_per_segment(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        complexity = await self._build_complexity(server)
+
+        body = await self._render(server, {"passage": passage, "complexity": complexity})
+        assert body.count('class="ow-leg"') == len(passage["segments"])
+
+    async def test_includes_openwind_deeplink(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        body = await self._render(
+            server,
+            {
+                "passage": passage,
+                "waypoints": [{"lat": 43.30, "lon": 5.35}, {"lat": 43.00, "lon": 6.20}],
+            },
+        )
+        # Deep-link uses the explicit waypoints arg — fail loudly if the URL
+        # ever moves or the encoder drops args.
+        assert "https://openwind.fr/plan?" in body
+        assert "wpts=43.300,5.350;43.000,6.200" in body
+        assert "archetype=cruiser_40ft" in body
+
+    async def test_locale_fr_swaps_labels(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        body = await self._render(server, {"passage": passage, "locale": "fr"})
+        # FR swap targets the label text between tags, not arbitrary occurrences.
+        assert ">DÉPART<" in body
+        assert ">Durée<" in body
+        assert ">Complexité<" in body
+        assert ">Ouvrir dans OpenWind &rarr;<" in body
+        assert ">DEPARTURE<" not in body
+
+    async def test_locale_en_keeps_english(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        body = await self._render(server, {"passage": passage, "locale": "en"})
+        assert ">DEPARTURE<" in body
+        assert ">DÉPART<" not in body
+
+    async def test_complexity_optional(self) -> None:
+        # Without complexity, score shows "-" and no bars are filled.
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        body = await self._render(server, {"passage": passage})
+        # 5 bar elements present, none with a background colour set.
+        assert body.count('<span class="ow-cx-bar"') == 5
+        assert 'class="ow-cx-bar" style="background:#' not in body
+
+    async def test_boat_name_and_leg_titles(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        passage = await self._build_passage(server)
+        custom_titles = [f"Custom leg {i}" for i in range(len(passage["segments"]))]
+        body = await self._render(
+            server,
+            {
+                "passage": passage,
+                "boat_name": "OTAGO III",
+                "leg_titles": custom_titles,
+            },
+        )
+        assert "OTAGO III" in body
+        for title in custom_titles:
+            assert title in body
 
 
 class TestReadMeTool:


### PR DESCRIPTION
## Summary

Two changes bundled on this branch:

- **`feat(mcp-core)`**: new `render_passage_widget` tool that does the HTML substitution server-side and returns ready-to-display markup. The LLM passes the dicts from `estimate_passage` (+ optionally `score_complexity`) and gets back ~5 KB of self-contained HTML — no `{{placeholders}}` left, deterministic, no formatting mistakes. Cuts a "render the widget" turn from minutes of token-by-token regeneration to a single tool call + verbatim relay.
- **`docs`**: wire the passage-plan screenshot into the hero refs (root README, HF Space README, Starlette landing).

`read_me` stays as the fallback for clients that want to customise rendering or for debugging. Both paths share the same `PASSAGE_WIDGET_HTML` template — single source of visual truth.

New tool surface is **6 tools** (5 existing + `render_passage_widget`). `mcp-core` stays cloud-agnostic — no Gradio / HF imports, only stdlib (`zoneinfo`, `urllib.parse`).

## Test plan

- [x] Local unit tests: `uv run pytest` in `packages/mcp-core` (17/17 pass — 6 new for `render_passage_widget`)
- [x] Local unit tests: `uv run pytest` in `packages/data-adapters` (89/89 pass, untouched)
- [x] Lint clean: `uv run ruff check . && uv run ruff format --check .`
- [x] Smoke render against realistic Toulon → Porquerolles fixture — labels FR (DÉPART, Durée, Complexité), TZ "CEST", date "Mar 28 avr. 2026", URL deep-link properly encoded, VMG = boat_speed (cohérent avec la capture de référence)
- [ ] Live MCP smoke against the deployed HF Space (per pre-PR routine) — to run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)