### PR TITLE
fix(web): center day label in sticky header cell

### DIFF
--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -81,7 +81,7 @@ export function TimelineHeader({
           className="sticky left-0 z-20 min-w-[56px] px-2 border-r"
           style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
         >
-          <div className="flex flex-col leading-none gap-[1px]">
+          <div className="flex flex-col items-center leading-none gap-[1px]">
             <span className="text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--ow-accent)' }}>
               {weekday}
             </span>


### PR DESCRIPTION
Ajoute `items-center` sur le flex container du label jour (TUE/28) dans la cellule sticky — centré au lieu de collé à gauche sur mobile.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)