### PR TITLE
feat(web): merge footer + departure defaults to local now

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -39,9 +39,6 @@ function App() {
   const [forecasts, setForecasts] = useState<ModelForecast[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedHour, setSelectedHour] = useState<string | null>(null);
-  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
-
-
   useEffect(() => {
     if (!spot) return;
     let cancelled = false;
@@ -49,7 +46,6 @@ function App() {
     fetchAllModels(spot.latitude, spot.longitude).then((data) => {
       if (!cancelled) {
         setForecasts(data);
-        setFetchedAt(Date.now());
         setIsLoading(false);
         // Auto-select current hour so wind arrows show by default
         const nowHour = nowParisHourPrefix();
@@ -113,30 +109,6 @@ function App() {
           ) : (
             <EmptyState />
           )}
-          <footer className="hidden sm:flex items-center justify-center gap-3 text-[11px] py-1 shrink-0" style={{ color: 'var(--ow-fg-2)' }}>
-            <span>
-              Data by{" "}
-              <a
-                href="https://open-meteo.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline transition-colors"
-                style={{ color: 'var(--ow-fg-1)' }}
-              >
-                Open-Meteo.com
-              </a>{" "}
-              (CC BY 4.0)
-            </span>
-            {fetchedAt != null && (
-              <>
-                <span aria-hidden>·</span>
-                <span>
-                  Updated at{" "}
-                  {new Date(fetchedAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}
-                </span>
-              </>
-            )}
-          </footer>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -91,6 +91,15 @@ function BeaufortLegend({ timezoneMode, onCycleTz }: { timezoneMode: TimezoneMod
         </div>
       ))}
       <div className="flex-1 min-w-2" />
+      <a
+        href="https://open-meteo.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 text-[10px] mr-2 mb-0.5 transition-colors"
+        style={{ color: 'var(--ow-fg-3)' }}
+      >
+        Open-Meteo (CC BY 4.0)
+      </a>
       <button
         onClick={onCycleTz}
         title={tzTitle}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTheme } from "../design/theme";
 import type { PassageReport, ComplexityScore, SegmentReport, Archetype } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
 
@@ -164,6 +165,7 @@ export function PlanSidebar({
   onRefetch,
   forecastUpdatedAt,
 }: PlanSidebarProps) {
+  const { resolvedTheme } = useTheme();
   if (isLoading) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
@@ -233,7 +235,7 @@ export function PlanSidebar({
             color: "var(--ow-fg-0)",
             border: "1px solid var(--ow-line-2)",
             fontFamily: "var(--ow-font-mono)",
-            colorScheme: "dark",
+            colorScheme: resolvedTheme === "light" ? "light" : "dark",
           }}
         />
       </div>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -10,6 +10,13 @@ import { cxLevel, CX_COLORS } from "../plan/types";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
+function nowRoundedLocal(): string {
+  const d = new Date();
+  d.setMinutes(Math.ceil(d.getMinutes() / 15) * 15, 0, 0);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function fmtTime(iso: string) {
   return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
@@ -188,9 +195,11 @@ export function PlanPage() {
   const [archetype, setArchetype] = useState(
     isParsedOk(initialParsed) ? initialParsed.archetype : ""
   );
-  const [departure, setDeparture] = useState(
-    isParsedOk(initialParsed) ? initialParsed.departure : ""
-  );
+  const [departure, setDeparture] = useState(() => {
+    const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";
+    if (!raw || new Date(raw) < new Date()) return nowRoundedLocal();
+    return raw;
+  });
 
   const [passage, setPassage] = useState<PassageReport | null>(null);
   const [complexity, setComplexity] = useState<ComplexityScore | null>(null);


### PR DESCRIPTION
## Summary
- **Footer merged**: Open-Meteo attribution moved into the Beaufort legend bar (right side), separate footer removed from App.tsx, "Updated at" time removed
- **Departure defaults to local now**: if URL departure is in the past or missing, initialize to current local time rounded to next 15 min
- **datetime-local colorScheme**: adapts to light/dark theme so the native date picker looks correct

## Test plan
- [ ] Explore: Beaufort scale + "Open-Meteo (CC BY 4.0)" in same bar, no second footer
- [ ] Plan with past departure URL → input shows current local time on load
- [ ] Plan in light mode → datetime picker renders correctly
- [ ] Plan in dark mode → datetime picker renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)