### PR TITLE
fix(web): default archetype to cruiser_30ft when missing from URL

### DIFF
--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -205,7 +205,7 @@ export function PlanPage() {
     isParsedOk(initialParsed) ? initialParsed.waypoints : []
   );
   const [archetype, setArchetype] = useState(
-    isParsedOk(initialParsed) ? initialParsed.archetype : ""
+    isParsedOk(initialParsed) && initialParsed.archetype ? initialParsed.archetype : "cruiser_30ft"
   );
   const [departure, setDeparture] = useState(() => {
     const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";


### PR DESCRIPTION
Empty plan URL has no archetype param → empty string → API error. Default to cruiser_30ft.