### PR TITLE
feat(mcp+web): wire compare-windows table (sweep step 2)

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -28,7 +28,11 @@ from openwind_data.adapters.base import ForecastHorizonError
 from openwind_data.routing.archetypes import list_archetypes_metadata
 from openwind_data.routing.complexity import score_complexity
 from openwind_data.routing.geometry import Point
-from openwind_data.routing.passage import estimate_passage
+from openwind_data.routing.passage import (
+    _build_conditions_summary,
+    estimate_passage,
+    estimate_passage_windows,
+)
 from openwind_mcp_core import build_server
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -279,6 +283,87 @@ async def _api_passage(request: Request) -> JSONResponse:
     except (TypeError, ValueError) as exc:
         return JSONResponse({"error": f"invalid efficiency: {exc}"}, status_code=422)
 
+    # Sweep mode — triggered when ``latest_departure`` is provided.
+    latest_raw = body.get("latest_departure")
+    if latest_raw is not None:
+        try:
+            latest_departure = datetime.fromisoformat(latest_raw)
+        except (ValueError, TypeError) as exc:
+            return JSONResponse({"error": f"invalid latest_departure: {exc}"}, status_code=422)
+        try:
+            sweep_interval = int(body.get("sweep_interval_hours", 1))
+        except (TypeError, ValueError) as exc:
+            return JSONResponse({"error": f"invalid sweep_interval_hours: {exc}"}, status_code=422)
+
+        target_eta_raw = body.get("target_eta")
+        target_eta_dt: datetime | None = None
+        if target_eta_raw is not None:
+            try:
+                target_eta_dt = datetime.fromisoformat(target_eta_raw)
+            except (ValueError, TypeError) as exc:
+                return JSONResponse({"error": f"invalid target_eta: {exc}"}, status_code=422)
+
+        try:
+            reports = await estimate_passage_windows(
+                waypoints, departure, latest_departure, body["archetype"],
+                sweep_interval_hours=sweep_interval, efficiency=efficiency, model="auto",
+            )
+        except KeyError as exc:
+            return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=422)
+        except ForecastHorizonError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=422)
+
+        windows: list[dict[str, Any]] = []
+        for report in reports:
+            score = score_complexity(report)
+            windows.append({
+                "departure": report.departure_time.isoformat(),
+                "arrival": report.arrival_time.isoformat(),
+                "duration_h": round(report.duration_h, 2),
+                "distance_nm": round(report.distance_nm, 1),
+                "complexity": {
+                    "level": score.level,
+                    "label": score.label,
+                    "tws_max_kn": round(score.tws_max_kn, 1),
+                    "rationale": score.rationale,
+                },
+                "conditions_summary": _build_conditions_summary(report),
+                "warnings": list(report.warnings) + [w.message for w in score.warnings],
+            })
+
+        meta_warnings: list[str] = []
+        if target_eta_dt is not None:
+            from datetime import timedelta
+            tol = timedelta(hours=2).total_seconds()
+            target_utc = target_eta_dt.astimezone(UTC)
+            filtered = [
+                w for w in windows
+                if abs((datetime.fromisoformat(w["arrival"]) - target_utc).total_seconds()) <= tol
+            ]
+            if not filtered:
+                meta_warnings.append(
+                    f"aucune fenêtre n'arrive dans ±2h de target_eta={target_eta_raw} ; "
+                    f"toutes les {len(windows)} fenêtres retournées"
+                )
+            else:
+                windows = filtered
+
+        return JSONResponse({
+            "mode": "multi_window",
+            "sweep": {
+                "earliest": departure.isoformat(),
+                "latest": latest_departure.isoformat(),
+                "interval_hours": sweep_interval,
+                "window_count": len(windows),
+            },
+            "windows": windows,
+            "meta_warnings": meta_warnings,
+            "forecast_updated_at": datetime.now(UTC).isoformat(),
+        })
+
+    # Single mode — unchanged.
     try:
         passage = await estimate_passage(
             waypoints, departure, body["archetype"], efficiency=efficiency, model="auto"

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -1,4 +1,4 @@
-import type { PassageResponse, Archetype } from "../plan/types";
+import type { PassageResponse, MultiWindowResponse, Archetype } from "../plan/types";
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https://qdonnars-openwind-mcp.hf.space";
 
@@ -23,6 +23,37 @@ export async function fetchPassage(params: {
     throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
   }
   return res.json() as Promise<PassageResponse>;
+}
+
+export async function fetchPassageWindows(params: {
+  waypoints: [number, number][];
+  earliest: string;
+  latest: string;
+  archetype: string;
+  intervalHours: number;
+  targetEta?: string;
+  efficiency?: number;
+}): Promise<MultiWindowResponse> {
+  const body: Record<string, unknown> = {
+    waypoints: params.waypoints,
+    departure: params.earliest,
+    archetype: params.archetype,
+    efficiency: params.efficiency ?? 0.75,
+    latest_departure: params.latest,
+    sweep_interval_hours: params.intervalHours,
+  };
+  if (params.targetEta) body["target_eta"] = params.targetEta;
+
+  const res = await fetch(`${API_BASE}/api/v1/passage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as Record<string, string>;
+    throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
+  }
+  return res.json() as Promise<MultiWindowResponse>;
 }
 
 export async function fetchArchetypes(): Promise<Archetype[]> {

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
 import { useTheme } from "../design/theme";
-import type { PassageReport, ComplexityScore, SegmentReport, Archetype } from "./types";
+import type { PassageReport, ComplexityScore, SegmentReport, Archetype, PassageWindow } from "./types";
 import { aggregateLegs } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
+import { WindowsTable } from "./WindowsTable";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -418,6 +419,20 @@ interface PlanSidebarProps {
   forecastUpdatedAt: string | null;
   waypointCount: number;
   waypoints: [number, number][];
+  // Compare-windows mode (lifted from local state in step 2)
+  mode: PlanMode;
+  onModeChange: (m: PlanMode) => void;
+  sweepEarliest: string;
+  sweepLatest: string;
+  sweepIntervalHours: number;
+  sweepTargetEta: string;
+  onSweepEarliestChange: (iso: string) => void;
+  onSweepLatestChange: (iso: string) => void;
+  onSweepIntervalChange: (h: number) => void;
+  onSweepTargetEtaChange: (iso: string) => void;
+  windows: PassageWindow[] | null;
+  metaWarnings: string[];
+  onCompareFetch: () => void;
 }
 
 export function PlanSidebar({
@@ -435,21 +450,22 @@ export function PlanSidebar({
   forecastUpdatedAt,
   waypointCount,
   waypoints,
+  mode,
+  onModeChange,
+  sweepEarliest,
+  sweepLatest,
+  sweepIntervalHours,
+  sweepTargetEta,
+  onSweepEarliestChange,
+  onSweepLatestChange,
+  onSweepIntervalChange,
+  onSweepTargetEtaChange,
+  windows,
+  metaWarnings,
+  onCompareFetch,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
   const canCalculate = waypointCount >= 2;
-
-  // Step 1 (UI only): mode toggle + sweep form local state.
-  // No API wiring yet — calculate stays disabled in compare mode with a hint.
-  const [mode, setMode] = useState<PlanMode>("single");
-  const [sweepEarliest, setSweepEarliest] = useState(() => departure);
-  const [sweepLatest, setSweepLatest] = useState(() => {
-    const d = new Date(departure);
-    d.setDate(d.getDate() + 2);
-    return toLocalIso(d);
-  });
-  const [sweepInterval, setSweepInterval] = useState(3);
-  const [targetEta, setTargetEta] = useState("");
 
   if (isLoading) {
     return (
@@ -508,7 +524,7 @@ export function PlanSidebar({
         </p>
 
         {/* Mode toggle */}
-        <ModeToggle value={mode} onChange={setMode} />
+        <ModeToggle value={mode} onChange={onModeChange} />
 
         {/* Departure (single) or sweep form (compare) */}
         {mode === "single" ? (
@@ -517,12 +533,12 @@ export function PlanSidebar({
           <SweepForm
             earliest={sweepEarliest}
             latest={sweepLatest}
-            intervalHours={sweepInterval}
-            targetEta={targetEta}
-            onEarliestChange={setSweepEarliest}
-            onLatestChange={setSweepLatest}
-            onIntervalChange={setSweepInterval}
-            onTargetEtaChange={setTargetEta}
+            intervalHours={sweepIntervalHours}
+            targetEta={sweepTargetEta}
+            onEarliestChange={onSweepEarliestChange}
+            onLatestChange={onSweepLatestChange}
+            onIntervalChange={onSweepIntervalChange}
+            onTargetEtaChange={onSweepTargetEtaChange}
             resolvedTheme={resolvedTheme}
           />
         )}
@@ -535,37 +551,41 @@ export function PlanSidebar({
         />
 
         {/* Calculate button */}
-        {mode === "single" ? (
-          <button
-            onClick={onRefetch}
-            disabled={!canCalculate}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold transition-all"
-            style={{
-              background: canCalculate ? "var(--ow-accent)" : "var(--ow-bg-2)",
-              color: canCalculate ? "#fff" : "var(--ow-fg-3)",
-              border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line-2)"}`,
-              cursor: canCalculate ? "pointer" : "not-allowed",
-            }}
-          >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/><path d="M14 1v4h-4"/>
-            </svg>
-            {canCalculate ? "Calculer le passage" : `${waypointCount}/2 waypoints`}
-          </button>
-        ) : (
-          <button
-            disabled
-            title="Comparateur — branchement MCP à venir"
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold"
-            style={{
-              background: "var(--ow-bg-2)",
-              color: "var(--ow-fg-3)",
-              border: "1px dashed var(--ow-line-2)",
-              cursor: "not-allowed",
-            }}
-          >
-            Comparer les créneaux · à venir
-          </button>
+        <button
+          onClick={mode === "single" ? onRefetch : onCompareFetch}
+          disabled={!canCalculate}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold transition-all"
+          style={{
+            background: canCalculate ? "var(--ow-accent)" : "var(--ow-bg-2)",
+            color: canCalculate ? "#fff" : "var(--ow-fg-3)",
+            border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line-2)"}`,
+            cursor: canCalculate ? "pointer" : "not-allowed",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/><path d="M14 1v4h-4"/>
+          </svg>
+          {canCalculate
+            ? mode === "single" ? "Calculer le passage" : "Comparer les créneaux"
+            : `${waypointCount}/2 waypoints`}
+        </button>
+
+        {/* Windows table — shown after a successful compare-mode fetch */}
+        {mode === "compare" && windows && windows.length > 0 && (
+          <div className="space-y-2">
+            {metaWarnings.map((m, i) => (
+              <p key={i} className="text-[11px] rounded-lg px-3 py-1.5"
+                 style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)" }}>
+                {m}
+              </p>
+            ))}
+            <div className="rounded-xl overflow-hidden border" style={{ borderColor: "var(--ow-line)" }}>
+              <WindowsTable windows={windows} />
+            </div>
+            <p className="text-[10px]" style={{ color: "var(--ow-fg-3)" }}>
+              {windows.length} fenêtre{windows.length > 1 ? "s" : ""} comparée{windows.length > 1 ? "s" : ""} · cliquez sur une ligne pour le détail (à venir)
+            </p>
+          </div>
         )}
       </div>
     );
@@ -655,10 +675,11 @@ export function PlanSidebar({
           <div>
             <div className="flex items-center gap-2 mb-1 px-1 text-[9px]" style={{ color: "var(--ow-fg-3)" }}>
               <span className="w-5 shrink-0" />
-              <span className="flex-1 grid grid-cols-4 gap-1">
+              <span className="flex-1 grid grid-cols-5 gap-1">
                 <span>Heure</span>
                 <span>Allure</span>
                 <span>Vent</span>
+                <span>Mer</span>
                 <span className="text-right">Vitesse</span>
               </span>
             </div>
@@ -668,6 +689,9 @@ export function PlanSidebar({
                 const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
                   ? `${Math.round(leg.tws_min)} kn`
                   : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
+                const seaLabel = leg.hs_avg_m == null
+                  ? "—"
+                  : `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction}`;
                 return (
                   <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-bg-2)" }}>
                     <span
@@ -676,10 +700,11 @@ export function PlanSidebar({
                     >
                       {i + 1}
                     </span>
-                    <div className="flex-1 grid grid-cols-4 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
+                    <div className="flex-1 grid grid-cols-5 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
                       <span style={{ color: "var(--ow-fg-1)" }}>{fmtTime(leg.end_time)}</span>
                       <span style={{ color: "var(--ow-fg-0)" }}>{leg.point_of_sail}</span>
                       <span style={{ color: "var(--ow-fg-1)" }}>{windLabel}</span>
+                      <span style={{ color: "var(--ow-fg-1)" }}>{seaLabel}</span>
                       <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{leg.boat_speed_kn.toFixed(1)} kn</span>
                     </div>
                   </div>

--- a/packages/web/src/plan/WindowsTable.tsx
+++ b/packages/web/src/plan/WindowsTable.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from "react";
+import type { PassageWindow } from "./types";
+import { CX_COLORS } from "./types";
+
+type SortKey = "departure" | "duration" | "complexity";
+
+const SAIL_LABELS: Record<string, string> = {
+  pres: "Près",
+  travers: "Travers",
+  largue: "Largue",
+  portant: "Portant",
+};
+
+function fmtDeparture(iso: string): string {
+  const d = new Date(iso);
+  const day = d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
+  const hh = d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+  return `${day} · ${hh}`;
+}
+
+function fmtDuration(h: number): string {
+  const hrs = Math.floor(h);
+  const mins = Math.round((h - hrs) * 60);
+  return mins > 0 ? `${hrs}h${String(mins).padStart(2, "0")}` : `${hrs}h`;
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function fmtRange(min: number, max: number, unit: string, decimals = 0): string {
+  const a = min.toFixed(decimals);
+  const b = max.toFixed(decimals);
+  return a === b ? `${a} ${unit}` : `${a}–${b} ${unit}`;
+}
+
+function fmtHsRange(min: number | null, max: number | null): string {
+  if (min === null || max === null) return "—";
+  return fmtRange(min, max, "m", 1);
+}
+
+export interface WindowsTableProps {
+  windows: PassageWindow[];
+  onSelect?: (w: PassageWindow) => void;
+}
+
+export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("departure");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+
+  const sorted = useMemo(() => {
+    const list = [...windows];
+    list.sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === "departure") {
+        cmp = new Date(a.departure).getTime() - new Date(b.departure).getTime();
+      } else if (sortKey === "duration") {
+        cmp = a.duration_h - b.duration_h;
+      } else if (sortKey === "complexity") {
+        cmp = a.complexity.level - b.complexity.level;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return list;
+  }, [windows, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "complexity" ? "asc" : "asc");
+    }
+  }
+
+  function SortHeader({ k, label, align = "left" }: { k: SortKey; label: string; align?: "left" | "right" | "center" }) {
+    const active = sortKey === k;
+    const arrow = active ? (sortDir === "asc" ? "▲" : "▼") : "";
+    return (
+      <button
+        onClick={() => toggleSort(k)}
+        className="flex items-center gap-1 transition-colors w-full"
+        style={{
+          color: active ? "var(--ow-fg-0)" : "var(--ow-fg-3)",
+          justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start",
+          fontWeight: 600,
+        }}
+      >
+        {label} <span className="text-[8px] opacity-60">{arrow || "↕"}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className="grid items-center gap-2 px-2 py-1.5 text-[9px] uppercase tracking-widest border-b"
+        style={{
+          gridTemplateColumns: "1.4fr 0.7fr 0.7fr 0.9fr 0.9fr 0.9fr 0.55fr",
+          borderColor: "var(--ow-line)",
+          color: "var(--ow-fg-3)",
+        }}
+      >
+        <SortHeader k="departure" label="Départ" />
+        <SortHeader k="duration" label="Durée" />
+        <span className="text-left">ETA</span>
+        <span className="text-left">Allure</span>
+        <span className="text-left">Vent (kn)</span>
+        <span className="text-left">Mer</span>
+        <SortHeader k="complexity" label="⚡" align="center" />
+      </div>
+
+      <div className="divide-y" style={{ borderColor: "var(--ow-line)" }}>
+        {sorted.map((w) => {
+          const cs = w.conditions_summary;
+          return (
+            <button
+              key={w.departure}
+              onClick={() => onSelect?.(w)}
+              className="w-full text-left grid items-center gap-2 px-2 py-2 text-xs transition-colors hover:bg-[var(--ow-bg-2)]"
+              style={{
+                gridTemplateColumns: "1.4fr 0.7fr 0.7fr 0.9fr 0.9fr 0.9fr 0.55fr",
+                fontFamily: "var(--ow-font-mono)",
+                color: "var(--ow-fg-1)",
+              }}
+              title="Voir le détail de cette fenêtre"
+            >
+              <span className="tabular-nums" style={{ color: "var(--ow-fg-0)" }}>
+                {fmtDeparture(w.departure)}
+              </span>
+              <span className="tabular-nums">{fmtDuration(w.duration_h)}</span>
+              <span className="tabular-nums">{fmtTime(w.arrival)}</span>
+              <span className="capitalize" style={{ color: "var(--ow-fg-1)" }}>
+                {SAIL_LABELS[cs.predominant_sail_angle] ?? cs.predominant_sail_angle}
+              </span>
+              <span className="tabular-nums">{fmtRange(cs.tws_min_kn, cs.tws_max_kn, "")}</span>
+              <span className="tabular-nums">{fmtHsRange(cs.hs_min_m, cs.hs_max_m)}</span>
+              <span className="flex justify-center">
+                <span
+                  className="inline-flex items-center justify-center w-7 h-6 rounded-md text-[11px] font-bold"
+                  style={{
+                    background: CX_COLORS[w.complexity.level] + "22",
+                    color: CX_COLORS[w.complexity.level],
+                    border: `1px solid ${CX_COLORS[w.complexity.level]}55`,
+                  }}
+                  title={`${w.complexity.label} — ${w.complexity.rationale}`}
+                >
+                  {w.complexity.level}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -58,6 +58,52 @@ export interface PassageResponse {
   forecast_updated_at: string;
 }
 
+// ── Sweep mode (compare-windows) ─────────────────────────────────────────────
+
+export type SailAngle = "pres" | "travers" | "largue" | "portant";
+
+export interface ConditionsSummary {
+  tws_min_kn: number;
+  tws_max_kn: number;
+  predominant_sail_angle: SailAngle;
+  hs_min_m: number | null;
+  hs_max_m: number | null;
+}
+
+export interface PassageWindow {
+  departure: string;
+  arrival: string;
+  duration_h: number;
+  distance_nm: number;
+  complexity: {
+    level: number;
+    label: string;
+    tws_max_kn: number;
+    rationale: string;
+  };
+  conditions_summary: ConditionsSummary;
+  warnings: string[];
+}
+
+export interface MultiWindowResponse {
+  mode: "multi_window";
+  sweep: {
+    earliest: string;
+    latest: string;
+    interval_hours: number;
+    window_count: number;
+  };
+  windows: PassageWindow[];
+  meta_warnings: string[];
+  forecast_updated_at: string;
+}
+
+export type PassageOrSweepResponse = PassageResponse | MultiWindowResponse;
+
+export function isMultiWindow(r: PassageOrSweepResponse): r is MultiWindowResponse {
+  return (r as MultiWindowResponse).mode === "multi_window";
+}
+
 export interface Archetype {
   slug: string;
   name: string;

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -2,10 +2,10 @@ import { useState, useEffect, useRef } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
-import { fetchPassage, fetchArchetypes } from "../api/passage";
+import { fetchPassage, fetchPassageWindows, fetchArchetypes } from "../api/passage";
 import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
-import type { PassageReport, ComplexityScore, Archetype } from "../plan/types";
+import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import { cxLevel, CX_COLORS } from "../plan/types";
 import { aggregateLegs } from "../plan/aggregateLegs";
 
@@ -141,6 +141,9 @@ function CompactDrawer({
           const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
             ? `${Math.round(leg.tws_min)} kn`
             : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
+          const seaLabel = leg.hs_avg_m == null
+            ? null
+            : `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction}`;
           return (
             <div
               key={i}
@@ -154,7 +157,7 @@ function CompactDrawer({
                 {i + 1}
               </span>
               <span className="flex-1 tabular-nums" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
-                {leg.point_of_sail} · {windLabel} · {leg.boat_speed_kn.toFixed(1)} kn
+                {leg.point_of_sail} · {windLabel}{seaLabel ? ` · ${seaLabel}` : ""} · {leg.boat_speed_kn.toFixed(1)} kn
               </span>
               <span className="tabular-nums shrink-0" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
                 {fmtTime(leg.end_time)}
@@ -226,6 +229,20 @@ export function PlanPage() {
   const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(null);
   const [isStale, setIsStale] = useState(false);
 
+  // Compare-windows mode (lifted from PlanSidebar in step 2)
+  const [planMode, setPlanMode] = useState<"single" | "compare">("single");
+  const [sweepEarliest, setSweepEarliest] = useState(() => departure);
+  const [sweepLatest, setSweepLatest] = useState(() => {
+    const d = new Date(departure);
+    d.setDate(d.getDate() + 2);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  });
+  const [sweepInterval, setSweepInterval] = useState<number>(3);
+  const [sweepTargetEta, setSweepTargetEta] = useState("");
+  const [windows, setWindows] = useState<PassageWindow[] | null>(null);
+  const [metaWarnings, setMetaWarnings] = useState<string[]>([]);
+
   useEffect(() => {
     fetchArchetypes().then(setArchetypes).catch(() => {});
   }, []);
@@ -291,6 +308,35 @@ export function PlanPage() {
 
   function handleRefetch() {
     doFetch(waypoints, archetype, departure);
+  }
+
+  function doFetchWindows() {
+    setIsLoading(true);
+    setApiError(null);
+    fetchPassageWindows({
+      waypoints,
+      earliest: toTzAware(sweepEarliest),
+      latest: toTzAware(sweepLatest),
+      archetype,
+      intervalHours: sweepInterval,
+      targetEta: sweepTargetEta ? toTzAware(sweepTargetEta) : undefined,
+    })
+      .then((res) => {
+        setWindows(res.windows);
+        setMetaWarnings(res.meta_warnings);
+        setForecastUpdatedAt(res.forecast_updated_at);
+        // Clear single-mode results so the sidebar swaps view cleanly.
+        setPassage(null);
+        setComplexity(null);
+        setIsStale(false);
+      })
+      .catch((e: Error) => setApiError(e.message))
+      .finally(() => setIsLoading(false));
+  }
+
+  function handleModeChange(next: "single" | "compare") {
+    setPlanMode(next);
+    setApiError(null);
   }
 
   if (!isParsedOk(initialParsed)) {
@@ -398,6 +444,19 @@ export function PlanPage() {
             forecastUpdatedAt={forecastUpdatedAt}
             waypointCount={waypoints.length}
             waypoints={waypoints}
+            mode={planMode}
+            onModeChange={handleModeChange}
+            sweepEarliest={sweepEarliest}
+            sweepLatest={sweepLatest}
+            sweepIntervalHours={sweepInterval}
+            sweepTargetEta={sweepTargetEta}
+            onSweepEarliestChange={setSweepEarliest}
+            onSweepLatestChange={setSweepLatest}
+            onSweepIntervalChange={setSweepInterval}
+            onSweepTargetEtaChange={setSweepTargetEta}
+            windows={windows}
+            metaWarnings={metaWarnings}
+            onCompareFetch={doFetchWindows}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

End-to-end plumbing for the compare-windows feature on `/plan`: backend endpoint extension + web table render. Builds on [#58](https://github.com/qdonnars/openwind/pull/58) (MCP sweep mode) and [#64](https://github.com/qdonnars/openwind/pull/64) (UI toggle skeleton).

### hf-space

Extend `POST /api/v1/passage` to support sweep mode when `latest_departure` is provided. Calls `estimate_passage_windows`, scores complexity per window, applies the optional `target_eta` filter (±2h tolerance), and returns the same shape as the MCP `plan_passage` sweep response: `{mode: "multi_window", sweep, windows[], meta_warnings}`. Single mode is unchanged.

### web

- **Types**: `ConditionsSummary`, `PassageWindow`, `MultiWindowResponse` + `isMultiWindow` guard.
- **API**: `fetchPassageWindows()` — separate from `fetchPassage` to keep types clean.
- **PlanPage**: lift mode + sweep params from `PlanSidebar` local state so the page owns the windows fetch. Add `windows` + `metaWarnings` state. `doFetchWindows` clears single-mode results so the sidebar swaps views cleanly.
- **PlanSidebar**: receives mode and sweep state via props. Calculate button wires to either `onRefetch` (single) or `onCompareFetch` (compare). After a successful sweep, renders `WindowsTable` below the form.
- **WindowsTable**: sortable by départ / durée / complexité. Columns: `Départ · Durée · ETA · Allure · Vent (kn) · Mer · ⚡` (level badge). Uses `hs_min_m–hs_max_m` range for the Mer column. Click handler wired to `onSelect` but no drill-down yet (step 3).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vite build` clean (39 modules, +5KB JS)
- [x] `ruff check` on `hf-space/app.py` clean
- [ ] Live smoke after HF redeploy: `POST /api/v1/passage` with `latest_departure` → expect `mode=multi_window`, populated `windows[]`
- [ ] Browser check: toggle to "Comparer les fenêtres", set form, click "Comparer les créneaux" → table renders with sortable columns

## Next steps

- **Step 3**: drill-down click row → single-plan view (use the window's `departure` to re-fetch single mode)
- **Step 4**: mobile cards stack
- **Step 5**: polish (hs warning colors, transitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)