### PR TITLE
feat(hf): REST API v1 — GET /api/v1/archetypes + POST /api/v1/passage

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/archetypes.py
+++ b/packages/data-adapters/src/openwind_data/routing/archetypes.py
@@ -71,6 +71,23 @@ def list_archetypes() -> list[BoatPolar]:
     return [reg[n] for n in _ARCHETYPE_NAMES]
 
 
+def list_archetypes_metadata() -> list[dict]:
+    """Return archetype metadata (no polars) suitable for REST API responses."""
+    reg = _registry()
+    return [
+        {
+            "slug": n,
+            "name": reg[n].name,
+            "length_ft": reg[n].length_ft,
+            "type": reg[n].type,
+            "category": reg[n].category,
+            "examples": list(reg[n].examples),
+            "performance_class": reg[n].performance_class,
+        }
+        for n in _ARCHETYPE_NAMES
+    ]
+
+
 def get_polar(name: str) -> BoatPolar:
     """Fetch one archetype by name. Raises KeyError if unknown."""
     reg = _registry()

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -17,13 +17,24 @@ website, not via the HF catalog. Re-evaluate if traffic plateaus.
 
 from __future__ import annotations
 
+import dataclasses
 import os
+from datetime import UTC, datetime
+from typing import Any
 
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
+from openwind_data.adapters.base import ForecastHorizonError
+from openwind_data.routing.archetypes import list_archetypes_metadata
+from openwind_data.routing.complexity import score_complexity
+from openwind_data.routing.geometry import Point
+from openwind_data.routing.passage import estimate_passage
 from openwind_mcp_core import build_server
 from starlette.applications import Starlette
-from starlette.responses import HTMLResponse
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 
 PORT = 7860
@@ -220,8 +231,72 @@ LANDING_HTML = """<!doctype html>
 """
 
 
+def _to_json(obj: Any) -> Any:
+    """Recursively convert dataclasses and datetimes to JSON-serializable types."""
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _to_json(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, (tuple, list)):
+        return [_to_json(v) for v in obj]
+    return obj
+
+
 async def _index(_request) -> HTMLResponse:
     return HTMLResponse(LANDING_HTML)
+
+
+async def _api_archetypes(_request: Request) -> JSONResponse:
+    return JSONResponse(list_archetypes_metadata())
+
+
+async def _api_passage(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON body"}, status_code=422)
+
+    missing = [k for k in ("waypoints", "departure", "archetype") if body.get(k) is None]
+    if missing:
+        return JSONResponse({"error": f"missing fields: {missing}"}, status_code=422)
+
+    try:
+        departure = datetime.fromisoformat(body["departure"])
+    except (ValueError, TypeError) as exc:
+        return JSONResponse({"error": f"invalid departure: {exc}"}, status_code=422)
+
+    try:
+        waypoints = [Point(lat=float(w[0]), lon=float(w[1])) for w in body["waypoints"]]
+    except (TypeError, IndexError, ValueError) as exc:
+        return JSONResponse({"error": f"invalid waypoints: {exc}"}, status_code=422)
+
+    if len(waypoints) < 2:
+        return JSONResponse({"error": "at least 2 waypoints required"}, status_code=422)
+
+    efficiency: float = body.get("efficiency", 0.75)
+    try:
+        efficiency = float(efficiency)
+    except (TypeError, ValueError) as exc:
+        return JSONResponse({"error": f"invalid efficiency: {exc}"}, status_code=422)
+
+    try:
+        passage = await estimate_passage(
+            waypoints, departure, body["archetype"], efficiency=efficiency, model="auto"
+        )
+    except KeyError as exc:
+        return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
+    except ForecastHorizonError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
+
+    complexity = score_complexity(passage)
+
+    return JSONResponse({
+        "passage": _to_json(passage),
+        "complexity": _to_json(complexity),
+        "forecast_updated_at": datetime.now(UTC).isoformat(),
+    })
 
 
 def main() -> None:
@@ -244,7 +319,17 @@ def main() -> None:
     app = Starlette(
         routes=[
             Route("/", _index),
+            Route("/api/v1/archetypes", _api_archetypes, methods=["GET"]),
+            Route("/api/v1/passage", _api_passage, methods=["POST"]),
             Mount("/", app=mcp_app),
+        ],
+        middleware=[
+            Middleware(
+                CORSMiddleware,
+                allow_origins=["*"],
+                allow_methods=["GET", "POST", "OPTIONS"],
+                allow_headers=["Content-Type"],
+            )
         ],
         lifespan=mcp_app.router.lifespan_context,
     )


### PR DESCRIPTION
## Summary

- **`GET /api/v1/archetypes`** — returns 5 boat archetypes with slug, metadata (no polars matrix)
- **`POST /api/v1/passage`** — estimates passage + complexity score
  - Body: `{waypoints: [[lat,lon],...], departure: ISO8601+tz, archetype: str, efficiency?: float}`
  - Response: `{passage: PassageReport, complexity: ComplexityScore, forecast_updated_at: ISO8601}`
- CORS `allow_origins=["*"]` (public keyless API — consistent with Open-Meteo)
- Recursive `_to_json()` serializer handles dataclasses, datetimes (→ ISO), tuples (→ lists)
- Error handling: 422 for missing fields, invalid departure, unknown archetype, ForecastHorizonError

These are PRs 2.1 + 2.2 from Sprint 2. Required by the `/plan` frontend (PR 2.4).  
**Depends on PR #36 (complexity warnings) being merged before the HF Space redeploys** — once #36 merges, the `/passage` response will include structured warnings in `complexity.warnings`.

## Test plan

- [ ] `GET /api/v1/archetypes` returns 5 archetypes with `slug`, `name`, `length_ft`, `type`, `category`, `examples`, `performance_class`
- [ ] `POST /api/v1/passage` with Marseille→Porquerolles waypoints returns valid passage + complexity
- [ ] Missing `archetype` → 422
- [ ] Unknown archetype slug → 422
- [ ] Departure without timezone → 422 (fromisoformat rejects naive datetimes for tz-offset formats)
- [ ] Existing MCP endpoint `GET /mcp` still works
- [ ] `GET /` landing page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)