### PR TITLE
feat(mcp+web): per-window sweep tolerance + dual-thumb range slider

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -452,20 +452,29 @@ async def estimate_passage_windows(
             ]
         )
 
-        # Sweep remaining departure windows sequentially (all cache hits, no I/O).
+        # Sweep remaining departure windows sequentially. Per-window tolerance:
+        # if a single departure raises ForecastHorizonError (e.g. its mid-time
+        # extends past the resolved model's horizon), skip it and continue —
+        # the user gets partial results instead of a hard failure on the whole
+        # sweep. The caller compares expected window count vs len(reports) and
+        # surfaces a meta-warning. ValueError / KeyError still bubble (those
+        # are caller-side bugs).
         current = earliest_utc + timedelta(hours=sweep_interval_hours)
         while current <= latest_utc:
-            report = await estimate_passage(
-                waypoints,
-                current,
-                boat_archetype,
-                efficiency=efficiency,
-                segment_length_nm=segment_length_nm,
-                adapter=fetch_adapter,
-                model=resolved_model,
-                use_wave_correction=use_wave_correction,
-            )
-            reports.append(report)
+            try:
+                report = await estimate_passage(
+                    waypoints,
+                    current,
+                    boat_archetype,
+                    efficiency=efficiency,
+                    segment_length_nm=segment_length_nm,
+                    adapter=fetch_adapter,
+                    model=resolved_model,
+                    use_wave_correction=use_wave_correction,
+                )
+                reports.append(report)
+            except ForecastHorizonError:
+                pass
             current += timedelta(hours=sweep_interval_hours)
     finally:
         if own_adapter and hasattr(fetch_adapter, "aclose"):

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -620,6 +620,52 @@ class TestEstimatePassageWindows:
             assert r.duration_h > 0
             assert r.distance_nm > 0
 
+    async def test_partial_skip_on_per_window_horizon_error(self) -> None:
+        """Some windows hitting ForecastHorizonError must NOT fail the whole sweep.
+        Caller infers skip count from len(reports) vs expected window count."""
+        from openwind_data.adapters.base import (
+            ForecastBundle as _FB, SeaSeries as _SS, WindSeries as _WS,
+        )
+
+        class FlakyAdapter(StubAdapter):
+            """Returns empty wind for the 3rd fetch onward (mid-times past 2nd window)."""
+            def __init__(self) -> None:
+                super().__init__(tws_kn=10.0, twd_deg=0.0)
+                self.fetch_count = 0
+                self.fail_at_call = 6  # let prewarm + first sweep window pass
+
+            async def fetch(
+                self,
+                lat: float,
+                lon: float,
+                start: datetime,
+                end: datetime,
+                models: list[str] | None = None,
+            ) -> _FB:
+                self.fetch_count += 1
+                if self.fetch_count >= self.fail_at_call:
+                    return _FB(
+                        lat=lat, lon=lon, start=start, end=end,
+                        wind_by_model={(models or ["meteofrance_arome_france"])[0]: _WS(
+                            model=(models or ["meteofrance_arome_france"])[0], points=()
+                        )},
+                        sea=_SS(points=()),
+                        requested_at=start,
+                    )
+                return await super().fetch(lat, lon, start, end, models)
+
+        adapter = FlakyAdapter()
+        earliest = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+        latest = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)  # 7 windows at 1h
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES], earliest, latest, "cruiser_40ft",
+            adapter=adapter, segment_length_nm=20.0,
+        )
+        # First window must succeed (resolved before flakiness kicks in).
+        assert len(reports) >= 1
+        # Some windows skipped → fewer than 7 total, no exception bubbled.
+        assert len(reports) < 7
+
 
 class TestSeaStateAlwaysSurfaced:
     """Hs must be populated on every segment when sea data is available,

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -315,6 +315,15 @@ async def _api_passage(request: Request) -> JSONResponse:
         except ForecastHorizonError as exc:
             return JSONResponse({"error": str(exc)}, status_code=422)
 
+        # Sweep is partial-tolerant: estimate_passage_windows skips windows
+        # that hit ForecastHorizonError. Compute the expected count to surface
+        # a meta-warning if some were dropped.
+        from datetime import timedelta as _td
+        expected_windows = (
+            int((latest_departure - departure).total_seconds() / 3600 / sweep_interval) + 1
+        )
+        skipped_count = max(0, expected_windows - len(reports))
+
         windows: list[dict[str, Any]] = []
         for report in reports:
             score = score_complexity(report)
@@ -334,9 +343,13 @@ async def _api_passage(request: Request) -> JSONResponse:
             })
 
         meta_warnings: list[str] = []
+        if skipped_count > 0:
+            meta_warnings.append(
+                f"{skipped_count} fenêtre(s) ignorée(s) faute de couverture météo "
+                f"(horizon dépassé) — affichage des {len(windows)} restantes."
+            )
         if target_eta_dt is not None:
-            from datetime import timedelta
-            tol = timedelta(hours=2).total_seconds()
+            tol = _td(hours=2).total_seconds()
             target_utc = target_eta_dt.astimezone(UTC)
             filtered = [
                 w for w in windows

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -262,6 +262,79 @@ body {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--ow-accent) 35%, transparent);
 }
 
+/* Dual-thumb range (compare-windows form). Two overlapping native sliders;
+   z-index swaps in JS based on which thumb is closer to either edge. */
+.ow-range-track {
+  position: relative;
+  height: 22px;
+  display: flex;
+  align-items: center;
+}
+.ow-range-track-bg {
+  position: absolute;
+  inset: 8px 0 8px 0;
+  background: var(--ow-bg-2);
+  border: 1px solid var(--ow-line-2);
+  border-radius: 3px;
+}
+.ow-range-track-fill {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  background: var(--ow-accent-soft);
+  border-top: 1px solid var(--ow-accent);
+  border-bottom: 1px solid var(--ow-accent);
+}
+.ow-range-input {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  height: 22px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  pointer-events: none; /* track itself ignores clicks; thumbs re-enable */
+  margin: 0;
+}
+.ow-range-input:focus { outline: none; }
+.ow-range-input::-webkit-slider-runnable-track {
+  height: 6px;
+  background: transparent;
+  border: none;
+}
+.ow-range-input::-moz-range-track {
+  height: 6px;
+  background: transparent;
+  border: none;
+}
+.ow-range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ow-accent);
+  border: 2px solid var(--ow-bg-1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  margin-top: -7px;
+  cursor: pointer;
+  pointer-events: auto;
+}
+.ow-range-input::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ow-accent);
+  border: 2px solid var(--ow-bg-1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  pointer-events: auto;
+}
+.ow-range-input:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ow-accent) 35%, transparent);
+}
+
 /* Leaflet attribution smaller on mobile */
 .leaflet-control-attribution {
   font-size: 9px !important;

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -169,6 +169,133 @@ function ModeToggle({ value, onChange }: { value: PlanMode; onChange: (m: PlanMo
   );
 }
 
+// ── DepartureRangeSlider ─────────────────────────────────────────────────────
+// Dual-thumb slider for the compare-windows form. Two overlapping native ranges
+// keyed in hours-from-now; the right thumb is constrained to stay >= 1 h after
+// the left thumb. Constraints by construction = no out-of-range dates can be
+// picked, replacing the error-prone datetime-local pair.
+
+const RANGE_MAX_HOURS = 14 * 24; // mirror Open-Meteo cap (today+14d)
+
+function DepartureRangeSlider({
+  earliestHours,
+  latestHours,
+  onChange,
+}: {
+  earliestHours: number;
+  latestHours: number;
+  onChange: (earliest: number, latest: number) => void;
+}) {
+  const anchor = useMemo(() => {
+    const d = new Date();
+    d.setMinutes(0, 0, 0);
+    return d;
+  }, []);
+
+  const eClamped = Math.max(0, Math.min(RANGE_MAX_HOURS - 1, earliestHours));
+  const lClamped = Math.max(eClamped + 1, Math.min(RANGE_MAX_HOURS, latestHours));
+
+  function setEarliest(h: number) {
+    const next = Math.max(0, Math.min(RANGE_MAX_HOURS - 1, h));
+    const newLatest = Math.max(next + 1, lClamped);
+    onChange(next, Math.min(RANGE_MAX_HOURS, newLatest));
+  }
+  function setLatest(h: number) {
+    const next = Math.min(RANGE_MAX_HOURS, Math.max(eClamped + 1, h));
+    onChange(eClamped, next);
+  }
+
+  function fmt(hours: number): { date: string; time: string; offset: string } {
+    const d = new Date(anchor.getTime() + hours * 3_600_000);
+    return {
+      date: d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" }),
+      time: d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }),
+      offset: (() => {
+        const days = Math.floor(hours / 24);
+        if (days === 0) return "Aujourd'hui";
+        if (days === 1) return "Demain";
+        return `J+${days}`;
+      })(),
+    };
+  }
+
+  const eFmt = fmt(eClamped);
+  const lFmt = fmt(lClamped);
+  const windowHours = lClamped - eClamped;
+  const windowLabel = windowHours >= 24
+    ? `${(windowHours / 24).toFixed(windowHours % 24 === 0 ? 0 : 1)} j`
+    : `${windowHours} h`;
+
+  // Track fill % for visual fill between thumbs
+  const fillStart = (eClamped / RANGE_MAX_HOURS) * 100;
+  const fillEnd = (lClamped / RANGE_MAX_HOURS) * 100;
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1">
+        <span className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: "var(--ow-fg-2)" }}>
+          Fenêtre de départ
+        </span>
+        <span className="text-[10px] tabular-nums" style={{ color: "var(--ow-accent)" }}>
+          {windowLabel}
+        </span>
+      </div>
+
+      {/* Two readouts, one per thumb */}
+      <div className="flex items-baseline justify-between text-xs mb-2 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
+        <div>
+          <div className="capitalize font-semibold" style={{ color: "var(--ow-fg-0)" }}>
+            {eFmt.date} · {eFmt.time}
+          </div>
+          <div className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>{eFmt.offset}</div>
+        </div>
+        <div className="text-right">
+          <div className="capitalize font-semibold" style={{ color: "var(--ow-fg-0)" }}>
+            {lFmt.date} · {lFmt.time}
+          </div>
+          <div className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>{lFmt.offset}</div>
+        </div>
+      </div>
+
+      <div className="ow-range-track">
+        <div className="ow-range-track-bg" />
+        <div
+          className="ow-range-track-fill"
+          style={{ left: `${fillStart}%`, right: `${100 - fillEnd}%` }}
+        />
+        <input
+          type="range"
+          min={0}
+          max={RANGE_MAX_HOURS}
+          step={1}
+          value={eClamped}
+          onChange={(e) => setEarliest(Number(e.target.value))}
+          className="ow-range-input"
+          aria-label="Départ au plus tôt"
+          style={{ zIndex: eClamped > RANGE_MAX_HOURS / 2 ? 3 : 2 }}
+        />
+        <input
+          type="range"
+          min={0}
+          max={RANGE_MAX_HOURS}
+          step={1}
+          value={lClamped}
+          onChange={(e) => setLatest(Number(e.target.value))}
+          className="ow-range-input"
+          aria-label="Départ au plus tard"
+          style={{ zIndex: eClamped > RANGE_MAX_HOURS / 2 ? 2 : 3 }}
+        />
+      </div>
+
+      <div className="flex justify-between text-[10px] mt-1" style={{ color: "var(--ow-fg-2)" }}>
+        <span>Maintenant</span>
+        <span>+1 sem.</span>
+        <span>+2 sem.</span>
+      </div>
+    </div>
+  );
+}
+
 // ── SweepForm ─────────────────────────────────────────────────────────────────
 
 const SWEEP_INTERVALS: { value: number; label: string }[] = [
@@ -247,15 +374,32 @@ function SweepForm({
   const colorScheme = resolvedTheme === "light" ? "light" : "dark";
   const [showEta, setShowEta] = useState(targetEta !== "");
 
-  // Bound the date pickers to [now, now + SWEEP_HORIZON_DAYS] so users can't
-  // pick something the forecast won't cover. Memoised so the picker doesn't
-  // jitter as the user types.
+  // Bound target_eta to [now, now+14d] when shown — same horizon as the slider.
   const { minIso, maxIso } = useMemo(() => {
     const now = new Date();
     now.setSeconds(0, 0);
     const max = new Date(now.getTime() + SWEEP_HORIZON_DAYS * 86_400_000);
     return { minIso: toLocalIsoMin(now), maxIso: toLocalIsoMin(max) };
   }, []);
+
+  // Convert ISO local strings <-> hours-from-now so the slider can drive them.
+  const anchor = useMemo(() => {
+    const d = new Date();
+    d.setMinutes(0, 0, 0);
+    return d;
+  }, []);
+  function isoToHours(iso: string): number {
+    if (!iso) return 0;
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return 0;
+    return Math.round((t - anchor.getTime()) / 3_600_000);
+  }
+  function hoursToIso(h: number): string {
+    return toLocalIsoMin(new Date(anchor.getTime() + h * 3_600_000));
+  }
+
+  const earliestHours = Math.max(0, isoToHours(earliest));
+  const latestHours = Math.max(earliestHours + 1, isoToHours(latest));
 
   const validation = validateSweep(earliest, latest, intervalHours);
 
@@ -269,40 +413,19 @@ function SweepForm({
 
   return (
     <div className="space-y-3">
-      <div>
-        <label className="block text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--ow-fg-2)" }}>
-          Départ au plus tôt
-        </label>
-        <input
-          type="datetime-local"
-          value={earliest}
-          min={minIso}
-          max={maxIso}
-          onChange={(e) => onEarliestChange(e.target.value)}
-          className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
-          style={inputStyle}
-        />
-      </div>
-
-      <div>
-        <label className="block text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--ow-fg-2)" }}>
-          Départ au plus tard
-        </label>
-        <input
-          type="datetime-local"
-          value={latest}
-          min={earliest || minIso}
-          max={maxIso}
-          onChange={(e) => onLatestChange(e.target.value)}
-          className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums"
-          style={inputStyle}
-        />
-        {!validation.ok && validation.message && (
-          <p className="text-[11px] mt-1" style={{ color: "var(--ow-warn)" }}>
-            {validation.message}
-          </p>
-        )}
-      </div>
+      <DepartureRangeSlider
+        earliestHours={earliestHours}
+        latestHours={latestHours}
+        onChange={(e, l) => {
+          onEarliestChange(hoursToIso(e));
+          onLatestChange(hoursToIso(l));
+        }}
+      />
+      {!validation.ok && validation.message && (
+        <p className="text-[11px]" style={{ color: "var(--ow-warn)" }}>
+          {validation.message}
+        </p>
+      )}
 
       <div>
         <label className="block text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--ow-fg-2)" }}>


### PR DESCRIPTION
## Summary

User reports two pains on the compare-windows feature:
- *\"il but 2 fois sur 3\"* — the sweep fails on intermittent backend errors, losing all results instead of returning what worked.
- *\"un slider à 2 boutons éviterait tout ça\"* — the `datetime-local` inputs are clunky and let users pick out-of-horizon dates that 422.

Two complementary fixes shipped together.

## Backend: per-window tolerance

`estimate_passage_windows` now wraps each sweep iteration in `try/except ForecastHorizonError`. A failed window is silently skipped; successful ones are returned. The first-window resolution is still load-bearing (picks the model + seeds the cache), so it keeps its original \"must succeed\" semantics.

The HF endpoint compares expected vs actual count and adds a French meta-warning when N windows were dropped — the user sees partial results plus a clear note rather than a hard failure:

> \"3 fenêtre(s) ignorée(s) faute de couverture météo (horizon dépassé) — affichage des 14 restantes.\"

New test `test_partial_skip_on_per_window_horizon_error` proves the behaviour with a flaky stub adapter (47 passage tests pass).

## Web: dual-thumb `DepartureRangeSlider`

Replaces the two `datetime-local` inputs in `SweepForm` with a single range track carrying two thumbs (earliest / latest). Constraints by construction:

- both thumbs in `[0, 14d]` hours from now (matches Open-Meteo cap)
- right thumb `>= left + 1h`
- live readout above each thumb: date · time · offset label (\"Aujourd'hui\", \"Demain\", \"J+5\")
- \"Fenêtre de Xh / Xj\" badge top-right

This kills entire classes of validation errors: it's literally impossible to pick an invalid range. The pre-submit `validateSweep` guard stays as belt-and-suspenders for the windows count cap (`stride × range > 336`).

Built with two overlapping native `<input type=\"range\">` (z-index swap based on midpoint), CSS in `index.css`. Lighter than custom pointer-events, accessible by default.

## Out of scope

The mobile redesign (floating \"Simuler / Comparer\" buttons + sliding bottom sheet) is a separate PR — different concern, larger surface.

## Test plan

- [x] `uv run pytest tests/test_passage.py` — 47/47 passes
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (+2 KB CSS for the new slider)
- [ ] Browser: switch to Comparer, drag both thumbs → values stay in valid range, dates update live
- [ ] Browser: simulate a sweep that hits horizon mid-way (live MCP) → table shows partial results + meta-warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)