### PR TITLE
feat(web): /plan mobile layout — hero stats overlay + compact drawer

### DIFF
--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -6,14 +6,150 @@ import { fetchPassage, fetchArchetypes } from "../api/passage";
 import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
 import type { PassageReport, ComplexityScore, Archetype } from "../plan/types";
+import { cxLevel, CX_COLORS } from "../plan/types";
+
+// ── local helpers (mobile components) ────────────────────────────────────────
+
+function fmtTime(iso: string) {
+  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+function fmtDuration(h: number) {
+  const hrs = Math.floor(h);
+  const mins = Math.round((h - hrs) * 60);
+  return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
+}
+function compassDir(deg: number) {
+  return ["N", "NE", "E", "SE", "S", "SO", "O", "NO"][Math.round(deg / 45) % 8];
+}
+
+function RefetchIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M13.5 2.5A7 7 0 1 0 14.5 9" /><path d="M14 1v4h-4" />
+    </svg>
+  );
+}
+
+// Hero stats overlay — absolute, bottom of map, mobile only
+function PlanHeroStats({ passage, complexity }: { passage: PassageReport; complexity: ComplexityScore }) {
+  const stats = [
+    { label: "ETA", value: fmtTime(passage.arrival_time) },
+    { label: "Durée", value: fmtDuration(passage.duration_h) },
+    { label: "Dist", value: `${passage.distance_nm.toFixed(1)} nm` },
+    { label: "Cx", value: `${complexity.level}/5`, color: CX_COLORS[complexity.level] },
+  ];
+  return (
+    <div className="flex gap-1.5">
+      {stats.map(({ label, value, color }) => (
+        <div
+          key={label}
+          className="flex-1 rounded-xl px-2 py-1.5 text-center"
+          style={{ background: "var(--ow-surface-glass)", backdropFilter: "blur(8px)", border: "1px solid var(--ow-line-2)" }}
+        >
+          <div className="text-[9px] font-semibold uppercase tracking-wide" style={{ color: "var(--ow-fg-2)" }}>{label}</div>
+          <div className="text-xs font-bold tabular-nums leading-tight mt-0.5" style={{ color: color ?? "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>{value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Compact drawer — replaces sidebar on mobile
+function CompactDrawer({
+  passage,
+  complexity,
+  isLoading,
+  error,
+  isStale,
+  onRefetch,
+}: {
+  passage: PassageReport | null;
+  complexity: ComplexityScore | null;
+  isLoading: boolean;
+  error: string | null;
+  isStale: boolean;
+  onRefetch: () => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="p-3 space-y-2 animate-fade-in">
+        {[0, 1, 2].map((i) => <div key={i} className="skeleton h-9 rounded-lg" />)}
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="p-3">
+        <p className="text-xs rounded-lg px-3 py-2" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)" }}>{error}</p>
+      </div>
+    );
+  }
+  if (!passage || !complexity) return null;
+
+  return (
+    <div>
+      {/* Sticky header */}
+      <div
+        className="sticky top-0 z-10 flex items-center gap-2 px-3 py-2 border-b"
+        style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+      >
+        <span className="text-xs font-semibold flex-1" style={{ color: "var(--ow-fg-1)" }}>
+          {passage.segments.length} segments · {passage.distance_nm.toFixed(1)} nm
+        </span>
+        {isStale && (
+          <span className="text-[10px] font-medium shrink-0" style={{ color: "var(--ow-warn)" }}>⚠ Obsolète</span>
+        )}
+        <button
+          onClick={onRefetch}
+          className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-semibold transition-colors"
+          style={{
+            background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
+            color: isStale ? "#fff" : "var(--ow-fg-2)",
+            border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
+          }}
+        >
+          <RefetchIcon />
+          Recalculer
+        </button>
+      </div>
+
+      {/* Segment rows */}
+      <div>
+        {passage.segments.map((seg, i) => {
+          const cx = cxLevel(seg.tws_kn);
+          return (
+            <div
+              key={i}
+              className="flex items-center gap-2 px-3 py-2.5 border-b text-xs"
+              style={{ borderColor: "var(--ow-line)" }}
+            >
+              <span
+                className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
+                style={{ background: CX_COLORS[cx], color: "#fff" }}
+              >
+                {i + 1}
+              </span>
+              <span className="flex-1 tabular-nums" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
+                {seg.distance_nm.toFixed(1)} nm · {seg.tws_kn.toFixed(0)} kn · {compassDir(seg.twd_deg)}
+              </span>
+              <span className="tabular-nums shrink-0" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+                {fmtTime(seg.end_time)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── CopyLinkButton ────────────────────────────────────────────────────────────
 
 function CopyLinkButton() {
   const [copied, setCopied] = useState(false);
   async function copy() {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     } catch {
       const el = document.createElement("textarea");
       el.value = window.location.href;
@@ -21,9 +157,9 @@ function CopyLinkButton() {
       el.select();
       document.execCommand("copy");
       document.body.removeChild(el);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
   return (
     <button
@@ -35,23 +171,23 @@ function CopyLinkButton() {
         border: "1px solid var(--ow-line-2)",
       }}
     >
-      {copied ? "Copié ✓" : "Copier le lien"}
+      {copied ? "Copié ✓" : "🔗"}
     </button>
   );
 }
+
+// ── PlanPage ──────────────────────────────────────────────────────────────────
 
 export function PlanPage() {
   const mapRef = useRef<PlanMapHandle>(null);
   const initialParsed = parsePlanUrl(window.location.search);
 
-  // Editable local state (does not trigger re-fetch automatically)
   const [waypoints, setWaypoints] = useState<[number, number][]>(
     isParsedOk(initialParsed) ? initialParsed.waypoints : []
   );
   const [archetype, setArchetype] = useState(
     isParsedOk(initialParsed) ? initialParsed.archetype : ""
   );
-  // departure is not editable in V1 — kept as constant from URL
   const departure = isParsedOk(initialParsed) ? initialParsed.departure : "";
 
   const [passage, setPassage] = useState<PassageReport | null>(null);
@@ -75,7 +211,6 @@ export function PlanPage() {
         setComplexity(res.complexity);
         setForecastUpdatedAt(res.forecast_updated_at);
         setIsStale(false);
-        // Persist canonical URL so Explore can show a "Plan" shortcut
         const ttl = 7 * 24 * 3600;
         document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
       })
@@ -83,7 +218,6 @@ export function PlanPage() {
       .finally(() => setIsLoading(false));
   }
 
-  // Initial fetch
   useEffect(() => {
     if (!isParsedOk(initialParsed)) return;
     doFetch(initialParsed.waypoints, initialParsed.archetype);
@@ -141,12 +275,12 @@ export function PlanPage() {
       >
         <a
           href="/"
-          className="shrink-0 flex items-center gap-1.5 text-sm font-medium transition-colors"
+          className="shrink-0 flex items-center gap-1 text-sm font-medium"
           style={{ color: "var(--ow-fg-1)" }}
         >
-          ← Explorer
+          ←
         </a>
-        <div className="flex-1 flex justify-center px-2">
+        <div className="flex-1 flex justify-center px-1">
           <SpotSearch
             onSelect={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
           />
@@ -157,10 +291,10 @@ export function PlanPage() {
         </div>
       </header>
 
-      {/* Body: map + sidebar */}
+      {/* Body */}
       <div className="flex-1 min-h-0 flex flex-col lg:flex-row">
-        {/* Map */}
-        <div className="flex-1 min-h-0">
+        {/* Map — full height on mobile, flex-1 on desktop */}
+        <div className="flex-1 min-h-0 relative">
           <PlanMap
             ref={mapRef}
             waypoints={waypoints}
@@ -168,11 +302,17 @@ export function PlanPage() {
             isStale={isStale}
             onWptMove={handleWptMove}
           />
+          {/* Hero stats overlay — mobile only, floats above compact drawer */}
+          {passage && complexity && (
+            <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
+              <PlanHeroStats passage={passage} complexity={complexity} />
+            </div>
+          )}
         </div>
 
-        {/* Sidebar */}
+        {/* Desktop sidebar */}
         <div
-          className="shrink-0 max-h-[50vh] lg:max-h-none lg:h-auto lg:w-80 xl:w-96 overflow-y-auto border-t lg:border-t-0 lg:border-l"
+          className="hidden lg:block shrink-0 w-80 xl:w-96 overflow-y-auto border-l"
           style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
         >
           <PlanSidebar
@@ -188,6 +328,21 @@ export function PlanPage() {
             forecastUpdatedAt={forecastUpdatedAt}
           />
         </div>
+      </div>
+
+      {/* Mobile compact drawer — below map */}
+      <div
+        className="lg:hidden shrink-0 overflow-y-auto border-t"
+        style={{ maxHeight: "38vh", background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+      >
+        <CompactDrawer
+          passage={passage}
+          complexity={complexity}
+          isLoading={isLoading}
+          error={apiError}
+          isStale={isStale}
+          onRefetch={handleRefetch}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Hero stats glass overlay (ETA, Durée, Dist, Cx) floating above map on mobile (`lg:hidden`)
- Compact drawer below map on mobile with sticky refetch header + segment rows
- Desktop sidebar unchanged (`hidden lg:block`)
- Header simplified: back arrow only, SpotSearch centered, CopyLinkButton + ThemeToggle

## Test plan
- [ ] Mobile: map fills top half, hero stats overlay at bottom of map, segment drawer below
- [ ] Desktop: sidebar visible on right, no drawer
- [ ] Stale warning + refetch button in compact drawer header
- [ ] Loading skeleton in drawer
- [ ] Error state in drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)