### PR TITLE
feat(web): PR 2.5 — drag waypoints + boat dropdown + stale tag + refetch

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { nowParisHourPrefix } from "./utils/format";
 import type { Spot, ModelForecast } from "./types";
 import { fetchAllModels } from "./api/openmeteo";
 import { useCustomSpots } from "./hooks/useCustomSpots";
@@ -51,7 +52,7 @@ function App() {
         setFetchedAt(Date.now());
         setIsLoading(false);
         // Auto-select current hour so wind arrows show by default
-        const nowHour = new Date().toISOString().slice(0, 13);
+        const nowHour = nowParisHourPrefix();
         const timeline = data[0]?.hourly.time ?? [];
         const match = timeline.find((t) => t.startsWith(nowHour)) ?? timeline.find((t) => t > nowHour) ?? null;
         setSelectedHour(match);

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -3,6 +3,7 @@ import type { ModelForecast } from "../types";
 import { TimelineHeader } from "./TimelineHeader";
 import { WindCell } from "./WindCell";
 import { useTimezone, type TimezoneMode } from "../hooks/useTimezone";
+import { nowParisHourPrefix } from "../utils/format";
 
 const MODEL_STEP: Record<string, number> = {
   AROME: 1,
@@ -141,7 +142,7 @@ export function WindTable({
     );
   }, [forecasts]);
 
-  const nowHour = new Date().toISOString().slice(0, 13);
+  const nowHour = nowParisHourPrefix();
 
   const updateVisibleDay = useCallback(() => {
     const el = scrollRef.current;

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -8,6 +8,8 @@ import { cxLevel, CX_COLORS } from "./types";
 interface PlanMapProps {
   waypoints: [number, number][];
   segments?: SegmentReport[];
+  isStale?: boolean;
+  onWptMove: (idx: number, lat: number, lon: number) => void;
 }
 
 function waypointIcon(label: string, bg: string): L.DivIcon {
@@ -18,6 +20,7 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
       display:flex;align-items:center;justify-content:center;
       font-size:11px;font-weight:700;color:#fff;
       box-shadow:0 1px 4px rgba(0,0,0,0.5);
+      cursor:grab;
       font-family:system-ui,sans-serif;
       ">${label}</div>`,
     className: "",
@@ -26,13 +29,19 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
   });
 }
 
-export function PlanMap({ waypoints, segments }: PlanMapProps) {
+export function PlanMap({ waypoints, segments, isStale, onWptMove }: PlanMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const polylinesRef = useRef<L.Polyline[]>([]);
   const markersRef = useRef<L.Marker[]>([]);
+  const dragLineRef = useRef<L.Polyline | null>(null);
+  const livePositionsRef = useRef<[number, number][]>(waypoints);
   const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    livePositionsRef.current = waypoints;
+  }, [waypoints]);
 
   // Switch tiles on theme change
   useEffect(() => {
@@ -75,7 +84,7 @@ export function PlanMap({ waypoints, segments }: PlanMapProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Draw waypoint markers (stable — waypoints don't change)
+  // Draw draggable waypoint markers
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
@@ -88,12 +97,44 @@ export function PlanMap({ waypoints, segments }: PlanMapProps) {
       const isLast = i === waypoints.length - 1;
       const label = isFirst ? "▶" : isLast ? "■" : String(i);
       const bg = isFirst ? "#2dd4bf" : isLast ? "#e84118" : "#6b7280";
-      const marker = L.marker([lat, lon], { icon: waypointIcon(label, bg) }).addTo(map);
+      const marker = L.marker([lat, lon], {
+        icon: waypointIcon(label, bg),
+        draggable: true,
+      }).addTo(map);
+
+      marker.on("drag", () => {
+        const pos = marker.getLatLng();
+        const positions = [...livePositionsRef.current];
+        positions[i] = [pos.lat, pos.lng];
+        livePositionsRef.current = positions;
+        const lls = positions.map(([la, lo]) => L.latLng(la, lo));
+        if (!dragLineRef.current) {
+          dragLineRef.current = L.polyline(lls, {
+            color: "#6b7280",
+            weight: 3,
+            dashArray: "6 4",
+            opacity: 0.85,
+          }).addTo(map);
+        } else {
+          dragLineRef.current.setLatLngs(lls);
+        }
+      });
+
+      marker.on("dragend", () => {
+        if (dragLineRef.current) {
+          dragLineRef.current.remove();
+          dragLineRef.current = null;
+        }
+        const pos = marker.getLatLng();
+        onWptMove(i, pos.lat, pos.lng);
+      });
+
       markersRef.current.push(marker);
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [waypoints]);
 
-  // Draw polyline — gray while loading, colored per segment once data arrives
+  // Draw polyline — gray while loading/stale, colored per segment when fresh
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
@@ -101,8 +142,7 @@ export function PlanMap({ waypoints, segments }: PlanMapProps) {
     for (const p of polylinesRef.current) p.remove();
     polylinesRef.current = [];
 
-    if (!segments) {
-      // Loading state: single dashed gray line
+    if (!segments || isStale) {
       const line = L.polyline(waypoints.map(([lat, lon]) => L.latLng(lat, lon)), {
         color: "#6b7280",
         weight: 3,
@@ -113,7 +153,6 @@ export function PlanMap({ waypoints, segments }: PlanMapProps) {
       return;
     }
 
-    // Colored per segment
     for (const seg of segments) {
       const color = CX_COLORS[cxLevel(seg.tws_kn)];
       const line = L.polyline(
@@ -122,7 +161,7 @@ export function PlanMap({ waypoints, segments }: PlanMapProps) {
       ).addTo(map);
       polylinesRef.current.push(line);
     }
-  }, [waypoints, segments]);
+  }, [waypoints, segments, isStale]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 }

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,4 +1,5 @@
-import type { PassageReport, ComplexityScore, SegmentReport } from "./types";
+import { useState } from "react";
+import type { PassageReport, ComplexityScore, SegmentReport, Archetype } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -34,10 +35,7 @@ function ComplexityBadge({ level, label }: { level: number; label: string }) {
       className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-sm font-bold"
       style={{ background: CX_COLORS[level] + "22", color: CX_COLORS[level], border: `1px solid ${CX_COLORS[level]}55` }}
     >
-      <span
-        className="w-2.5 h-2.5 rounded-full"
-        style={{ background: CX_COLORS[level] }}
-      />
+      <span className="w-2.5 h-2.5 rounded-full" style={{ background: CX_COLORS[level] }} />
       {level}/5 — {label}
     </div>
   );
@@ -81,6 +79,67 @@ function SegmentLegend() {
   );
 }
 
+// ── ArchetypeSelector ─────────────────────────────────────────────────────────
+
+function ArchetypeSelector({
+  currentSlug,
+  archetypes,
+  onChange,
+}: {
+  currentSlug: string;
+  archetypes: Archetype[];
+  onChange: (slug: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = archetypes.find((a) => a.slug === currentSlug);
+  const label = current?.name ?? currentSlug;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 text-sm transition-colors"
+        style={{ color: "var(--ow-fg-1)" }}
+        title="Changer le type de bateau"
+      >
+        {label}
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" style={{ opacity: 0.5 }}>
+          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round"/>
+        </svg>
+      </button>
+
+      {open && (
+        <>
+          {/* backdrop */}
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div
+            className="absolute left-0 top-7 z-20 min-w-[220px] rounded-xl shadow-xl border overflow-hidden"
+            style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line-2)", boxShadow: "var(--ow-shadow-pop)" }}
+          >
+            {archetypes.map((a) => (
+              <button
+                key={a.slug}
+                onClick={() => { onChange(a.slug); setOpen(false); }}
+                className="w-full text-left px-4 py-3 text-sm transition-colors"
+                style={{
+                  background: a.slug === currentSlug ? "var(--ow-accent-soft)" : "transparent",
+                  color: a.slug === currentSlug ? "var(--ow-accent)" : "var(--ow-fg-0)",
+                  borderBottom: "1px solid var(--ow-line)",
+                }}
+              >
+                <div className="font-semibold">{a.name}</div>
+                <div className="text-[11px] mt-0.5" style={{ color: "var(--ow-fg-2)" }}>
+                  {a.length_ft} ft · {a.type} · {a.examples[0]}
+                </div>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── PlanSidebar ───────────────────────────────────────────────────────────────
 
 interface PlanSidebarProps {
@@ -88,7 +147,11 @@ interface PlanSidebarProps {
   complexity: ComplexityScore | null;
   isLoading: boolean;
   error: string | null;
-  archetypeName: string;
+  archetypes: Archetype[];
+  currentArchetypeSlug: string;
+  onArchetypeChange: (slug: string) => void;
+  isStale: boolean;
+  onRefetch: () => void;
   forecastUpdatedAt: string | null;
 }
 
@@ -97,7 +160,11 @@ export function PlanSidebar({
   complexity,
   isLoading,
   error,
-  archetypeName,
+  archetypes,
+  currentArchetypeSlug,
+  onArchetypeChange,
+  isStale,
+  onRefetch,
   forecastUpdatedAt,
 }: PlanSidebarProps) {
   if (isLoading) {
@@ -131,6 +198,31 @@ export function PlanSidebar({
 
   return (
     <div className="p-4 space-y-4 animate-fade-in">
+      {/* Stale banner + Refetch */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onRefetch}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+          style={{
+            background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
+            color: isStale ? "#fff" : "var(--ow-fg-2)",
+            border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
+          }}
+          title="Recalculer avec les paramètres actuels"
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/>
+            <path d="M14 1v4h-4"/>
+          </svg>
+          Recalculer
+        </button>
+        {isStale && (
+          <span className="text-[11px] font-medium" style={{ color: "var(--ow-warn)" }}>
+            ⚠ Données obsolètes
+          </span>
+        )}
+      </div>
+
       {/* Departure */}
       <div>
         <p className="text-[10px] uppercase tracking-widest mb-0.5 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Départ</p>
@@ -139,10 +231,12 @@ export function PlanSidebar({
         </p>
       </div>
 
-      {/* Archetype */}
-      <p className="text-sm" style={{ color: "var(--ow-fg-1)" }}>
-        {archetypeName || passage.archetype}
-      </p>
+      {/* Archetype dropdown */}
+      <ArchetypeSelector
+        currentSlug={currentArchetypeSlug}
+        archetypes={archetypes}
+        onChange={onArchetypeChange}
+      />
 
       {/* Stats grid */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">

--- a/packages/web/src/plan/parseUrl.ts
+++ b/packages/web/src/plan/parseUrl.ts
@@ -37,3 +37,12 @@ export function parsePlanUrl(search: string): ParseResult {
 export function isParsedOk(r: ParseResult): r is ParsedPlanParams {
   return !("error" in r);
 }
+
+export function buildPlanUrl(
+  waypoints: [number, number][],
+  departure: string,
+  archetype: string
+): string {
+  const wpts = waypoints.map(([lat, lon]) => `${lat.toFixed(5)},${lon.toFixed(5)}`).join(";");
+  return `/plan?wpts=${wpts}&departure=${encodeURIComponent(departure)}&archetype=${encodeURIComponent(archetype)}`;
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { parsePlanUrl, isParsedOk } from "../plan/parseUrl";
+import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchArchetypes } from "../api/passage";
@@ -14,7 +14,6 @@ function CopyLinkButton() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // fallback for older browsers
       const el = document.createElement("textarea");
       el.value = window.location.href;
       document.body.appendChild(el);
@@ -41,38 +40,69 @@ function CopyLinkButton() {
 }
 
 export function PlanPage() {
-  const parsed = parsePlanUrl(window.location.search);
+  const initialParsed = parsePlanUrl(window.location.search);
+
+  // Editable local state (does not trigger re-fetch automatically)
+  const [waypoints, setWaypoints] = useState<[number, number][]>(
+    isParsedOk(initialParsed) ? initialParsed.waypoints : []
+  );
+  const [archetype, setArchetype] = useState(
+    isParsedOk(initialParsed) ? initialParsed.archetype : ""
+  );
+  // departure is not editable in V1 — kept as constant from URL
+  const departure = isParsedOk(initialParsed) ? initialParsed.departure : "";
+
   const [passage, setPassage] = useState<PassageReport | null>(null);
   const [complexity, setComplexity] = useState<ComplexityScore | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [archetypes, setArchetypes] = useState<Archetype[]>([]);
   const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(null);
+  const [isStale, setIsStale] = useState(false);
 
   useEffect(() => {
     fetchArchetypes().then(setArchetypes).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    if (!isParsedOk(parsed)) return;
+  function doFetch(wpts: [number, number][], arch: string) {
     setIsLoading(true);
     setApiError(null);
-    fetchPassage({
-      waypoints: parsed.waypoints,
-      departure: parsed.departure,
-      archetype: parsed.archetype,
-    })
+    fetchPassage({ waypoints: wpts, departure, archetype: arch })
       .then((res) => {
         setPassage(res.passage);
         setComplexity(res.complexity);
         setForecastUpdatedAt(res.forecast_updated_at);
+        setIsStale(false);
       })
       .catch((e: Error) => setApiError(e.message))
       .finally(() => setIsLoading(false));
+  }
+
+  // Initial fetch
+  useEffect(() => {
+    if (!isParsedOk(initialParsed)) return;
+    doFetch(initialParsed.waypoints, initialParsed.archetype);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!isParsedOk(parsed)) {
+  function handleWptMove(idx: number, lat: number, lon: number) {
+    const next = waypoints.map((wp, i): [number, number] => (i === idx ? [lat, lon] : wp));
+    setWaypoints(next);
+    setIsStale(true);
+    window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
+  }
+
+  function handleArchetypeChange(slug: string) {
+    setArchetype(slug);
+    setIsStale(true);
+    window.history.replaceState(null, "", buildPlanUrl(waypoints, departure, slug));
+  }
+
+  function handleRefetch() {
+    doFetch(waypoints, archetype);
+  }
+
+  if (!isParsedOk(initialParsed)) {
     return (
       <div
         className="h-screen flex flex-col items-center justify-center px-6"
@@ -81,7 +111,7 @@ export function PlanPage() {
         <div className="max-w-sm text-center space-y-4">
           <p className="text-4xl">⚓</p>
           <h1 className="text-xl font-bold">URL invalide</h1>
-          <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>{parsed.error}</p>
+          <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>{initialParsed.error}</p>
           <a
             href="/"
             className="inline-block mt-4 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
@@ -93,9 +123,6 @@ export function PlanPage() {
       </div>
     );
   }
-
-  const archetypeName =
-    archetypes.find((a) => a.slug === parsed.archetype)?.name ?? parsed.archetype;
 
   return (
     <div
@@ -128,8 +155,10 @@ export function PlanPage() {
         {/* Map */}
         <div className="flex-1 min-h-0">
           <PlanMap
-            waypoints={parsed.waypoints}
+            waypoints={waypoints}
             segments={passage?.segments}
+            isStale={isStale}
+            onWptMove={handleWptMove}
           />
         </div>
 
@@ -143,7 +172,11 @@ export function PlanPage() {
             complexity={complexity}
             isLoading={isLoading}
             error={apiError}
-            archetypeName={archetypeName}
+            archetypes={archetypes}
+            currentArchetypeSlug={archetype}
+            onArchetypeChange={handleArchetypeChange}
+            isStale={isStale}
+            onRefetch={handleRefetch}
             forecastUpdatedAt={forecastUpdatedAt}
           />
         </div>

--- a/packages/web/src/utils/format.ts
+++ b/packages/web/src/utils/format.ts
@@ -70,6 +70,22 @@ export function formatDayHeader(iso: string, mode: TimezoneMode = "local"): stri
   return `${DAYS_EN[d.getDay()]} ${d.getDate()}`;
 }
 
+/** Return "YYYY-MM-DDTHH" for the current moment in Europe/Paris time.
+ * The heatmap timeline is keyed in Paris time, so nowHour must match. */
+export function nowParisHourPrefix(): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date());
+  const get = (t: string) => parts.find(p => p.type === t)?.value ?? "";
+  const h = get("hour");
+  return `${get("year")}-${get("month")}-${get("day")}T${h === "24" ? "00" : h}`;
+}
+
 export function groupHoursByDay(times: string[]): Map<string, number[]> {
   const map = new Map<string, number[]>();
   times.forEach((t, i) => {


### PR DESCRIPTION
## Summary

Implements sprint 2 decisions D1 (editable waypoints), D2 (editable archetype), and the stale/refetch UX doctrine: **Refetch is the only action that re-fetches data.** All local changes (drag, archetype swap) mark the data as stale and update the URL via `replaceState` — never trigger an API call automatically.

- **Drag waypoints** — markers are now draggable; a live gray dashed line follows during drag; on drop the position is applied locally and the URL is updated
- **Polyline state** — colored complexity segments when data is fresh; gray dashed when `isStale` (visual cue that the route data no longer matches the waypoints)
- **Boat archetype dropdown** — archetype row opens a panel listing all 5 archetypes with name, length, and example boat; selecting one marks data stale and updates the URL
- **Stale tag** — `⚠ Données obsolètes` appears next to the Refetch button on any local change
- **Refetch button** — always visible, turns accent-colored when stale; calls `POST /api/v1/passage` with current local params; clears stale flag on success; sidebar shows skeleton during call
- **`buildPlanUrl()`** added to `parseUrl.ts` for URL reconstruction after edits

## Test plan

- [ ] Open a `/plan?wpts=…` URL — colored polyline shown, stale tag absent
- [ ] Drag a waypoint — gray dashed line appears, stale tag shows, URL updates
- [ ] Click the archetype name — dropdown opens with 5 archetypes
- [ ] Change archetype — stale tag shows, URL `archetype=` param updates
- [ ] Click Refetch — sidebar goes to skeleton, comes back with new data, stale tag clears
- [ ] Drag during a live Refetch — drag completes, Refetch result overwrites (no cancellation per spec)
- [ ] Copy link after a drag — copied URL reflects the dragged positions
- [ ] Light + dark theme — dropdown and stale banner render correctly in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)