### PR TITLE
fix(web): header cleanup + gray arrows + footer hidden mobile

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -106,12 +106,11 @@ function App() {
               isLoading={isLoading}
               selectedHour={selectedHour}
               onSelectHour={setSelectedHour}
-              spotName={spot?.name}
             />
           ) : (
             <EmptyState />
           )}
-          <footer className="text-center text-[11px] py-1 shrink-0" style={{ color: 'var(--ow-fg-2)' }}>
+          <footer className="hidden sm:block text-center text-[11px] py-1 shrink-0" style={{ color: 'var(--ow-fg-2)' }}>
             Data by{" "}
             <a
               href="https://open-meteo.com/"

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -348,7 +348,7 @@ export function SpotMap({
       const dir = forecast.hourly.wind_direction_10m[timeIdx];
       const spd = forecast.hourly.wind_speed_10m[timeIdx];
       if (dir == null || spd == null) continue;
-      const color = resolvedTheme === "light" ? "#0d2030" : "#ffffff";
+      const color = resolvedTheme === "light" ? "#64748b" : "#ffffff";
       const length = Math.min(36 + spd * 2.4, 120);
       svgContent += createArrowSvg(dir, spd, color, forecast.modelName, length);
     }

--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -2,11 +2,6 @@ import { formatHour } from "../utils/format";
 import type { ModelForecast } from "../types";
 import type { TimezoneMode } from "../hooks/useTimezone";
 
-const TZ_TITLES: Record<TimezoneMode, string> = {
-  local: "Local time — click to switch to UTC",
-  utc: "UTC — click to switch to Boat (Europe/Paris)",
-  boat: "Boat time (Europe/Paris) — click to switch to Local",
-};
 
 interface TimelineHeaderProps {
   times: string[];
@@ -15,7 +10,6 @@ interface TimelineHeaderProps {
   forecasts: ModelForecast[];
   nowHour: string;
   timezoneMode: TimezoneMode;
-  onCycleTimezone: () => void;
   visibleDay: string; // ISO date "2025-04-26" of leftmost visible day
 }
 
@@ -50,7 +44,6 @@ export function TimelineHeader({
   forecasts,
   nowHour,
   timezoneMode,
-  onCycleTimezone,
   visibleDay,
 }: TimelineHeaderProps) {
   function weatherCode(timeStr: string): number | null {
@@ -75,13 +68,14 @@ export function TimelineHeader({
 
   return (
     <>
-      {/* Row 1: weather icons — sticky left shows visible day */}
+      {/* Row 1: weather icons — sticky left spans both rows, shows day */}
       <tr>
         <td
-          className="sticky left-0 z-20 min-w-[56px] px-2 border-r"
+          rowSpan={2}
+          className="sticky left-0 z-20 min-w-[56px] px-2 border-r border-b"
           style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
         >
-          <div className="flex flex-col items-center justify-center h-full leading-none gap-[1px]">
+          <div className="flex flex-col items-center justify-center h-full leading-none gap-[2px]">
             <span className="text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--ow-accent)' }}>
               {weekday}
             </span>
@@ -106,23 +100,8 @@ export function TimelineHeader({
         ))}
       </tr>
 
-      {/* Row 2: hour numbers — sticky left shows "KN" unit (click to cycle timezone) */}
+      {/* Row 2: hour numbers — no sticky left (spanned by row above) */}
       <tr>
-        <th
-          className="sticky left-0 z-20 ow-tbl-bg min-w-[56px] px-2 border-r border-b"
-          style={{ borderColor: 'var(--ow-line-2)' }}
-          scope="col"
-        >
-          <button
-            onClick={onCycleTimezone}
-            title={TZ_TITLES[timezoneMode]}
-            aria-label={`Unit: KN. Timezone: ${timezoneMode}. Click to cycle.`}
-            className="text-[10px] lg:text-[11px] font-bold hover:opacity-70 active:scale-95 transition-all leading-none"
-            style={{ color: 'var(--ow-accent)' }}
-          >
-            KN
-          </button>
-        </th>
         {times.map((t, i) => {
           const isNow = t.startsWith(nowHour);
           const isDayStart = dayStarts.has(t) && i > 0;

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -43,7 +43,6 @@ interface WindTableProps {
   isLoading: boolean;
   selectedHour: string | null;
   onSelectHour: (time: string) => void;
-  spotName?: string;
 }
 
 function getMasterTimeline(forecasts: ModelForecast[]): string[] {
@@ -108,12 +107,11 @@ export function WindTable({
   isLoading,
   selectedHour,
   onSelectHour,
-  spotName,
 }: WindTableProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrolledEnd, setScrolledEnd] = useState(false);
   const [visibleDay, setVisibleDay] = useState("");
-  const [timezoneMode, cycleTimezone] = useTimezone();
+  const [timezoneMode] = useTimezone();
 
   const masterTimeline = useMemo(() => {
     const resolution = autoResolution(forecasts);
@@ -172,23 +170,6 @@ export function WindTable({
 
   return (
     <div className="animate-fade-in">
-      {/* Spot name bar */}
-      <div
-        className="flex items-center px-3 py-1.5 border-b"
-        style={{ background: 'var(--ow-surface-glass)', borderColor: 'var(--ow-line)' }}
-      >
-        {spotName ? (
-          <div className="flex items-center gap-2 min-w-0">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--ow-accent)' }} className="shrink-0">
-              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-              <circle cx="12" cy="10" r="3" />
-            </svg>
-            <span className="text-sm font-semibold truncate" style={{ color: 'var(--ow-fg-0)' }}>{spotName}</span>
-          </div>
-        ) : (
-          <div />
-        )}
-      </div>
       <div className={`scroll-container ${scrolledEnd ? "scrolled-end" : ""}`}>
         <div ref={scrollRef} className="overflow-x-auto wind-table-scroll">
           <table className="border-collapse" role="table">
@@ -200,7 +181,6 @@ export function WindTable({
                 forecasts={forecasts}
                 nowHour={nowHour}
                 timezoneMode={timezoneMode}
-                onCycleTimezone={cycleTimezone}
                 visibleDay={visibleDay}
               />
             </thead>
@@ -214,13 +194,16 @@ export function WindTable({
                       style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
                       role="rowheader"
                     >
-                      <span
-                        className="text-[11px] lg:text-[12px] font-bold tracking-wide"
-                        style={{ color: 'var(--ow-fg-0)' }}
-                        title={MODEL_DESCRIPTIONS[forecast.modelName] ?? forecast.modelName}
-                      >
-                        {MODEL_LABELS[forecast.modelName] ?? forecast.modelName}
-                      </span>
+                      <div className="flex flex-col items-center leading-none gap-[2px]">
+                        <span
+                          className="text-[11px] lg:text-[12px] font-bold tracking-wide"
+                          style={{ color: 'var(--ow-fg-0)' }}
+                          title={MODEL_DESCRIPTIONS[forecast.modelName] ?? forecast.modelName}
+                        >
+                          {MODEL_LABELS[forecast.modelName] ?? forecast.modelName}
+                        </span>
+                        <span className="text-[8px] font-medium" style={{ color: 'var(--ow-fg-2)' }}>kn</span>
+                      </div>
                     </td>
                     {masterTimeline.map((t, i) => {
                       const idx = timeIndex.get(t);


### PR DESCRIPTION
## Summary
- Cellule sticky date+KN fusionnée en une (rowSpan=2) — "kn" passe sous chaque nom de modèle
- Barre nom du spot supprimée
- Bouton timezone supprimé (KN disparu du header)
- Footer Open-Meteo masqué sur mobile (`hidden sm:block`)
- Flèches carte : gris `#64748b` en light au lieu de quasi-noir

🤖 Generated with [Claude Code](https://claude.ai/claude-code)