### PR TITLE
fix(mcp): always surface Hs + add sea-state warnings

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -49,6 +49,8 @@ MIN_BOAT_SPEED_KN = 0.5  # floor to avoid division blow-up in extreme stalls
 
 STRONG_WIND_THRESHOLD_KN = 25.0
 LIGHT_WIND_THRESHOLD_KN = 4.0
+MODERATE_SEA_HS_M = 1.5  # >= 1.5m: "mer formee" warning
+ROUGH_SEA_HS_M = 2.5     # >= 2.5m: "forte mer" warning
 
 PREWARM_MIN_SPEED_KN = 2.0  # conservative floor to upper-bound passage duration for cache prewarm
 MAX_SWEEP_WINDOWS = 336  # 14 days x 24h hard cap
@@ -306,12 +308,12 @@ async def _estimate_with_model(
             effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
         else:
             effective_polar = polar_speed
-        hs_m: float | None = None
+        # Always surface Hs from the bundle so callers see sea state, even if
+        # wave correction is off. Derate only applies when explicitly requested.
+        hs_m = _closest_sea_hs(bundle.sea.points, mid_time)
         derate = 1.0
-        if use_wave_correction:
-            hs_m = _closest_sea_hs(bundle.sea.points, mid_time)
-            if hs_m is not None:
-                derate = wave_derate(hs_m, twa)
+        if use_wave_correction and hs_m is not None:
+            derate = wave_derate(hs_m, twa)
         boat_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
         seg_duration = timedelta(hours=seg.distance_nm / boat_speed)
         seg_start = departure_utc + cumulative_actual
@@ -343,6 +345,13 @@ async def _estimate_with_model(
         warnings.append(f"vent fort: TWS max {max_tws:.0f} kn (≥{STRONG_WIND_THRESHOLD_KN:.0f})")
     if min_boat_speed < LIGHT_WIND_THRESHOLD_KN:
         warnings.append(f"vent faible: vitesse mini {min_boat_speed:.1f} kn — passage très lent")
+    hs_values = [s.hs_m for s in reports if s.hs_m is not None]
+    if hs_values:
+        hs_max = max(hs_values)
+        if hs_max >= ROUGH_SEA_HS_M:
+            warnings.append(f"forte mer: Hs max {hs_max:.1f} m (≥{ROUGH_SEA_HS_M:.1f})")
+        elif hs_max >= MODERATE_SEA_HS_M:
+            warnings.append(f"mer formée: Hs max {hs_max:.1f} m (≥{MODERATE_SEA_HS_M:.1f})")
 
     arrival = departure_utc + cumulative_actual
     total_distance = sum(s.distance_nm for s in segments)

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -19,6 +19,8 @@ from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import (
     LIGHT_WIND_THRESHOLD_KN,
     MAX_SWEEP_WINDOWS,
+    MODERATE_SEA_HS_M,
+    ROUGH_SEA_HS_M,
     STRONG_WIND_THRESHOLD_KN,
     best_vmg_upwind,
     estimate_passage,
@@ -265,8 +267,10 @@ class TestWaveDerate:
 
 
 class TestEstimatePassageWaveCorrection:
-    async def test_disabled_by_default_ignores_sea(self) -> None:
-        adapter = StubAdapter(tws_kn=12.0, twd_deg=180.0, hs_m=3.0)  # head seas-ish
+    async def test_disabled_by_default_keeps_speed_but_surfaces_hs(self) -> None:
+        # Hs is now always surfaced so callers see sea state. The flag only
+        # gates the boat-speed derate.
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=180.0, hs_m=3.0)
         report = await estimate_passage(
             [Point(43.0, 5.0), Point(43.0, 5.5)],
             DEPARTURE,
@@ -275,8 +279,8 @@ class TestEstimatePassageWaveCorrection:
             segment_length_nm=20.0,
         )
         for s in report.segments:
-            assert s.wave_derate_factor == 1.0
-            assert s.hs_m is None
+            assert s.wave_derate_factor == 1.0  # no derate applied
+            assert s.hs_m == pytest.approx(3.0)  # but Hs is visible
 
     async def test_enabled_slows_in_head_seas(self) -> None:
         # TWD=90 (wind from east), course east → TWA=0 (head seas).
@@ -431,18 +435,18 @@ class TestBestVmgUpwind:
     def test_all_archetypes_return_positive(self) -> None:
         from openwind_data.routing.archetypes import list_archetypes
         for archetype in list_archetypes():
-            opt_twa, opt_speed = best_vmg_upwind(archetype, 10.0)
+            _, opt_speed = best_vmg_upwind(archetype, 10.0)
             assert opt_speed > 0.0, f"{archetype.name} returned zero speed"
 
     def test_light_wind_still_positive(self) -> None:
         polar = get_polar("cruiser_30ft")
-        opt_twa, opt_speed = best_vmg_upwind(polar, 3.0)
+        _, opt_speed = best_vmg_upwind(polar, 3.0)
         assert opt_speed > 0.0
 
 
 class TestVmgUpwindCorrection:
     async def test_upwind_correction_gives_correct_vmg(self) -> None:
-        # Dead upwind (TWA=0°): effective speed = polar(opt_twa) × cos(opt_twa).
+        # Dead upwind (TWA=0 deg): effective speed = polar(opt_twa) * cos(opt_twa).
         # This is the real VMG toward destination when tacking — always less than
         # polar(opt_twa) itself, and less than the clamped polar at 0° (which
         # lookup_polar returns as the first-column value, an inaccurate shortcut).
@@ -614,3 +618,85 @@ class TestEstimatePassageWindows:
             assert isinstance(r, PassageReport)
             assert r.duration_h > 0
             assert r.distance_nm > 0
+
+
+class TestSeaStateAlwaysSurfaced:
+    """Hs must be populated on every segment when sea data is available,
+    regardless of use_wave_correction. The flag only gates the speed derate."""
+
+    async def test_hs_populated_when_correction_disabled(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=0.6)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+            use_wave_correction=False,
+        )
+        for seg in report.segments:
+            assert seg.hs_m == pytest.approx(0.6)
+            assert seg.wave_derate_factor == 1.0  # no derate applied
+
+    async def test_hs_populated_when_correction_enabled(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=0.6)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+            use_wave_correction=True,
+        )
+        for seg in report.segments:
+            assert seg.hs_m == pytest.approx(0.6)
+
+    async def test_hs_none_when_no_sea_data(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=None)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=20.0,
+        )
+        for seg in report.segments:
+            assert seg.hs_m is None
+
+
+class TestSeaStateWarnings:
+    async def test_calm_sea_no_warning(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=0.5)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES], DEPARTURE, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        assert not any("mer formée" in w or "forte mer" in w for w in report.warnings)
+
+    async def test_moderate_sea_warning(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=MODERATE_SEA_HS_M + 0.2)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES], DEPARTURE, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        assert any("mer formée" in w for w in report.warnings)
+        # Should not also trigger forte mer at 1.7m
+        assert not any("forte mer" in w for w in report.warnings)
+
+    async def test_rough_sea_warning(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=ROUGH_SEA_HS_M + 0.5)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES], DEPARTURE, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        assert any("forte mer" in w for w in report.warnings)
+        # Forte mer takes precedence; mer formée should not also fire
+        assert not any("mer formée" in w for w in report.warnings)
+
+    async def test_no_sea_data_no_warning(self) -> None:
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0, hs_m=None)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES], DEPARTURE, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        assert not any("mer" in w.lower() for w in report.warnings)


### PR DESCRIPTION
## Summary

In production, `plan_passage` always returned `hs_m: null` for every segment, even though the Open-Meteo Marine API returns valid wave data. Verified: a direct call to the marine API for Porquerolles (43.0, 6.2) returned 24 valid `wave_height` values (0.14 → 0.28 m).

**Root cause** ([passage.py:309-314](packages/data-adapters/src/openwind_data/routing/passage.py#L309-L314) before this PR): `hs_m` was only populated on segments when `use_wave_correction=True`. Since `plan_passage` doesn't expose that flag (default = False), Hs was never surfaced to callers.

## Fix

Decouple two concerns that were conflated:

1. **`hs_m` is now always populated** from the bundle's sea data → callers (LLM, web widget) always see the sea state, regardless of the speed-derate flag.
2. **`wave_derate_factor` still requires `use_wave_correction=True`** → V1 keeps wind-only boat-speed timing, unchanged behaviour.

Add two new warning thresholds based on max segment Hs:
- `≥ 1.5 m` → `"mer formée"`
- `≥ 2.5 m` → `"forte mer"`

## Test plan

- [x] 46/46 passage tests pass (added `TestSeaStateAlwaysSurfaced` + `TestSeaStateWarnings`)
- [x] `ruff check` clean
- [ ] Live MCP smoke after redeploy: confirm `passage.segments[*].hs_m` returns non-null values for a typical Med passage

## Followup to

[#58](https://github.com/qdonnars/openwind/pull/58) (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)