### PR TITLE
feat(web): PR 2.7 — search ports/capes in /plan header → recenter map

### DIFF
--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useTheme } from "../design/theme";
 import type { SegmentReport } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
+
+export interface PlanMapHandle {
+  recenter: (lat: number, lon: number) => void;
+}
 
 interface PlanMapProps {
   waypoints: [number, number][];
@@ -29,7 +33,10 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
   });
 }
 
-export function PlanMap({ waypoints, segments, isStale, onWptMove }: PlanMapProps) {
+export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
+  { waypoints, segments, isStale, onWptMove }: PlanMapProps,
+  ref
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
@@ -38,6 +45,12 @@ export function PlanMap({ waypoints, segments, isStale, onWptMove }: PlanMapProp
   const dragLineRef = useRef<L.Polyline | null>(null);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const { resolvedTheme } = useTheme();
+
+  useImperativeHandle(ref, () => ({
+    recenter(lat, lon) {
+      mapRef.current?.setView([lat, lon], 12, { animate: true });
+    },
+  }));
 
   useEffect(() => {
     livePositionsRef.current = waypoints;
@@ -164,4 +177,4 @@ export function PlanMap({ waypoints, segments, isStale, onWptMove }: PlanMapProp
   }, [waypoints, segments, isStale]);
 
   return <div ref={containerRef} className="w-full h-full" />;
-}
+});

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
-import { PlanMap } from "../plan/PlanMap";
+import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchArchetypes } from "../api/passage";
 import { ThemeToggle } from "../design/theme";
+import { SpotSearch } from "../components/SpotSearch";
 import type { PassageReport, ComplexityScore, Archetype } from "../plan/types";
 
 function CopyLinkButton() {
@@ -40,6 +41,7 @@ function CopyLinkButton() {
 }
 
 export function PlanPage() {
+  const mapRef = useRef<PlanMapHandle>(null);
   const initialParsed = parsePlanUrl(window.location.search);
 
   // Editable local state (does not trigger re-fetch automatically)
@@ -144,10 +146,12 @@ export function PlanPage() {
         >
           ← Explorer
         </a>
-        <span className="flex-1 text-center text-sm font-semibold truncate hidden sm:block" style={{ color: "var(--ow-fg-0)" }}>
-          Plan de navigation
-        </span>
-        <div className="ml-auto flex items-center gap-1">
+        <div className="flex-1 flex justify-center px-2">
+          <SpotSearch
+            onSelect={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
+          />
+        </div>
+        <div className="flex items-center gap-1">
           <CopyLinkButton />
           <ThemeToggle />
         </div>
@@ -158,6 +162,7 @@ export function PlanPage() {
         {/* Map */}
         <div className="flex-1 min-h-0">
           <PlanMap
+            ref={mapRef}
             waypoints={waypoints}
             segments={passage?.segments}
             isStale={isStale}


### PR DESCRIPTION
## Summary

Adds a geocoding search bar to the `/plan` TopNav. Selecting a result recenters the Leaflet map — no changes to the route or waypoints.

- Reuses `SpotSearch` + the Open-Meteo geocoding API already wired in Explore
- `PlanMap` converted to a `forwardRef` component exposing a `recenter(lat, lon)` handle via `useImperativeHandle`
- `PlanPage` holds a `mapRef` and passes `recenter` as the `SpotSearch.onSelect` callback
- The title "Plan de navigation" is replaced by the search bar (cleaner header, same info from the ← Explorer link)

## Test plan

- [ ] Open a `/plan` URL → search bar visible in the header
- [ ] Type "Porquerolles" → dropdown shows results
- [ ] Select a result → map recenters with zoom 12, animated
- [ ] Waypoints and route unchanged after recentering
- [ ] Light + dark theme render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)