### PR TITLE
feat(web): route /plan — progressive render, map + sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ dist-ssr
 .claude/
 
 # Internal scoping/decision docs (not part of the public repo)
-plan/
+/plan/
 
 # Test artifacts
 test-results/

--- a/packages/web/public/404.html
+++ b/packages/web/public/404.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8">
+<script>
+  // GitHub Pages SPA redirect — store the original URL and redirect to root.
+  // main.tsx reads spa_redirect and restores the path via history.replaceState.
+  sessionStorage.setItem("spa_redirect", location.pathname + location.search + location.hash);
+  location.replace("/");
+</script>
+</head>
+</html>

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -1,0 +1,32 @@
+import type { PassageResponse, Archetype } from "../plan/types";
+
+const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https://qdonnars-openwind-mcp.hf.space";
+
+export async function fetchPassage(params: {
+  waypoints: [number, number][];
+  departure: string;
+  archetype: string;
+  efficiency?: number;
+}): Promise<PassageResponse> {
+  const res = await fetch(`${API_BASE}/api/v1/passage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      waypoints: params.waypoints,
+      departure: params.departure,
+      archetype: params.archetype,
+      efficiency: params.efficiency ?? 0.75,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as Record<string, string>;
+    throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
+  }
+  return res.json() as Promise<PassageResponse>;
+}
+
+export async function fetchArchetypes(): Promise<Archetype[]> {
+  const res = await fetch(`${API_BASE}/api/v1/archetypes`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<Archetype[]>;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -2,12 +2,22 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { PlanPage } from "./routes/PlanPage";
 import { ThemeProvider } from "./design/theme";
+
+// GitHub Pages 404.html redirect: restore original path stored in sessionStorage
+const spaRedirect = sessionStorage.getItem("spa_redirect");
+if (spaRedirect) {
+  sessionStorage.removeItem("spa_redirect");
+  window.history.replaceState(null, "", spaRedirect);
+}
+
+const isPlan = window.location.pathname === "/plan";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      {isPlan ? <PlanPage /> : <App />}
     </ThemeProvider>
   </StrictMode>
 );

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useTheme } from "../design/theme";
+import type { SegmentReport } from "./types";
+import { cxLevel, CX_COLORS } from "./types";
+
+interface PlanMapProps {
+  waypoints: [number, number][];
+  segments?: SegmentReport[];
+}
+
+function waypointIcon(label: string, bg: string): L.DivIcon {
+  return L.divIcon({
+    html: `<div style="
+      width:28px;height:28px;border-radius:50%;
+      background:${bg};border:2px solid rgba(255,255,255,0.9);
+      display:flex;align-items:center;justify-content:center;
+      font-size:11px;font-weight:700;color:#fff;
+      box-shadow:0 1px 4px rgba(0,0,0,0.5);
+      font-family:system-ui,sans-serif;
+      ">${label}</div>`,
+    className: "",
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+  });
+}
+
+export function PlanMap({ waypoints, segments }: PlanMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const tileLayerRef = useRef<L.TileLayer | null>(null);
+  const polylinesRef = useRef<L.Polyline[]>([]);
+  const markersRef = useRef<L.Marker[]>([]);
+  const { resolvedTheme } = useTheme();
+
+  // Switch tiles on theme change
+  useEffect(() => {
+    if (!tileLayerRef.current) return;
+    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
+    tileLayerRef.current.setUrl(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`);
+  }, [resolvedTheme]);
+
+  // Init map once
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+
+    const bounds = L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon)));
+    const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
+
+    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
+    const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
+      maxZoom: 19,
+    }).addTo(map);
+    tileLayerRef.current = tile;
+
+    L.control.attribution({ position: "bottomright", prefix: false })
+      .addAttribution('&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>')
+      .addTo(map);
+
+    L.control.zoom({ position: "bottomright" }).addTo(map);
+
+    map.fitBounds(bounds, { padding: [40, 40] });
+    mapRef.current = map;
+
+    const ro = new ResizeObserver(() => map.invalidateSize());
+    ro.observe(containerRef.current!);
+    setTimeout(() => map.invalidateSize(), 100);
+
+    return () => {
+      ro.disconnect();
+      map.remove();
+      mapRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Draw waypoint markers (stable — waypoints don't change)
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    for (const m of markersRef.current) m.remove();
+    markersRef.current = [];
+
+    waypoints.forEach(([lat, lon], i) => {
+      const isFirst = i === 0;
+      const isLast = i === waypoints.length - 1;
+      const label = isFirst ? "▶" : isLast ? "■" : String(i);
+      const bg = isFirst ? "#2dd4bf" : isLast ? "#e84118" : "#6b7280";
+      const marker = L.marker([lat, lon], { icon: waypointIcon(label, bg) }).addTo(map);
+      markersRef.current.push(marker);
+    });
+  }, [waypoints]);
+
+  // Draw polyline — gray while loading, colored per segment once data arrives
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    for (const p of polylinesRef.current) p.remove();
+    polylinesRef.current = [];
+
+    if (!segments) {
+      // Loading state: single dashed gray line
+      const line = L.polyline(waypoints.map(([lat, lon]) => L.latLng(lat, lon)), {
+        color: "#6b7280",
+        weight: 3,
+        dashArray: "6 4",
+        opacity: 0.7,
+      }).addTo(map);
+      polylinesRef.current = [line];
+      return;
+    }
+
+    // Colored per segment
+    for (const seg of segments) {
+      const color = CX_COLORS[cxLevel(seg.tws_kn)];
+      const line = L.polyline(
+        [L.latLng(seg.start.lat, seg.start.lon), L.latLng(seg.end.lat, seg.end.lon)],
+        { color, weight: 4, opacity: 0.9 }
+      ).addTo(map);
+      polylinesRef.current.push(line);
+    }
+  }, [waypoints, segments]);
+
+  return <div ref={containerRef} className="w-full h-full" />;
+}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,0 +1,241 @@
+import type { PassageReport, ComplexityScore, SegmentReport } from "./types";
+import { cxLevel, CX_COLORS } from "./types";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function fmtDuration(h: number): string {
+  const hrs = Math.floor(h);
+  const mins = Math.round((h - hrs) * 60);
+  return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function fmtDeparture(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("fr-FR", {
+    weekday: "short", day: "numeric", month: "short",
+    hour: "2-digit", minute: "2-digit",
+  });
+}
+
+function compassDir(deg: number): string {
+  const dirs = ["N", "NE", "E", "SE", "S", "SO", "O", "NO"];
+  return dirs[Math.round(deg / 45) % 8];
+}
+
+// ── ComplexityBadge ───────────────────────────────────────────────────────────
+
+function ComplexityBadge({ level, label }: { level: number; label: string }) {
+  return (
+    <div
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-sm font-bold"
+      style={{ background: CX_COLORS[level] + "22", color: CX_COLORS[level], border: `1px solid ${CX_COLORS[level]}55` }}
+    >
+      <span
+        className="w-2.5 h-2.5 rounded-full"
+        style={{ background: CX_COLORS[level] }}
+      />
+      {level}/5 — {label}
+    </div>
+  );
+}
+
+// ── ComplexityBar ─────────────────────────────────────────────────────────────
+
+function ComplexityBar({ segments }: { segments: SegmentReport[] }) {
+  const total = segments.reduce((s, seg) => s + seg.distance_nm, 0);
+  return (
+    <div className="flex h-2.5 rounded-full overflow-hidden gap-[1px]" role="progressbar">
+      {segments.map((seg, i) => (
+        <div
+          key={i}
+          style={{
+            width: `${(seg.distance_nm / total) * 100}%`,
+            background: CX_COLORS[cxLevel(seg.tws_kn)],
+            minWidth: 2,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── SegmentLegend ─────────────────────────────────────────────────────────────
+
+function SegmentLegend() {
+  const items: [number, string][] = [
+    [1, "< 10 kn"], [2, "10–15"], [3, "15–20"], [4, "20–25"], [5, "> 25"],
+  ];
+  return (
+    <div className="hidden lg:flex items-center gap-2 text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
+      {items.map(([lvl, label]) => (
+        <div key={lvl} className="flex items-center gap-1">
+          <span className="w-2.5 h-2.5 rounded-sm" style={{ background: CX_COLORS[lvl] }} />
+          {label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── PlanSidebar ───────────────────────────────────────────────────────────────
+
+interface PlanSidebarProps {
+  passage: PassageReport | null;
+  complexity: ComplexityScore | null;
+  isLoading: boolean;
+  error: string | null;
+  archetypeName: string;
+  forecastUpdatedAt: string | null;
+}
+
+export function PlanSidebar({
+  passage,
+  complexity,
+  isLoading,
+  error,
+  archetypeName,
+  forecastUpdatedAt,
+}: PlanSidebarProps) {
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-4 animate-fade-in">
+        <div className="skeleton h-8 w-48 rounded-lg" />
+        <div className="skeleton h-5 w-32 rounded" />
+        <div className="grid grid-cols-4 gap-2">
+          {[0, 1, 2, 3].map((i) => <div key={i} className="skeleton h-14 rounded-lg" />)}
+        </div>
+        <div className="skeleton h-2.5 rounded-full" />
+        {[0, 1, 2].map((i) => <div key={i} className="skeleton h-10 rounded-lg" />)}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <div className="rounded-xl p-4 text-sm" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)", border: "1px solid var(--ow-err-line)" }}>
+          <p className="font-semibold mb-1">Erreur</p>
+          <p className="leading-relaxed">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!passage || !complexity) return null;
+
+  const hasWarnings = (complexity.warnings?.length ?? 0) > 0 || passage.warnings.length > 0;
+
+  return (
+    <div className="p-4 space-y-4 animate-fade-in">
+      {/* Departure */}
+      <div>
+        <p className="text-[10px] uppercase tracking-widest mb-0.5 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Départ</p>
+        <p className="text-xl font-bold tabular-nums" style={{ fontFamily: "var(--ow-font-mono)", color: "var(--ow-fg-0)" }}>
+          {fmtDeparture(passage.departure_time)}
+        </p>
+      </div>
+
+      {/* Archetype */}
+      <p className="text-sm" style={{ color: "var(--ow-fg-1)" }}>
+        {archetypeName || passage.archetype}
+      </p>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+        {[
+          { label: "Distance", value: `${passage.distance_nm.toFixed(1)} nm` },
+          { label: "Durée", value: fmtDuration(passage.duration_h) },
+          { label: "Arrivée", value: fmtTime(passage.arrival_time) },
+        ].map(({ label, value }) => (
+          <div key={label} className="rounded-xl p-3" style={{ background: "var(--ow-bg-2)" }}>
+            <p className="text-[9px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>{label}</p>
+            <p className="text-sm font-bold tabular-nums" style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>{value}</p>
+          </div>
+        ))}
+        <div className="rounded-xl p-3" style={{ background: "var(--ow-bg-2)" }}>
+          <p className="text-[9px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Complexité</p>
+          <p className="text-sm font-bold" style={{ color: CX_COLORS[complexity.level], fontFamily: "var(--ow-font-mono)" }}>
+            {complexity.level}/5 — {complexity.label}
+          </p>
+        </div>
+      </div>
+
+      {/* Complexity bar */}
+      <div className="space-y-1.5">
+        <ComplexityBar segments={passage.segments} />
+        <SegmentLegend />
+      </div>
+
+      {/* Complexity badge */}
+      <ComplexityBadge level={complexity.level} label={complexity.label} />
+
+      {/* Warnings */}
+      {hasWarnings && (
+        <div className="space-y-1.5">
+          {complexity.warnings?.map((w, i) => (
+            <div key={i} className="flex items-start gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)", border: "1px solid var(--ow-warn-line)" }}>
+              <span className="shrink-0 mt-0.5">⚠</span>
+              <span>{w.message}</span>
+            </div>
+          ))}
+          {passage.warnings.map((w, i) => (
+            <div key={`pw-${i}`} className="flex items-start gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)", border: "1px solid var(--ow-warn-line)" }}>
+              <span className="shrink-0 mt-0.5">⚠</span>
+              <span>{w}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Legs */}
+      <div>
+        <p className="text-[10px] uppercase tracking-widest mb-2 font-semibold" style={{ color: "var(--ow-fg-2)" }}>
+          Segments ({passage.segments.length})
+        </p>
+        <div className="space-y-1">
+          {passage.segments.map((seg, i) => {
+            const cx = cxLevel(seg.tws_kn);
+            return (
+              <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-bg-2)" }}>
+                <span
+                  className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
+                  style={{ background: CX_COLORS[cx], color: "#fff" }}
+                >
+                  {i + 1}
+                </span>
+                <div className="flex-1 grid grid-cols-5 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
+                  <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{seg.distance_nm.toFixed(1)} nm</span>
+                  <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.tws_kn.toFixed(0)} kn</span>
+                  <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{compassDir(seg.twd_deg)}</span>
+                  <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.boat_speed_kn.toFixed(1)} kn</span>
+                  <span className="text-right" style={{ color: "var(--ow-fg-2)" }}>{fmtTime(seg.end_time)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex justify-between text-[9px] mt-1 px-1" style={{ color: "var(--ow-fg-3)" }}>
+          <span />
+          <span className="grid grid-cols-5 gap-1 w-[calc(100%-28px)]">
+            <span className="text-right">Dist</span>
+            <span className="text-right">TWS</span>
+            <span className="text-right">Dir</span>
+            <span className="text-right">Vit</span>
+            <span className="text-right">ETA</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Footer */}
+      {forecastUpdatedAt && (
+        <p className="text-[10px] pt-1 border-t" style={{ color: "var(--ow-fg-2)", borderColor: "var(--ow-line)" }}>
+          Données fraîches au {new Date(forecastUpdatedAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })} · Open-Meteo.com (CC BY 4.0)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/plan/parseUrl.ts
+++ b/packages/web/src/plan/parseUrl.ts
@@ -1,0 +1,39 @@
+export interface ParsedPlanParams {
+  waypoints: [number, number][];
+  departure: string;
+  archetype: string;
+}
+
+export type ParseResult = ParsedPlanParams | { error: string };
+
+export function parsePlanUrl(search: string): ParseResult {
+  const p = new URLSearchParams(search);
+  const wpts = p.get("wpts");
+  const departure = p.get("departure");
+  const archetype = p.get("archetype");
+
+  if (!wpts) return { error: "Paramètre wpts manquant dans l'URL" };
+  if (!departure) return { error: "Paramètre departure manquant dans l'URL" };
+  if (!archetype) return { error: "Paramètre archetype manquant dans l'URL" };
+
+  try {
+    const parts = wpts.split(";").filter(Boolean);
+    if (parts.length < 2) return { error: "Au moins 2 waypoints requis" };
+    const waypoints = parts.map((wp): [number, number] => {
+      const [latStr, lonStr] = wp.split(",");
+      const lat = parseFloat(latStr);
+      const lon = parseFloat(lonStr);
+      if (isNaN(lat) || isNaN(lon)) throw new Error(`waypoint invalide: "${wp}"`);
+      if (lat < -90 || lat > 90) throw new Error(`latitude hors plage: ${lat}`);
+      if (lon < -180 || lon > 180) throw new Error(`longitude hors plage: ${lon}`);
+      return [lat, lon];
+    });
+    return { waypoints, departure, archetype };
+  } catch (e) {
+    return { error: `Waypoints invalides: ${e instanceof Error ? e.message : e}` };
+  }
+}
+
+export function isParsedOk(r: ParseResult): r is ParsedPlanParams {
+  return !("error" in r);
+}

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -1,0 +1,87 @@
+export interface PlanWaypoint {
+  lat: number;
+  lon: number;
+}
+
+export interface SegmentReport {
+  start: PlanWaypoint;
+  end: PlanWaypoint;
+  distance_nm: number;
+  bearing_deg: number;
+  start_time: string;
+  end_time: string;
+  tws_kn: number;
+  twd_deg: number;
+  twa_deg: number;
+  polar_speed_kn: number;
+  boat_speed_kn: number;
+  duration_h: number;
+  hs_m: number | null;
+  wave_derate_factor: number;
+}
+
+export interface PassageReport {
+  archetype: string;
+  departure_time: string;
+  arrival_time: string;
+  duration_h: number;
+  distance_nm: number;
+  efficiency: number;
+  model: string;
+  segments: SegmentReport[];
+  warnings: string[];
+}
+
+export interface ComplexityWarning {
+  kind: "wind" | "sea";
+  level: number;
+  message: string;
+  affected_segments: number[];
+}
+
+export interface ComplexityScore {
+  level: number;
+  label: string;
+  wind_level: number;
+  wind_label: string;
+  sea_level: number | null;
+  sea_label: string | null;
+  tws_max_kn: number;
+  hs_max_m: number | null;
+  rationale: string;
+  warnings?: ComplexityWarning[];
+}
+
+export interface PassageResponse {
+  passage: PassageReport;
+  complexity: ComplexityScore;
+  forecast_updated_at: string;
+}
+
+export interface Archetype {
+  slug: string;
+  name: string;
+  length_ft: number;
+  type: string;
+  category: string;
+  examples: string[];
+  performance_class: string;
+}
+
+// Complexity level 1-5 derived from per-segment TWS
+export function cxLevel(tws_kn: number): 1 | 2 | 3 | 4 | 5 {
+  if (tws_kn < 10) return 1;
+  if (tws_kn < 15) return 2;
+  if (tws_kn < 20) return 3;
+  if (tws_kn < 25) return 4;
+  return 5;
+}
+
+// Same values in both themes (tokens.css --ow-c-1..5)
+export const CX_COLORS: Record<number, string> = {
+  1: "#2dc97a",
+  2: "#8fcc30",
+  3: "#e8c432",
+  4: "#e87a18",
+  5: "#e84118",
+};

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from "react";
+import { parsePlanUrl, isParsedOk } from "../plan/parseUrl";
+import { PlanMap } from "../plan/PlanMap";
+import { PlanSidebar } from "../plan/PlanSidebar";
+import { fetchPassage, fetchArchetypes } from "../api/passage";
+import { ThemeToggle } from "../design/theme";
+import type { PassageReport, ComplexityScore, Archetype } from "../plan/types";
+
+function CopyLinkButton() {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback for older browsers
+      const el = document.createElement("textarea");
+      el.value = window.location.href;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand("copy");
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+  return (
+    <button
+      onClick={copy}
+      className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+      style={{
+        background: copied ? "var(--ow-accent-soft)" : "var(--ow-bg-2)",
+        color: copied ? "var(--ow-accent)" : "var(--ow-fg-1)",
+        border: "1px solid var(--ow-line-2)",
+      }}
+    >
+      {copied ? "Copié ✓" : "Copier le lien"}
+    </button>
+  );
+}
+
+export function PlanPage() {
+  const parsed = parsePlanUrl(window.location.search);
+  const [passage, setPassage] = useState<PassageReport | null>(null);
+  const [complexity, setComplexity] = useState<ComplexityScore | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [archetypes, setArchetypes] = useState<Archetype[]>([]);
+  const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchArchetypes().then(setArchetypes).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!isParsedOk(parsed)) return;
+    setIsLoading(true);
+    setApiError(null);
+    fetchPassage({
+      waypoints: parsed.waypoints,
+      departure: parsed.departure,
+      archetype: parsed.archetype,
+    })
+      .then((res) => {
+        setPassage(res.passage);
+        setComplexity(res.complexity);
+        setForecastUpdatedAt(res.forecast_updated_at);
+      })
+      .catch((e: Error) => setApiError(e.message))
+      .finally(() => setIsLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!isParsedOk(parsed)) {
+    return (
+      <div
+        className="h-screen flex flex-col items-center justify-center px-6"
+        style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
+      >
+        <div className="max-w-sm text-center space-y-4">
+          <p className="text-4xl">⚓</p>
+          <h1 className="text-xl font-bold">URL invalide</h1>
+          <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>{parsed.error}</p>
+          <a
+            href="/"
+            className="inline-block mt-4 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
+            style={{ background: "var(--ow-accent)", color: "#fff" }}
+          >
+            ← Explorer la météo
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  const archetypeName =
+    archetypes.find((a) => a.slug === parsed.archetype)?.name ?? parsed.archetype;
+
+  return (
+    <div
+      className="h-screen flex flex-col overflow-hidden"
+      style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
+    >
+      {/* Header */}
+      <header
+        className="shrink-0 h-12 flex items-center px-3 gap-2 border-b"
+        style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+      >
+        <a
+          href="/"
+          className="shrink-0 flex items-center gap-1.5 text-sm font-medium transition-colors"
+          style={{ color: "var(--ow-fg-1)" }}
+        >
+          ← Explorer
+        </a>
+        <span className="flex-1 text-center text-sm font-semibold truncate hidden sm:block" style={{ color: "var(--ow-fg-0)" }}>
+          Plan de navigation
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <CopyLinkButton />
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {/* Body: map + sidebar */}
+      <div className="flex-1 min-h-0 flex flex-col lg:flex-row">
+        {/* Map */}
+        <div className="flex-1 min-h-0">
+          <PlanMap
+            waypoints={parsed.waypoints}
+            segments={passage?.segments}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <div
+          className="shrink-0 max-h-[50vh] lg:max-h-none lg:h-auto lg:w-80 xl:w-96 overflow-y-auto border-t lg:border-t-0 lg:border-l"
+          style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+        >
+          <PlanSidebar
+            passage={passage}
+            complexity={complexity}
+            isLoading={isLoading}
+            error={apiError}
+            archetypeName={archetypeName}
+            forecastUpdatedAt={forecastUpdatedAt}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR 2.4 — Sprint 2. Implements the `/plan` route consumed when clicking the deep-link generated by the OpenWind MCP.

**URL format**: `https://openwind.fr/plan?wpts=lat,lon;lat,lon;...&departure=ISO8601+tz&archetype=slug`

### What's new

- **`src/plan/parseUrl.ts`** — strict URL parser with validation (≥2 waypoints, lat/lon ranges, required fields)
- **`src/plan/PlanMap.tsx`** — Leaflet map with Carto tiles (theme-aware):
  - Gray dashed polyline while API is loading (progressive rendering)
  - Per-segment colored polyline after API response (`--ow-c-1..5` = complexity colors)
  - Numbered waypoint markers (▶ start, ■ end, n intermediates), auto-fitBounds
- **`src/plan/PlanSidebar.tsx`** — full sidebar:
  - Departure date/time in large mono font
  - Archetype name (resolved from `GET /api/v1/archetypes`)
  - 4-stat grid: Distance · Duration · ETA · Complexity
  - Complexity bar segmented by distance, each segment colored by TWS level
  - Complexity legend (desktop only)
  - Structured warnings from `complexity.warnings` + passage-level warnings
  - Legs breakdown: Dist / TWS / Dir / Vit / ETA per segment
  - Footer with `forecast_updated_at`
- **`src/routes/PlanPage.tsx`** — orchestrates fetch + renders loading skeleton / error state
- **`src/api/passage.ts`** — `fetchPassage()` + `fetchArchetypes()` (env override via `VITE_API_BASE`)
- **`main.tsx`** — `pathname === '/plan'` → PlanPage, GitHub Pages 404 restore via sessionStorage
- **`public/404.html`** — GitHub Pages SPA redirect (stores path → redirects to `/`)
- **`.gitignore`** — `/plan/` (root-only) to stop shadowing `packages/web/src/plan/`

### Layout
- **Desktop** (`lg:`): header bar | map (left, flex-1) + sidebar (right, w-80/96)
- **Mobile**: header bar | map (flex-1) | sidebar (max-h-50vh scrollable)

### Dependencies
- **Requires PR #36** (ComplexityWarning) merged before HF Space is redeployed — `complexity.warnings` will be populated once both are live
- **Requires PR #37** (REST APIs) merged and HF Space redeployed before `/plan` is fully functional

## Test plan

- [ ] Navigate to `/plan?wpts=43.3,5.35;43.0,6.2&departure=2026-04-28T08:00:00%2B02:00&archetype=cruiser_40ft`
- [ ] Map renders immediately with gray dashed polyline, then colors update when API responds
- [ ] Waypoint markers: teal ▶ at start, red ■ at end
- [ ] Sidebar shows skeleton → full data after ~5s (HF cold start)
- [ ] Complexity bar colors match per-segment TWS
- [ ] Copy link button copies URL to clipboard, shows "Copié ✓"
- [ ] Invalid URL (missing `wpts`) → error page with ← Explorer link
- [ ] Theme toggle works on the plan page (tiles switch, colors adapt)
- [ ] Mobile: map fills screen, sidebar scrollable at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)