### PR TITLE
feat(web): toggle always reachable + mobile controls + softer horizon msg

### DIFF
--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -6,7 +6,10 @@ const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https
 // original string if no rule matches, so unknown errors stay debuggable.
 export function friendlyError(raw: string): string {
   if (/forecast horizon exceeded/i.test(raw)) {
-    return "Cette date est trop loin dans le futur — la météo n'est fiable que sur ~14 jours. Choisissez une date plus proche.";
+    // Cause la plus fréquente : date > today+15 (cap Open-Meteo). Mais peut
+    // aussi survenir transitoirement quand un modèle de la chaîne tombe ;
+    // d'où la formulation prudente.
+    return "Le service météo n'a pas pu couvrir cette période. Essayez une date plus proche, ou réessayez dans quelques instants.";
   }
   if (/at least 2 waypoints/i.test(raw)) {
     return "Placez au moins 2 waypoints sur la carte pour calculer une route.";

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -667,6 +667,9 @@ export function PlanSidebar({
 
   return (
     <div className="p-4 space-y-4 animate-fade-in">
+      {/* Mode toggle — always visible so the user can switch back to compare */}
+      <ModeToggle value={mode} onChange={onModeChange} />
+
       {/* Recalculate — grows when stale */}
       <button
         onClick={onRefetch}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -335,8 +335,17 @@ export function PlanPage() {
   }
 
   function handleModeChange(next: "single" | "compare") {
+    if (next === planMode) return;
     setPlanMode(next);
     setApiError(null);
+    // Drop the opposite mode's results so the sidebar renders the right view.
+    if (next === "compare") {
+      setPassage(null);
+      setComplexity(null);
+    } else {
+      setWindows(null);
+      setMetaWarnings([]);
+    }
   }
 
   if (!isParsedOk(initialParsed)) {
@@ -461,20 +470,59 @@ export function PlanPage() {
         </div>
       </div>
 
-      {/* Mobile compact drawer — below map */}
+      {/* Mobile drawer — below map */}
+      {/* When a single-mode passage is computed: compact leg-rows view (38vh).
+          Otherwise (no passage, compare mode, error): full PlanSidebar so the
+          mode toggle, form, and Calculate/Compare buttons stay reachable. */}
       <div
         className="lg:hidden shrink-0 overflow-y-auto border-t"
-        style={{ maxHeight: "38vh", background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+        style={{
+          maxHeight: passage ? "38vh" : "60vh",
+          background: "var(--ow-bg-1)",
+          borderColor: "var(--ow-line)",
+        }}
       >
-        <CompactDrawer
-          passage={passage}
-          complexity={complexity}
-          waypoints={waypoints}
-          isLoading={isLoading}
-          error={apiError}
-          isStale={isStale}
-          onRefetch={handleRefetch}
-        />
+        {passage && complexity && planMode === "single" ? (
+          <CompactDrawer
+            passage={passage}
+            complexity={complexity}
+            waypoints={waypoints}
+            isLoading={isLoading}
+            error={apiError}
+            isStale={isStale}
+            onRefetch={handleRefetch}
+          />
+        ) : (
+          <PlanSidebar
+            passage={passage}
+            complexity={complexity}
+            isLoading={isLoading}
+            error={apiError}
+            archetypes={archetypes}
+            currentArchetypeSlug={archetype}
+            onArchetypeChange={handleArchetypeChange}
+            departure={departure}
+            onDepartureChange={handleDepartureChange}
+            isStale={isStale}
+            onRefetch={handleRefetch}
+            forecastUpdatedAt={forecastUpdatedAt}
+            waypointCount={waypoints.length}
+            waypoints={waypoints}
+            mode={planMode}
+            onModeChange={handleModeChange}
+            sweepEarliest={sweepEarliest}
+            sweepLatest={sweepLatest}
+            sweepIntervalHours={sweepInterval}
+            sweepTargetEta={sweepTargetEta}
+            onSweepEarliestChange={setSweepEarliest}
+            onSweepLatestChange={setSweepLatest}
+            onSweepIntervalChange={setSweepInterval}
+            onSweepTargetEtaChange={setSweepTargetEta}
+            windows={windows}
+            metaWarnings={metaWarnings}
+            onCompareFetch={doFetchWindows}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

User feedback after compare-windows landed: on mobile, after placing waypoints there was no UI at all to trigger a calculation; the Simuler/Comparer toggle was also unreachable from the post-results state.

### 1. Toggle always at top

Before, the `ModeToggle` only rendered in the empty-state branch. Once a single passage was computed, the user had no way back to compare without manually clearing the URL. Now rendered at the top of the post-results sidebar too. `handleModeChange` clears the opposite mode's results so the branch matches the new mode (no stale view).

### 2. Mobile controls

Before, mobile users had no UI at all until a single passage was computed (`CompactDrawer` returned `null` in the empty state). The mobile bottom drawer now renders the full `PlanSidebar` when there is no single-mode passage — toggle, sweep form, archetype selector, and Calculate/Compare buttons are all reachable on touch. Drawer `maxHeight` grows from 38vh → 60vh in this state so the form doesn't get clipped. The compact leg-rows view stays for the post-passage single-mode case.

### 3. Softer horizon error

The previous `friendlyError` for `forecast horizon exceeded` was prescriptive (\"date trop loin dans le futur\"), misleading for the T+48h edge case where AROME fails but the ICON-EU/ECMWF/GFS fallback should pick up. New copy is neutral and actionable:

> Le service météo n'a pas pu couvrir cette période. Essayez une date plus proche, ou réessayez dans quelques instants.

## Out of scope

- Drag-to-resize drawer (the user mentioned wanting to slide the footer up/down to expose the map). Future polish.
- Verifying the ICON-EU fallback actually works end-to-end on the deployed HF Space — code path looks correct on `main`, but a live smoke would help confirm.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [ ] Mobile (≤1024px wide): place 2 waypoints → bottom drawer shows toggle + DepartureSlider + Calculate. Toggle to Comparer → SweepForm + Comparer button. Click Calculer → bottom drawer becomes the compact leg-rows view (passage view).
- [ ] Desktop: in single-mode results, toggle visible at top of sidebar; clicking Comparer clears single results and shows the compare form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)