### PR TITLE
feat(mcp): multi-window sweep + VMG tacking correction + read_me tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ That's it. No account. No API key. No credit card.
 
 ## What the LLM sees
 
-Five MCP tools, all async, all keyless:
+Four MCP tools, all async, all keyless:
 
 | Tool                      | What it does                                                              |
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `estimate_passage`        | Per-segment timing along a polyline of waypoints.                         |
-| `score_complexity`        | 1–5 difficulty score from wind (and optional max wave height).            |
-| `read_me`                 | Hands the client a self-contained HTML widget for inline rendering.       |
+| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + HTML widget + deep-link, in one call. Optional sweep mode for multi-window departures. |
+| `read_me`                 | Returns OpenWind's calculation methodology — call when the user asks how things are computed. |
 
 The widget switches palette via `prefers-color-scheme` — looks right in light
 and dark hosts, no Claude-specific CSS variables, no vendor lock-in.
@@ -102,6 +101,46 @@ Wind, sea (`Hs` max), per-leg ETA, 1–5 complexity. Tides and currents ignored
 on the Med (negligible). No automatic routing optimisation — the LLM and the
 human stay in the loop. Roadmap and scope decisions live in
 [`plan/`](plan/) (local).
+
+## Calculation method
+
+Defaults below are what the MCP server uses unless overridden by tool parameters.
+Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](packages/data-adapters/src/openwind_data/routing/passage.py).
+
+### Polar speed model
+
+- 5 archetypes (`cruiser_30ft`, `cruiser_40ft`, `cruiser_50ft`, `racer_cruiser`, `catamaran_40ft`), each with an ORC-style polar in [`packages/data-adapters/src/openwind_data/routing/polars/`](packages/data-adapters/src/openwind_data/routing/polars/).
+- Lookup is **bilinear interpolation** in (TWS, TWA), clamped at grid edges.
+- TWA is symmetric — `[0°, 180°]` only, no port/starboard distinction.
+
+### Boat speed adjustments
+
+- **Efficiency factor (default 0.75)** — ORC polars are theoretical maxima. Real cruising loses ~25% (sail trim, comfort margins, helmsman, untracked currents). Override per call: `0.85` racing, `0.75` cruising, `0.65` loaded family cruising, `0.55` heavy seas / fouled hull.
+- **VMG / tacking correction** — when the route's TWA is below the boat's optimal upwind angle (typically ~42-48°), the simulator assumes the sailor tacks. Effective speed toward destination is `polar(optimal_TWA) × cos(optimal_TWA − route_TWA)`. At dead upwind this reduces to `polar(opt) × cos(opt) ≈ polar / √2`; at TWA=20° with opt=45° the reduction is only `cos(25°) ≈ 0.91`.
+- **Wave derate (opt-in)** — `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Disabled by default — sea state feeds the warning bar rather than slowing the boat.
+- **Minimum boat speed** — 0.5 kn floor, prevents division blow-up in extreme stalls.
+
+### Timing
+
+- **Single-pass approximation** — a 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
+- Routes are split into ~10 nm sub-segments by default for per-segment weather sampling. Drop to 5 nm for tight coastal work; raise to 20 nm for long offshore legs.
+
+### Multi-window sweep mode
+
+`plan_passage` accepts an optional `latest_departure` to sweep N hourly departure windows over the same route. Weather is fetched once (cache prewarm), simulations are in-memory. Hard cap: 14 d × 24 h = 336 windows. Returns a list of windows; the LLM (not the server) picks the best option qualitatively.
+
+### Mediterranean defaults
+
+- **Tides ignored** — < 40 cm in the Med, negligible vs. forecast uncertainty.
+- **Currents ignored** — Liguro-Provençal current too weak / variable for V1.
+- **Wind model** — AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → GFS (≤16 d) when the passage extends past AROME.
+- **Wave model** — Open-Meteo Marine (significant Hs, period, direction).
+
+### What's not modelled (V1)
+
+- No automatic routing optimisation — the LLM and human stay in the loop on departure choice.
+- No coastal acceleration zones (capes, peninsulas) — caller adds intermediate waypoints.
+- No port/starboard polar asymmetry, no spinnaker-specific curves, no hull condition modelling beyond the `efficiency` knob.
 
 ## Credits
 

--- a/packages/data-adapters/src/openwind_data/routing/__init__.py
+++ b/packages/data-adapters/src/openwind_data/routing/__init__.py
@@ -21,7 +21,10 @@ from openwind_data.routing.geometry import (
 from openwind_data.routing.passage import (
     PassageReport,
     SegmentReport,
+    _build_conditions_summary,
+    best_vmg_upwind,
     estimate_passage,
+    estimate_passage_windows,
 )
 
 __all__ = [
@@ -32,8 +35,11 @@ __all__ = [
     "Point",
     "Segment",
     "SegmentReport",
+    "_build_conditions_summary",
     "bearing",
+    "best_vmg_upwind",
     "estimate_passage",
+    "estimate_passage_windows",
     "get_polar",
     "haversine_distance",
     "interpolate_great_circle",

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -35,7 +35,7 @@ from openwind_data.adapters.openmeteo import (
     DEFAULT_MODEL,
     OpenMeteoAdapter,
 )
-from openwind_data.routing.archetypes import get_polar, lookup_polar
+from openwind_data.routing.archetypes import BoatPolar, get_polar, lookup_polar
 from openwind_data.routing.geometry import (
     Point,
     midpoint,
@@ -49,6 +49,9 @@ MIN_BOAT_SPEED_KN = 0.5  # floor to avoid division blow-up in extreme stalls
 
 STRONG_WIND_THRESHOLD_KN = 25.0
 LIGHT_WIND_THRESHOLD_KN = 4.0
+
+PREWARM_MIN_SPEED_KN = 2.0  # conservative floor to upper-bound passage duration for cache prewarm
+MAX_SWEEP_WINDOWS = 336  # 14 days x 24h hard cap
 
 # Wave derate — see README "References" section for sources.
 WAVE_DERATE_K = 0.05
@@ -67,6 +70,53 @@ def wave_derate(hs_m: float, twa_deg: float) -> float:
         raise ValueError("hs_m must be >= 0")
     angular_factor = math.cos(math.radians(twa_deg / 2)) ** 2
     return max(WAVE_DERATE_FLOOR, 1.0 - WAVE_DERATE_K * hs_m**WAVE_DERATE_P * angular_factor)
+
+
+def best_vmg_upwind(polar: BoatPolar, tws_kn: float) -> tuple[float, float]:
+    """Return (optimal_twa_deg, polar_speed_kn) that maximises VMG upwind.
+
+    Sweeps TWA in [30, 90] deg to find the angle maximising polar(twa) * cos(twa).
+    Returns the optimal TWA and the polar speed at that angle (not the VMG value
+    itself), so the caller can compute the tacking-geometry correction:
+      effective_speed = polar_speed * cos(optimal_twa - segment_twa)
+    """
+    best_twa, best_speed, best_vmg = 45.0, 0.0, 0.0
+    for twa_int in range(30, 91):
+        twa = float(twa_int)
+        sp = lookup_polar(polar, tws_kn, twa)
+        vmg = sp * math.cos(math.radians(twa))
+        if vmg > best_vmg:
+            best_vmg = vmg
+            best_twa = twa
+            best_speed = sp
+    return best_twa, best_speed
+
+
+def _categorize_twa(twa_deg: float) -> str:
+    if twa_deg < 45.0:
+        return "pres"
+    elif twa_deg < 90.0:
+        return "travers"
+    elif twa_deg < 135.0:
+        return "largue"
+    else:
+        return "portant"
+
+
+def _build_conditions_summary(report: PassageReport) -> dict:
+    tws = [s.tws_kn for s in report.segments]
+    counts: dict[str, int] = {}
+    for s in report.segments:
+        cat = _categorize_twa(s.twa_deg)
+        counts[cat] = counts.get(cat, 0) + 1
+    predominant = max(counts, key=lambda k: counts[k])
+    hs = [s.hs_m for s in report.segments if s.hs_m is not None]
+    return {
+        "tws_min_kn": round(min(tws), 1),
+        "tws_max_kn": round(max(tws), 1),
+        "predominant_sail_angle": predominant,
+        "hs_max_m": round(max(hs), 2) if hs else None,
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,13 +298,21 @@ async def _estimate_with_model(
         wp = _closest_wind_point(wind_series.points, mid_time)
         twa = normalize_twa(twd=wp.direction_deg, course=seg.bearing_deg)
         polar_speed = lookup_polar(polar, wp.speed_kn, twa)
+        opt_twa, opt_polar_speed = best_vmg_upwind(polar, wp.speed_kn)
+        if twa < opt_twa:
+            # Sailor tacks at optimal VMG angle; effective speed toward destination:
+            #   v_eff = polar(opt) * cos(opt - twa)
+            # At twa=0 reduces to VMG_pure_upwind; at twa->opt transitions smoothly.
+            effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
+        else:
+            effective_polar = polar_speed
         hs_m: float | None = None
         derate = 1.0
         if use_wave_correction:
             hs_m = _closest_sea_hs(bundle.sea.points, mid_time)
             if hs_m is not None:
                 derate = wave_derate(hs_m, twa)
-        boat_speed = max(polar_speed * efficiency * derate, MIN_BOAT_SPEED_KN)
+        boat_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
         seg_duration = timedelta(hours=seg.distance_nm / boat_speed)
         seg_start = departure_utc + cumulative_actual
         seg_end = seg_start + seg_duration
@@ -299,3 +357,109 @@ async def _estimate_with_model(
         segments=tuple(reports),
         warnings=tuple(warnings),
     )
+
+
+async def estimate_passage_windows(
+    waypoints: list[Point],
+    earliest_departure: datetime,
+    latest_departure: datetime,
+    boat_archetype: str,
+    *,
+    sweep_interval_hours: int = 1,
+    efficiency: float = 0.75,
+    segment_length_nm: float = 10.0,
+    adapter: MarineDataAdapter | None = None,
+    model: str = AUTO_MODEL,
+    use_wave_correction: bool = False,
+) -> list[PassageReport]:
+    """Simulate multiple departure windows for a fixed route.
+
+    Fetches weather data once (prewarm) then sweeps over departure times from
+    ``earliest_departure`` to ``latest_departure`` every ``sweep_interval_hours``,
+    returning one ``PassageReport`` per window. All simulations after the first
+    are cache hits — API cost is identical to a single ``estimate_passage`` call.
+
+    Args:
+        waypoints: ordered route waypoints (>=2 points).
+        earliest_departure: start of sweep window (timezone-aware).
+        latest_departure: end of sweep window (timezone-aware, inclusive).
+        boat_archetype: one of the registry names (see ``list_archetypes()``).
+        sweep_interval_hours: spacing between departure windows (default 1h).
+        efficiency: multiplier on polar speeds (see ``estimate_passage``).
+        segment_length_nm: sub-segment length for weather sampling.
+        adapter: any ``MarineDataAdapter`` (defaults to a fresh ``OpenMeteoAdapter``).
+        model: wind model; ``"auto"`` tries AROME → ICON → GFS in order.
+        use_wave_correction: if True, apply wave derate to each segment.
+
+    Raises:
+        ValueError: if datetimes are naive, earliest > latest, interval < 1, or
+            the sweep would exceed ``MAX_SWEEP_WINDOWS`` windows.
+        ForecastHorizonError: if no model covers the full sweep horizon.
+    """
+    if earliest_departure.tzinfo is None or latest_departure.tzinfo is None:
+        raise ValueError("earliest_departure and latest_departure must be timezone-aware")
+    if earliest_departure > latest_departure:
+        raise ValueError("earliest_departure must be <= latest_departure")
+    if sweep_interval_hours < 1:
+        raise ValueError("sweep_interval_hours must be >= 1")
+
+    earliest_utc = earliest_departure.astimezone(UTC)
+    latest_utc = latest_departure.astimezone(UTC)
+
+    n_windows = int((latest_utc - earliest_utc).total_seconds() / 3600 / sweep_interval_hours) + 1
+    if n_windows > MAX_SWEEP_WINDOWS:
+        raise ValueError(
+            f"sweep would produce {n_windows} windows, exceeding the {MAX_SWEEP_WINDOWS} cap "
+            f"(14 d x 24 h). Reduce the sweep range or increase sweep_interval_hours."
+        )
+
+    segments = segment_route(waypoints, segment_length_nm)
+    seg_mid_points = [midpoint(s.start, s.end) for s in segments]
+    route_nm = sum(s.distance_nm for s in segments)
+
+    own_adapter = adapter is None
+    fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
+    try:
+        # Simulate the first window to resolve the model (needed before prewarm).
+        first = await estimate_passage(
+            waypoints,
+            earliest_utc,
+            boat_archetype,
+            efficiency=efficiency,
+            segment_length_nm=segment_length_nm,
+            adapter=fetch_adapter,
+            model=model,
+            use_wave_correction=use_wave_correction,
+        )
+        resolved_model = first.model
+        reports: list[PassageReport] = [first]
+
+        # Prewarm cache for the entire sweep horizon so all remaining calls are hits.
+        prewarm_end = latest_utc + timedelta(hours=route_nm / PREWARM_MIN_SPEED_KN) + WIND_FETCH_WINDOW
+        await asyncio.gather(
+            *[
+                fetch_adapter.fetch(pt.lat, pt.lon, earliest_utc, prewarm_end, models=[resolved_model])
+                for pt in seg_mid_points
+            ]
+        )
+
+        # Sweep remaining departure windows sequentially (all cache hits, no I/O).
+        current = earliest_utc + timedelta(hours=sweep_interval_hours)
+        while current <= latest_utc:
+            report = await estimate_passage(
+                waypoints,
+                current,
+                boat_archetype,
+                efficiency=efficiency,
+                segment_length_nm=segment_length_nm,
+                adapter=fetch_adapter,
+                model=resolved_model,
+                use_wave_correction=use_wave_correction,
+            )
+            reports.append(report)
+            current += timedelta(hours=sweep_interval_hours)
+    finally:
+        if own_adapter and hasattr(fetch_adapter, "aclose"):
+            await fetch_adapter.aclose()  # pragma: no cover
+
+    return reports

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 
@@ -17,8 +18,11 @@ from openwind_data.routing.archetypes import get_polar, lookup_polar
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import (
     LIGHT_WIND_THRESHOLD_KN,
+    MAX_SWEEP_WINDOWS,
     STRONG_WIND_THRESHOLD_KN,
+    best_vmg_upwind,
     estimate_passage,
+    estimate_passage_windows,
     wave_derate,
 )
 
@@ -410,3 +414,203 @@ class TestModelFallback:
                 segment_length_nm=10.0,
             )
         assert excinfo.value.model == "gfs_seamless"
+
+
+class TestBestVmgUpwind:
+    def test_returns_positive_vmg_speed(self) -> None:
+        polar = get_polar("cruiser_40ft")
+        opt_twa, opt_speed = best_vmg_upwind(polar, 12.0)
+        assert opt_twa > 0.0
+        assert opt_speed > 0.0
+
+    def test_optimal_twa_in_upwind_range(self) -> None:
+        polar = get_polar("cruiser_40ft")
+        opt_twa, _ = best_vmg_upwind(polar, 12.0)
+        assert 30.0 <= opt_twa <= 90.0
+
+    def test_all_archetypes_return_positive(self) -> None:
+        from openwind_data.routing.archetypes import list_archetypes
+        for archetype in list_archetypes():
+            opt_twa, opt_speed = best_vmg_upwind(archetype, 10.0)
+            assert opt_speed > 0.0, f"{archetype.name} returned zero speed"
+
+    def test_light_wind_still_positive(self) -> None:
+        polar = get_polar("cruiser_30ft")
+        opt_twa, opt_speed = best_vmg_upwind(polar, 3.0)
+        assert opt_speed > 0.0
+
+
+class TestVmgUpwindCorrection:
+    async def test_upwind_correction_gives_correct_vmg(self) -> None:
+        # Dead upwind (TWA=0°): effective speed = polar(opt_twa) × cos(opt_twa).
+        # This is the real VMG toward destination when tacking — always less than
+        # polar(opt_twa) itself, and less than the clamped polar at 0° (which
+        # lookup_polar returns as the first-column value, an inaccurate shortcut).
+        polar = get_polar("cruiser_40ft")
+        tws = 12.0
+        opt_twa, opt_speed = best_vmg_upwind(polar, tws)
+        vmg_effective = opt_speed * math.cos(math.radians(opt_twa))  # twa=0°
+        # Must be positive and strictly less than the uncorrected polar at opt_twa.
+        assert vmg_effective > 0.0
+        assert vmg_effective < opt_speed
+        # Also less than beam-reach speed (physically expected: upwind is slower).
+        beam_speed = lookup_polar(polar, tws, 90.0)
+        assert vmg_effective < beam_speed
+
+    async def test_partial_upwind_less_penalty_than_dead_upwind(self) -> None:
+        # TWA=20° → cos(opt-20°) is larger than cos(opt-0°) → less speed reduction.
+        polar = get_polar("cruiser_40ft")
+        tws = 12.0
+        opt_twa, opt_speed = best_vmg_upwind(polar, tws)
+        # Both are upwind (< opt_twa assumed > 20°)
+        assert opt_twa > 20.0, "test premise: optimal twa must be >20° for this archetype"
+        eff_0 = opt_speed * math.cos(math.radians(opt_twa - 0.0))
+        eff_20 = opt_speed * math.cos(math.radians(opt_twa - 20.0))
+        assert eff_20 > eff_0
+
+    async def test_smooth_transition_at_optimal_angle(self) -> None:
+        # At twa == opt_twa: cos(0) = 1 → effective_polar = opt_speed = lookup(polar, tws, opt_twa)
+        polar = get_polar("cruiser_40ft")
+        tws = 12.0
+        opt_twa, opt_speed = best_vmg_upwind(polar, tws)
+        effective = opt_speed * math.cos(math.radians(opt_twa - opt_twa))
+        assert effective == pytest.approx(opt_speed, rel=1e-9)
+
+    async def test_beam_reach_unchanged(self) -> None:
+        # TWA=90° equals opt_twa threshold boundary or above → use direct polar.
+        # Simulate: wind from west (270°), route northward (bearing≈0°).
+        # normalize_twa(twd=270, course=0) → |270-0| normalized → 90°
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=270.0)
+        report = await estimate_passage(
+            [Point(43.0, 5.0), Point(44.0, 5.0)],  # northward
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        polar = get_polar("cruiser_40ft")
+        for seg in report.segments:
+            # At TWA=90°, no VMG correction should be applied.
+            expected = lookup_polar(polar, seg.tws_kn, seg.twa_deg)
+            assert seg.polar_speed_kn == pytest.approx(expected, rel=1e-9)
+
+    async def test_downwind_route_unchanged(self) -> None:
+        # TWD=270 (wind from west), route westward (bearing≈270°) → TWA=180°.
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=270.0)
+        report = await estimate_passage(
+            [Point(43.0, 6.0), Point(43.0, 5.0)],  # westward
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        polar = get_polar("cruiser_40ft")
+        for seg in report.segments:
+            expected = lookup_polar(polar, seg.tws_kn, seg.twa_deg)
+            assert seg.polar_speed_kn == pytest.approx(expected, rel=1e-9)
+
+
+class TestEstimatePassageWindows:
+    async def test_returns_correct_window_count_exact(self) -> None:
+        # 6h sweep at 1h → 7 windows (06:00, 07:00, ..., 12:00)
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES],
+            earliest,
+            latest,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        assert len(reports) == 7
+
+    async def test_returns_correct_window_count_interval(self) -> None:
+        # 6h sweep at 2h → 4 windows (06:00, 08:00, 10:00, 12:00)
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES],
+            earliest,
+            latest,
+            "cruiser_40ft",
+            sweep_interval_hours=2,
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        assert len(reports) == 4
+
+    async def test_each_window_departure_is_correct(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 8, 0, tzinfo=UTC)
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES],
+            earliest,
+            latest,
+            "cruiser_40ft",
+            sweep_interval_hours=1,
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        assert len(reports) == 3
+        assert reports[0].departure_time == earliest
+        assert reports[1].departure_time == earliest + timedelta(hours=1)
+        assert reports[2].departure_time == earliest + timedelta(hours=2)
+
+    async def test_single_window_when_equal(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        t = datetime(2026, 5, 1, 8, 0, tzinfo=UTC)
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES], t, t, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        assert len(reports) == 1
+        assert reports[0].departure_time == t
+
+    async def test_window_cap_raises(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+        latest = earliest + timedelta(days=15)  # 360 windows > 336 cap
+        with pytest.raises(ValueError, match=str(MAX_SWEEP_WINDOWS)):
+            await estimate_passage_windows(
+                [MARSEILLE, PORQUEROLLES], earliest, latest, "cruiser_40ft",
+                adapter=adapter,
+            )
+
+    async def test_naive_departure_rejected(self) -> None:
+        adapter = StubAdapter()
+        with pytest.raises(ValueError, match="timezone-aware"):
+            await estimate_passage_windows(
+                [MARSEILLE, PORQUEROLLES],
+                datetime(2026, 5, 1, 6, 0),  # naive
+                datetime(2026, 5, 1, 8, 0, tzinfo=UTC),
+                "cruiser_40ft",
+                adapter=adapter,
+            )
+
+    async def test_latest_before_earliest_rejected(self) -> None:
+        adapter = StubAdapter()
+        earliest = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        with pytest.raises(ValueError):
+            await estimate_passage_windows(
+                [MARSEILLE, PORQUEROLLES], earliest, latest, "cruiser_40ft",
+                adapter=adapter,
+            )
+
+    async def test_all_windows_are_passagereports(self) -> None:
+        from openwind_data.routing.passage import PassageReport
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 8, 0, tzinfo=UTC)
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES], earliest, latest, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        for r in reports:
+            assert isinstance(r, PassageReport)
+            assert r.duration_h > 0
+            assert r.distance_nm > 0

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -4,8 +4,8 @@ Cloud-agnostic FastMCP server for OpenWind. Exposes 4 tools:
 
 - `list_boat_archetypes` — descriptive list, no server-side mapping
 - `get_marine_forecast` — wind + sea around a point/window
-- `estimate_passage` — per-segment timing along a polyline
-- `score_complexity` — 1-5 difficulty score
+- `plan_passage` — end-to-end timing + complexity + HTML widget + deep-link, optional multi-window sweep
+- `read_me` — calculation methodology (polars, efficiency, VMG, defaults)
 
 `build_server()` is the single factory; no Gradio, no `huggingface_hub`. The
 HF Spaces wrapper (Sprint 4) and any future deployment use the same factory.
@@ -65,7 +65,7 @@ asyncio.run(main())
 Expected output:
 
 ```
-['list_boat_archetypes', 'get_marine_forecast', 'estimate_passage', 'score_complexity']
+['read_me', 'list_boat_archetypes', 'get_marine_forecast', 'plan_passage']
 ```
 
 ### Smoke conversation prompt
@@ -75,9 +75,10 @@ Once wired, ask the client something like:
 > Je pars demain matin de Marseille pour Porquerolles avec un Sun Odyssey 36.
 > Bonne idée ? Tu as combien de temps de route et quelle complexité ?
 
-The client should call `list_boat_archetypes` (to map → `cruiser_40ft`),
-`get_marine_forecast` for one or more points, then `estimate_passage`,
-then `score_complexity`, and narrate the result.
+The client should call `list_boat_archetypes` (to map → `cruiser_40ft`)
+then `plan_passage` once with the waypoints, departure, and chosen archetype.
+The single response includes timing, complexity, a rendered HTML widget,
+and a deep-link to openwind.fr.
 
 > First request after inactivity may incur ~5s of cold-start once deployed
 > on HF Spaces. Local stdio has no cold-start.
@@ -90,3 +91,19 @@ uv run pytest -q
 
 Six tests cover the factory, tool registration, and the four tool surfaces
 against a stub adapter.
+
+## Calculation method
+
+The simulation engine lives in `openwind_data.routing.passage`. Defaults below are what `plan_passage` uses unless overridden.
+
+- **Polar lookup** — 5 ORC-style archetypes, bilinear interpolation in (TWS, TWA), clamped at grid edges. TWA symmetric on [0°, 180°].
+- **Efficiency 0.75** by default (cruising). Override via the `efficiency` arg: `0.85` racing, `0.65` loaded family, `0.55` heavy seas / fouled hull.
+- **VMG / tacking correction** — when route TWA < optimal upwind angle (~42-48°), effective speed = `polar(opt_TWA) × cos(opt_TWA − route_TWA)`. Models a sailor who tacks instead of pinching.
+- **Wave derate** — opt-in via `use_wave_correction`: `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Off by default; sea state feeds warnings instead.
+- **Single-pass timing** — heuristic 6 kn → segment mid-times → real polar at each mid-time's wind. No convergence iteration.
+- **Sub-segments** — routes split into ~10 nm chunks for weather sampling.
+- **Multi-window sweep** — `plan_passage(latest_departure=...)` runs N hourly simulations from the same fetched weather; cap 14 d × 24 h = 336 windows.
+- **Default model** — AROME 1.3 km (Med thermals); auto-falls back to ICON-EU → GFS for longer horizons.
+- **Mediterranean simplifications** — tides and currents ignored (negligible in V1).
+
+Full rationale and references in the [main README's calculation section](../../README.md#calculation-method).

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -32,7 +32,7 @@ Typical orchestration pattern (LLM perspective):
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -40,10 +40,14 @@ from openwind_data.adapters.base import MarineDataAdapter
 from openwind_data.adapters.openmeteo import AUTO_MODEL, OpenMeteoAdapter
 from openwind_data.routing import (
     Point,
+    _build_conditions_summary,
     list_archetypes,
 )
 from openwind_data.routing import (
     estimate_passage as _estimate_passage,
+)
+from openwind_data.routing import (
+    estimate_passage_windows as _estimate_passage_windows,
 )
 from openwind_data.routing import (
     score_complexity as _score_complexity,
@@ -74,6 +78,90 @@ def _passage_to_dict(report: Any) -> dict[str, Any]:
     return d
 
 
+_METHODOLOGY = """\
+# OpenWind — Calculation method
+
+How `plan_passage` simulates a passage. Defaults below are what the server
+uses unless overridden by tool parameters.
+
+## Polar speed model
+
+- 5 ORC-style archetypes (cruiser_30ft / cruiser_40ft / cruiser_50ft /
+  racer_cruiser / catamaran_40ft).
+- Lookup is bilinear interpolation in (TWS, TWA), clamped at grid edges.
+- TWA symmetric on [0, 180] only (no port/starboard distinction).
+
+## Boat speed adjustments
+
+- Efficiency factor (default 0.75): ORC polars are theoretical maxima;
+  real cruising loses ~25% (sail trim, comfort margins, helm, untracked
+  currents). Override per call: 0.85 racing, 0.65 loaded family cruising,
+  0.55 heavy seas / fouled hull.
+
+- VMG / tacking correction: when route TWA is below the boat's optimal
+  upwind angle (typically ~42-48 deg), the simulator assumes the sailor
+  tacks at the optimal VMG angle. Effective speed toward destination =
+  polar(opt_TWA) * cos(opt_TWA - route_TWA). At dead upwind this reduces
+  to polar(opt) * cos(opt) ~= polar / sqrt(2). At route_TWA=20 deg with
+  opt=45 deg, the reduction is only cos(25 deg) ~= 0.91 (much less penalty).
+
+- Wave derate (opt-in): max(0.5, 1 - 0.05 * Hs^1.75 * cos^2(TWA/2)).
+  Off by default; sea state feeds the warning bar instead of slowing.
+
+- Minimum boat speed: 0.5 kn floor to avoid blow-up in extreme stalls.
+
+## Timing
+
+- Single-pass approximation: a 6 kn heuristic estimates segment mid-times,
+  then real polar speeds are computed at each mid-time's actual wind. No
+  convergence iteration. Bias bounded by Mediterranean wind correlation.
+- Routes split into ~10 nm sub-segments by default for weather sampling.
+
+## Multi-window sweep mode
+
+`plan_passage` accepts an optional `latest_departure` to sweep N hourly
+departure windows over the same route. Weather is fetched once (cache
+prewarm), simulations are in-memory. Hard cap: 14 d x 24 h = 336 windows.
+Returns a list of windows; the LLM picks qualitatively (no server-side
+ranking).
+
+## Mediterranean defaults
+
+- Tides ignored (< 40 cm, negligible vs forecast uncertainty).
+- Currents ignored (Liguro-Provencal too weak / variable for V1).
+- Wind model: AROME 1.3 km (<= 48 h horizon, captures thermals and local
+  winds). Auto-falls back to ICON-EU (<= 5 d) -> GFS (<= 16 d).
+- Wave model: Open-Meteo Marine (significant Hs, period, direction).
+
+## What is NOT modelled (V1)
+
+- No automatic routing optimisation (LLM + human choose).
+- No coastal acceleration zones (caller adds intermediate waypoints).
+- No port/starboard polar asymmetry, no spinnaker-specific curves.
+- No hull condition modelling beyond the `efficiency` knob.
+"""
+
+
+def _build_window_dict(report: Any, score: Any, waypoints_raw: list[dict[str, float]]) -> dict[str, Any]:
+    dep_iso = report.departure_time.isoformat()
+    warnings = list(report.warnings) + [w.message for w in score.warnings]
+    return {
+        "departure": dep_iso,
+        "arrival": report.arrival_time.isoformat(),
+        "duration_h": round(report.duration_h, 2),
+        "distance_nm": round(report.distance_nm, 1),
+        "complexity": {
+            "level": score.level,
+            "label": score.label,
+            "tws_max_kn": round(score.tws_max_kn, 1),
+            "rationale": score.rationale,
+        },
+        "conditions_summary": _build_conditions_summary(report),
+        "warnings": warnings,
+        "openwind_url": build_openwind_url(waypoints_raw, dep_iso, report.archetype),
+    }
+
+
 def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
     """Build a FastMCP server with all OpenWind tools registered.
 
@@ -83,6 +171,21 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
     """
     server: FastMCP = FastMCP("openwind")
     fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
+
+    @server.tool()
+    def read_me() -> str:
+        """Return OpenWind's calculation methodology as Markdown.
+
+        Call this when the user asks how passage timing, complexity, or
+        boat speed are computed (e.g. "comment c'est calculé ?",
+        "what assumptions does the model use?", "is tacking modelled?").
+
+        The returned text covers: polar lookup, default efficiency 0.75,
+        VMG / tacking correction, wave derate, single-pass timing,
+        multi-window sweep semantics, Mediterranean simplifications
+        (tides, currents), and what is intentionally NOT modelled in V1.
+        """
+        return _METHODOLOGY
 
     @server.tool()
     def list_boat_archetypes() -> list[dict[str, Any]]:
@@ -158,6 +261,9 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         leg_titles: list[str] | None = None,
         locale: str = "fr",
         timezone: str = "Europe/Paris",
+        latest_departure: str | None = None,
+        sweep_interval_hours: int = 1,
+        target_eta: str | None = None,
     ) -> dict[str, Any]:
         """Plan an A→B passage end-to-end: timing + complexity + widget + deep-link.
 
@@ -219,6 +325,23 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
             timezone: IANA tz for time display in the widget (default
                 ``"Europe/Paris"``).
 
+        ## Sweep mode (latest_departure set)
+
+        When ``latest_departure`` is provided, the tool sweeps departure times
+        from ``departure`` to ``latest_departure`` every ``sweep_interval_hours``
+        (default 1 h). Returns ``{"mode": "multi_window", "sweep": {...},
+        "windows": [...]}`` instead of the single-passage payload. Each window
+        contains ``departure``, ``arrival``, ``duration_h``, ``distance_nm``,
+        ``complexity``, ``conditions_summary``, ``warnings``, and its own
+        ``openwind_url``. HTML is never rendered in sweep mode — the LLM reasons
+        qualitatively over the windows and presents 2-3 options; the user picks
+        one; the LLM then calls ``plan_passage`` once more with that specific
+        departure to get the rendered widget.
+
+        ``target_eta``: optional ISO-8601 datetime. When set, only windows that
+        arrive within ±2 h of the target are returned. If none match, all windows
+        are returned with a ``meta_warnings`` note.
+
         ## Failure modes
 
         Raises ``ForecastHorizonError`` if the chosen model's horizon doesn't
@@ -228,6 +351,52 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         pts = [Point(w["lat"], w["lon"]) for w in waypoints]
         dep = datetime.fromisoformat(departure)
 
+        # --- SWEEP MODE ---
+        if latest_departure is not None:
+            latest_dep = datetime.fromisoformat(latest_departure)
+            reports = await _estimate_passage_windows(
+                pts,
+                dep,
+                latest_dep,
+                archetype,
+                sweep_interval_hours=sweep_interval_hours,
+                efficiency=efficiency,
+                segment_length_nm=segment_length_nm,
+                adapter=fetch_adapter,
+                model=model,
+            )
+            windows = [_build_window_dict(r, _score_complexity(r, max_hs_m=max_hs_m), waypoints) for r in reports]
+
+            meta_warnings: list[str] = []
+            if target_eta is not None:
+                target_utc = datetime.fromisoformat(target_eta).astimezone(UTC)
+                tolerance = timedelta(hours=2)
+                filtered = [
+                    w for w in windows
+                    if abs((datetime.fromisoformat(w["arrival"]) - target_utc).total_seconds())
+                    <= tolerance.total_seconds()
+                ]
+                if not filtered:
+                    meta_warnings.append(
+                        f"aucune fenêtre n'arrive dans ±2h de target_eta={target_eta} ; "
+                        f"toutes les {len(windows)} fenêtres retournées"
+                    )
+                else:
+                    windows = filtered
+
+            return {
+                "mode": "multi_window",
+                "sweep": {
+                    "earliest": dep.isoformat(),
+                    "latest": latest_dep.isoformat(),
+                    "interval_hours": sweep_interval_hours,
+                    "window_count": len(windows),
+                },
+                "windows": windows,
+                "meta_warnings": meta_warnings,
+            }
+
+        # --- SINGLE MODE (unchanged) ---
         report = await _estimate_passage(
             pts,
             dep,

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -70,16 +70,29 @@ class TestBuildServer:
         server = build_server(adapter=StubAdapter())
         assert isinstance(server, FastMCP)
 
-    async def test_lists_three_tools(self) -> None:
-        # The collapsed surface — anything that drifts here is a regression.
+    async def test_lists_four_tools(self) -> None:
+        # The V1 surface: 3 functional tools + read_me for methodology Q&A.
         server = build_server(adapter=StubAdapter())
         tools = await server.list_tools()
         names = {t.name for t in tools}
         assert names == {
+            "read_me",
             "list_boat_archetypes",
             "get_marine_forecast",
             "plan_passage",
         }
+
+
+class TestReadMe:
+    async def test_returns_methodology_string(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "read_me", {})
+        text = out["result"] if isinstance(out, dict) and "result" in out else out
+        assert isinstance(text, str)
+        assert len(text) > 500  # substantive content
+        # Mentions key methodology keywords
+        for keyword in ["polar", "VMG", "efficiency", "AROME"]:
+            assert keyword in text, f"missing keyword: {keyword}"
 
 
 class TestListArchetypes:
@@ -194,6 +207,103 @@ class TestPlanPassage:
         server = build_server(adapter=StubAdapter())
         out = await _call(server, "plan_passage", _BASE_PLAN_ARGS)
         assert out["passage"]["model"] == "meteofrance_arome_france"
+
+
+_SWEEP_ARGS: dict = {
+    **_BASE_PLAN_ARGS,
+    "latest_departure": datetime(2026, 5, 1, 9, 0, tzinfo=UTC).isoformat(),
+    "sweep_interval_hours": 3,
+}
+
+
+class TestPlanPassageSweep:
+    async def test_sweep_returns_multi_window_mode(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        assert out["mode"] == "multi_window"
+        assert "sweep" in out
+        assert "windows" in out
+
+    async def test_sweep_window_count_matches_interval(self) -> None:
+        # departure 06:00, latest 09:00, interval 3h → 2 windows: 06:00, 09:00
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        assert out["sweep"]["window_count"] == 2
+        assert len(out["windows"]) == 2
+
+    async def test_sweep_window_shape(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        w = out["windows"][0]
+        assert {"departure", "arrival", "duration_h", "distance_nm", "complexity",
+                "conditions_summary", "warnings", "openwind_url"} <= w.keys()
+        assert 1 <= w["complexity"]["level"] <= 5
+        cs = w["conditions_summary"]
+        assert {"tws_min_kn", "tws_max_kn", "predominant_sail_angle", "hs_max_m"} <= cs.keys()
+        assert cs["predominant_sail_angle"] in ("pres", "travers", "largue", "portant")
+
+    async def test_html_never_rendered_in_sweep(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", {**_SWEEP_ARGS, "render": True})
+        assert "html" not in out
+        for w in out["windows"]:
+            assert "html" not in w
+
+    async def test_each_window_has_openwind_url(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        for w in out["windows"]:
+            assert w["openwind_url"].startswith("https://openwind.fr/plan?")
+            assert "wpts=" in w["openwind_url"]
+
+    async def test_sweep_departures_ordered_and_spaced(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        args = {**_BASE_PLAN_ARGS,
+                "latest_departure": datetime(2026, 5, 1, 8, 0, tzinfo=UTC).isoformat(),
+                "sweep_interval_hours": 1}
+        out = await _call(server, "plan_passage", args)
+        windows = out["windows"]
+        assert len(windows) == 3  # 06:00, 07:00, 08:00
+        deps = [datetime.fromisoformat(w["departure"]) for w in windows]
+        for i in range(1, len(deps)):
+            delta_h = (deps[i] - deps[i - 1]).total_seconds() / 3600
+            assert abs(delta_h - 1.0) < 1e-9
+
+    async def test_single_mode_backward_compatible(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _BASE_PLAN_ARGS)
+        assert {"passage", "complexity", "html", "openwind_url"} <= out.keys()
+        assert "mode" not in out
+
+    async def test_target_eta_filters_windows(self) -> None:
+        # With constant 12 kn from north, passage ~8h → arrival ~14:00 from 06:00
+        # Requesting latest=12:00 at interval 3h → windows at 06:00, 09:00, 12:00
+        # target_eta near 14:00 should keep 06:00 window (arrival closest to 14h)
+        server = build_server(adapter=StubAdapter())
+        args = {
+            **_BASE_PLAN_ARGS,
+            "latest_departure": datetime(2026, 5, 1, 12, 0, tzinfo=UTC).isoformat(),
+            "sweep_interval_hours": 3,
+            "target_eta": datetime(2026, 5, 1, 14, 0, tzinfo=UTC).isoformat(),
+        }
+        out = await _call(server, "plan_passage", args)
+        assert "windows" in out
+        # At least one window was evaluated
+        assert len(out["windows"]) >= 1
+
+    async def test_sweep_cap_exceeded_raises(self) -> None:
+        import pytest
+        server = build_server(adapter=StubAdapter())
+        args = {
+            **_BASE_PLAN_ARGS,
+            "latest_departure": datetime(2026, 5, 20, 0, 0, tzinfo=UTC).isoformat(),
+            "sweep_interval_hours": 1,
+        }
+        try:
+            await _call(server, "plan_passage", args)
+            assert False, "expected an exception for oversized sweep"
+        except Exception as exc:
+            assert "336" in str(exc) or "cap" in str(exc).lower() or "windows" in str(exc).lower()
 
 
 class TestGetMarineForecast:


### PR DESCRIPTION
## Summary

Three related improvements to the passage planning engine and MCP tool surface:

- **VMG / tacking correction** in `estimate_passage`: when a segment's TWA is below the boat's optimal upwind angle, use `polar(opt_TWA) × cos(opt_TWA − segment_TWA)` as the effective speed toward destination. Models a sailor who tacks rather than pinching. Smooth transition at the boundary (cos(0°)=1).
- **Multi-window sweep mode** for `plan_passage`: optional `latest_departure` + `sweep_interval_hours` triggers a sweep returning N simulated windows. Cache prewarm makes API cost = 1 regular `plan_passage` call regardless of N. Each window includes `conditions_summary` + `complexity` + its own `openwind_url`. No server-side ranking — LLM picks qualitatively. Optional `target_eta` filter (±2h tolerance).
- **`read_me` MCP tool**: returns OpenWind's calculation methodology as Markdown so the LLM can answer "comment c'est calculé ?" without guessing about polars, efficiency, VMG, or Mediterranean defaults. Surface goes from 3 → 4 tools.

Calculation method section also added to root and `packages/mcp-core/` READMEs.

## Why now

Smoke-tested by 5 simulated user personas via the deployed MCP. Three of the four common complaints across personas map directly to these features:
- "ETA optimiste, le calcul ignore le tirage de bords" → VMG fix
- "Quel est le meilleur jour cette semaine ? → 6 appels MCP, lourd" → sweep mode
- "Méthodologie opaque, verdict confiance: faible" → read_me tool

## Backward compatibility

`plan_passage(...)` without `latest_departure` is unchanged. The single-mode test suite passes intact. Sweep mode is purely additive.

## Test plan

- [x] `cd packages/data-adapters && uv run pytest tests/test_passage.py -q` (39 passed)
- [x] `cd packages/mcp-core && uv run pytest tests/test_server.py -q` (23 passed)
- [x] `uv run ruff check` on both packages — clean
- [ ] Live MCP smoke after merge + redeploy: Marseille → Porquerolles single-mode (regression), then sweep over 24h to validate the new path against real Open-Meteo data

## Out of scope (separate issues to file)

Production bugs surfaced by smoke tests but unrelated to this PR:
- `hs_m: null` returned by deployed MCP across multiple routes (Marine API integration)
- `model="auto"` propagates raw HTTP 400 when departure is beyond all model horizons (J+11)
- Timezone divergence between widget href and `openwind_url` at root

🤖 Generated with [Claude Code](https://claude.com/claude-code)