### PR TITLE
fix(web): GFS gusts < wind — drop physically impossible values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1320,6 +1321,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1602,6 +1610,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1985,6 +2011,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2047,6 +2186,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2143,6 +2292,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2272,6 +2431,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2514,6 +2680,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2522,6 +2698,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3245,6 +3431,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3327,6 +3524,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3520,6 +3724,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3529,6 +3740,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3577,6 +3802,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3592,6 +3834,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3814,6 +4066,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3828,6 +4170,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "leaflet": "^1.9.4",
@@ -29,6 +30,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/api/openmeteo.test.ts
+++ b/src/api/openmeteo.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHourly } from "./openmeteo";
+import type { HourlyData } from "../types";
+
+function makeHourly(
+  speeds: (number | null)[],
+  gusts: (number | null)[]
+): HourlyData {
+  const times = speeds.map((_, i) => `2026-04-26T${String(i).padStart(2, "0")}:00`);
+  return {
+    time: times,
+    wind_speed_10m: speeds,
+    wind_direction_10m: speeds.map(() => 270),
+    wind_gusts_10m: gusts,
+    weather_code: speeds.map(() => 1),
+  };
+}
+
+describe("sanitizeHourly", () => {
+  it("drops gusts that are strictly lower than wind speed (impossible)", () => {
+    // Real GFS Marseille payload shape: gust < wind across the board.
+    const h = makeHourly(
+      [3.9, 5.3, 6.4, 6.0, 4.7],
+      [1.9, 3.1, 4.5, 4.9, 5.1] // last one is fine (5.1 >= 4.7)
+    );
+    const out = sanitizeHourly(h);
+    expect(out.wind_gusts_10m).toEqual([null, null, null, null, 5.1]);
+  });
+
+  it("keeps gusts >= wind speed unchanged (physical case)", () => {
+    const h = makeHourly([10, 12, 15], [12, 14, 18]);
+    const out = sanitizeHourly(h);
+    expect(out.wind_gusts_10m).toEqual([12, 14, 18]);
+  });
+
+  it("keeps gusts equal to wind speed (edge case, equality is physical)", () => {
+    const h = makeHourly([10, 5], [10, 5]);
+    const out = sanitizeHourly(h);
+    expect(out.wind_gusts_10m).toEqual([10, 5]);
+  });
+
+  it("preserves null wind speeds without flagging gust", () => {
+    const h = makeHourly([null, 5, null], [3, 8, 1]);
+    const out = sanitizeHourly(h);
+    // index 0: wind null → cannot compare, leave gust as-is
+    // index 1: 8 >= 5 OK
+    // index 2: wind null → leave gust as-is
+    expect(out.wind_gusts_10m).toEqual([3, 8, 1]);
+  });
+
+  it("preserves null gusts (no fabrication, leaves null as null)", () => {
+    const h = makeHourly([10, 12], [null, null]);
+    const out = sanitizeHourly(h);
+    expect(out.wind_gusts_10m).toEqual([null, null]);
+  });
+
+  it("does not mutate the input arrays", () => {
+    const speeds = [10, 5];
+    const gusts = [3, 8];
+    const h = makeHourly(speeds, gusts);
+    const out = sanitizeHourly(h);
+    expect(gusts).toEqual([3, 8]);
+    expect(out.wind_gusts_10m).toEqual([null, 8]);
+    expect(out.wind_gusts_10m).not.toBe(gusts);
+  });
+
+  it("passes other series through unchanged (time, direction, weather_code)", () => {
+    const h = makeHourly([10], [5]);
+    const out = sanitizeHourly(h);
+    expect(out.time).toBe(h.time);
+    expect(out.wind_direction_10m).toBe(h.wind_direction_10m);
+    expect(out.weather_code).toBe(h.weather_code);
+    expect(out.wind_speed_10m).toBe(h.wind_speed_10m);
+  });
+
+  it("handles arrays of mismatched length without crashing", () => {
+    const h: HourlyData = {
+      time: ["t0", "t1", "t2"],
+      wind_speed_10m: [10, 12, 15],
+      wind_direction_10m: [270, 270, 270],
+      wind_gusts_10m: [3, 14], // shorter
+      weather_code: [1, 1, 1],
+    };
+    const out = sanitizeHourly(h);
+    // Index 0: 3 < 10 → null. Index 1: 14 >= 12 → keep.
+    expect(out.wind_gusts_10m).toEqual([null, 14]);
+  });
+
+  it("realistic GFS Mediterranean payload: drops the broken values, leaves OK ones", () => {
+    // Sampled live from GFS Marseille 2026-04-26.
+    const h = makeHourly(
+      [3.9, 5.3, 6.4, 6.0, 4.7, 3.8, 1.8, 1.4],
+      [1.9, 3.1, 4.5, 4.9, 5.1, 5.1, 3.3, 1.6]
+    );
+    const out = sanitizeHourly(h);
+    // 0..3: gust < wind → null. 4..7: gust >= wind → kept.
+    expect(out.wind_gusts_10m).toEqual([null, null, null, null, 5.1, 5.1, 3.3, 1.6]);
+  });
+});

--- a/src/api/openmeteo.ts
+++ b/src/api/openmeteo.ts
@@ -1,4 +1,4 @@
-import type { ModelForecast, GeocodingResult } from "../types";
+import type { ModelForecast, HourlyData, GeocodingResult } from "../types";
 
 const MODELS = [
   { name: "ECMWF", endpoint: "https://api.open-meteo.com/v1/ecmwf" },
@@ -16,6 +16,48 @@ const PARAMS =
 
 const cache = new Map<string, { models: ModelForecast[]; fetchedAt: number }>();
 const CACHE_TTL = 30 * 60 * 1000;
+
+/**
+ * Sanitize the gust series so that physically impossible values (gust < wind)
+ * are dropped to `null`.
+ *
+ * Why this is needed: GFS surface gust diagnostics are unreliable in the
+ * Mediterranean at low-to-moderate wind speeds — Open-Meteo passes them through
+ * as-is, so we can routinely observe `wind_gusts_10m < wind_speed_10m` in the
+ * upstream payload (verified live, see PR 1.1). A gust by definition is the
+ * maximum wind over the preceding interval, so it cannot be lower than the
+ * mean wind speed.
+ *
+ * We do not fabricate a value (no clamping to wind speed): we drop the gust
+ * to `null`, and the front renders the cell with the wind speed only. This
+ * keeps the UI honest about missing data rather than displaying a synthetic
+ * gust equal to the mean wind.
+ *
+ * Mutates a shallow copy of `hourly` and returns it. Other arrays (time,
+ * direction, weather_code) are passed through unchanged.
+ */
+export function sanitizeHourly(hourly: HourlyData): HourlyData {
+  const speeds = hourly.wind_speed_10m;
+  const gusts = hourly.wind_gusts_10m;
+  const len = Math.min(speeds.length, gusts.length);
+
+  const cleanedGusts: (number | null)[] = new Array(gusts.length);
+  for (let i = 0; i < gusts.length; i++) {
+    cleanedGusts[i] = gusts[i];
+  }
+  for (let i = 0; i < len; i++) {
+    const w = speeds[i];
+    const g = gusts[i];
+    if (w != null && g != null && g < w) {
+      cleanedGusts[i] = null;
+    }
+  }
+
+  return {
+    ...hourly,
+    wind_gusts_10m: cleanedGusts,
+  };
+}
 
 export async function fetchAllModels(
   lat: number,
@@ -35,7 +77,7 @@ export async function fetchAllModels(
         .then((r) => r.json())
         .then((data) => ({
           modelName: model.name,
-          hourly: data.hourly,
+          hourly: data.hourly ? sanitizeHourly(data.hourly) : data.hourly,
         }))
     )
   );


### PR DESCRIPTION
## Summary

- Open-Meteo GFS produces `wind_gusts_10m < wind_speed_10m` natively in the Mediterranean — confirmed live (Marseille 43.3,5.35 today: 41/48h with gust < wind, e.g. ws=6.6 kn / gs=3.3 kn). Not a unit/alignment/null bug — verified across AROME / ICON / GFS-Atlantic which are clean.
- New `sanitizeHourly()` in `src/api/openmeteo.ts` sets gust to `null` whenever it's strictly below wind speed. `WindCell` already hides null gusts.
- 9 Vitest unit tests added (`src/api/openmeteo.test.ts`); `vitest` added as devDep + `test` script.

## Decision to validate in review

Hide vs clamp — picked **hide** (set `null`) over `Math.max(gust, wind)`. More honest about upstream data quality but the user loses gust info on those cells. Alternative would be a clamp + footnote "gust unreliable". Easy to flip if you prefer the cosmetic approach.

## Out of scope (follow-up)

The same upstream anomaly may pollute `estimate_passage` if it ever uses GFS for routing. CLAUDE.md says AROME is the V1 default for passage, so likely fine, but worth a quick check on the Python side — separate ticket.

## Test plan

- [ ] `npm run build` and `npm test` pass on the branch
- [ ] On Marseille today, the GFS column in the wind table shows `—` (or empty) for gust where it would have shown an impossible value, instead of an under-wind number

🤖 Generated with [Claude Code](https://claude.com/claude-code)