### PR TITLE
fix(docs): align read_me field names + bump tool count

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -155,11 +155,12 @@ LANDING_HTML = """<!doctype html>
     <li><strong>Open source, MIT.</strong> Self-host on Fly, Modal, your VPS.</li>
   </ul>
 
-  <h2>Five tools</h2>
+  <h2>Six tools</h2>
   <p><code>list_boat_archetypes</code>, <code>get_marine_forecast</code>,
     <code>estimate_passage</code>, <code>score_complexity</code>,
-    <code>read_me</code> — the last one hands the client a self-contained
-    HTML widget for inline rendering of the result.</p>
+    <code>render_passage_widget</code> (returns ready-to-display HTML),
+    <code>read_me</code> (template + instructions, fallback for clients
+    that customise rendering).</p>
 
   <h2>Source</h2>
   <p>Project site: <a href="https://openwind.fr">openwind.fr</a> &middot;

--- a/packages/mcp-core/src/openwind_mcp_core/widget.py
+++ b/packages/mcp-core/src/openwind_mcp_core/widget.py
@@ -150,13 +150,14 @@ markup, scripts, fetches, or iframes — the widget must stay static.
 ## Data mapping
 
 From the `estimate_passage` response:
-- `total_distance_nm` -> `{{{{total_distance}}}}` (1 decimal)
+- `distance_nm` -> `{{{{total_distance}}}}` (1 decimal)
 - `departure_time` (ISO) -> `{{{{departure_time}}}}` (HH:MM, in the departure
   tz), `{{{{departure_date_display}}}}` (e.g. "Sun 26 Apr"),
   `{{{{timezone}}}}` (e.g. "CEST")
 - `arrival_time` (ISO) -> `{{{{eta_time}}}}` (HH:MM, same tz)
-- `duration_s` -> `{{{{duration_hours}}}}` and `{{{{duration_minutes}}}}`
-  (integers; floor-divide by 3600 / 60)
+- `duration_h` -> `{{{{duration_hours}}}}` and `{{{{duration_minutes}}}}`
+  (integers; ``total_min = round(duration_h * 60)``, then
+  ``hours = total_min // 60``, ``minutes = total_min % 60``)
 - `archetype` -> `{{{{archetype_display}}}}` (humanised, e.g.
   "Sun Odyssey 380" or fallback "Cruiser 30ft"). Pair with `{{{{efficiency}}}}`
   formatted as `0.75`.


### PR DESCRIPTION
## Summary

Two doc bugs spotted during the post-deploy smoke of #18:

1. **`read_me` data-mapping wrong**: advertised `total_distance_nm` and `duration_s` from the `estimate_passage` response. Actual fields are `distance_nm` and `duration_h` — strict clients reading the instructions would `KeyError` on those. LLMs were silently correcting from the live output, which is why nobody noticed sooner.
2. **HF Space landing copy stale**: said *"Five tools"*. With `render_passage_widget` shipped in #18 we're at six.

Same fix updates the duration formula in the instructions to match what `render.py` actually does (round-to-nearest-minute then split, instead of the now-impossible "floor-divide by 3600").

## Test plan

- [x] `uv run pytest` in `packages/mcp-core` (17/17 pass — `read_me` placeholder contract test still green; only the prose changed)
- [x] `uv run ruff check . && uv run ruff format --check .` in `packages/mcp-core`
- [ ] Eyeball the redeployed HF Space landing page at `qdonnars-openwind-mcp.hf.space` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)