### PR TITLE
feat(web): aggregate sub-segments by waypoint leg + Heure/Allure/Vent/Vitesse

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTheme } from "../design/theme";
 import type { PassageReport, ComplexityScore, SegmentReport, Archetype } from "./types";
+import { aggregateLegs } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -16,10 +17,6 @@ function fmtTime(iso: string): string {
 }
 
 
-function compassDir(deg: number): string {
-  const dirs = ["N", "NE", "E", "SE", "S", "SO", "O", "NO"];
-  return dirs[Math.round(deg / 45) % 8];
-}
 
 // ── ComplexityBadge ───────────────────────────────────────────────────────────
 
@@ -150,6 +147,7 @@ interface PlanSidebarProps {
   onRefetch: () => void;
   forecastUpdatedAt: string | null;
   waypointCount: number;
+  waypoints: [number, number][];
 }
 
 export function PlanSidebar({
@@ -166,6 +164,7 @@ export function PlanSidebar({
   onRefetch,
   forecastUpdatedAt,
   waypointCount,
+  waypoints,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
   const canCalculate = waypointCount >= 2;
@@ -364,39 +363,47 @@ export function PlanSidebar({
         </div>
       )}
 
-      {/* Legs */}
-      <div>
-        <div className="flex items-center gap-2 mb-1 px-1 text-[9px]" style={{ color: "var(--ow-fg-3)" }}>
-          <span className="w-5 shrink-0" />
-          <span className="flex-1 grid grid-cols-4 gap-1">
-            <span className="text-right">Dist</span>
-            <span className="text-right">TWS</span>
-            <span className="text-right">Dir</span>
-            <span className="text-right">Vit</span>
-          </span>
-        </div>
-        <div className="space-y-1">
-          {passage.segments.map((seg, i) => {
-            const cx = cxLevel(seg.tws_kn);
-            return (
-              <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-bg-2)" }}>
-                <span
-                  className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
-                  style={{ background: CX_COLORS[cx], color: "#fff" }}
-                >
-                  {i + 1}
-                </span>
-                <div className="flex-1 grid grid-cols-4 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
-                  <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{seg.distance_nm.toFixed(1)} nm</span>
-                  <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.tws_kn.toFixed(0)} kn</span>
-                  <span className="text-right" style={{ color: "var(--ow-fg-1)" }}>{compassDir(seg.twd_deg)}</span>
-                  <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{seg.boat_speed_kn.toFixed(1)} kn</span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      {/* Legs — one row per user waypoint segment */}
+      {(() => {
+        const legs = aggregateLegs(passage.segments, waypoints);
+        return (
+          <div>
+            <div className="flex items-center gap-2 mb-1 px-1 text-[9px]" style={{ color: "var(--ow-fg-3)" }}>
+              <span className="w-5 shrink-0" />
+              <span className="flex-1 grid grid-cols-4 gap-1">
+                <span>Heure</span>
+                <span>Allure</span>
+                <span>Vent</span>
+                <span className="text-right">Vitesse</span>
+              </span>
+            </div>
+            <div className="space-y-1">
+              {legs.map((leg, i) => {
+                const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
+                const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
+                  ? `${Math.round(leg.tws_min)} kn`
+                  : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
+                return (
+                  <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-bg-2)" }}>
+                    <span
+                      className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
+                      style={{ background: CX_COLORS[cx], color: "#fff" }}
+                    >
+                      {i + 1}
+                    </span>
+                    <div className="flex-1 grid grid-cols-4 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
+                      <span style={{ color: "var(--ow-fg-1)" }}>{fmtTime(leg.end_time)}</span>
+                      <span style={{ color: "var(--ow-fg-0)" }}>{leg.point_of_sail}</span>
+                      <span style={{ color: "var(--ow-fg-1)" }}>{windLabel}</span>
+                      <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{leg.boat_speed_kn.toFixed(1)} kn</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Footer */}
       {forecastUpdatedAt && (

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -1,0 +1,63 @@
+import type { SegmentReport } from "./types";
+
+export interface AggregatedLeg {
+  distance_nm: number;
+  tws_min: number;
+  tws_max: number;
+  boat_speed_kn: number;
+  end_time: string;
+  point_of_sail: string;
+}
+
+function circularMeanDeg(angles: number[]): number {
+  const s = angles.reduce((sum, a) => sum + Math.sin((a * Math.PI) / 180), 0);
+  const c = angles.reduce((sum, a) => sum + Math.cos((a * Math.PI) / 180), 0);
+  return (((Math.atan2(s, c) * 180) / Math.PI) + 360) % 360;
+}
+
+function twaToPointOfSail(twa: number): string {
+  // twa_deg is signed (-180..180) or unsigned (0..360), normalise to 0-180
+  const a = Math.abs(twa) > 180 ? 360 - Math.abs(twa) : Math.abs(twa);
+  if (a < 50) return "Près";
+  if (a < 90) return "Travers";
+  if (a < 135) return "Largue";
+  return "Arrière";
+}
+
+export function aggregateLegs(
+  segments: SegmentReport[],
+  waypoints: [number, number][],
+): AggregatedLeg[] {
+  if (waypoints.length < 2 || segments.length === 0) return [];
+
+  // For each intermediate waypoint, find the segment index that starts there
+  const legStarts: number[] = [0];
+  for (let w = 1; w < waypoints.length - 1; w++) {
+    const [wlat, wlon] = waypoints[w];
+    let best = legStarts[legStarts.length - 1] + 1;
+    let bestD = Infinity;
+    for (let i = best; i < segments.length; i++) {
+      const d = Math.hypot(segments[i].start.lat - wlat, segments[i].start.lon - wlon);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    legStarts.push(best);
+  }
+  legStarts.push(segments.length);
+
+  return legStarts.slice(0, -1).map((start, li) => {
+    const segs = segments.slice(start, legStarts[li + 1]);
+    const totalDist = segs.reduce((s, seg) => s + seg.distance_nm, 0);
+    const twsVals = segs.map((s) => s.tws_kn);
+    const avgSpeed = segs.reduce((s, seg) => s + seg.boat_speed_kn * seg.distance_nm, 0) / totalDist;
+    const avgTwa = circularMeanDeg(segs.map((s) => s.twa_deg));
+
+    return {
+      distance_nm: totalDist,
+      tws_min: Math.min(...twsVals),
+      tws_max: Math.max(...twsVals),
+      boat_speed_kn: avgSpeed,
+      end_time: segs[segs.length - 1].end_time,
+      point_of_sail: twaToPointOfSail(avgTwa),
+    };
+  });
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
 import type { PassageReport, ComplexityScore, Archetype } from "../plan/types";
 import { cxLevel, CX_COLORS } from "../plan/types";
+import { aggregateLegs } from "../plan/aggregateLegs";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
@@ -36,9 +37,6 @@ function fmtDuration(h: number) {
   const hrs = Math.floor(h);
   const mins = Math.round((h - hrs) * 60);
   return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
-}
-function compassDir(deg: number) {
-  return ["N", "NE", "E", "SE", "S", "SO", "O", "NO"][Math.round(deg / 45) % 8];
 }
 
 function RefetchIcon() {
@@ -77,6 +75,7 @@ function PlanHeroStats({ passage, complexity }: { passage: PassageReport; comple
 function CompactDrawer({
   passage,
   complexity,
+  waypoints,
   isLoading,
   error,
   isStale,
@@ -84,6 +83,7 @@ function CompactDrawer({
 }: {
   passage: PassageReport | null;
   complexity: ComplexityScore | null;
+  waypoints: [number, number][];
   isLoading: boolean;
   error: string | null;
   isStale: boolean;
@@ -105,6 +105,8 @@ function CompactDrawer({
   }
   if (!passage || !complexity) return null;
 
+  const legs = aggregateLegs(passage.segments, waypoints);
+
   return (
     <div>
       {/* Sticky header */}
@@ -113,7 +115,7 @@ function CompactDrawer({
         style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
       >
         <span className="text-xs font-semibold flex-1" style={{ color: "var(--ow-fg-1)" }}>
-          {passage.segments.length} segments · {passage.distance_nm.toFixed(1)} nm
+          {legs.length} tronçon{legs.length > 1 ? "s" : ""} · {passage.distance_nm.toFixed(1)} nm
         </span>
         {isStale && (
           <span className="text-[10px] font-medium shrink-0" style={{ color: "var(--ow-warn)" }}>⚠ Obsolète</span>
@@ -132,10 +134,13 @@ function CompactDrawer({
         </button>
       </div>
 
-      {/* Segment rows */}
+      {/* Leg rows */}
       <div>
-        {passage.segments.map((seg, i) => {
-          const cx = cxLevel(seg.tws_kn);
+        {legs.map((leg, i) => {
+          const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
+          const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
+            ? `${Math.round(leg.tws_min)} kn`
+            : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
           return (
             <div
               key={i}
@@ -149,10 +154,10 @@ function CompactDrawer({
                 {i + 1}
               </span>
               <span className="flex-1 tabular-nums" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
-                {seg.distance_nm.toFixed(1)} nm · {seg.tws_kn.toFixed(0)} kn · {compassDir(seg.twd_deg)}
+                {leg.point_of_sail} · {windLabel} · {leg.boat_speed_kn.toFixed(1)} kn
               </span>
               <span className="tabular-nums shrink-0" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-                {fmtTime(seg.end_time)}
+                {fmtTime(leg.end_time)}
               </span>
             </div>
           );
@@ -384,6 +389,7 @@ export function PlanPage() {
             onRefetch={handleRefetch}
             forecastUpdatedAt={forecastUpdatedAt}
             waypointCount={waypoints.length}
+            waypoints={waypoints}
           />
         </div>
       </div>
@@ -396,6 +402,7 @@ export function PlanPage() {
         <CompactDrawer
           passage={passage}
           complexity={complexity}
+          waypoints={waypoints}
           isLoading={isLoading}
           error={apiError}
           isStale={isStale}


### PR DESCRIPTION
## Summary
- **One row per user-defined leg** (between consecutive waypoints), not one per 10nm sub-segment
- **New columns**: Heure (ETA at waypoint), Allure (Près/Travers/Largue/Arrière from TWA), Vent (min–max kn range), Vitesse (distance-weighted average)
- Allure computed from `twa_deg` (already in SegmentReport) averaged with circular mean across sub-segments
- Wind shown as range `6–8 kn` when min≠max, single value when uniform
- `aggregateLegs.ts` utility shared between desktop sidebar and mobile compact drawer

## Test plan
- [ ] 2 waypoints → 1 row in table
- [ ] 3 waypoints → 2 rows
- [ ] Wind column shows range when conditions vary across the leg
- [ ] Allure column shows correct point of sail (verify with a known upwind/downwind route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)