### PR TITLE
feat(web): drill-down from Comparer table to Simuler ma route

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -625,6 +625,7 @@ interface PlanSidebarProps {
   windows: PassageWindow[] | null;
   metaWarnings: string[];
   onCompareFetch: () => void;
+  onWindowSelect?: (w: PassageWindow) => void;
 }
 
 export function PlanSidebar({
@@ -655,6 +656,7 @@ export function PlanSidebar({
   windows,
   metaWarnings,
   onCompareFetch,
+  onWindowSelect,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
   const sweepValid = mode === "compare"
@@ -775,10 +777,10 @@ export function PlanSidebar({
               </p>
             ))}
             <div className="rounded-xl overflow-hidden border" style={{ borderColor: "var(--ow-line)" }}>
-              <WindowsTable windows={windows} />
+              <WindowsTable windows={windows} onSelect={onWindowSelect} />
             </div>
             <p className="text-[10px]" style={{ color: "var(--ow-fg-3)" }}>
-              {windows.length} fenêtre{windows.length > 1 ? "s" : ""} comparée{windows.length > 1 ? "s" : ""} · cliquez sur une ligne pour le détail (à venir)
+              {windows.length} fenêtre{windows.length > 1 ? "s" : ""} comparée{windows.length > 1 ? "s" : ""} · cliquez sur une ligne pour ouvrir la simulation détaillée
             </p>
           </div>
         )}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -348,6 +348,23 @@ export function PlanPage() {
     }
   }
 
+  // Drill-down from the compare-windows table: pick a window → switch to
+  // single mode with that window's departure pre-filled, then fetch.
+  function handleWindowSelect(w: PassageWindow) {
+    // Convert TZ-aware ISO from the backend to the naive local "YYYY-MM-DDTHH:MM"
+    // shape that the single-mode departure input expects.
+    const d = new Date(w.departure);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const naiveDep = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+    setPlanMode("single");
+    setDeparture(naiveDep);
+    setWindows(null);
+    setMetaWarnings([]);
+    setApiError(null);
+    doFetch(waypoints, archetype, naiveDep);
+  }
+
   if (!isParsedOk(initialParsed)) {
     return (
       <div
@@ -466,6 +483,7 @@ export function PlanPage() {
             windows={windows}
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}
+            onWindowSelect={handleWindowSelect}
           />
         </div>
       </div>
@@ -521,6 +539,7 @@ export function PlanPage() {
             windows={windows}
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}
+            onWindowSelect={handleWindowSelect}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

Step 3 of the compare-windows feature. Clicking a row in `WindowsTable` now opens that specific window's detailed plan in single-mode.

User ask: *\"quand je clique sur une simulation j'aimerai que ça me dirige vers le tab simuler ma route avec la route donnée\"*.

## Changes

- **`handleWindowSelect`** in `PlanPage`:
  - Converts the TZ-aware window departure to the naive `\"YYYY-MM-DDTHH:MM\"` shape the single-mode departure input expects.
  - Flips `planMode` to `\"single\"`, clears the windows array.
  - Calls `doFetch` with the new departure → URL / cookie / sidebar all sync.

- **`PlanSidebar`** gains an optional `onWindowSelect` prop, threaded down to `WindowsTable`'s existing `onSelect` callback (which was wired but unused pending this PR).

- Footer text updated from *\"à venir\"* to *\"cliquez sur une ligne pour ouvrir la simulation détaillée\"*.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [ ] Browser: in Comparer mode, click a row → sidebar swaps to single-mode, departure picker shows the selected time, fetch fires, single passage results render with the chosen window's conditions.
- [ ] URL updates to reflect the chosen `departure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)