### PR TITLE
feat(web): mobile polish — long-press 400ms + table height 38vh

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -100,7 +100,7 @@ function App() {
 
         {/* Wind table — bottom panel */}
         <div
-          className="shrink-0 max-h-[45vh] md:max-h-[40vh] overflow-y-auto"
+          className="shrink-0 max-h-[38vh] md:max-h-[40vh] overflow-y-auto"
           style={{ background: 'var(--ow-bg-0)', borderTop: '1px solid var(--ow-line)' }}
         >
           {spot ? (

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -184,7 +184,7 @@ export function SpotMap({
       if (editSpot) {
         pressTimerRef.current = setTimeout(() => {
           setPendingEditRef.current(editSpot);
-        }, 800);
+        }, 400);
         return;
       }
 
@@ -199,7 +199,7 @@ export function SpotMap({
         const latlng = map.containerPointToLatLng(point);
         const name = await reverseGeocode(latlng.lat, latlng.lng);
         setPendingRef.current({ lat: latlng.lat, lng: latlng.lng, name });
-      }, 800);
+      }, 400);
     };
 
     const handlePointerUp = () => {


### PR DESCRIPTION
## Summary
- Long-press delay reduced 800ms → 400ms (both add-spot and edit-spot gestures)
- Explore table max-height on mobile 45vh → 38vh (gives map more breathing room)

## Test plan
- [ ] Long-press on map creates spot after ~0.4s (feels snappy, no false triggers on scroll)
- [ ] Long-press on existing spot opens edit after ~0.4s
- [ ] Table doesn't crowd the map on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)