### PR TITLE
fix(web): plan bugs — FAB DOM order, timezone, multi-waypoint, stale UX

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -82,17 +82,6 @@ function App() {
       <div className="flex-1 min-h-0 flex flex-col">
         {/* Map — fills all available space */}
         <div className="flex-1 min-h-0 relative">
-          {/* Plan FAB */}
-          <a
-            href="/plan"
-            className="absolute top-3 left-3 z-[400] w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95"
-            style={{ background: "var(--ow-accent)", color: "#fff" }}
-            title="Planifier un passage"
-          >
-            <svg width="18" height="18" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
-            </svg>
-          </a>
           <SpotMap
             current={mapCenter}
             customSpots={customSpots}
@@ -103,6 +92,17 @@ function App() {
             forecasts={forecasts}
             selectedHour={selectedHour}
           />
+          {/* Plan FAB — after SpotMap so it renders on top */}
+          <a
+            href="/plan"
+            className="absolute top-3 left-3 z-[400] w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95"
+            style={{ background: "var(--ow-accent)", color: "#fff" }}
+            title="Planifier un passage"
+          >
+            <svg width="18" height="18" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M2 12 L8 2 L14 12" /><path d="M5 8 L11 8" />
+            </svg>
+          </a>
         </div>
 
         {/* Wind table — bottom panel */}

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -89,13 +89,13 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
     L.control.zoom({ position: "bottomright" }).addTo(map);
 
-    // Initial view: fit bounds if ≥2 waypoints, else Mediterranean default
+    // Initial view: fit bounds if ≥2 waypoints, else Marseille/Riviera area
     if (waypoints.length >= 2) {
       map.fitBounds(L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon))), { padding: [40, 40] });
     } else if (waypoints.length === 1) {
       map.setView([waypoints[0][0], waypoints[0][1]], 10);
     } else {
-      map.setView([42.5, 9.0], 6);
+      map.setView([43.1, 5.9], 8);
     }
 
     mapRef.current = map;
@@ -124,6 +124,14 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     if (!container) return;
     container.style.cursor = onMapClick ? "crosshair" : "";
   }, [onMapClick]);
+
+  // Gray out markers when stale (no full redraw)
+  useEffect(() => {
+    for (const m of markersRef.current) {
+      const el = m.getElement()?.querySelector("div") as HTMLElement | null;
+      if (el) el.style.opacity = isStale ? "0.45" : "1";
+    }
+  }, [isStale]);
 
   // Draw draggable waypoint markers
   useEffect(() => {

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -276,30 +276,21 @@ export function PlanSidebar({
 
   return (
     <div className="p-4 space-y-4 animate-fade-in">
-      {/* Stale banner + Refetch */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={onRefetch}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
-          style={{
-            background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
-            color: isStale ? "#fff" : "var(--ow-fg-2)",
-            border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
-          }}
-          title="Recalculer avec les paramètres actuels"
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/>
-            <path d="M14 1v4h-4"/>
-          </svg>
-          Recalculer
-        </button>
-        {isStale && (
-          <span className="text-[11px] font-medium" style={{ color: "var(--ow-warn)" }}>
-            ⚠ Données obsolètes
-          </span>
-        )}
-      </div>
+      {/* Recalculate — grows when stale */}
+      <button
+        onClick={onRefetch}
+        className={`w-full flex items-center justify-center gap-2 rounded-xl font-bold transition-all ${isStale ? "py-3 text-base" : "py-1.5 text-xs"}`}
+        style={{
+          background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
+          color: isStale ? "#fff" : "var(--ow-fg-2)",
+          border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
+        }}
+      >
+        <svg width={isStale ? 16 : 12} height={isStale ? 16 : 12} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/><path d="M14 1v4h-4"/>
+        </svg>
+        Recalculer
+      </button>
 
       {/* Departure — editable */}
       <div>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -17,6 +17,18 @@ function nowRoundedLocal(): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+// Append local timezone offset to a naive "YYYY-MM-DDTHH:MM" string.
+// If already timezone-aware (ends with Z or ±HH:MM), return as-is.
+function toTzAware(iso: string): string {
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(iso)) return iso;
+  const off = -new Date().getTimezoneOffset();
+  const sign = off >= 0 ? "+" : "-";
+  const abs = Math.abs(off);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
+  return `${iso}:00${sign}${hh}:${mm}`;
+}
+
 function fmtTime(iso: string) {
   return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
@@ -213,15 +225,18 @@ export function PlanPage() {
     fetchArchetypes().then(setArchetypes).catch(() => {});
   }, []);
 
-  function doFetch(wpts: [number, number][], arch: string) {
+  function doFetch(wpts: [number, number][], arch: string, dep: string) {
     setIsLoading(true);
     setApiError(null);
-    fetchPassage({ waypoints: wpts, departure, archetype: arch })
+    fetchPassage({ waypoints: wpts, departure: toTzAware(dep), archetype: arch })
       .then((res) => {
         setPassage(res.passage);
         setComplexity(res.complexity);
         setForecastUpdatedAt(res.forecast_updated_at);
         setIsStale(false);
+        // Update URL + cookie only on successful fetch
+        const url = buildPlanUrl(wpts, dep, arch);
+        window.history.replaceState(null, "", url);
         const ttl = 7 * 24 * 3600;
         document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
       })
@@ -231,47 +246,41 @@ export function PlanPage() {
 
   useEffect(() => {
     if (!isParsedOk(initialParsed) || initialParsed.waypoints.length < 2) return;
-    doFetch(initialParsed.waypoints, initialParsed.archetype);
+    doFetch(initialParsed.waypoints, initialParsed.archetype, departure);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Functional updaters avoid stale closure when clicks happen fast
   function handleMapClick(lat: number, lon: number) {
-    const next: [number, number][] = [...waypoints, [lat, lon]];
-    setWaypoints(next);
-    if (next.length >= 2) {
-      window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
-    }
+    setWaypoints((prev) => [...prev, [lat, lon]]);
   }
 
   function handleWptMove(idx: number, lat: number, lon: number) {
-    const next = waypoints.map((wp, i): [number, number] => (i === idx ? [lat, lon] : wp));
-    setWaypoints(next);
+    setWaypoints((prev) => prev.map((wp, i): [number, number] => (i === idx ? [lat, lon] : wp)));
     setIsStale(true);
-    window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
   }
 
   function handleWptAdd(afterIdx: number, lat: number, lon: number) {
-    const next = [...waypoints];
-    next.splice(afterIdx + 1, 0, [lat, lon]);
-    setWaypoints(next);
+    setWaypoints((prev) => {
+      const next = [...prev];
+      next.splice(afterIdx + 1, 0, [lat, lon]);
+      return next;
+    });
     setIsStale(true);
-    window.history.replaceState(null, "", buildPlanUrl(next, departure, archetype));
   }
 
   function handleArchetypeChange(slug: string) {
     setArchetype(slug);
     setIsStale(true);
-    window.history.replaceState(null, "", buildPlanUrl(waypoints, departure, slug));
   }
 
   function handleDepartureChange(iso: string) {
     setDeparture(iso);
     setIsStale(true);
-    window.history.replaceState(null, "", buildPlanUrl(waypoints, iso, archetype));
   }
 
   function handleRefetch() {
-    doFetch(waypoints, archetype);
+    doFetch(waypoints, archetype, departure);
   }
 
   if (!isParsedOk(initialParsed)) {


### PR DESCRIPTION
## Bugs fixed

| # | Bug | Fix |
|---|-----|-----|
| 1 | FAB disappears (Leaflet covers it) | Move FAB after SpotMap in DOM — later in DOM = on top with same z-index |
| 2 | Empty plan map too zoomed out | Default view `[43.1, 5.9], zoom 8` (Marseille/Riviera) instead of Med-wide zoom 6 |
| 3 | `departure_time must be timezone-aware` | `toTzAware()` appends local UTC offset to naive datetime strings before API call |
| 4 | Can't add multiple waypoints (stale closure) | Use `setWaypoints(prev => ...)` functional updater — always operates on latest state |
| 5 | URL updated on every drag/change | URL now only updated on successful fetch (`doFetch` success handler) |
| 6 | No visual feedback when route is stale | Markers faded to 45% opacity when stale; Recalculer button grows from `py-1.5 text-xs` to `py-3 text-base` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)