### PR TITLE
feat(web): footer freshness timestamp + PWA manifest + SEO/OG

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,7 +9,28 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="OpenWind" />
-    <link rel="apple-touch-icon" href="/icon-192.png" />
+
+    <meta name="description" content="OpenWind — Mediterranean sailing planner. Get wind forecasts, passage estimates and complexity scores for your next passage, powered by AROME high-resolution models.">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://openwind.fr/">
+    <meta property="og:title" content="OpenWind — Mediterranean sailing planner">
+    <meta property="og:description" content="Wind forecasts, passage estimates and complexity scores for Mediterranean sailors. Powered by AROME 1.3 km model.">
+    <meta property="og:image" content="https://openwind.fr/icon-512.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="OpenWind — Mediterranean sailing planner">
+    <meta name="twitter:description" content="Wind forecasts, passage estimates and complexity scores for Mediterranean sailors.">
+    <meta name="twitter:image" content="https://openwind.fr/icon-512.png">
+
+    <!-- Canonical -->
+    <link rel="canonical" href="https://openwind.fr/">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" sizes="192x192" href="/icon-192.png">
   </head>
   <body class="bg-gray-950 text-white">
     <div id="root"></div>

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,12 +1,12 @@
 {
   "name": "OpenWind",
   "short_name": "OpenWind",
-  "description": "Prévisions vent kitesurf et voile",
+  "description": "Mediterranean sailing planner — wind forecasts and passage estimates",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#030712",
   "theme_color": "#030712",
-  "orientation": "portrait-primary",
+  "orientation": "any",
   "icons": [
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   const [forecasts, setForecasts] = useState<ModelForecast[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedHour, setSelectedHour] = useState<string | null>(null);
+  const [dataFetchedAt, setDataFetchedAt] = useState<Date | null>(null);
 
 
   useEffect(() => {
@@ -47,6 +48,7 @@ function App() {
     fetchAllModels(spot.latitude, spot.longitude).then((data) => {
       if (!cancelled) {
         setForecasts(data);
+        setDataFetchedAt(new Date());
         setIsLoading(false);
         // Auto-select current hour so wind arrows show by default
         const nowHour = new Date().toISOString().slice(0, 13);
@@ -67,7 +69,7 @@ function App() {
   const mapCenter: Spot = spot ?? RADE_MARSEILLE;
 
   return (
-    <div className="h-screen flex flex-col bg-gray-950 text-white overflow-hidden">
+    <div className="h-screen flex flex-col overflow-hidden" style={{ background: 'var(--ow-bg-0)', color: 'var(--ow-fg-0)' }}>
       <Header
         onSelectSpot={setSpot}
         canSave={canSave}
@@ -93,7 +95,7 @@ function App() {
         </div>
 
         {/* Wind table — bottom panel */}
-        <div className="shrink-0 max-h-[45vh] md:max-h-[40vh] overflow-y-auto bg-gray-950 border-t border-gray-700/50">
+        <div className="shrink-0 max-h-[45vh] md:max-h-[40vh] overflow-y-auto" style={{ background: 'var(--ow-bg-0)', borderTop: '1px solid var(--ow-line)' }}>
           {spot ? (
             <WindTable
               forecasts={forecasts}
@@ -116,6 +118,9 @@ function App() {
               Open-Meteo.com
             </a>{" "}
             (CC BY 4.0)
+            {dataFetchedAt && (
+              <span className="ml-2 opacity-60">· Updated {dataFetchedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+            )}
           </footer>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Footer freshness**: Added `dataFetchedAt: Date | null` state in `App.tsx`, set to `new Date()` on each `fetchAllModels` success. Footer displays `· Updated HH:MM` when data is available.
- **PWA manifest**: Changed `orientation` from `"portrait-primary"` to `"any"` (allows landscape on iPad cockpit). Updated description to English, matching the app pivot.
- **SEO/OG**: Added `<meta name="description">`, full Open Graph block (`og:type`, `og:url`, `og:title`, `og:description`, `og:image`), Twitter Card (`summary`), `<link rel="canonical">`, and favicon links (`favicon.svg` + `apple-touch-icon 192x192`). All referenced icon files already exist in `public/`.

## Test plan

- [x] `npm run build --workspace=packages/web` — clean build (0 errors)
- [x] `npm run test --workspace=packages/web` — 9/9 tests pass
- [ ] Visual check: load app, wait for data fetch, confirm footer shows "· Updated HH:MM"
- [ ] Check `<head>` in browser DevTools for OG/Twitter tags
- [ ] Validate manifest in Chrome DevTools → Application → Manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)