### PR TITLE
feat(web): add waypoints by clicking route + editable departure + segment table cleanup

### DIFF
--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -14,6 +14,7 @@ interface PlanMapProps {
   segments?: SegmentReport[];
   isStale?: boolean;
   onWptMove: (idx: number, lat: number, lon: number) => void;
+  onWptAdd?: (afterIdx: number, lat: number, lon: number) => void;
 }
 
 function waypointIcon(label: string, bg: string): L.DivIcon {
@@ -34,7 +35,7 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -44,7 +45,11 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const markersRef = useRef<L.Marker[]>([]);
   const dragLineRef = useRef<L.Polyline | null>(null);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
+  const isDraggingRef = useRef(false);
+  const onWptAddRef = useRef(onWptAdd);
   const { resolvedTheme } = useTheme();
+
+  useEffect(() => { onWptAddRef.current = onWptAdd; }, [onWptAdd]);
 
   useImperativeHandle(ref, () => ({
     recenter(lat, lon) {
@@ -115,6 +120,10 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         draggable: true,
       }).addTo(map);
 
+      marker.on("dragstart", () => {
+        isDraggingRef.current = true;
+      });
+
       marker.on("drag", () => {
         const pos = marker.getLatLng();
         const positions = [...livePositionsRef.current];
@@ -140,6 +149,8 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         }
         const pos = marker.getLatLng();
         onWptMove(i, pos.lat, pos.lng);
+        // Short cooldown so polyline click handlers don't fire after drag release
+        setTimeout(() => { isDraggingRef.current = false; }, 150);
       });
 
       markersRef.current.push(marker);
@@ -148,6 +159,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   }, [waypoints]);
 
   // Draw polyline — gray while loading/stale, colored per segment when fresh
+  // Clicking a line inserts a new waypoint at that position
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
@@ -158,22 +170,44 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     if (!segments || isStale) {
       const line = L.polyline(waypoints.map(([lat, lon]) => L.latLng(lat, lon)), {
         color: "#6b7280",
-        weight: 3,
+        weight: 5,
         dashArray: "6 4",
         opacity: 0.7,
       }).addTo(map);
+      line.on("click", (e: L.LeafletMouseEvent) => {
+        if (isDraggingRef.current || !onWptAddRef.current) return;
+        L.DomEvent.stopPropagation(e);
+        // Find closest segment by midpoint distance
+        const click = e.latlng;
+        let bestIdx = 0;
+        let bestDist = Infinity;
+        for (let i = 0; i < waypoints.length - 1; i++) {
+          const mid = L.latLng(
+            (waypoints[i][0] + waypoints[i + 1][0]) / 2,
+            (waypoints[i][1] + waypoints[i + 1][1]) / 2,
+          );
+          const d = click.distanceTo(mid);
+          if (d < bestDist) { bestDist = d; bestIdx = i; }
+        }
+        onWptAddRef.current(bestIdx, click.lat, click.lng);
+      });
       polylinesRef.current = [line];
       return;
     }
 
-    for (const seg of segments) {
+    segments.forEach((seg, i) => {
       const color = CX_COLORS[cxLevel(seg.tws_kn)];
       const line = L.polyline(
         [L.latLng(seg.start.lat, seg.start.lon), L.latLng(seg.end.lat, seg.end.lon)],
-        { color, weight: 4, opacity: 0.9 }
+        { color, weight: 6, opacity: 0.9 }
       ).addTo(map);
+      line.on("click", (e: L.LeafletMouseEvent) => {
+        if (isDraggingRef.current || !onWptAddRef.current) return;
+        L.DomEvent.stopPropagation(e);
+        onWptAddRef.current(i, e.latlng.lat, e.latlng.lng);
+      });
       polylinesRef.current.push(line);
-    }
+    });
   }, [waypoints, segments, isStale]);
 
   return <div ref={containerRef} className="w-full h-full" />;

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -14,13 +14,6 @@ function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
 
-function fmtDeparture(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString("fr-FR", {
-    weekday: "short", day: "numeric", month: "short",
-    hour: "2-digit", minute: "2-digit",
-  });
-}
 
 function compassDir(deg: number): string {
   const dirs = ["N", "NE", "E", "SE", "S", "SO", "O", "NO"];
@@ -150,6 +143,8 @@ interface PlanSidebarProps {
   archetypes: Archetype[];
   currentArchetypeSlug: string;
   onArchetypeChange: (slug: string) => void;
+  departure: string;
+  onDepartureChange: (iso: string) => void;
   isStale: boolean;
   onRefetch: () => void;
   forecastUpdatedAt: string | null;
@@ -163,6 +158,8 @@ export function PlanSidebar({
   archetypes,
   currentArchetypeSlug,
   onArchetypeChange,
+  departure,
+  onDepartureChange,
   isStale,
   onRefetch,
   forecastUpdatedAt,
@@ -223,12 +220,22 @@ export function PlanSidebar({
         )}
       </div>
 
-      {/* Departure */}
+      {/* Departure — editable */}
       <div>
-        <p className="text-[10px] uppercase tracking-widest mb-0.5 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Départ</p>
-        <p className="text-xl font-bold tabular-nums" style={{ fontFamily: "var(--ow-font-mono)", color: "var(--ow-fg-0)" }}>
-          {fmtDeparture(passage.departure_time)}
-        </p>
+        <p className="text-[10px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Départ</p>
+        <input
+          type="datetime-local"
+          value={departure}
+          onChange={(e) => onDepartureChange(e.target.value)}
+          className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
+          style={{
+            background: "var(--ow-bg-2)",
+            color: "var(--ow-fg-0)",
+            border: "1px solid var(--ow-line-2)",
+            fontFamily: "var(--ow-font-mono)",
+            colorScheme: "dark",
+          }}
+        />
       </div>
 
       {/* Archetype dropdown */}
@@ -287,9 +294,15 @@ export function PlanSidebar({
 
       {/* Legs */}
       <div>
-        <p className="text-[10px] uppercase tracking-widest mb-2 font-semibold" style={{ color: "var(--ow-fg-2)" }}>
-          Segments ({passage.segments.length})
-        </p>
+        <div className="flex items-center gap-2 mb-1 px-1 text-[9px]" style={{ color: "var(--ow-fg-3)" }}>
+          <span className="w-5 shrink-0" />
+          <span className="flex-1 grid grid-cols-4 gap-1">
+            <span className="text-right">Dist</span>
+            <span className="text-right">TWS</span>
+            <span className="text-right">Dir</span>
+            <span className="text-right">Vit</span>
+          </span>
+        </div>
         <div className="space-y-1">
           {passage.segments.map((seg, i) => {
             const cx = cxLevel(seg.tws_kn);
@@ -301,26 +314,15 @@ export function PlanSidebar({
                 >
                   {i + 1}
                 </span>
-                <div className="flex-1 grid grid-cols-5 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
+                <div className="flex-1 grid grid-cols-4 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
                   <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{seg.distance_nm.toFixed(1)} nm</span>
                   <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.tws_kn.toFixed(0)} kn</span>
                   <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{compassDir(seg.twd_deg)}</span>
                   <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.boat_speed_kn.toFixed(1)} kn</span>
-                  <span className="text-right" style={{ color: "var(--ow-fg-2)" }}>{fmtTime(seg.end_time)}</span>
                 </div>
               </div>
             );
           })}
-        </div>
-        <div className="flex justify-between text-[9px] mt-1 px-1" style={{ color: "var(--ow-fg-3)" }}>
-          <span />
-          <span className="grid grid-cols-5 gap-1 w-[calc(100%-28px)]">
-            <span className="text-right">Dist</span>
-            <span className="text-right">TWS</span>
-            <span className="text-right">Dir</span>
-            <span className="text-right">Vit</span>
-            <span className="text-right">ETA</span>
-          </span>
         </div>
       </div>
 

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -188,7 +188,9 @@ export function PlanPage() {
   const [archetype, setArchetype] = useState(
     isParsedOk(initialParsed) ? initialParsed.archetype : ""
   );
-  const departure = isParsedOk(initialParsed) ? initialParsed.departure : "";
+  const [departure, setDeparture] = useState(
+    isParsedOk(initialParsed) ? initialParsed.departure : ""
+  );
 
   const [passage, setPassage] = useState<PassageReport | null>(null);
   const [complexity, setComplexity] = useState<ComplexityScore | null>(null);
@@ -231,10 +233,24 @@ export function PlanPage() {
     window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
   }
 
+  function handleWptAdd(afterIdx: number, lat: number, lon: number) {
+    const next = [...waypoints];
+    next.splice(afterIdx + 1, 0, [lat, lon]);
+    setWaypoints(next);
+    setIsStale(true);
+    window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
+  }
+
   function handleArchetypeChange(slug: string) {
     setArchetype(slug);
     setIsStale(true);
     window.history.replaceState(null, "", buildPlanUrl(waypoints, departure, slug));
+  }
+
+  function handleDepartureChange(iso: string) {
+    setDeparture(iso);
+    setIsStale(true);
+    window.history.replaceState(null, "", buildPlanUrl(waypoints, iso, archetype));
   }
 
   function handleRefetch() {
@@ -301,6 +317,7 @@ export function PlanPage() {
             segments={passage?.segments}
             isStale={isStale}
             onWptMove={handleWptMove}
+            onWptAdd={handleWptAdd}
           />
           {/* Hero stats overlay — mobile only, floats above compact drawer */}
           {passage && complexity && (
@@ -323,6 +340,8 @@ export function PlanPage() {
             archetypes={archetypes}
             currentArchetypeSlug={archetype}
             onArchetypeChange={handleArchetypeChange}
+            departure={departure}
+            onDepartureChange={handleDepartureChange}
             isStale={isStale}
             onRefetch={handleRefetch}
             forecastUpdatedAt={forecastUpdatedAt}


### PR DESCRIPTION
## Summary
- **Click on route line** to insert a waypoint at that position (works on both colored segments and gray stale line)
- **Drag guard**: `isDraggingRef` + 150ms cooldown ensures dragging a marker never triggers the line click handler
- **Editable departure**: `datetime-local` input in sidebar; changing it marks route as stale
- **Segment table**: column headers moved to top, ETA column removed (4 columns: Dist / TWS / Dir / Vit)

## Test plan
- [ ] Click on a segment line → new waypoint appears between adjacent waypoints
- [ ] Drag existing waypoint → moves cleanly, no extra waypoint created
- [ ] Change departure date → stale banner appears, Recalculer fetches with new time
- [ ] Segment headers visible at top of list

🤖 Generated with [Claude Code](https://claude.com/claude-code)