### PR TITLE
feat(web): plan empty state + FAB + click-to-add first waypoints

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -82,6 +82,17 @@ function App() {
       <div className="flex-1 min-h-0 flex flex-col">
         {/* Map — fills all available space */}
         <div className="flex-1 min-h-0 relative">
+          {/* Plan FAB */}
+          <a
+            href="/plan"
+            className="absolute top-3 left-3 z-[400] w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95"
+            style={{ background: "var(--ow-accent)", color: "#fff" }}
+            title="Planifier un passage"
+          >
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
+            </svg>
+          </a>
           <SpotMap
             current={mapCenter}
             customSpots={customSpots}

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -2,45 +2,6 @@ import type { Spot } from "../types";
 import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";
 
-function getLastTrip(): string | null {
-  const match = document.cookie.split(";").find((c) => c.trim().startsWith("ow_last_trip="));
-  if (!match) return null;
-  try {
-    return decodeURIComponent(match.split("=").slice(1).join("=").trim());
-  } catch {
-    return null;
-  }
-}
-
-function PlanTab() {
-  const lastTrip = getLastTrip();
-  if (lastTrip) {
-    return (
-      <a
-        href={lastTrip}
-        className="shrink-0 flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors"
-        style={{ color: "var(--ow-accent)", background: "var(--ow-accent-soft)", border: "1px solid var(--ow-accent-line)" }}
-      >
-        <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
-        </svg>
-        Plan
-      </a>
-    );
-  }
-  return (
-    <span
-      className="shrink-0 hidden sm:flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold cursor-default select-none"
-      style={{ color: "var(--ow-fg-3)", border: "1px solid var(--ow-line)" }}
-      title="Pas encore de plan. Génère-en un via Claude Desktop ou un assistant MCP."
-    >
-      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
-      </svg>
-      Plan
-    </span>
-  );
-}
 
 interface HeaderProps {
   onSelectSpot: (spot: Spot) => void;
@@ -80,7 +41,6 @@ export function Header({
             <span style={{ color: 'var(--ow-accent)' }}>Wind</span>
           </h1>
         </div>
-        <PlanTab />
         <div className="flex-1 flex justify-center">
           <SpotSearch onSelect={onSelectSpot} />
         </div>

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -15,6 +15,7 @@ interface PlanMapProps {
   isStale?: boolean;
   onWptMove: (idx: number, lat: number, lon: number) => void;
   onWptAdd?: (afterIdx: number, lat: number, lon: number) => void;
+  onMapClick?: (lat: number, lon: number) => void;
 }
 
 function waypointIcon(label: string, bg: string): L.DivIcon {
@@ -35,7 +36,7 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove, onWptAdd }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd, onMapClick }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -47,9 +48,11 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const isDraggingRef = useRef(false);
   const onWptAddRef = useRef(onWptAdd);
+  const onMapClickRef = useRef(onMapClick);
   const { resolvedTheme } = useTheme();
 
   useEffect(() => { onWptAddRef.current = onWptAdd; }, [onWptAdd]);
+  useEffect(() => { onMapClickRef.current = onMapClick; }, [onMapClick]);
 
   useImperativeHandle(ref, () => ({
     recenter(lat, lon) {
@@ -72,7 +75,6 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
-    const bounds = L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon)));
     const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
 
     const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
@@ -87,8 +89,22 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
     L.control.zoom({ position: "bottomright" }).addTo(map);
 
-    map.fitBounds(bounds, { padding: [40, 40] });
+    // Initial view: fit bounds if ≥2 waypoints, else Mediterranean default
+    if (waypoints.length >= 2) {
+      map.fitBounds(L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon))), { padding: [40, 40] });
+    } else if (waypoints.length === 1) {
+      map.setView([waypoints[0][0], waypoints[0][1]], 10);
+    } else {
+      map.setView([42.5, 9.0], 6);
+    }
+
     mapRef.current = map;
+
+    // Map click — for adding initial waypoints (guarded by onMapClickRef)
+    map.on("click", (e: L.LeafletMouseEvent) => {
+      if (isDraggingRef.current || !onMapClickRef.current) return;
+      onMapClickRef.current(e.latlng.lat, e.latlng.lng);
+    });
 
     const ro = new ResizeObserver(() => map.invalidateSize());
     ro.observe(containerRef.current!);
@@ -101,6 +117,13 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Update cursor when onMapClick is active
+  useEffect(() => {
+    const container = mapRef.current?.getContainer();
+    if (!container) return;
+    container.style.cursor = onMapClick ? "crosshair" : "";
+  }, [onMapClick]);
 
   // Draw draggable waypoint markers
   useEffect(() => {
@@ -149,7 +172,6 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         }
         const pos = marker.getLatLng();
         onWptMove(i, pos.lat, pos.lng);
-        // Short cooldown so polyline click handlers don't fire after drag release
         setTimeout(() => { isDraggingRef.current = false; }, 150);
       });
 
@@ -159,13 +181,14 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   }, [waypoints]);
 
   // Draw polyline — gray while loading/stale, colored per segment when fresh
-  // Clicking a line inserts a new waypoint at that position
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
 
     for (const p of polylinesRef.current) p.remove();
     polylinesRef.current = [];
+
+    if (waypoints.length < 2) return;
 
     if (!segments || isStale) {
       const line = L.polyline(waypoints.map(([lat, lon]) => L.latLng(lat, lon)), {
@@ -177,7 +200,6 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       line.on("click", (e: L.LeafletMouseEvent) => {
         if (isDraggingRef.current || !onWptAddRef.current) return;
         L.DomEvent.stopPropagation(e);
-        // Find closest segment by midpoint distance
         const click = e.latlng;
         let bestIdx = 0;
         let bestDist = Infinity;

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -149,6 +149,7 @@ interface PlanSidebarProps {
   isStale: boolean;
   onRefetch: () => void;
   forecastUpdatedAt: string | null;
+  waypointCount: number;
 }
 
 export function PlanSidebar({
@@ -164,8 +165,11 @@ export function PlanSidebar({
   isStale,
   onRefetch,
   forecastUpdatedAt,
+  waypointCount,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
+  const canCalculate = waypointCount >= 2;
+
   if (isLoading) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
@@ -191,7 +195,82 @@ export function PlanSidebar({
     );
   }
 
-  if (!passage || !complexity) return null;
+  if (!passage || !complexity) {
+    return (
+      <div className="p-4 space-y-4 animate-fade-in">
+        {/* Waypoint progress */}
+        <div className="flex items-center gap-3">
+          {[0, 1].map((i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <span
+                className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold"
+                style={{
+                  background: waypointCount > i ? (i === 0 ? "#2dd4bf" : "#e84118") : "var(--ow-bg-2)",
+                  color: waypointCount > i ? "#fff" : "var(--ow-fg-3)",
+                  border: `2px solid ${waypointCount > i ? "transparent" : "var(--ow-line-2)"}`,
+                }}
+              >
+                {i === 0 ? "▶" : "■"}
+              </span>
+              <span className="text-xs" style={{ color: waypointCount > i ? "var(--ow-fg-1)" : "var(--ow-fg-3)" }}>
+                {i === 0 ? "Départ" : "Arrivée"}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Instruction */}
+        <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-2)" }}>
+          {waypointCount === 0
+            ? "Cliquez sur la carte pour placer votre point de départ."
+            : "Cliquez sur la carte pour placer votre point d'arrivée."}
+        </p>
+
+        {/* Departure */}
+        <div>
+          <p className="text-[10px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Départ</p>
+          <input
+            type="datetime-local"
+            value={departure}
+            onChange={(e) => onDepartureChange(e.target.value)}
+            className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
+            style={{
+              background: "var(--ow-bg-2)",
+              color: "var(--ow-fg-0)",
+              border: "1px solid var(--ow-line-2)",
+              fontFamily: "var(--ow-font-mono)",
+              colorScheme: resolvedTheme === "light" ? "light" : "dark",
+            }}
+          />
+        </div>
+
+        {/* Archetype */}
+        <ArchetypeSelector
+          currentSlug={currentArchetypeSlug}
+          archetypes={archetypes}
+          onChange={onArchetypeChange}
+        />
+
+        {/* Calculate button */}
+        <button
+          onClick={onRefetch}
+          disabled={!canCalculate}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold transition-all"
+          style={{
+            background: canCalculate ? "var(--ow-accent)" : "var(--ow-bg-2)",
+            color: canCalculate ? "#fff" : "var(--ow-fg-3)",
+            border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line-2)"}`,
+            cursor: canCalculate ? "pointer" : "not-allowed",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/><path d="M14 1v4h-4"/>
+          </svg>
+          {canCalculate ? "Calculer le passage" : `${waypointCount}/2 waypoints`}
+        </button>
+      </div>
+    );
+  }
 
   const hasWarnings = (complexity.warnings?.length ?? 0) > 0 || passage.warnings.length > 0;
 

--- a/packages/web/src/plan/parseUrl.ts
+++ b/packages/web/src/plan/parseUrl.ts
@@ -9,12 +9,11 @@ export type ParseResult = ParsedPlanParams | { error: string };
 export function parsePlanUrl(search: string): ParseResult {
   const p = new URLSearchParams(search);
   const wpts = p.get("wpts");
-  const departure = p.get("departure");
-  const archetype = p.get("archetype");
+  const departure = p.get("departure") ?? "";
+  const archetype = p.get("archetype") ?? "";
 
-  if (!wpts) return { error: "Paramètre wpts manquant dans l'URL" };
-  if (!departure) return { error: "Paramètre departure manquant dans l'URL" };
-  if (!archetype) return { error: "Paramètre archetype manquant dans l'URL" };
+  // No wpts at all → fresh empty plan (valid, not an error)
+  if (!wpts) return { waypoints: [], departure, archetype };
 
   try {
     const parts = wpts.split(";").filter(Boolean);

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -230,10 +230,18 @@ export function PlanPage() {
   }
 
   useEffect(() => {
-    if (!isParsedOk(initialParsed)) return;
+    if (!isParsedOk(initialParsed) || initialParsed.waypoints.length < 2) return;
     doFetch(initialParsed.waypoints, initialParsed.archetype);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  function handleMapClick(lat: number, lon: number) {
+    const next: [number, number][] = [...waypoints, [lat, lon]];
+    setWaypoints(next);
+    if (next.length >= 2) {
+      window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
+    }
+  }
 
   function handleWptMove(idx: number, lat: number, lon: number) {
     const next = waypoints.map((wp, i): [number, number] => (i === idx ? [lat, lon] : wp));
@@ -326,8 +334,20 @@ export function PlanPage() {
             segments={passage?.segments}
             isStale={isStale}
             onWptMove={handleWptMove}
-            onWptAdd={handleWptAdd}
+            onWptAdd={waypoints.length >= 2 ? handleWptAdd : undefined}
+            onMapClick={waypoints.length < 2 ? handleMapClick : undefined}
           />
+          {/* Hint overlay when adding initial waypoints */}
+          {waypoints.length < 2 && (
+            <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">
+              <div
+                className="px-4 py-2 rounded-xl text-sm font-medium"
+                style={{ background: "var(--ow-surface-glass)", backdropFilter: "blur(8px)", border: "1px solid var(--ow-line-2)", color: "var(--ow-fg-1)" }}
+              >
+                {waypoints.length === 0 ? "Cliquez pour placer le départ" : "Cliquez pour placer l'arrivée"}
+              </div>
+            </div>
+          )}
           {/* Hero stats overlay — mobile only, floats above compact drawer */}
           {passage && complexity && (
             <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
@@ -354,6 +374,7 @@ export function PlanPage() {
             isStale={isStale}
             onRefetch={handleRefetch}
             forecastUpdatedAt={forecastUpdatedAt}
+            waypointCount={waypoints.length}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Plan FAB**: circular teal bubble top-left on the Explore map, links to `/plan` (empty)
- **PlanTab removed** from the main header
- **Empty plan state** (`/plan` with no params): map centered on Mediterranean, click to add departure then arrival
- **Crosshair cursor** on map while placing initial waypoints
- **Hint overlay** at bottom of map: "Cliquez pour placer le départ" → "Cliquez pour placer l'arrivée"
- **Setup panel** in sidebar: waypoint progress indicators (▶/■), departure input, archetype selector, "Calculer" button (disabled until 2 waypoints placed)
- Existing URL-based flow unchanged

## Test plan
- [ ] Explore: FAB bubble visible top-left of map
- [ ] Click FAB → `/plan` empty, map shows Med, cursor crosshair
- [ ] Click map → departure waypoint appears, hint updates to "Cliquez pour placer l'arrivée"
- [ ] Click again → 2nd waypoint appears, "Calculer" button enabled
- [ ] Hit Calculer → fetches passage, sidebar shows full plan
- [ ] Existing MCP-generated URL still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)