### PR TITLE
feat(web): sweep form guardrails + friendly API errors

### DIFF
--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -2,6 +2,30 @@ import type { PassageResponse, MultiWindowResponse, Archetype } from "../plan/ty
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https://qdonnars-openwind-mcp.hf.space";
 
+// Translate known backend error messages to actionable French. Returns the
+// original string if no rule matches, so unknown errors stay debuggable.
+export function friendlyError(raw: string): string {
+  if (/forecast horizon exceeded/i.test(raw)) {
+    return "Cette date est trop loin dans le futur — la météo n'est fiable que sur ~14 jours. Choisissez une date plus proche.";
+  }
+  if (/at least 2 waypoints/i.test(raw)) {
+    return "Placez au moins 2 waypoints sur la carte pour calculer une route.";
+  }
+  if (/unknown archetype/i.test(raw)) {
+    return "Type de bateau inconnu. Sélectionnez un archétype dans la liste.";
+  }
+  if (/invalid (departure|latest_departure|target_eta)/i.test(raw)) {
+    return "Date invalide. Vérifiez le format des champs date.";
+  }
+  if (/sweep would produce \d+ windows/i.test(raw)) {
+    return "Trop de créneaux à comparer. Réduisez la fenêtre ou augmentez le pas d'échantillonnage.";
+  }
+  if (/Erreur serveur 5\d\d/.test(raw) || /HTTP 5\d\d/.test(raw)) {
+    return "Le serveur météo est indisponible. Réessayez dans quelques instants.";
+  }
+  return raw;
+}
+
 export async function fetchPassage(params: {
   waypoints: [number, number][];
   departure: string;

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -177,6 +177,52 @@ const SWEEP_INTERVALS: { value: number; label: string }[] = [
   { value: 6, label: "Toutes les 6h" },
 ];
 
+// Match the single-mode slider cap: Open-Meteo forecast tops out at ~today+15;
+// we keep 14 d to leave 1 d of margin for clock skew / TZ crossings.
+const SWEEP_HORIZON_DAYS = 14;
+// Backend safety cap: 14 d × 24 h = 336 windows. Mirror it here so we can
+// surface a friendly hint before sending an oversize request.
+const MAX_SWEEP_WINDOWS = 336;
+
+export interface SweepValidation {
+  ok: boolean;
+  message?: string;
+}
+
+export function validateSweep(earliest: string, latest: string, intervalHours: number): SweepValidation {
+  if (!earliest || !latest) return { ok: false, message: "Renseignez une fenêtre de départ." };
+  const e = new Date(earliest);
+  const l = new Date(latest);
+  if (Number.isNaN(e.getTime()) || Number.isNaN(l.getTime())) {
+    return { ok: false, message: "Dates invalides." };
+  }
+  if (l.getTime() <= e.getTime()) {
+    return { ok: false, message: "Le « plus tard » doit être après le « plus tôt »." };
+  }
+  const horizonMs = SWEEP_HORIZON_DAYS * 86_400_000;
+  const now = new Date();
+  if (l.getTime() - now.getTime() > horizonMs) {
+    return {
+      ok: false,
+      message: `La météo n'est fiable que sur ${SWEEP_HORIZON_DAYS} jours. Choisissez une date plus tôt.`,
+    };
+  }
+  const windows = Math.floor((l.getTime() - e.getTime()) / 3_600_000 / intervalHours) + 1;
+  if (windows > MAX_SWEEP_WINDOWS) {
+    return {
+      ok: false,
+      message: `Trop de créneaux à comparer (${windows}). Réduisez la fenêtre ou augmentez le pas.`,
+    };
+  }
+  return { ok: true };
+}
+
+// Minimal "YYYY-MM-DDTHH:MM" formatter from a Date (local time).
+function toLocalIsoMin(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function SweepForm({
   earliest,
   latest,
@@ -201,6 +247,18 @@ function SweepForm({
   const colorScheme = resolvedTheme === "light" ? "light" : "dark";
   const [showEta, setShowEta] = useState(targetEta !== "");
 
+  // Bound the date pickers to [now, now + SWEEP_HORIZON_DAYS] so users can't
+  // pick something the forecast won't cover. Memoised so the picker doesn't
+  // jitter as the user types.
+  const { minIso, maxIso } = useMemo(() => {
+    const now = new Date();
+    now.setSeconds(0, 0);
+    const max = new Date(now.getTime() + SWEEP_HORIZON_DAYS * 86_400_000);
+    return { minIso: toLocalIsoMin(now), maxIso: toLocalIsoMin(max) };
+  }, []);
+
+  const validation = validateSweep(earliest, latest, intervalHours);
+
   const inputStyle = {
     background: "var(--ow-bg-2)",
     color: "var(--ow-fg-0)",
@@ -218,6 +276,8 @@ function SweepForm({
         <input
           type="datetime-local"
           value={earliest}
+          min={minIso}
+          max={maxIso}
           onChange={(e) => onEarliestChange(e.target.value)}
           className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
           style={inputStyle}
@@ -231,10 +291,17 @@ function SweepForm({
         <input
           type="datetime-local"
           value={latest}
+          min={earliest || minIso}
+          max={maxIso}
           onChange={(e) => onLatestChange(e.target.value)}
           className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
           style={inputStyle}
         />
+        {!validation.ok && validation.message && (
+          <p className="text-[11px] mt-1" style={{ color: "var(--ow-warn)" }}>
+            {validation.message}
+          </p>
+        )}
       </div>
 
       <div>
@@ -279,6 +346,8 @@ function SweepForm({
           <input
             type="datetime-local"
             value={targetEta}
+            min={earliest || minIso}
+            max={maxIso}
             onChange={(e) => onTargetEtaChange(e.target.value)}
             className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums mt-1.5"
             style={inputStyle}
@@ -465,7 +534,10 @@ export function PlanSidebar({
   onCompareFetch,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
-  const canCalculate = waypointCount >= 2;
+  const sweepValid = mode === "compare"
+    ? validateSweep(sweepEarliest, sweepLatest, sweepIntervalHours)
+    : { ok: true } as SweepValidation;
+  const canCalculate = waypointCount >= 2 && (mode === "single" || sweepValid.ok);
 
   if (isLoading) {
     return (

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
-import { fetchPassage, fetchPassageWindows, fetchArchetypes } from "../api/passage";
+import { fetchPassage, fetchPassageWindows, fetchArchetypes, friendlyError } from "../api/passage";
 import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
@@ -262,7 +262,7 @@ export function PlanPage() {
         const ttl = 7 * 24 * 3600;
         document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
       })
-      .catch((e: Error) => setApiError(e.message))
+      .catch((e: Error) => setApiError(friendlyError(e.message)))
       .finally(() => setIsLoading(false));
   }
 
@@ -330,7 +330,7 @@ export function PlanPage() {
         setComplexity(null);
         setIsStale(false);
       })
-      .catch((e: Error) => setApiError(e.message))
+      .catch((e: Error) => setApiError(friendlyError(e.message)))
       .finally(() => setIsLoading(false));
   }
 


### PR DESCRIPTION
## Summary

User report: \"forecast horizon exceeded for model 'meteofrance_arome_france'\" when picking a date too far out via the compare-windows form. The form let users pick any date — including past Open-Meteo's ~15 day forecast cap — and surfaced the raw backend stack trace.

Three layers of safeguards, smallest first:

### 1. HTML date constraints

`min`/`max` attributes on the `SweepForm` `datetime-local` inputs:
- **earliest**: `min=now`, `max=now+14d`
- **latest**: `min=earliest`, `max=now+14d`
- **target_eta**: same bounds when shown

Blocks the worst inputs at the picker level.

### 2. Pre-submit validation (`validateSweep`)

- earliest/latest both required
- `latest > earliest`
- `latest <= now + 14 d`
- resulting window count `<= 336` (matches `MAX_SWEEP_WINDOWS` server cap)

The "Comparer les créneaux" button disables when invalid; the reason surfaces as a small warn-coloured line under the date inputs.

### 3. `friendlyError` mapping

In `api/passage.ts`. Translates known backend errors to actionable French:
- `forecast horizon exceeded` → \"Cette date est trop loin dans le futur — la météo n'est fiable que sur ~14 jours.\"
- `at least 2 waypoints` → \"Placez au moins 2 waypoints sur la carte…\"
- `unknown archetype` → \"Type de bateau inconnu…\"
- `invalid (departure|latest_departure|target_eta)` → \"Date invalide…\"
- `sweep would produce N windows` → \"Trop de créneaux à comparer…\"
- HTTP 5xx → \"Le serveur météo est indisponible…\"

Unknown errors fall through verbatim so they stay debuggable.

Both single-mode and sweep-mode catches in `PlanPage` now run their error message through `friendlyError` before `setApiError`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [ ] Browser check: in compare mode, set latest = today+30d → button disables, hint reads \"La météo n'est fiable que sur 14 jours.\"
- [ ] Browser check: set interval=1h with earliest..latest = 14d → button disables, hint reads \"Trop de créneaux à comparer (337).\"
- [ ] Backend error path: temporarily force a backend horizon error → UI shows the friendly French message instead of the raw stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)