### PR TITLE
feat(mcp+web): instant drill-down + persisted last simulation

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -327,6 +327,10 @@ async def _api_passage(request: Request) -> JSONResponse:
         windows: list[dict[str, Any]] = []
         for report in reports:
             score = score_complexity(report)
+            # Include the full passage + complexity per window so a frontend
+            # drill-down ("click a row → see detail") needs zero re-fetch.
+            # The summary fields above (`complexity` partial, `conditions_summary`,
+            # `duration_h`, `distance_nm`) stay for compact table rendering.
             windows.append({
                 "departure": report.departure_time.isoformat(),
                 "arrival": report.arrival_time.isoformat(),
@@ -340,6 +344,8 @@ async def _api_passage(request: Request) -> JSONResponse:
                 },
                 "conditions_summary": _build_conditions_summary(report),
                 "warnings": list(report.warnings) + [w.message for w in score.warnings],
+                "passage": _to_json(report),
+                "complexity_full": _to_json(score),
             })
 
         meta_warnings: list[str] = []

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -689,7 +689,10 @@ export function PlanSidebar({
     );
   }
 
-  if (!passage || !complexity) {
+  // In compare mode we always show the form + (optional) windows table,
+  // even if a single-mode `passage` is also in memory. That way toggling
+  // back to single shows the cached single result without a re-fetch.
+  if (mode === "compare" || !passage || !complexity) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
         {/* Waypoint progress */}

--- a/packages/web/src/plan/lastSimulation.ts
+++ b/packages/web/src/plan/lastSimulation.ts
@@ -1,0 +1,77 @@
+import type {
+  PassageReport,
+  ComplexityScore,
+  PassageWindow,
+} from "./types";
+
+// Persists the last successful simulation (single-mode passage and/or
+// compare-mode windows) so the user sees their plan immediately on reload —
+// no re-fetch, no empty form. Cache is invalidated implicitly when the URL
+// route changes (we restore only when waypoints + archetype match the URL).
+
+const STORAGE_KEY = "ow_last_simulation_v1";
+
+export interface LastSimulation {
+  waypoints: [number, number][];
+  archetype: string;
+  // Single-mode (may be null if the user only ran a sweep)
+  single?: {
+    departure: string; // naive local "YYYY-MM-DDTHH:MM"
+    passage: PassageReport;
+    complexity: ComplexityScore;
+    forecastUpdatedAt: string;
+  };
+  // Compare-mode (may be null if the user only ran single)
+  compare?: {
+    sweepEarliest: string;
+    sweepLatest: string;
+    sweepIntervalHours: number;
+    sweepTargetEta?: string;
+    windows: PassageWindow[];
+    metaWarnings: string[];
+    forecastUpdatedAt: string;
+  };
+  cachedAt: number;
+}
+
+export function saveLastSimulation(sim: LastSimulation): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sim));
+  } catch {
+    // localStorage unavailable / full — silently skip; next load just won't
+    // restore. Better than crashing the success path.
+  }
+}
+
+export function loadLastSimulation(): LastSimulation | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as LastSimulation;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLastSimulation(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}
+
+// Tolerance ~10 m at typical latitudes — accounts for floating-point round-trip
+// through the URL. Tighter than human eyeball precision, looser than IEEE bits.
+const COORD_EPS = 1e-4;
+
+export function waypointsEqual(
+  a: [number, number][],
+  b: [number, number][],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every(
+    ([lat, lon], i) =>
+      Math.abs(lat - b[i][0]) < COORD_EPS && Math.abs(lon - b[i][1]) < COORD_EPS,
+  );
+}

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -83,6 +83,11 @@ export interface PassageWindow {
   };
   conditions_summary: ConditionsSummary;
   warnings: string[];
+  // Full per-window detail for instant drill-down (no re-fetch). Optional
+  // because older HF Space deployments may still serve responses without
+  // these fields — frontend must fall back to fetching when missing.
+  passage?: PassageReport;
+  complexity_full?: ComplexityScore;
 }
 
 export interface MultiWindowResponse {

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -6,6 +6,12 @@ import { fetchPassage, fetchPassageWindows, fetchArchetypes, friendlyError } fro
 import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
+import {
+  loadLastSimulation,
+  saveLastSimulation,
+  waypointsEqual,
+  type LastSimulation,
+} from "../plan/lastSimulation";
 import { cxLevel, CX_COLORS } from "../plan/types";
 import { aggregateLegs } from "../plan/aggregateLegs";
 
@@ -261,6 +267,23 @@ export function PlanPage() {
         window.history.replaceState(null, "", url);
         const ttl = 7 * 24 * 3600;
         document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
+        // Persist for next visit. Merge into existing cache so a previously
+        // saved compare-mode result stays available.
+        const prev = loadLastSimulation();
+        const sameRoute =
+          prev && waypointsEqual(prev.waypoints, wpts) && prev.archetype === arch;
+        saveLastSimulation({
+          waypoints: wpts,
+          archetype: arch,
+          single: {
+            departure: dep,
+            passage: res.passage,
+            complexity: res.complexity,
+            forecastUpdatedAt: res.forecast_updated_at,
+          },
+          compare: sameRoute ? prev?.compare : undefined,
+          cachedAt: Date.now(),
+        });
       })
       .catch((e: Error) => setApiError(friendlyError(e.message)))
       .finally(() => setIsLoading(false));
@@ -268,6 +291,37 @@ export function PlanPage() {
 
   useEffect(() => {
     if (!isParsedOk(initialParsed) || initialParsed.waypoints.length < 2) return;
+    // Try the localStorage cache first: if we have a saved simulation for the
+    // same route + archetype, hydrate state directly and skip the network call.
+    // The user sees their last plan instantly on reload.
+    const cached: LastSimulation | null = loadLastSimulation();
+    const cacheMatches =
+      cached &&
+      waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
+      cached.archetype === initialParsed.archetype;
+    if (cacheMatches) {
+      // Restore single-mode result if its departure matches the URL departure.
+      if (cached.single && cached.single.departure === departure) {
+        setPassage(cached.single.passage);
+        setComplexity(cached.single.complexity);
+        setForecastUpdatedAt(cached.single.forecastUpdatedAt);
+      }
+      // Always restore compare-mode windows + sweep params if present —
+      // sweep range isn't encoded in the URL, so we trust the cache.
+      if (cached.compare) {
+        setWindows(cached.compare.windows);
+        setMetaWarnings(cached.compare.metaWarnings);
+        setSweepEarliest(cached.compare.sweepEarliest);
+        setSweepLatest(cached.compare.sweepLatest);
+        setSweepInterval(cached.compare.sweepIntervalHours);
+        setSweepTargetEta(cached.compare.sweepTargetEta ?? "");
+        if (!cached.single || cached.single.departure !== departure) {
+          setForecastUpdatedAt(cached.compare.forecastUpdatedAt);
+        }
+      }
+      // If we restored anything, skip the auto-fetch.
+      if (cached.single || cached.compare) return;
+    }
     doFetch(initialParsed.waypoints, initialParsed.archetype, departure);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -325,10 +379,28 @@ export function PlanPage() {
         setWindows(res.windows);
         setMetaWarnings(res.meta_warnings);
         setForecastUpdatedAt(res.forecast_updated_at);
-        // Clear single-mode results so the sidebar swaps view cleanly.
-        setPassage(null);
-        setComplexity(null);
+        // Don't clear single-mode results — render gates on `mode` instead.
         setIsStale(false);
+        // Persist for next visit. Merge with existing single-mode cache if
+        // the route still matches.
+        const prev = loadLastSimulation();
+        const sameRoute =
+          prev && waypointsEqual(prev.waypoints, waypoints) && prev.archetype === archetype;
+        saveLastSimulation({
+          waypoints,
+          archetype,
+          single: sameRoute ? prev?.single : undefined,
+          compare: {
+            sweepEarliest,
+            sweepLatest,
+            sweepIntervalHours: sweepInterval,
+            sweepTargetEta: sweepTargetEta || undefined,
+            windows: res.windows,
+            metaWarnings: res.meta_warnings,
+            forecastUpdatedAt: res.forecast_updated_at,
+          },
+          cachedAt: Date.now(),
+        });
       })
       .catch((e: Error) => setApiError(friendlyError(e.message)))
       .finally(() => setIsLoading(false));
@@ -338,31 +410,47 @@ export function PlanPage() {
     if (next === planMode) return;
     setPlanMode(next);
     setApiError(null);
-    // Drop the opposite mode's results so the sidebar renders the right view.
-    if (next === "compare") {
-      setPassage(null);
-      setComplexity(null);
-    } else {
-      setWindows(null);
-      setMetaWarnings([]);
-    }
+    // Don't clear opposite-mode results: keeping `passage` and `windows`
+    // both in memory lets the user toggle back and forth without re-fetching.
+    // The render branches gate on `mode` so stale data never leaks visually.
   }
 
   // Drill-down from the compare-windows table: pick a window → switch to
-  // single mode with that window's departure pre-filled, then fetch.
+  // single mode with that window's departure pre-filled.
+  // Fast path: the sweep response already includes `passage` and
+  // `complexity_full` per window — hydrate state directly, zero re-fetch.
+  // Fallback: older HF Space deployments don't include those fields → call
+  // doFetch as before so the UX still works during deployment lag.
   function handleWindowSelect(w: PassageWindow) {
-    // Convert TZ-aware ISO from the backend to the naive local "YYYY-MM-DDTHH:MM"
-    // shape that the single-mode departure input expects.
     const d = new Date(w.departure);
     const pad = (n: number) => String(n).padStart(2, "0");
     const naiveDep = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 
     setPlanMode("single");
     setDeparture(naiveDep);
-    setWindows(null);
     setMetaWarnings([]);
     setApiError(null);
-    doFetch(waypoints, archetype, naiveDep);
+
+    if (w.passage && w.complexity_full) {
+      // Hydrate from the in-memory window — instant.
+      setPassage(w.passage);
+      setComplexity(w.complexity_full);
+      setIsLoading(false);
+      setIsStale(false);
+      // Update URL + cookie so reload restores the same view.
+      const url = buildPlanUrl(waypoints, naiveDep, archetype);
+      window.history.replaceState(null, "", url);
+      const ttl = 7 * 24 * 3600;
+      document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
+      // Keep windows around so the user can switch back to compare mode and
+      // see the table again without re-fetching the sweep.
+      // setWindows(null) intentionally NOT called — user toggling back to
+      // compare should see their table immediately.
+    } else {
+      // Backwards-compatible fallback: re-fetch.
+      setWindows(null);
+      doFetch(waypoints, archetype, naiveDep);
+    }
   }
 
   if (!isParsedOk(initialParsed)) {


### PR DESCRIPTION
## Summary

Two user observations:
- *\"quand on fait la comparaison on a les simulations en mémoire donc quand on clique sur la route je ne m'attends pas à ce qu'on la resimule\"* — drill-down should be free.
- *\"garder la dernière simu dans les cookies sauf si la route change\"* — reload should restore the last plan, no empty form.

Three threads.

## 1. Backend: full passage per window

The HF `/api/v1/passage` sweep endpoint already simulates a full `PassageReport` for each window (it has `segments`, warnings, the works), then strips them down to summary fields for the response. We now keep both:

- `windows[i].complexity_full` — full `ComplexityScore` (wind/sea breakdowns + structured warnings)
- `windows[i].passage` — full `PassageReport` with `segments[]`

The compact `complexity` and `conditions_summary` stay for the table view. Added fields are **optional** in the TS type so older HF Space deployments keep working — frontend falls back to a re-fetch when either is missing.

## 2. Frontend: zero-fetch drill-down

`handleWindowSelect` now hydrates state directly from the clicked window's `passage` + `complexity_full`. No network round-trip, no loading skeleton — the single-mode view appears instantly. Backwards-compatible: if those fields are absent (older backend), the previous `doFetch` path fires.

## 3. Frontend: persisted simulation + mode toggle preserves both views

New helper `lastSimulation.ts` saves a `LastSimulation` entry to `localStorage` on every successful fetch. The entry holds: `waypoints` + `archetype` + the latest `single` result + the latest `compare` result. On `PlanPage` init, if URL `waypoints` + `archetype` match the cached route, state is hydrated immediately — the user sees their last plan with **no fetch**.

Cache invalidation is implicit: when the URL diverges from the cached route, hydration is skipped and the auto-fetch runs as before.

Side effect: `handleModeChange` no longer clears the opposite mode's results. Render now gates on `mode` instead — a `passage` from a previous single-mode run stays in memory while the user explores compare mode, and vice versa. Toggling back is instant.

(Used `localStorage` rather than cookies — no 4 KB limit, simpler API. The dead `ow_last_trip` cookie set by `doFetch` stays for now; could be removed in a follow-up.)

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [x] `ruff check` on `hf-space/app.py` clean
- [x] Live: in compare mode, click a row → single view appears instantly, no skeleton flash, no network call
- [x] Live: reload the page → last plan restores immediately from localStorage, no fetch
- [x] Live: change a waypoint → reload → cache miss (route diverged), fresh fetch
- [x] Live: in single mode, toggle to compare → form + table appear (compare cache restored), toggle back → single results restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)