### PR TITLE
fix(mcp): clean horizon error past Open-Meteo cap + ECMWF in fallback

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/base.py
+++ b/packages/data-adapters/src/openwind_data/adapters/base.py
@@ -19,7 +19,7 @@ class ForecastHorizonError(RuntimeError):
         super().__init__(
             f"forecast horizon exceeded for model {model!r} at "
             f"{requested_time.isoformat()}; AROME ~48h, ICON-EU ~5d, "
-            f"GFS ~16d, ECMWF ~10d — try a longer-range model "
+            f"ECMWF ~10d, GFS ~16d — try a longer-range model "
             f"or pass model='auto' to fall back automatically"
         )
 

--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -10,6 +10,7 @@ import httpx
 
 from openwind_data.adapters.base import (
     ForecastBundle,
+    ForecastHorizonError,
     SeaPoint,
     SeaSeries,
     WindPoint,
@@ -21,15 +22,24 @@ MARINE_URL = "https://marine-api.open-meteo.com/v1/marine"
 
 DEFAULT_MODEL = "meteofrance_arome_france"
 
-# Ordered fallback when caller passes model="auto": from highest-resolution /
-# shortest-horizon to lowest / longest. AROME captures Med thermals at 1.3 km
-# but only ~48 h; ICON-EU covers ~5 d; GFS covers ~16 d.
+# Ordered fallback when caller passes model="auto": horizon-increasing, with
+# the highest-resolution model at each tier. AROME 1.3 km captures Med thermals
+# (~48 h); ICON-EU 7 km Europe (~5 d); ECMWF IFS 25 km global (~10 d); GFS 25 km
+# global (~16 d, last resort — least skilful in the Med).
 AUTO_MODEL = "auto"
 AUTO_FALLBACK_CHAIN: tuple[str, ...] = (
     "meteofrance_arome_france",
     "icon_eu",
+    "ecmwf_ifs025",
     "gfs_seamless",
 )
+
+# Open-Meteo's forecast endpoint caps both ``start_date`` and ``end_date`` to
+# roughly today + 16 d (model-agnostic — the cap is on the API, not the model).
+# We cap one day below that to leave margin for clock skew and same-day TZ
+# crossings. Beyond this, we surface ``ForecastHorizonError`` directly without
+# burning an HTTP round-trip — no model in the chain can serve the request.
+API_MAX_FUTURE_DAYS = 14
 
 _WIND_VARS = "wind_speed_10m,wind_direction_10m,wind_gusts_10m"
 _MARINE_VARS = "wave_height,wave_period,wave_direction,wind_wave_height,swell_wave_height"
@@ -132,6 +142,13 @@ class OpenMeteoAdapter:
             models=tuple(sorted(models)),
         )
         now = datetime.now(UTC)
+        # Open-Meteo's start_date/end_date both must fall within ~today+15. If the
+        # caller wants data past that cap, no model in the chain can help — fail
+        # fast with ForecastHorizonError so the auto-fallback exhausts cleanly
+        # and the API layer returns 422 instead of bubbling an httpx 400 → 500.
+        api_max_end = now + timedelta(days=API_MAX_FUTURE_DAYS)
+        if start_utc > api_max_end:
+            raise ForecastHorizonError(models[0], start_utc)
         cached = self._cache.get(key)
         if (
             cached is not None
@@ -143,11 +160,15 @@ class OpenMeteoAdapter:
 
         # Fetch a wide window so future calls with later `departure` can be served
         # from cache. If a stale-but-narrower entry exists, widen to cover both.
+        # Always cap at api_max_end so the prefetch never exceeds Open-Meteo's
+        # date-range limit (the +7 d widening would otherwise trip the cap as
+        # soon as start_utc is within 7 d of api_max_end).
         fetch_start = start_utc.replace(hour=0, minute=0, second=0, microsecond=0)
         fetch_end = max(end_utc, start_utc + timedelta(days=FETCH_HORIZON_DAYS))
         if cached is not None:
             fetch_start = min(fetch_start, cached.bundle.start)
             fetch_end = max(fetch_end, cached.bundle.end)
+        fetch_end = min(fetch_end, api_max_end)
 
         owns_client = self._client is None
         client = self._client or httpx.AsyncClient(timeout=self._timeout)
@@ -198,7 +219,7 @@ class OpenMeteoAdapter:
         }
         await self._pace_http()
         resp = await client.get(FORECAST_URL, params=params)
-        resp.raise_for_status()
+        _raise_for_status_with_horizon(resp, model, start)
         return _parse_wind(resp.json(), model, start, end)
 
     async def _fetch_sea(
@@ -219,8 +240,30 @@ class OpenMeteoAdapter:
         }
         await self._pace_http()
         resp = await client.get(MARINE_URL, params=params)
-        resp.raise_for_status()
+        _raise_for_status_with_horizon(resp, "open-meteo-marine", start)
         return _parse_sea(resp.json(), start, end)
+
+
+def _raise_for_status_with_horizon(
+    resp: httpx.Response, model: str, requested_time: datetime
+) -> None:
+    """Defense-in-depth: if Open-Meteo rejects the date range with a 400,
+    translate to ``ForecastHorizonError`` so the auto-fallback chain reacts
+    instead of surfacing a raw ``HTTPStatusError`` (which would 500 the API).
+    Other 400s (malformed params, etc.) keep their native exception so real
+    bugs stay visible.
+    """
+    if resp.status_code == 400:
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = {}
+        reason = str(payload.get("reason", ""))
+        if "out of allowed range" in reason and (
+            "start_date" in reason or "end_date" in reason
+        ):
+            raise ForecastHorizonError(model, requested_time)
+    resp.raise_for_status()
 
 
 def _slice_bundle(bundle: ForecastBundle, start: datetime, end: datetime) -> ForecastBundle:

--- a/packages/data-adapters/tests/test_openmeteo.py
+++ b/packages/data-adapters/tests/test_openmeteo.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
 import respx
 
+from openwind_data.adapters.base import ForecastHorizonError
 from openwind_data.adapters.openmeteo import (
+    API_MAX_FUTURE_DAYS,
     DEFAULT_MODEL,
     FORECAST_URL,
     MARINE_URL,
@@ -183,6 +185,85 @@ async def test_end_before_start_raises():
 @respx.mock
 async def test_http_error_propagates(marine_porquerolles):
     respx.get(FORECAST_URL).mock(return_value=httpx.Response(500))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    start, end = _start_end()
+    with pytest.raises(httpx.HTTPStatusError):
+        await adapter.fetch(lat=43.0, lon=5.0, start=start, end=end)
+
+
+async def test_start_past_api_cap_raises_horizon_error_without_http():
+    """If start_date exceeds Open-Meteo's date-range cap, fail fast with
+    ForecastHorizonError — no HTTP call burned, auto-fallback exhausts cleanly,
+    API layer returns 422 instead of bubbling httpx 400 → 500.
+    """
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    far_start = datetime.now(UTC) + timedelta(days=API_MAX_FUTURE_DAYS + 5)
+    far_end = far_start + timedelta(hours=12)
+    with respx.mock(assert_all_called=False) as r:
+        forecast = r.get(FORECAST_URL).mock(return_value=httpx.Response(200, json={}))
+        marine = r.get(MARINE_URL).mock(return_value=httpx.Response(200, json={}))
+        with pytest.raises(ForecastHorizonError):
+            await adapter.fetch(lat=43.0, lon=5.0, start=far_start, end=far_end)
+        assert forecast.call_count == 0
+        assert marine.call_count == 0
+
+
+@respx.mock
+async def test_prefetch_end_capped_to_api_max(forecast_marseille_arome, marine_porquerolles):
+    """The +7d prefetch widening must not push end_date past Open-Meteo's cap —
+    otherwise even passages within the cap break."""
+    forecast_route = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=forecast_marseille_arome)
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    now = datetime.now(UTC)
+    start = now + timedelta(days=API_MAX_FUTURE_DAYS - 2)
+    end = start + timedelta(hours=12)
+    await adapter.fetch(lat=43.30, lon=5.35, start=start, end=end)
+
+    sent = forecast_route.calls.last.request
+    end_date_sent = datetime.fromisoformat(sent.url.params["end_date"]).date()
+    api_max = (now + timedelta(days=API_MAX_FUTURE_DAYS)).date()
+    assert end_date_sent <= api_max
+
+
+@respx.mock
+async def test_om_400_horizon_translates_to_forecast_horizon_error(marine_porquerolles):
+    """Open-Meteo returns 400 with 'out of allowed range' when start/end_date
+    exceed the API cap. We translate that to ForecastHorizonError so the auto-
+    fallback chain reacts (defense-in-depth — the cap above should prevent it).
+    """
+    respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(
+            400,
+            json={
+                "error": True,
+                "reason": "Parameter 'end_date' is out of allowed range from X to Y",
+            },
+        )
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    start, end = _start_end()
+    with pytest.raises(ForecastHorizonError):
+        await adapter.fetch(lat=43.0, lon=5.0, start=start, end=end)
+
+
+@respx.mock
+async def test_om_400_other_keeps_http_error(marine_porquerolles):
+    """A 400 with an unrelated reason (e.g. malformed param) must keep its
+    HTTPStatusError so real bugs stay visible — only horizon errors translate.
+    """
+    respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(
+            400, json={"error": True, "reason": "Parameter 'latitude' must be a number"}
+        )
+    )
     respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
 
     adapter = OpenMeteoAdapter(http_min_interval_s=0)

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -405,6 +405,7 @@ class TestModelFallback:
             short_horizon_models=(
                 "meteofrance_arome_france",
                 "icon_eu",
+                "ecmwf_ifs025",
                 "gfs_seamless",
             )
         )

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -24,7 +24,9 @@ function toLocalIso(d: Date): string {
 
 // ── DepartureSlider ──────────────────────────────────────────────────────────
 
-const SLIDER_MAX_HOURS = 21 * 24; // 3 weeks
+// Open-Meteo's forecast endpoint caps start_date/end_date at ~today+15. We cap
+// the slider at 14 d to leave 1 d of margin (clock skew, TZ crossings).
+const SLIDER_MAX_HOURS = 14 * 24;
 
 function DepartureSlider({
   value,
@@ -117,7 +119,6 @@ function DepartureSlider({
             <span>Maintenant</span>
             <span>+1 sem.</span>
             <span>+2 sem.</span>
-            <span>+3 sem.</span>
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

- **Bug**: late-date simulations (e.g. d+19 from the 3-week web slider) returned **500** instead of a clean error. Open-Meteo rejects `start_date` past ~today+15 with HTTP 400; the auto-fallback chain caught only `ForecastHorizonError`, so `httpx.HTTPStatusError` bubbled past it into `_api_passage` as an unhandled 500.
- **Root cause is layered**: even passages within the API cap broke as soon as `start > today+8`, because the +7d prefetch widening pushed `end_date` past the API limit too.
- **Fix**:
  - Cap `fetch_end` at `now + 14d` in `OpenMeteoAdapter.fetch` so the prefetch never trips Open-Meteo's date limit.
  - Past `now + 14d`, raise `ForecastHorizonError` **before any HTTP round-trip** → the auto-fallback chain exhausts cleanly and `_api_passage` returns **422** with a clear message instead of 500.
  - Defense-in-depth: translate Open-Meteo 400 `"out of allowed range"` responses to `ForecastHorizonError`. Unrelated 400s (malformed params, etc.) keep their `HTTPStatusError` so real bugs stay visible.
  - Add `ecmwf_ifs025` to `AUTO_FALLBACK_CHAIN` between ICON-EU and GFS — ECMWF's ~10d horizon at 25km global beats GFS for the 5-10d window. New chain: AROME → ICON-EU → ECMWF → GFS.
  - Cap web slider at 14d (was 21d) to match what the API can actually serve.

## Test plan

- [x] `uv run pytest` in `packages/data-adapters` (123/123) and `packages/mcp-core` (23/23)
- [x] `npm test` in `packages/web` (9/9), `npx tsc -b` clean
- [x] Live smoke vs real Open-Meteo (Marseille → Porquerolles, `cruiser_30ft`, in-process MCP `plan_passage`):
  - d+1 → AROME ✓
  - d+10 → ECMWF (would have been GFS before, was sometimes 500 due to prefetch widening) ✓
  - d+19 → clean `ForecastHorizonError`, no httpx 400/500 leak ✓
- [ ] After merge: hit `mcp.openwind.fr` (or HF Space URL) with a passage at d+10 and d+19 to confirm the deployed behaviour matches the local smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)