### PR TITLE
feat(web): click-to-trace waypoints + hover delete badge

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -159,6 +159,60 @@ body {
   animation: emptyPulse 3s ease-in-out infinite;
 }
 
+/* Plan waypoint marker + hover delete badge */
+.ow-wpt {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  font-family: system-ui, sans-serif;
+}
+.ow-wpt-circle {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+}
+.ow-wpt-x {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(20, 20, 22, 0.92);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  pointer-events: auto;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.ow-wpt:hover .ow-wpt-x {
+  opacity: 1;
+}
+.ow-wpt-x:hover {
+  background: #e84118;
+}
+@media (hover: none) {
+  .ow-wpt-x { opacity: 1; }
+}
+
 /* Leaflet attribution smaller on mobile */
 .leaflet-control-attribution {
   font-size: 9px !important;

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -15,20 +15,16 @@ interface PlanMapProps {
   isStale?: boolean;
   onWptMove: (idx: number, lat: number, lon: number) => void;
   onWptAdd?: (afterIdx: number, lat: number, lon: number) => void;
+  onWptDelete?: (idx: number) => void;
   onMapClick?: (lat: number, lon: number) => void;
 }
 
-function waypointIcon(label: string, bg: string): L.DivIcon {
+function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon {
+  const xBtn = deletable
+    ? `<button type="button" class="ow-wpt-x" aria-label="Supprimer ce point">×</button>`
+    : "";
   return L.divIcon({
-    html: `<div style="
-      width:28px;height:28px;border-radius:50%;
-      background:${bg};border:2px solid rgba(255,255,255,0.9);
-      display:flex;align-items:center;justify-content:center;
-      font-size:11px;font-weight:700;color:#fff;
-      box-shadow:0 1px 4px rgba(0,0,0,0.5);
-      cursor:grab;
-      font-family:system-ui,sans-serif;
-      ">${label}</div>`,
+    html: `<div class="ow-wpt"><div class="ow-wpt-circle" style="background:${bg}">${label}</div>${xBtn}</div>`,
     className: "",
     iconSize: [28, 28],
     iconAnchor: [14, 14],
@@ -36,7 +32,7 @@ function waypointIcon(label: string, bg: string): L.DivIcon {
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove, onWptAdd, onMapClick }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -48,10 +44,12 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const isDraggingRef = useRef(false);
   const onWptAddRef = useRef(onWptAdd);
+  const onWptDeleteRef = useRef(onWptDelete);
   const onMapClickRef = useRef(onMapClick);
   const { resolvedTheme } = useTheme();
 
   useEffect(() => { onWptAddRef.current = onWptAdd; }, [onWptAdd]);
+  useEffect(() => { onWptDeleteRef.current = onWptDelete; }, [onWptDelete]);
   useEffect(() => { onMapClickRef.current = onMapClick; }, [onMapClick]);
 
   useImperativeHandle(ref, () => ({
@@ -143,13 +141,30 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
     waypoints.forEach(([lat, lon], i) => {
       const isFirst = i === 0;
-      const isLast = i === waypoints.length - 1;
+      const isLast = i === waypoints.length - 1 && waypoints.length > 1;
       const label = isFirst ? "▶" : isLast ? "■" : String(i);
       const bg = isFirst ? "#2dd4bf" : isLast ? "#e84118" : "#6b7280";
       const marker = L.marker([lat, lon], {
-        icon: waypointIcon(label, bg),
+        icon: waypointIcon(label, bg, !!onWptDelete),
         draggable: true,
       }).addTo(map);
+
+      // Stop marker clicks from bubbling to the map (would re-add a wpt).
+      const el = marker.getElement();
+      if (el) L.DomEvent.disableClickPropagation(el);
+
+      // Wire delete-X button (rendered inside the divIcon)
+      const xBtn = el?.querySelector<HTMLButtonElement>(".ow-wpt-x");
+      if (xBtn) {
+        L.DomEvent.disableClickPropagation(xBtn);
+        L.DomEvent.on(xBtn, "mousedown touchstart pointerdown", (ev) => {
+          L.DomEvent.stop(ev as Event);
+        });
+        L.DomEvent.on(xBtn, "click", (ev) => {
+          L.DomEvent.stop(ev as Event);
+          onWptDeleteRef.current?.(i);
+        });
+      }
 
       marker.on("dragstart", () => {
         isDraggingRef.current = true;

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -274,6 +274,11 @@ export function PlanPage() {
     setIsStale(true);
   }
 
+  function handleWptDelete(idx: number) {
+    setWaypoints((prev) => prev.filter((_, i) => i !== idx));
+    setIsStale(true);
+  }
+
   function handleArchetypeChange(slug: string) {
     setArchetype(slug);
     setIsStale(true);
@@ -349,16 +354,17 @@ export function PlanPage() {
             isStale={isStale}
             onWptMove={handleWptMove}
             onWptAdd={waypoints.length >= 2 ? handleWptAdd : undefined}
-            onMapClick={waypoints.length < 2 ? handleMapClick : undefined}
+            onWptDelete={handleWptDelete}
+            onMapClick={handleMapClick}
           />
-          {/* Hint overlay when adding initial waypoints */}
+          {/* Hint overlay while building the route */}
           {waypoints.length < 2 && (
             <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">
               <div
                 className="px-4 py-2 rounded-xl text-sm font-medium"
                 style={{ background: "var(--ow-surface-glass)", backdropFilter: "blur(8px)", border: "1px solid var(--ow-line-2)", color: "var(--ow-fg-1)" }}
               >
-                {waypoints.length === 0 ? "Cliquez pour placer le départ" : "Cliquez pour placer l'arrivée"}
+                {waypoints.length === 0 ? "Cliquez pour placer le départ" : "Cliquez pour tracer votre route"}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Each map click on `/plan` now appends a waypoint to the end of the route. First click = départ (▶), last becomes arrivée (■) automatically — no more separate "place start, place end" two-shot.
- Hovering a marker reveals a small `×` badge (top-right corner) to remove that waypoint. Always visible on touch devices.
- Polyline mid-segment insertion (click on the line) still works once ≥2 points exist.

## Changes
- `packages/web/src/routes/PlanPage.tsx` — `onMapClick` always active; new `handleWptDelete`; updated hint copy ("Cliquez pour placer le départ" / "Cliquez pour tracer votre route").
- `packages/web/src/plan/PlanMap.tsx` — new `onWptDelete` prop; restructured `waypointIcon` (`.ow-wpt` wrapper + `.ow-wpt-x` button); `disableClickPropagation` on marker el to prevent marker clicks from re-adding a waypoint.
- `packages/web/src/index.css` — `.ow-wpt`, `.ow-wpt-circle`, `.ow-wpt-x` styles with hover/touch behavior.

## Test plan
- [ ] Open `/plan` with empty URL → hint reads "Cliquez pour placer le départ".
- [ ] Click → marker ▶ at clicked point, hint becomes "Cliquez pour tracer votre route".
- [ ] Click again → marker ■ at end, polyline draws between them, hint disappears.
- [ ] Click again → previous ■ becomes a numbered intermediate, new click is now ■.
- [ ] Hover any marker → red `×` appears top-right; click it → that waypoint is removed and isStale flips.
- [ ] Click on the polyline (between two waypoints) → midpoint inserts between them.
- [ ] Drag a marker → no duplicate point added when releasing.
- [ ] Mobile / touch device → `×` badge always visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)