### PR TITLE
feat(web): full light theme + density + sticky day

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -19,10 +19,10 @@ function EmptyState() {
             <path d="M12.6 19.4A2 2 0 1 0 14 16H2" />
           </svg>
         </div>
-        <p className="text-gray-200 text-base font-semibold mb-1.5">
+        <p className="text-base font-semibold mb-1.5" style={{ color: 'var(--ow-fg-0)' }}>
           Add a spot
         </p>
-        <p className="text-gray-400 text-sm leading-relaxed">
+        <p className="text-sm leading-relaxed" style={{ color: 'var(--ow-fg-1)' }}>
           <span className="lg:hidden">Long press on the map to place a wind spot</span>
           <span className="hidden lg:inline">Long click on the map to place a wind spot</span>
         </p>

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -4,6 +4,7 @@ import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast } from "../types";
 import { QUICK_SPOTS } from "../spots";
 import { getWindColor } from "../utils/colors";
+import { useTheme } from "../design/theme";
 
 function createArrowSvg(
   degrees: number,
@@ -116,6 +117,19 @@ export function SpotMap({
   const cancelPressRef = useRef<() => void>(() => {});
   // Maps each marker's SVG element → its spot (for native long-press detection)
   const elementToSpotRef = useRef<Map<Element, Spot>>(new Map());
+  const tileLayerRef = useRef<L.TileLayer | null>(null);
+
+  const { resolvedTheme } = useTheme();
+
+  // Switch Carto tiles when theme changes
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
+    const url = `https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`;
+    if (tileLayerRef.current) {
+      tileLayerRef.current.setUrl(url);
+    }
+  }, [resolvedTheme]);
 
   // Init map once
   useEffect(() => {
@@ -126,9 +140,11 @@ export function SpotMap({
       attributionControl: false,
     }).setView([current.latitude, current.longitude], 10);
 
-    L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
+    const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
       maxZoom: 19,
     }).addTo(map);
+    tileLayerRef.current = tile;
 
     L.control.attribution({ position: "bottomright", prefix: false })
       .addAttribution('&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>')
@@ -357,14 +373,14 @@ export function SpotMap({
       {/* Marker long-press: rename or delete */}
       {pendingEdit && (
         <div className="absolute inset-0 flex items-center justify-center z-[1000] bg-black/50 backdrop-blur-sm animate-fade-in" role="dialog" aria-label="Spot options">
-          <div className="bg-gray-800/95 backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs shadow-2xl border border-gray-700/50 animate-modal-in">
-            <p className="text-white text-sm font-semibold mb-1">{pendingEdit.name}</p>
-            <p className="text-gray-400 text-xs mb-4">
+          <div className="ow-modal-surface backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs animate-modal-in">
+            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--ow-fg-0)' }}>{pendingEdit.name}</p>
+            <p className="text-xs mb-4" style={{ color: 'var(--ow-fg-1)' }}>
               {pendingEdit.latitude.toFixed(4)}, {pendingEdit.longitude.toFixed(4)}
             </p>
             <div className="flex flex-col gap-2">
               <button
-                className="w-full min-h-[44px] py-2.5 rounded-lg bg-gray-700 text-white text-sm font-medium hover:bg-gray-600 active:bg-gray-500 active:scale-[0.98] transition-all"
+                className="ow-modal-btn w-full min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
                 onClick={() => {
                   const s = pendingEdit;
                   setPendingEdit(null);
@@ -383,7 +399,7 @@ export function SpotMap({
                 Delete
               </button>
               <button
-                className="w-full min-h-[44px] py-2.5 rounded-lg border border-gray-600 text-gray-300 text-sm hover:bg-gray-700/50 hover:text-gray-200 active:scale-[0.98] transition-all"
+                className="ow-modal-btn-outline w-full min-h-[44px] py-2.5 rounded-lg text-sm transition-all"
                 onClick={() => setPendingEdit(null)}
               >
                 Cancel
@@ -396,15 +412,15 @@ export function SpotMap({
       {/* New spot / rename spot */}
       {pendingSpot && (
         <div className="absolute inset-0 flex items-center justify-center z-[1000] bg-black/50 backdrop-blur-sm animate-fade-in" role="dialog" aria-label={pendingSpot.editingSpot ? "Rename spot" : "New spot"}>
-          <div className="bg-gray-800/95 backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs shadow-2xl border border-gray-700/50 animate-modal-in">
-            <p className="text-white text-sm font-semibold mb-1">
+          <div className="ow-modal-surface backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs animate-modal-in">
+            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--ow-fg-0)' }}>
               {pendingSpot.editingSpot ? "Rename spot" : "New spot"}
             </p>
-            <p className="text-gray-400 text-xs mb-3">
+            <p className="text-xs mb-3" style={{ color: 'var(--ow-fg-1)' }}>
               {pendingSpot.lat.toFixed(4)}, {pendingSpot.lng.toFixed(4)}
             </p>
             <input
-              className="w-full bg-gray-700 text-white text-sm rounded-lg px-3 py-2.5 mb-4 outline-none border border-gray-600 focus:border-teal-500 focus:ring-1 focus:ring-teal-500/30 transition-colors"
+              className="ow-modal-input w-full text-sm rounded-lg px-3 py-2.5 mb-4 transition-colors"
               value={pendingSpot.name}
               onChange={(e) => setPendingSpot({ ...pendingSpot, name: e.target.value })}
               autoFocus
@@ -412,7 +428,7 @@ export function SpotMap({
             />
             <div className="flex gap-2">
               <button
-                className="flex-1 min-h-[44px] py-2.5 rounded-lg border border-gray-600 text-gray-300 text-sm font-medium hover:bg-gray-700/50 hover:text-gray-200 active:scale-[0.98] transition-all"
+                className="ow-modal-btn-outline flex-1 min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
                 onClick={() => setPendingSpot(null)}
               >
                 Cancel

--- a/packages/web/src/components/SpotSearch.tsx
+++ b/packages/web/src/components/SpotSearch.tsx
@@ -56,7 +56,7 @@ export function SpotSearch({ onSelect }: SpotSearchProps) {
   return (
     <div ref={containerRef} className="relative w-full max-w-md lg:max-w-lg">
       <div className="relative">
-        <svg className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <svg className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--ow-fg-2)' }} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
           <circle cx="11" cy="11" r="8" />
           <path d="M21 21l-4.35-4.35" />
         </svg>
@@ -68,22 +68,22 @@ export function SpotSearch({ onSelect }: SpotSearchProps) {
             if (e.key === "Escape") setOpen(false);
           }}
           placeholder="Search..."
-          className="w-full pl-9 pr-3 py-2.5 min-h-[44px] bg-gray-800/80 border border-gray-700/60 rounded-xl text-sm text-white placeholder-gray-500 focus:outline-none focus:border-teal-500/60 focus:ring-1 focus:ring-teal-500/20 transition-all"
+          className="ow-search-input w-full pl-9 pr-3 py-2.5 min-h-[44px] rounded-xl text-sm transition-all"
         />
       </div>
       {open && (
-        <ul className="absolute top-full left-0 right-0 mt-1.5 bg-gray-800 border border-gray-700/60 rounded-xl overflow-hidden z-50 shadow-2xl animate-fade-in">
+        <ul className="ow-search-dropdown absolute top-full left-0 right-0 mt-1.5 rounded-xl overflow-hidden z-50 animate-fade-in">
           {results.map((r) => (
             <li
               key={r.id}
               onClick={() => handleSelect(r)}
-              className="px-3 py-2.5 min-h-[44px] flex items-center hover:bg-gray-700/80 active:bg-gray-600 cursor-pointer text-sm transition-colors border-b border-gray-700/30 last:border-b-0"
+              className="ow-search-item px-3 py-2.5 min-h-[44px] flex items-center cursor-pointer text-sm transition-colors"
             >
-              <span className="text-white font-medium">{r.name}</span>
+              <span className="font-medium" style={{ color: 'var(--ow-fg-0)' }}>{r.name}</span>
               {r.admin1 && (
-                <span className="text-gray-400">, {r.admin1}</span>
+                <span style={{ color: 'var(--ow-fg-1)' }}>, {r.admin1}</span>
               )}
-              <span className="text-gray-500"> — {r.country}</span>
+              <span style={{ color: 'var(--ow-fg-2)' }}> — {r.country}</span>
             </li>
           ))}
         </ul>

--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -23,6 +23,7 @@ interface TimelineHeaderProps {
   nowHour: string;
   timezoneMode: TimezoneMode;
   onCycleTimezone: () => void;
+  visibleDay: string; // ISO date string "2025-04-26" of leftmost visible day
 }
 
 function wmoIcon(code: number | null): string {
@@ -41,6 +42,12 @@ function wmoIcon(code: number | null): string {
   return "";
 }
 
+function formatStickyDay(isoDate: string): string {
+  if (!isoDate) return "";
+  const d = new Date(isoDate + "T12:00:00Z");
+  return d.toLocaleDateString("en-US", { weekday: "short", day: "numeric", timeZone: "UTC" });
+}
+
 export function TimelineHeader({
   times,
   selectedHour,
@@ -49,6 +56,7 @@ export function TimelineHeader({
   nowHour,
   timezoneMode,
   onCycleTimezone,
+  visibleDay,
 }: TimelineHeaderProps) {
   const days = groupHoursByDay(times);
 
@@ -77,15 +85,21 @@ export function TimelineHeader({
 
   return (
     <>
-      {/* Day headers */}
+      {/* Day headers — sticky left cell shows currently-visible day */}
       <tr>
-        <th className="sticky left-0 z-20 bg-gray-900 min-w-[56px]" scope="col" />
+        <th
+          className="sticky left-0 z-20 min-w-[56px] px-1 text-[10px] font-bold uppercase tracking-wide"
+          style={{ background: 'var(--ow-bg-1)', color: 'var(--ow-accent)' }}
+          scope="col"
+        >
+          {formatStickyDay(visibleDay)}
+        </th>
         {Array.from(days.entries()).map(([dateKey, indices]) => (
           <th
             key={dateKey}
             colSpan={indices.length}
             scope="colgroup"
-            className="bg-gray-900 text-gray-200 text-xs lg:text-sm font-bold py-2 border-b border-gray-700 border-l border-l-gray-600 uppercase tracking-wide"
+            className="ow-tbl-day-th text-[10px] lg:text-xs font-bold py-1.5 uppercase tracking-wide"
           >
             {formatDayHeader(times[indices[0]], timezoneMode)}
           </th>
@@ -93,12 +107,12 @@ export function TimelineHeader({
       </tr>
       {/* Weather icons */}
       <tr>
-        <td className="sticky left-0 z-20 bg-gray-900 min-w-[56px]" />
+        <td className="sticky left-0 z-20 ow-tbl-bg min-w-[56px]" />
         {times.map((t, i) => (
           <td
             key={i}
-            className="text-center p-0 bg-gray-900 cursor-pointer leading-none"
-            style={{ fontSize: "16px", lineHeight: "22px" }}
+            className="text-center p-0 ow-tbl-bg cursor-pointer leading-none"
+            style={{ fontSize: "14px", lineHeight: "20px" }}
             onClick={() => onSelectHour(t)}
           >
             {wmoIcon(weatherCode(t))}
@@ -107,11 +121,11 @@ export function TimelineHeader({
       </tr>
       {/* Color bar */}
       <tr>
-        <td className="sticky left-0 z-20 bg-gray-900 min-w-[56px]" />
+        <td className="sticky left-0 z-20 ow-tbl-bg min-w-[56px]" />
         {times.map((t, i) => (
           <td
             key={i}
-            className="h-3 p-0 cursor-pointer transition-colors"
+            className="h-2 p-0 cursor-pointer transition-colors"
             style={{ backgroundColor: getWindColor(avgSpeed(t)) }}
             onClick={() => onSelectHour(t)}
           />
@@ -119,12 +133,15 @@ export function TimelineHeader({
       </tr>
       {/* Hour numbers + timezone toggle */}
       <tr>
-        <th className="sticky left-0 z-20 bg-gray-900 min-w-[56px] px-1" scope="col">
+        <th
+          className="sticky left-0 z-20 ow-tbl-bg min-w-[56px] px-1"
+          scope="col"
+        >
           <button
             onClick={onCycleTimezone}
             title={TZ_TITLES[timezoneMode]}
             aria-label={`Timezone: ${timezoneMode}. Click to cycle.`}
-            className="text-[10px] lg:text-[11px] font-bold text-teal-400 hover:text-teal-200 active:scale-95 transition-all leading-none whitespace-nowrap"
+            className="text-[9px] lg:text-[10px] font-bold text-teal-400 hover:text-teal-200 active:scale-95 transition-all leading-none whitespace-nowrap"
           >
             {TZ_LABELS[timezoneMode]}
           </button>
@@ -135,18 +152,18 @@ export function TimelineHeader({
             <th
               key={i}
               scope="col"
-              className={`text-xs lg:text-sm font-semibold py-1.5 cursor-pointer transition-colors relative ${
+              className={`text-[10px] lg:text-xs font-semibold py-1 cursor-pointer transition-colors relative ${
                 t === selectedHour
                   ? "text-white bg-teal-600"
                   : isNow
                   ? "text-teal-100 bg-teal-700/70 font-bold"
-                  : "text-gray-400 bg-gray-900 hover:text-gray-200 hover:bg-gray-800"
+                  : "ow-hour-cell"
               }`}
               onClick={() => onSelectHour(t)}
             >
               {formatHour(t, timezoneMode)}
               {isNow && (
-                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-teal-400" />
+                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-teal-400" />
               )}
             </th>
           );

--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -17,7 +17,7 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
     return (
       <td
         role="cell"
-        className={`wind-cell min-w-[44px] lg:min-w-[52px] h-12 lg:h-16 bg-gray-800/40 text-center text-gray-600 text-xs align-middle cursor-pointer ${nowBorder} ${selectedStyle}`}
+        className={`wind-cell ow-null-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center text-xs align-middle cursor-pointer ${nowBorder} ${selectedStyle}`}
         onClick={onSelect}
       >
         —
@@ -28,41 +28,38 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
   const bg = getWindColor(speed);
   const color = getTextColor(speed);
 
-  // Gusts are visually subdued when close to wind speed (within 5 kn)
   const gustClose = gusts != null && gusts <= speed + 5;
   const gustOpacity = gustClose ? "opacity-70" : "opacity-90";
 
   return (
     <td
       role="cell"
-      className={`wind-cell min-w-[44px] lg:min-w-[52px] h-12 lg:h-16 text-center align-middle p-0 cursor-pointer ${nowBorder} ${selectedStyle}`}
+      className={`wind-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center align-middle p-0 cursor-pointer ${nowBorder} ${selectedStyle}`}
       style={{ backgroundColor: bg, color }}
       onClick={onSelect}
       aria-label={`${Math.round(speed)} knots${gusts != null ? `, gusts ${Math.round(gusts)}` : ""}${direction != null ? `, direction ${direction}°` : ""}`}
     >
-      <div className="flex flex-col items-center justify-center leading-none gap-[3px]">
-        {/* Row 1: arrow + speed (dominant) */}
+      <div className="flex flex-col items-center justify-center leading-none gap-[2px]">
+        {/* Row 1: arrow + speed */}
         <div className="flex items-center gap-0.5">
           {direction != null && (
             <svg
-              width="14"
-              height="14"
-              className="lg:w-4 lg:h-4 shrink-0"
+              width="11"
+              height="11"
+              className="lg:w-[14px] lg:h-[14px] shrink-0"
               viewBox="0 0 16 16"
               style={{ transform: `rotate(${direction + 180}deg)`, transition: "transform 0.3s ease" }}
             >
               <polygon points="8,1 13,15 8,10 3,15" fill="currentColor" />
             </svg>
           )}
-          <span className="text-[22px] lg:text-[26px] font-bold tabular-nums leading-none">
+          <span className="text-[17px] lg:text-[21px] font-bold tabular-nums leading-none">
             {Math.round(speed)}
           </span>
         </div>
-        {/* Row 2: gust, smaller, slightly subdued */}
+        {/* Row 2: gust */}
         {gusts != null && (
-          <span
-            className={`text-[12px] lg:text-[13px] font-semibold tabular-nums leading-none ${gustOpacity}`}
-          >
+          <span className={`text-[10px] lg:text-[11px] font-semibold tabular-nums leading-none ${gustOpacity}`}>
             ↑{Math.round(gusts)}
           </span>
         )}

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -5,8 +5,6 @@ import { WindCell } from "./WindCell";
 import { BEAUFORT_STEPS } from "../utils/colors";
 import { useTimezone } from "../hooks/useTimezone";
 
-// Native time step (hours) for each model — Open-Meteo interpolates to 1h,
-// but these are the actual forecast resolution worth displaying
 const MODEL_STEP: Record<string, number> = {
   AROME: 1,
   ICON: 3,
@@ -27,6 +25,9 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
   GFS: "GFS — Modèle global (3h) — NOAA États-Unis",
   ECMWF: "ECMWF — Modèle global (6h) — Centre européen",
 };
+
+// Approximate cell width (must match WindCell min-w-[36px])
+const CELL_W = 36;
 
 function autoResolution(forecasts: ModelForecast[]): number {
   let finest = 6;
@@ -62,21 +63,21 @@ function buildTimeIndex(times: string[]): Map<string, number> {
 }
 
 const BEAUFORT_LABELS = [
-  "calme", "1–3", "4–6", "7–10", "11–15", "16–19", "20–24", "25–30", "31+",
+  "calm", "1–3", "4–6", "7–10", "11–15", "16–19", "20–24", "25–30", "31+",
 ];
 
 function BeaufortLegend() {
   return (
-    <div className="flex items-end gap-1.5 px-3 py-2 border-t border-gray-800/60 overflow-x-auto">
+    <div className="hidden sm:flex items-end gap-1 px-3 py-2 border-t overflow-x-auto" style={{ borderColor: 'var(--ow-line)' }}>
       {BEAUFORT_STEPS.map(([, bg, text], i) => (
         <div key={i} className="flex flex-col items-center shrink-0">
           <div
-            className="w-7 h-5 rounded-sm flex items-center justify-center text-[10px] font-bold leading-none"
+            className="w-6 h-4 rounded-sm flex items-center justify-center text-[9px] font-bold leading-none"
             style={{ backgroundColor: bg, color: text }}
           >
             B{i}
           </div>
-          <span className="text-[9px] text-gray-500 mt-0.5 whitespace-nowrap">{BEAUFORT_LABELS[i]}</span>
+          <span className="text-[8px] mt-0.5 whitespace-nowrap" style={{ color: 'var(--ow-fg-2)' }}>{BEAUFORT_LABELS[i]}</span>
         </div>
       ))}
     </div>
@@ -86,17 +87,15 @@ function BeaufortLegend() {
 function SkeletonTable() {
   return (
     <div className="px-3 py-4 space-y-3 animate-fade-in">
-      {/* Header skeleton */}
       <div className="flex gap-2 items-center">
         <div className="skeleton h-4 w-20" />
         <div className="skeleton h-4 flex-1 max-w-[200px]" />
       </div>
-      {/* Rows */}
       {[0, 1, 2, 3].map((i) => (
-        <div key={i} className="flex gap-1.5">
-          <div className="skeleton h-12 w-14 shrink-0" />
+        <div key={i} className="flex gap-1">
+          <div className="skeleton h-10 w-14 shrink-0" />
           {Array.from({ length: 10 }).map((_, j) => (
-            <div key={j} className="skeleton h-12 w-11 shrink-0" />
+            <div key={j} className="skeleton h-10 w-9 shrink-0" />
           ))}
         </div>
       ))}
@@ -113,6 +112,7 @@ export function WindTable({
 }: WindTableProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrolledEnd, setScrolledEnd] = useState(false);
+  const [visibleDay, setVisibleDay] = useState("");
   const [timezoneMode, cycleTimezone] = useTimezone();
 
   const masterTimeline = useMemo(() => {
@@ -125,20 +125,28 @@ export function WindTable({
 
   const nowHour = new Date().toISOString().slice(0, 13);
 
+  const updateVisibleDay = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || masterTimeline.length === 0) return;
+    const leftmostIdx = Math.max(0, Math.floor(el.scrollLeft / CELL_W));
+    const t = masterTimeline[Math.min(leftmostIdx, masterTimeline.length - 1)];
+    if (t) setVisibleDay(t.slice(0, 10));
+  }, [masterTimeline]);
+
   const checkScrollEnd = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
     const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 10;
     setScrolledEnd(atEnd);
-  }, []);
+    updateVisibleDay();
+  }, [updateVisibleDay]);
 
   useEffect(() => {
     if (!scrollRef.current || masterTimeline.length === 0) return;
     const idx = masterTimeline.findIndex((t) => t.startsWith(nowHour));
     const nearestIdx = idx >= 0 ? idx : masterTimeline.findIndex((t) => t > nowHour.slice(0, 13));
     if (nearestIdx > 0) {
-      const cellWidth = 44;
-      scrollRef.current.scrollLeft = Math.max(0, nearestIdx * cellWidth - 60);
+      scrollRef.current.scrollLeft = Math.max(0, nearestIdx * CELL_W - 60);
     }
     checkScrollEnd();
   }, [masterTimeline, nowHour, checkScrollEnd]);
@@ -150,14 +158,13 @@ export function WindTable({
     return () => el.removeEventListener("scroll", checkScrollEnd);
   }, [checkScrollEnd]);
 
-
   if (isLoading) {
     return <SkeletonTable />;
   }
 
   if (forecasts.length === 0) {
     return (
-      <div className="text-gray-500 text-center py-8 text-sm">
+      <div className="text-center py-8 text-sm" style={{ color: 'var(--ow-fg-2)' }}>
         No data available
       </div>
     );
@@ -166,14 +173,17 @@ export function WindTable({
   return (
     <div className="animate-fade-in">
       {/* Spot name bar */}
-      <div className="flex items-center px-3 py-1.5 bg-gray-900/80 border-b border-gray-800/60">
+      <div
+        className="flex items-center px-3 py-1.5 border-b"
+        style={{ background: 'var(--ow-surface-glass)', borderColor: 'var(--ow-line)' }}
+      >
         {spotName ? (
           <div className="flex items-center gap-2 min-w-0">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-teal-400 shrink-0">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--ow-accent)' }} className="shrink-0">
               <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
               <circle cx="12" cy="10" r="3" />
             </svg>
-            <span className="text-sm font-semibold text-gray-200 truncate">{spotName}</span>
+            <span className="text-sm font-semibold truncate" style={{ color: 'var(--ow-fg-0)' }}>{spotName}</span>
           </div>
         ) : (
           <div />
@@ -191,6 +201,7 @@ export function WindTable({
                 nowHour={nowHour}
                 timezoneMode={timezoneMode}
                 onCycleTimezone={cycleTimezone}
+                visibleDay={visibleDay}
               />
             </thead>
             <tbody>
@@ -198,19 +209,24 @@ export function WindTable({
                 const timeIndex = buildTimeIndex(forecast.hourly.time);
                 return (
                   <tr key={forecast.modelName} className={forecasts.indexOf(forecast) % 2 === 1 ? "model-row-alt" : ""}>
-                    <td className="sticky left-0 z-10 bg-gray-900 px-2 py-1.5 whitespace-nowrap border-r border-gray-700 min-w-[56px]" role="rowheader">
-                      <span className="text-[12px] lg:text-[13px] font-bold text-gray-200 tracking-wide" title={MODEL_DESCRIPTIONS[forecast.modelName] ?? forecast.modelName}>{MODEL_LABELS[forecast.modelName] ?? forecast.modelName}</span>
+                    <td
+                      className="sticky left-0 z-10 px-2 py-1 whitespace-nowrap border-r min-w-[56px]"
+                      style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
+                      role="rowheader"
+                    >
+                      <span
+                        className="text-[11px] lg:text-[12px] font-bold tracking-wide"
+                        style={{ color: 'var(--ow-fg-0)' }}
+                        title={MODEL_DESCRIPTIONS[forecast.modelName] ?? forecast.modelName}
+                      >
+                        {MODEL_LABELS[forecast.modelName] ?? forecast.modelName}
+                      </span>
                     </td>
                     {masterTimeline.map((t, i) => {
                       const idx = timeIndex.get(t);
-                      const speed =
-                        idx != null ? forecast.hourly.wind_speed_10m[idx] : null;
-                      const gusts =
-                        idx != null ? forecast.hourly.wind_gusts_10m[idx] : null;
-                      const direction =
-                        idx != null
-                          ? forecast.hourly.wind_direction_10m[idx]
-                          : null;
+                      const speed = idx != null ? forecast.hourly.wind_speed_10m[idx] : null;
+                      const gusts = idx != null ? forecast.hourly.wind_gusts_10m[idx] : null;
+                      const direction = idx != null ? forecast.hourly.wind_direction_10m[idx] : null;
                       return (
                         <WindCell
                           key={i}

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -1,32 +1,46 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
 type ThemeMode = 'light' | 'dark' | 'system';
+type ResolvedTheme = 'light' | 'dark';
 
 const STORAGE_KEY = 'ow_theme';
 
+function resolveMode(m: ThemeMode): ResolvedTheme {
+  if (m !== 'system') return m;
+  try {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
 const ThemeCtx = createContext<{
   mode: ThemeMode;
+  resolvedTheme: ResolvedTheme;
   setMode: (m: ThemeMode) => void;
-}>({ mode: 'system', setMode: () => {} });
+}>({ mode: 'system', resolvedTheme: 'dark', setMode: () => {} });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [mode, setModeState] = useState<ThemeMode>(() => {
     try { return (localStorage.getItem(STORAGE_KEY) as ThemeMode) ?? 'system'; }
     catch { return 'system'; }
   });
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => resolveMode(
+    (() => { try { return (localStorage.getItem(STORAGE_KEY) as ThemeMode) ?? 'system'; } catch { return 'system'; } })()
+  ));
 
   useEffect(() => {
     function apply(m: ThemeMode) {
-      const resolved = m === 'system'
-        ? (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
-        : m;
+      const resolved = resolveMode(m);
+      setResolvedTheme(resolved);
       document.documentElement.setAttribute('data-theme', resolved);
     }
     apply(mode);
     if (mode === 'system') {
       const mq = window.matchMedia('(prefers-color-scheme: light)');
-      mq.addEventListener('change', () => apply('system'));
-      return () => mq.removeEventListener('change', () => apply('system'));
+      const handler = () => apply('system');
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
     }
   }, [mode]);
 
@@ -35,7 +49,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     try { localStorage.setItem(STORAGE_KEY, m); } catch {}
   }
 
-  return <ThemeCtx.Provider value={{ mode, setMode }}>{children}</ThemeCtx.Provider>;
+  return <ThemeCtx.Provider value={{ mode, resolvedTheme, setMode }}>{children}</ThemeCtx.Provider>;
 }
 
 export function useTheme() { return useContext(ThemeCtx); }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -169,3 +169,85 @@ body {
 .leaflet-control-attribution a {
   color: #9ca3af !important;
 }
+
+/* ── Theme-aware table header ────────────────────────────────── */
+.ow-tbl-bg {
+  background: var(--ow-bg-1);
+}
+.ow-tbl-day-th {
+  background: var(--ow-bg-1);
+  color: var(--ow-fg-0);
+  border-bottom: 1px solid var(--ow-line-2);
+  border-left: 1px solid var(--ow-line-2);
+}
+.ow-hour-cell {
+  background: var(--ow-bg-1);
+  color: var(--ow-fg-1);
+}
+.ow-hour-cell:hover {
+  background: var(--ow-bg-2);
+  color: var(--ow-fg-0);
+}
+.ow-null-cell {
+  background: var(--ow-bg-2);
+  color: var(--ow-fg-2);
+}
+
+/* ── Theme-aware search ──────────────────────────────────────── */
+.ow-search-input {
+  background: color-mix(in srgb, var(--ow-bg-2) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ow-line-2) 60%, transparent);
+  color: var(--ow-fg-0);
+}
+.ow-search-input::placeholder {
+  color: var(--ow-fg-3);
+}
+.ow-search-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--ow-accent) 60%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ow-accent) 20%, transparent);
+}
+.ow-search-dropdown {
+  background: var(--ow-bg-2);
+  border: 1px solid color-mix(in srgb, var(--ow-line-2) 60%, transparent);
+  box-shadow: var(--ow-shadow-pop);
+}
+.ow-search-item {
+  border-bottom: 1px solid color-mix(in srgb, var(--ow-line) 30%, transparent);
+  color: var(--ow-fg-0);
+}
+.ow-search-item:last-child { border-bottom: none; }
+.ow-search-item:hover { background: color-mix(in srgb, var(--ow-bg-1) 80%, transparent); }
+.ow-search-item:active { background: var(--ow-bg-1); }
+
+/* ── Theme-aware modals (SpotMap) ────────────────────────────── */
+.ow-modal-surface {
+  background: color-mix(in srgb, var(--ow-bg-2) 95%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ow-line-2) 50%, transparent);
+  box-shadow: var(--ow-shadow-pop);
+}
+.ow-modal-btn {
+  background: var(--ow-bg-1);
+  color: var(--ow-fg-0);
+}
+.ow-modal-btn:hover { background: var(--ow-bg-0); }
+.ow-modal-btn:active { background: var(--ow-bg-0); transform: scale(0.98); }
+.ow-modal-btn-outline {
+  border: 1px solid var(--ow-line-2);
+  color: var(--ow-fg-1);
+}
+.ow-modal-btn-outline:hover {
+  background: color-mix(in srgb, var(--ow-bg-1) 50%, transparent);
+  color: var(--ow-fg-0);
+}
+.ow-modal-btn-outline:active { transform: scale(0.98); }
+.ow-modal-input {
+  background: var(--ow-bg-1);
+  color: var(--ow-fg-0);
+  border: 1px solid var(--ow-line-2);
+  outline: none;
+}
+.ow-modal-input:focus {
+  border-color: var(--ow-accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ow-accent) 30%, transparent);
+}


### PR DESCRIPTION
## Summary

- **Light theme complet** — tous les `bg-gray-900/800/700`, `text-gray-*`, `border-gray-*` remplacés par `--ow-*` CSS vars dans `TimelineHeader`, `WindTable`, `WindCell`, `SpotSearch`, `SpotMap` (modals). Classes utilitaires thématisées ajoutées dans `index.css` (`ow-tbl-bg`, `ow-hour-cell`, `ow-null-cell`, `ow-search-*`, `ow-modal-*`)
- **Carto tiles dynamiques** — `SpotMap` switche `dark_all` ↔ `light_all` au changement de thème ; `useTheme()` expose maintenant `resolvedTheme`
- **Densité** — cellules 44→36px mobile / 52→44px desktop, fonts speed 22→17px, header 10px. +2–3 heures visibles sur mobile
- **Jour sticky** — cellule gauche fixe (header rangée jours) affiche le jour courant visible, mis à jour au scroll
- **Beaufort** — légende cachée sur mobile (`hidden sm:flex`), visible ≥ sm uniquement

## Test plan

- [ ] Passer en mode light (clic ☾→⊙→☀) : table, header, search, modals et tiles Carto doivent tous switcher
- [ ] Scroll horizontal : le jour en sticky gauche doit se mettre à jour (SUN → MON…)
- [ ] Mobile (< sm) : légende Beaufort invisible ; desktop (≥ sm) : visible
- [ ] `npm run build` + `npm run test` passent (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)