### PR TITLE
fix(web): wind cell sizing on desktop — bigger arrows, smaller speed

### DIFF
--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -47,14 +47,14 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
             <svg
               width="11"
               height="11"
-              className="lg:w-[14px] lg:h-[14px] shrink-0"
+              className="lg:w-[26px] lg:h-[26px] shrink-0"
               viewBox="0 0 16 16"
               style={{ transform: `rotate(${direction + 180}deg)`, transition: "transform 0.3s ease" }}
             >
               <polygon points="8,1 13,15 8,10 3,15" fill="currentColor" />
             </svg>
           )}
-          <span className="text-[17px] lg:text-[21px] font-bold tabular-nums leading-none">
+          <span className="text-[17px] lg:text-[18px] font-bold tabular-nums leading-none">
             {Math.round(speed)}
           </span>
         </div>


### PR DESCRIPTION
## Summary
- Wind table cells on desktop felt off-balance: speed numbers too prominent and arrows too small to read direction at a glance.
- Arrow `lg:` size: 14×14 → 26×26 (≈double, matching the user's ask).
- Speed font `lg:` size: 21px → 18px (a touch smaller).
- Mobile sizes (`text-[17px]` speed, 11×11 arrow) untouched.

## Test plan
- [ ] Open the home/explore wind table on desktop (≥`lg` breakpoint) → arrows clearly readable, speed slightly smaller, gust line unchanged.
- [ ] Resize below `lg` → mobile rendering identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)