### PR TITLE
feat(web): PR 2.6 — ow_last_trip cookie + Plan tab in Explore header

### DIFF
--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -2,6 +2,46 @@ import type { Spot } from "../types";
 import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";
 
+function getLastTrip(): string | null {
+  const match = document.cookie.split(";").find((c) => c.trim().startsWith("ow_last_trip="));
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match.split("=").slice(1).join("=").trim());
+  } catch {
+    return null;
+  }
+}
+
+function PlanTab() {
+  const lastTrip = getLastTrip();
+  if (lastTrip) {
+    return (
+      <a
+        href={lastTrip}
+        className="shrink-0 flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors"
+        style={{ color: "var(--ow-accent)", background: "var(--ow-accent-soft)", border: "1px solid var(--ow-accent-line)" }}
+      >
+        <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
+        </svg>
+        Plan
+      </a>
+    );
+  }
+  return (
+    <span
+      className="shrink-0 hidden sm:flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold cursor-default select-none"
+      style={{ color: "var(--ow-fg-3)", border: "1px solid var(--ow-line)" }}
+      title="Pas encore de plan. Génère-en un via Claude Desktop ou un assistant MCP."
+    >
+      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
+      </svg>
+      Plan
+    </span>
+  );
+}
+
 interface HeaderProps {
   onSelectSpot: (spot: Spot) => void;
   canSave: boolean;
@@ -40,6 +80,7 @@ export function Header({
             <span style={{ color: 'var(--ow-accent)' }}>Wind</span>
           </h1>
         </div>
+        <PlanTab />
         <div className="flex-1 flex justify-center">
           <SpotSearch onSelect={onSelectSpot} />
         </div>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -73,6 +73,9 @@ export function PlanPage() {
         setComplexity(res.complexity);
         setForecastUpdatedAt(res.forecast_updated_at);
         setIsStale(false);
+        // Persist canonical URL so Explore can show a "Plan" shortcut
+        const ttl = 7 * 24 * 3600;
+        document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
       })
       .catch((e: Error) => setApiError(e.message))
       .finally(() => setIsLoading(false));


### PR DESCRIPTION
## Summary

- **Cookie `ow_last_trip`** — written on every successful passage fetch in `/plan` (initial load + refetch). Stores the canonical URL (`/plan?wpts=…&departure=…&archetype=…`), 7-day TTL, `SameSite=Lax` so links from any MCP client work. Updates when the user refetches after editing waypoints or archetype.
- **Plan tab in Explore header** — small pill button left of the search bar:
  - Cookie present → teal accent link, navigates to the stored `/plan` URL
  - Cookie absent → muted disabled label (hidden on mobile), tooltip explains how to generate a plan

## Test plan

- [ ] Open a valid `/plan` URL and let it load → check `ow_last_trip` cookie is set in DevTools
- [ ] Navigate to `/` (Explore) → Plan tab should appear teal and clickable
- [ ] Click Plan tab → navigates back to the plan URL
- [ ] Clear cookies → Plan tab shows muted/disabled with tooltip
- [ ] Drag a waypoint then Refetch → cookie updates to new URL
- [ ] Mobile: disabled Plan tab is hidden (only visible when active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)