### PR TITLE
feat(data): structured ComplexityWarning in ComplexityScore

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/complexity.py
+++ b/packages/data-adapters/src/openwind_data/routing/complexity.py
@@ -14,6 +14,7 @@ V1 design choices:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from openwind_data.routing.passage import PassageReport
 
@@ -50,6 +51,24 @@ def _classify(value: float, bands: tuple[tuple[float, int, str], ...]) -> tuple[
     raise AssertionError("bands must end with +inf")  # pragma: no cover
 
 
+def _lower_bound(level: int, bands: tuple[tuple[float, int, str], ...]) -> float:
+    """Return the inclusive lower bound of value that maps to `level`."""
+    prev: float = 0.0
+    for upper, lv, _ in bands:
+        if lv == level:
+            return prev
+        prev = upper
+    return 0.0  # pragma: no cover
+
+
+@dataclass(frozen=True, slots=True)
+class ComplexityWarning:
+    kind: Literal["wind", "sea"]
+    level: int  # 1..5 — same scale as the axis that triggered it
+    message: str
+    affected_segments: tuple[int, ...]  # indices into PassageReport.segments
+
+
 @dataclass(frozen=True, slots=True)
 class ComplexityScore:
     level: int  # 1..5
@@ -61,6 +80,7 @@ class ComplexityScore:
     tws_max_kn: float
     hs_max_m: float | None
     rationale: str
+    warnings: tuple[ComplexityWarning, ...] = ()
 
 
 def score_complexity(
@@ -95,6 +115,29 @@ def score_complexity(
             f"vent max {tws_max:.0f} kn ({wind_label}), mer max Hs={max_hs_m:.1f} m ({sea_label})"
         )
 
+    warnings: list[ComplexityWarning] = []
+    if wind_level >= 3:
+        threshold = _lower_bound(wind_level, _WIND_BANDS)
+        affected = tuple(i for i, s in enumerate(passage.segments) if s.tws_kn >= threshold)
+        warnings.append(ComplexityWarning(
+            kind="wind",
+            level=wind_level,
+            message=f"Vent {wind_label} : TWS max {tws_max:.0f} kn sur {len(affected)} segment(s)",
+            affected_segments=affected,
+        ))
+    if sea_level is not None and sea_level >= 3 and max_hs_m is not None:
+        threshold = _lower_bound(sea_level, _SEA_BANDS)
+        affected_sea = tuple(
+            i for i, s in enumerate(passage.segments)
+            if s.hs_m is not None and s.hs_m >= threshold
+        )
+        warnings.append(ComplexityWarning(
+            kind="sea",
+            level=sea_level,
+            message=f"Mer {sea_label} : Hs max {max_hs_m:.1f} m sur {len(affected_sea)} segment(s)",
+            affected_segments=affected_sea,
+        ))
+
     return ComplexityScore(
         level=level,
         label=_LEVEL_LABELS[level],
@@ -105,4 +148,5 @@ def score_complexity(
         tws_max_kn=tws_max,
         hs_max_m=max_hs_m,
         rationale=rationale,
+        warnings=tuple(warnings),
     )

--- a/packages/data-adapters/tests/test_complexity.py
+++ b/packages/data-adapters/tests/test_complexity.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from openwind_data.routing.complexity import score_complexity
+from openwind_data.routing.complexity import score_complexity, ComplexityWarning
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import PassageReport, SegmentReport
 
@@ -96,6 +96,43 @@ class TestWithSea:
     def test_negative_hs_rejected(self) -> None:
         with pytest.raises(ValueError, match="max_hs_m"):
             score_complexity(_make_passage([5.0]), max_hs_m=-0.1)
+
+
+class TestWarnings:
+    def test_no_warnings_below_level_3(self) -> None:
+        s = score_complexity(_make_passage([12.0]))
+        assert s.warnings == ()
+
+    def test_wind_warning_at_level_3(self) -> None:
+        s = score_complexity(_make_passage([18.0]))
+        assert len(s.warnings) == 1
+        w = s.warnings[0]
+        assert w.kind == "wind"
+        assert w.level == 3
+        assert isinstance(w, ComplexityWarning)
+        assert 0 in w.affected_segments
+
+    def test_wind_warning_identifies_hot_segments(self) -> None:
+        # Segments 0 and 2 calm, segment 1 hits level 5 (>=25 kn)
+        s = score_complexity(_make_passage([8.0, 26.0, 8.0]))
+        assert len(s.warnings) == 1
+        assert s.warnings[0].affected_segments == (1,)
+
+    def test_sea_warning_at_level_4(self) -> None:
+        s = score_complexity(_make_passage([5.0]), max_hs_m=2.5)
+        sea_w = [w for w in s.warnings if w.kind == "sea"]
+        assert len(sea_w) == 1
+        assert sea_w[0].level == 4  # 2.5 m falls in level 4 (2–3 m band)
+        assert "2.5" in sea_w[0].message
+
+    def test_no_sea_warning_without_max_hs(self) -> None:
+        s = score_complexity(_make_passage([18.0]))
+        assert not any(w.kind == "sea" for w in s.warnings)
+
+    def test_both_axes_warned(self) -> None:
+        s = score_complexity(_make_passage([22.0]), max_hs_m=2.5)
+        assert any(w.kind == "wind" for w in s.warnings)
+        assert any(w.kind == "sea" for w in s.warnings)
 
 
 def test_empty_passage_rejected() -> None:


### PR DESCRIPTION
## Summary

- Adds `ComplexityWarning` dataclass with `kind` (wind/sea), `level`, `message`, and `affected_segments`
- Adds `warnings: tuple[ComplexityWarning, ...]` field to `ComplexityScore` (default empty)
- `score_complexity()` now populates warnings when `wind_level >= 3` or `sea_level >= 3`
- Affected segments are identified by per-segment `tws_kn` vs. the level's lower threshold

This is PR 2.3 from Sprint 2. Required by the `/plan` frontend to display structured warnings above the leg breakdown.

## Test plan

- [ ] 16 tests pass including 6 new warning tests (`TestWarnings`)
- [ ] `ruff check` clean
- [ ] No warnings for levels 1–2
- [ ] Wind + sea warnings generated independently when both axes hit level 3+
- [ ] `affected_segments` correctly identifies only hot segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)