### PR TITLE
fix(web): Beaufort legend colors + timezone toggle in legend bar

### DIFF
--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -2,8 +2,7 @@ import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import type { ModelForecast } from "../types";
 import { TimelineHeader } from "./TimelineHeader";
 import { WindCell } from "./WindCell";
-import { BEAUFORT_STEPS } from "../utils/colors";
-import { useTimezone } from "../hooks/useTimezone";
+import { useTimezone, type TimezoneMode } from "../hooks/useTimezone";
 
 const MODEL_STEP: Record<string, number> = {
   AROME: 1,
@@ -65,20 +64,41 @@ const BEAUFORT_LABELS = [
   "calm", "1–3", "4–6", "7–10", "11–15", "16–19", "20–24", "25–30", "31+",
 ];
 
-function BeaufortLegend() {
+function BeaufortLegend({ timezoneMode, onCycleTz }: { timezoneMode: TimezoneMode; onCycleTz: () => void }) {
+  const localTzCity =
+    Intl.DateTimeFormat().resolvedOptions().timeZone.split("/").pop()?.replace(/_/g, " ") ?? "Local";
+  const tzLabel =
+    timezoneMode === "local" ? localTzCity : timezoneMode === "utc" ? "UTC" : "Boat";
+  const tzTitle =
+    timezoneMode === "local"
+      ? `Local time (${Intl.DateTimeFormat().resolvedOptions().timeZone}) — click to switch to UTC`
+      : timezoneMode === "utc"
+      ? "UTC — click to switch to Boat (Europe/Paris)"
+      : "Boat time (Europe/Paris) — click to switch to Local";
+
   return (
     <div className="hidden sm:flex items-end gap-1 px-3 py-2 border-t overflow-x-auto" style={{ borderColor: 'var(--ow-line)' }}>
-      {BEAUFORT_STEPS.map(([, bg, text], i) => (
+      {Array.from({ length: 9 }, (_, i) => (
         <div key={i} className="flex flex-col items-center shrink-0">
           <div
             className="w-6 h-4 rounded-sm flex items-center justify-center text-[9px] font-bold leading-none"
-            style={{ backgroundColor: bg, color: text }}
+            style={{ backgroundColor: `var(--ow-w-${i})`, color: `var(--ow-cell-text-${i})` }}
           >
             B{i}
           </div>
           <span className="text-[8px] mt-0.5 whitespace-nowrap" style={{ color: 'var(--ow-fg-2)' }}>{BEAUFORT_LABELS[i]}</span>
         </div>
       ))}
+      <div className="flex-1 min-w-2" />
+      <button
+        onClick={onCycleTz}
+        title={tzTitle}
+        aria-label={`Timezone: ${tzLabel}. Click to cycle.`}
+        className="shrink-0 text-[10px] font-semibold px-2 py-1 rounded-md transition-colors mb-0.5"
+        style={{ color: 'var(--ow-accent)', background: 'var(--ow-accent-soft)', border: '1px solid var(--ow-accent-line)' }}
+      >
+        {tzLabel}
+      </button>
     </div>
   );
 }
@@ -111,7 +131,7 @@ export function WindTable({
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrolledEnd, setScrolledEnd] = useState(false);
   const [visibleDay, setVisibleDay] = useState("");
-  const [timezoneMode] = useTimezone();
+  const [timezoneMode, cycleTz] = useTimezone();
 
   const masterTimeline = useMemo(() => {
     const resolution = autoResolution(forecasts);
@@ -229,7 +249,7 @@ export function WindTable({
           </table>
         </div>
       </div>
-      <BeaufortLegend />
+      <BeaufortLegend timezoneMode={timezoneMode} onCycleTz={cycleTz} />
     </div>
   );
 }

--- a/packages/web/src/utils/format.ts
+++ b/packages/web/src/utils/format.ts
@@ -45,8 +45,10 @@ export function formatHour(iso: string, mode: TimezoneMode = "local"): string {
     const totalUTCMin = (parisHour * 60 + parisMin - offsetMin + 1440) % 1440;
     return String(Math.floor(totalUTCMin / 60));
   }
-  // local: interpret the string as local time (existing behaviour)
-  return String(new Date(iso).getHours());
+  // local: iso is Paris time without offset — convert Paris→UTC→browser-local
+  const offsetMin = parisTzOffsetMin(iso);
+  const realUtcMs = new Date(iso + "Z").getTime() - offsetMin * 60000;
+  return String(new Date(realUtcMs).getHours());
 }
 
 /**
@@ -62,7 +64,9 @@ export function formatDayHeader(iso: string, mode: TimezoneMode = "local"): stri
     const d = new Date(Date.UTC(year, month - 1, day));
     return `${DAYS_EN[d.getUTCDay()]} ${day}`;
   }
-  const d = new Date(iso);
+  const offsetMin = parisTzOffsetMin(iso);
+  const realUtcMs = new Date(iso + "Z").getTime() - offsetMin * 60000;
+  const d = new Date(realUtcMs);
   return `${DAYS_EN[d.getDay()]} ${d.getDate()}`;
 }
 


### PR DESCRIPTION
## Summary

- **Beaufort legend colors** — `BeaufortLegend` was using hardcoded dark-theme hex values from `BEAUFORT_STEPS`; palette never changed in light mode. Now uses CSS vars `var(--ow-w-N)` / `var(--ow-cell-text-N)` — follows light/dark theme correctly.
- **Timezone toggle re-wired** — The `cycle()` function from `useTimezone` was never connected to any UI element (button was lost when the sticky day header was redesigned in #32–34). New toggle button added to the right side of the Beaufort legend bar.
- **Local mode shows detected city** — In "local" mode the button shows the IANA city detected via `Intl.DateTimeFormat().resolvedOptions().timeZone` (e.g., "Paris", "New York") — no geolocation permission needed. Tooltip shows the full timezone string.

## Test plan

- [x] Switch to light theme — Beaufort B0–B2 swatches should use the pastel palette (not the dark green/navy)
- [x] Click the timezone button (should show your city name) — cycles Local → UTC → Boat → Local
- [x] UTC mode: hour labels in the heatmap shift by the Paris offset (−1h CET, −2h CEST)
- [x] Boat mode: always shows Europe/Paris time
- [x] Local mode button label matches the user's system timezone city

🤖 Generated with [Claude Code](https://claude.com/claude-code)