### PR TITLE
feat(web): Beaufort 9-step scale 0–50 kn + wind cell hierarchy

### DIFF
--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -1,4 +1,3 @@
-import { WindArrow } from "./WindArrow";
 import { getWindColor, getTextColor } from "../utils/colors";
 
 interface WindCellProps {
@@ -29,6 +28,10 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
   const bg = getWindColor(speed);
   const color = getTextColor(speed);
 
+  // Gusts are visually subdued when close to wind speed (within 5 kn)
+  const gustClose = gusts != null && gusts <= speed + 5;
+  const gustOpacity = gustClose ? "opacity-70" : "opacity-90";
+
   return (
     <td
       role="cell"
@@ -37,13 +40,31 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
       onClick={onSelect}
       aria-label={`${Math.round(speed)} knots${gusts != null ? `, gusts ${Math.round(gusts)}` : ""}${direction != null ? `, direction ${direction}°` : ""}`}
     >
-      <div className="flex flex-col items-center leading-none gap-0.5">
+      <div className="flex flex-col items-center justify-center leading-none gap-[3px]">
+        {/* Row 1: arrow + speed (dominant) */}
         <div className="flex items-center gap-0.5">
-          {direction != null && <WindArrow degrees={direction} />}
-          <span className="text-[17px] lg:text-[20px] font-bold">{Math.round(speed)}</span>
+          {direction != null && (
+            <svg
+              width="14"
+              height="14"
+              className="lg:w-4 lg:h-4 shrink-0"
+              viewBox="0 0 16 16"
+              style={{ transform: `rotate(${direction + 180}deg)`, transition: "transform 0.3s ease" }}
+            >
+              <polygon points="8,1 13,15 8,10 3,15" fill="currentColor" />
+            </svg>
+          )}
+          <span className="text-[22px] lg:text-[26px] font-bold tabular-nums leading-none">
+            {Math.round(speed)}
+          </span>
         </div>
+        {/* Row 2: gust, smaller, slightly subdued */}
         {gusts != null && (
-          <span className="text-[13px] lg:text-[14px] opacity-90 font-semibold">{Math.round(gusts)}</span>
+          <span
+            className={`text-[12px] lg:text-[13px] font-semibold tabular-nums leading-none ${gustOpacity}`}
+          >
+            ↑{Math.round(gusts)}
+          </span>
         )}
       </div>
     </td>

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import type { ModelForecast } from "../types";
 import { TimelineHeader } from "./TimelineHeader";
 import { WindCell } from "./WindCell";
+import { BEAUFORT_STEPS } from "../utils/colors";
 
 // Native time step (hours) for each model — Open-Meteo interpolates to 1h,
 // but these are the actual forecast resolution worth displaying
@@ -57,6 +58,28 @@ function buildTimeIndex(times: string[]): Map<string, number> {
   const map = new Map<string, number>();
   times.forEach((t, i) => map.set(t, i));
   return map;
+}
+
+const BEAUFORT_LABELS = [
+  "calme", "1–3", "4–6", "7–10", "11–15", "16–19", "20–24", "25–30", "31+",
+];
+
+function BeaufortLegend() {
+  return (
+    <div className="flex items-end gap-1.5 px-3 py-2 border-t border-gray-800/60 overflow-x-auto">
+      {BEAUFORT_STEPS.map(([, bg, text], i) => (
+        <div key={i} className="flex flex-col items-center shrink-0">
+          <div
+            className="w-7 h-5 rounded-sm flex items-center justify-center text-[10px] font-bold leading-none"
+            style={{ backgroundColor: bg, color: text }}
+          >
+            B{i}
+          </div>
+          <span className="text-[9px] text-gray-500 mt-0.5 whitespace-nowrap">{BEAUFORT_LABELS[i]}</span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function SkeletonTable() {
@@ -203,6 +226,7 @@ export function WindTable({
           </table>
         </div>
       </div>
+      <BeaufortLegend />
     </div>
   );
 }

--- a/packages/web/src/utils/colors.ts
+++ b/packages/web/src/utils/colors.ts
@@ -1,47 +1,38 @@
-// Smooth gradient between Beaufort color stops using linear interpolation
-const COLOR_STOPS: [number, [number, number, number]][] = [
-  [0, [120, 144, 156]],   // calm - blue gray
-  [1, [200, 230, 201]],   // light air - pale green
-  [4, [165, 214, 167]],   // light breeze
-  [7, [129, 199, 132]],   // gentle breeze
-  [11, [102, 187, 106]],  // moderate breeze
-  [17, [255, 235, 59]],   // fresh breeze - yellow
-  [22, [255, 193, 7]],    // strong breeze - amber
-  [28, [255, 152, 0]],    // near gale - orange
-  [34, [255, 87, 34]],    // gale - deep orange
-  [41, [211, 47, 47]],    // strong gale - red
-  [48, [156, 39, 176]],   // storm - purple
-  [56, [106, 27, 154]],   // violent storm - deep purple
+// 9 Beaufort steps — 0-50 kn, covers Mediterranean mistral (35-40 kn)
+const BEAUFORT_STEPS: [number, string, string][] = [
+  //  kn_max, bg_color,   text_color
+  [4,   '#1e2d40', '#e8eaf0'],   // B0 calm
+  [7,   '#0e7c4a', '#e8eaf0'],   // B1 light air
+  [11,  '#12a35e', '#0B1D14'],   // B2 light breeze
+  [15,  '#2dc97a', '#0B1D14'],   // B3 gentle breeze
+  [19,  '#e8c432', '#0B1D14'],   // B4 moderate breeze
+  [23,  '#e87a18', '#0B1D14'],   // B5 fresh breeze
+  [28,  '#e84118', '#fff5f5'],   // B6 strong breeze
+  [33,  '#c41408', '#fff5f5'],   // B7 near gale
+  [Infinity, '#8b1460', '#fff5f5'], // B8 gale+
 ];
 
-function lerp(a: number, b: number, t: number): number {
-  return Math.round(a + (b - a) * t);
-}
-
-function interpolateColor(knots: number): [number, number, number] {
-  if (knots <= COLOR_STOPS[0][0]) return COLOR_STOPS[0][1];
-  if (knots >= COLOR_STOPS[COLOR_STOPS.length - 1][0])
-    return COLOR_STOPS[COLOR_STOPS.length - 1][1];
-
-  for (let i = 0; i < COLOR_STOPS.length - 1; i++) {
-    const [k0, c0] = COLOR_STOPS[i];
-    const [k1, c1] = COLOR_STOPS[i + 1];
-    if (knots >= k0 && knots < k1) {
-      const t = (knots - k0) / (k1 - k0);
-      return [lerp(c0[0], c1[0], t), lerp(c0[1], c1[1], t), lerp(c0[2], c1[2], t)];
-    }
-  }
-  return COLOR_STOPS[COLOR_STOPS.length - 1][1];
-}
-
 export function getWindColor(knots: number): string {
-  const [r, g, b] = interpolateColor(knots);
-  return `rgb(${r},${g},${b})`;
+  if (knots == null || isNaN(knots)) return '#1e2d40';
+  for (const [max, bg] of BEAUFORT_STEPS) {
+    if (knots < max) return bg;
+  }
+  return BEAUFORT_STEPS[BEAUFORT_STEPS.length - 1][1];
 }
 
 export function getTextColor(knots: number): string {
-  const [r, g, b] = interpolateColor(knots);
-  // Luminance-based contrast
-  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return lum > 0.5 ? "#1a1a1a" : "#ffffff";
+  if (knots == null || isNaN(knots)) return '#e8eaf0';
+  for (const [max, , text] of BEAUFORT_STEPS) {
+    if (knots < max) return text;
+  }
+  return BEAUFORT_STEPS[BEAUFORT_STEPS.length - 1][2];
 }
+
+// Returns Beaufort number (0-8) for legend
+export function getBeaufortLevel(knots: number): number {
+  const maxes = [4, 7, 11, 15, 19, 23, 28, 33];
+  return maxes.findIndex(m => knots < m) === -1 ? 8 : maxes.findIndex(m => knots < m);
+}
+
+// Expose steps for legend rendering
+export { BEAUFORT_STEPS };


### PR DESCRIPTION
## Summary

- Replace continuous RGB interpolation in `colors.ts` with 9 discrete Beaufort paliers (B0–B8, 0–50 kn) with curated bg/text color pairs calibrated for Mediterranean mistral
- Rework `WindCell.tsx` layout: dominant speed (22px mobile / 26px lg), direction arrow (14px / 16px lg), gust row below with `↑` prefix and adaptive opacity (subdued when gust ≤ speed+5 kn)
- Add always-visible `BeaufortLegend` footer to `WindTable.tsx` — one colored square per Beaufort level with label below

## Test plan

- [x] `npm run build --workspace=packages/web` — clean build (no TS errors)
- [x] `npm run test --workspace=packages/web` — all 9 existing tests pass
- [ ] Visual smoke: load app in browser, select a Mediterranean spot, verify wind cells show discrete color steps and gust row with `↑` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)