### PR TITLE
fix(web): correct local-mode timezone in formatHour/formatDayHeader

### DIFF
--- a/packages/web/src/utils/format.ts
+++ b/packages/web/src/utils/format.ts
@@ -45,8 +45,10 @@ export function formatHour(iso: string, mode: TimezoneMode = "local"): string {
     const totalUTCMin = (parisHour * 60 + parisMin - offsetMin + 1440) % 1440;
     return String(Math.floor(totalUTCMin / 60));
   }
-  // local: interpret the string as local time (existing behaviour)
-  return String(new Date(iso).getHours());
+  // local: iso is Paris time without offset — convert Paris→UTC→browser-local
+  const offsetMin = parisTzOffsetMin(iso);
+  const realUtcMs = new Date(iso + "Z").getTime() - offsetMin * 60000;
+  return String(new Date(realUtcMs).getHours());
 }
 
 /**
@@ -62,7 +64,9 @@ export function formatDayHeader(iso: string, mode: TimezoneMode = "local"): stri
     const d = new Date(Date.UTC(year, month - 1, day));
     return `${DAYS_EN[d.getUTCDay()]} ${day}`;
   }
-  const d = new Date(iso);
+  const offsetMin = parisTzOffsetMin(iso);
+  const realUtcMs = new Date(iso + "Z").getTime() - offsetMin * 60000;
+  const d = new Date(realUtcMs);
   return `${DAYS_EN[d.getDay()]} ${d.getDate()}`;
 }
 


### PR DESCRIPTION
## Summary

- `formatHour` "local" mode was passing a Paris-time string (no offset suffix) straight to `new Date(iso)`, which JS interprets as the browser's local time — wrong for any user not in the Paris timezone
- Same bug applied to `formatDayHeader` local mode (day could flip at midnight)
- Both functions now use the existing `parisTzOffsetMin()` helper to convert the Paris timestamp to real UTC milliseconds, then let the browser convert to its own local time

## Test plan

- [ ] Visit the Explore heatmap with browser timezone set to UTC (Chrome DevTools → Sensors → Timezone override = UTC+0) — hours should shift by the Paris offset (UTC+1 in winter, UTC+2 in summer)
- [ ] Switch timezone mode toggle: boat = Paris hours, UTC = UTC hours, local = browser-local hours; all three should now be consistent
- [ ] Day headers should not mis-assign columns after midnight when local ≠ Paris

🤖 Generated with [Claude Code](https://claude.com/claude-code)