### PR TITLE
fix(mcp): UI widget receives result via postMessage + tool-routing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ https://qdonnars-openwind-mcp.hf.space/mcp
 > *"Demain matin, Marseille → Porquerolles, sur un Sun Odyssey 36. Bonne
 > idée ? Combien de temps et c'est tendu comment ?"*
 
-**3.** Your assistant calls four tools, renders an inline preview card, and
-hands you a deep-link to the full plan on [openwind.fr](https://openwind.fr).
-That's it. No account. No API key. No credit card.
+**3.** Your assistant calls the OpenWind tools and answers in plain language.
+On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix)
+(Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam) you
+also get a live, interactive widget — the [openwind.fr](https://openwind.fr)
+plan view rendered inline. On hosts that don't (Cursor, Le Chat, terminal),
+the assistant hands you the same plan as a [openwind.fr](https://openwind.fr)
+deep-link. No account. No API key. No credit card.
 
 > **First time with MCP?** It takes 2 minutes. Pick your client on
 > [modelcontextprotocol.io/clients](https://modelcontextprotocol.io/clients),
@@ -42,9 +46,11 @@ That's it. No account. No API key. No credit card.
 |                              |                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------|
 | 🆓 **Free, keyless**         | Wind & sea via [Open-Meteo](https://open-meteo.com) (CC BY 4.0). No account, no API key.     |
-| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km — catches thermals, mistral, tramontane. Falls back to ICON-EU/GFS. |
-| ⛵ **Boat-aware**             | Five archetypes from racer-cruiser to bluewater, real polars, an `efficiency` knob.          |
+| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km — catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
+| ⛵ **Boat-aware**             | Five archetypes from racer-cruiser to bluewater, real polars, an `efficiency` parameter for trim and crew level. |
+| 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot — no math by hand. |
 | 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
+| 🖼️ **Rich on supporting hosts** | On Claude / ChatGPT / VS Code Copilot / Goose, an interactive widget renders inline via [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix). Other hosts fall back to a clean text summary + deep-link. |
 | 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, your VPS — `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
 
 ## What the LLM sees
@@ -55,11 +61,14 @@ Four MCP tools, all async, all keyless:
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + HTML widget + deep-link, in one call. Optional sweep mode for multi-window departures. |
+| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out — the LLM picks the calmest slot. |
 | `read_me`                 | Returns OpenWind's calculation methodology — call when the user asks how things are computed. |
 
-The widget switches palette via `prefers-color-scheme` — looks right in light
-and dark hosts, no Claude-specific CSS variables, no vendor lock-in.
+`plan_passage` declares an MCP Apps UI resource (`ui://openwind/plan-passage`)
+on its `_meta`. Hosts that support [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix)
+render the live `openwind.fr/plan?…` view in a sandboxed iframe automatically
+— no host-specific CSS, no vendor lock-in. Hosts without MCP Apps support
+silently get the structured payload + the `openwind_url` deep-link.
 
 ## Architecture
 
@@ -125,15 +134,15 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 - **Single-pass approximation** — a 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
 - Routes are split into ~10 nm sub-segments by default for per-segment weather sampling. Drop to 5 nm for tight coastal work; raise to 20 nm for long offshore legs.
 
-### Multi-window sweep mode
+### Compare-windows mode
 
-`plan_passage` accepts an optional `latest_departure` to sweep N hourly departure windows over the same route. Weather is fetched once (cache prewarm), simulations are in-memory. Hard cap: 14 d × 24 h = 336 windows. Returns a list of windows; the LLM (not the server) picks the best option qualitatively.
+`plan_passage` accepts an optional `latest_departure` that turns the call into a window comparison: it walks N hourly departures over the same route and returns one entry per window. Weather is fetched once (cache prewarm), simulations are in-memory. Hard cap: 14 d × 24 h = 336 windows. The LLM (not the server) picks the best option qualitatively.
 
 ### Mediterranean defaults
 
 - **Tides ignored** — < 40 cm in the Med, negligible vs. forecast uncertainty.
 - **Currents ignored** — Liguro-Provençal current too weak / variable for V1.
-- **Wind model** — AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → GFS (≤16 d) when the passage extends past AROME.
+- **Wind model** — AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → ECMWF IFS 0.25° (≤10 d) → GFS (≤16 d) when the passage extends past AROME.
 - **Wave model** — Open-Meteo Marine (significant Hs, period, direction).
 
 ### What's not modelled (V1)

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -63,6 +63,114 @@ PLAN_UI_RESOURCE_URI = "ui://openwind/plan-passage"
 PLAN_UI_MIME = "text/html;profile=mcp-app"
 PLAN_UI_FRAME_DOMAINS = ["https://openwind.fr"]
 
+# Body of the MCP Apps UI resource. Vanilla JS — no external deps so the
+# sandbox CSP doesn't need to whitelist a CDN. Implements just enough of the
+# postMessage protocol to (a) surface ``ui/initialize`` ready-state to the
+# host and (b) listen for any incoming structured content with an
+# ``openwind_url`` field, then bind the inner iframe to it.
+#
+# Multi-shape match is intentional: the spec evolves, and different hosts
+# (Claude.ai, Claude Desktop, ChatGPT, …) ship slightly different framings.
+# Falls back to an "Open in openwind.fr" CTA if nothing lands in 6 s.
+_PLAN_WIDGET_HTML = """<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>OpenWind</title>
+  <style>
+    html,body{margin:0;height:100%;background:#FAF7EE;color:#1A1A1A;
+      font:16px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}
+    iframe{width:100%;height:100%;border:0;display:block}
+    .placeholder{display:flex;flex-direction:column;align-items:center;
+      justify-content:center;height:100%;padding:2rem;text-align:center;gap:.6rem}
+    .placeholder .dim{color:#777169;font-size:.95rem}
+    .placeholder a{color:#1D9E75;text-decoration:none;padding:.55rem 1rem;
+      border:1px solid #1D9E75;border-radius:8px;font-weight:600}
+    @media (prefers-color-scheme:dark){
+      html,body{background:#15140F;color:#F2F2F2}
+      .placeholder .dim{color:#888780}
+      .placeholder a{color:#2BBE93;border-color:#2BBE93}
+    }
+  </style>
+</head>
+<body>
+  <div id="root">
+    <div class="placeholder">
+      <p>Chargement du plan…</p>
+      <p class="dim">Si rien n'apparaît, ouvrez le plan complet :</p>
+      <a id="fallback" href="https://openwind.fr/plan" target="_blank" rel="noopener">openwind.fr →</a>
+    </div>
+  </div>
+  <script>
+  (function(){
+    var loaded = false;
+    function findUrl(o){
+      if(!o || typeof o !== 'object') return null;
+      if(typeof o.openwind_url === 'string') return o.openwind_url;
+      // Sweep mode: pick the first window's URL as a sensible default.
+      if(Array.isArray(o.windows) && o.windows[0] && o.windows[0].openwind_url){
+        return o.windows[0].openwind_url;
+      }
+      // Recurse into common wrappers used by various MCP hosts.
+      var keys = ['structuredContent','result','toolResult','params','content','data','payload'];
+      for(var i=0;i<keys.length;i++){
+        var v = o[keys[i]];
+        if(v){
+          var found = findUrl(v);
+          if(found) return found;
+        }
+      }
+      return null;
+    }
+    function show(url){
+      if(loaded) return;
+      loaded = true;
+      var root = document.getElementById('root');
+      var iframe = document.createElement('iframe');
+      iframe.src = url;
+      iframe.title = 'OpenWind passage plan';
+      iframe.allow = 'clipboard-write';
+      iframe.referrerPolicy = 'no-referrer';
+      root.innerHTML = '';
+      root.appendChild(iframe);
+    }
+    function showFallback(url){
+      var a = document.getElementById('fallback');
+      if(a && url){ a.href = url; }
+    }
+    window.addEventListener('message', function(ev){
+      try {
+        var url = findUrl(ev.data);
+        if(url){ show(url); }
+      } catch(e){ /* ignore */ }
+    });
+    // Announce ready-state to the host so it knows to push the result.
+    // We send a few well-known shapes since the spec field is method-name.
+    function announceReady(){
+      var msgs = [
+        {jsonrpc:'2.0',method:'ui/ready',params:{}},
+        {jsonrpc:'2.0',method:'ui/initialize',params:{}},
+        {type:'ui-ready'}
+      ];
+      try {
+        for(var i=0;i<msgs.length;i++){
+          window.parent && window.parent.postMessage(msgs[i],'*');
+        }
+      } catch(e){ /* ignore */ }
+    }
+    if(document.readyState === 'complete'){ announceReady(); }
+    else { window.addEventListener('load', announceReady); }
+    // Hard fallback: keep the placeholder + CTA visible if nothing lands.
+    setTimeout(function(){
+      if(!loaded){ /* placeholder stays; fallback link works */ }
+    }, 6000);
+  })();
+  </script>
+</body>
+</html>
+"""
+
 
 def _archetype_summary(p: Any) -> dict[str, Any]:
     return {
@@ -188,30 +296,18 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         meta={"ui": {"csp": {"frameDomains": PLAN_UI_FRAME_DOMAINS}}},
     )
     def plan_widget_resource() -> str:
-        """MCP Apps UI resource: a thin HTML doc that iframes openwind.fr/plan.
+        """MCP Apps UI resource — iframe wrapper for openwind.fr/plan.
 
-        The query string of the inner iframe is set client-side by the host
-        from the tool's structured output (waypoints, departure, archetype).
-        Hosts that support MCP Apps render this in a sandboxed iframe; the
-        nested openwind.fr iframe is allowed via the ``frameDomains`` CSP.
+        Receives the tool's ``structuredContent`` over postMessage (per the
+        MCP Apps spec — the host pushes results to the iframe via a
+        JSON-RPC dialect on the postMessage channel) and binds the inner
+        iframe's ``src`` to ``openwind_url`` from the result.
+
+        Defensive against multiple message shapes — different hosts have
+        different framings, and the spec is young — and falls back to a
+        deep-link CTA if no result arrives within 6 s.
         """
-        # The {{params}} placeholder is filled by the host from the tool's
-        # `structuredContent` (per the MCP Apps templating convention). If a
-        # host doesn't yet support templating, the iframe just opens
-        # openwind.fr's empty /plan view — still better than a render crash.
-        return (
-            "<!doctype html><html lang=\"fr\"><head>"
-            "<meta charset=\"utf-8\">"
-            "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
-            "<title>Plan</title>"
-            "<style>html,body{margin:0;height:100%;background:#FAF7EE}"
-            "iframe{width:100%;height:100%;border:0;display:block}</style>"
-            "</head><body>"
-            "<iframe src=\"https://openwind.fr/plan{{queryString}}\" "
-            "title=\"OpenWind passage plan\" "
-            "allow=\"geolocation; clipboard-write\"></iframe>"
-            "</body></html>"
-        )
+        return _PLAN_WIDGET_HTML
 
     @server.tool()
     def read_me() -> str:
@@ -303,14 +399,42 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         sweep_interval_hours: int = 1,
         target_eta: str | None = None,
     ) -> dict[str, Any]:
-        """Plan an A→B passage end-to-end: timing + complexity + deep-link.
+        """Plan an A→B passage. Compare departure windows by default; pin a
+        single departure only when the user gives an explicit time.
 
-        ONE call gives you everything for the typical "leaving Marseille for
-        Porquerolles tomorrow on a 30-footer" question. The server fetches
-        Open-Meteo once, computes the passage, scores its complexity from the
-        same report (no double-fetch), and emits the openwind.fr deep-link.
+        ## Tool routing — read this first
+
+        Before calling, classify the user's question:
+
+        1. **Pure weather lookup at a point** ("y aura-t-il du vent à Cassis
+           samedi à 14h ?", "quelles vagues dimanche au cap Sicié ?") — call
+           ``get_marine_forecast`` and answer in text. Do NOT call
+           ``plan_passage``: there's no route to plan.
+
+        2. **Trajet question with a flexible date** ("Marseille → Porquerolles
+           ce week-end", "demain ou après-demain", "dans les prochains jours")
+           — call ``plan_passage`` in **compare-windows mode**: pass
+           ``latest_departure`` (e.g. earliest+48h) and ``sweep_interval_hours``
+           (3 or 6 typically) so the user sees several departure scenarios
+           side-by-side. Then pick 2-3 good ones and let the user choose.
+           This is the **default** for trajet planning — same API cost as a
+           single passage thanks to cache prewarm, much more value.
+
+        3. **Trajet with a precise hour pinned by the user** ("je pars demain
+           à 8h", "départ Saturday 9am") — call ``plan_passage`` in single
+           mode (no ``latest_departure``). Used for the final "show me the
+           detailed plan for THIS departure" view, often after step 2.
+
+        4. **Methodology question** ("comment c'est calculé ?",
+           "quelle efficacité par défaut ?") — call ``read_me``.
+
+        Rule of thumb: if the user does NOT give an exact hour, prefer
+        compare-windows. The widget renders one of the windows by default
+        and the chat lets the user pick another.
 
         ## Returned payload
+
+        Single mode:
 
         - ``passage``: per-segment timing report (distance_nm, duration_h,
           model used, segments[] with TWS/TWA/boat_speed/Hs, warnings).
@@ -319,13 +443,26 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         - ``openwind_url``: deep-link to openwind.fr/plan that renders the
           same passage in the standalone web app.
 
+        Compare-windows mode (``latest_departure`` set):
+
+        - ``mode``: ``"multi_window"``.
+        - ``sweep``: ``earliest`` / ``latest`` / ``interval_hours`` /
+          ``window_count``.
+        - ``windows[]``: each entry has ``departure``, ``arrival``,
+          ``duration_h``, ``distance_nm``, ``complexity`` (level + label +
+          rationale), ``conditions_summary`` (tws_min/max, predominant sail
+          angle, hs_min/max), ``warnings``, ``passage`` (full per-segment
+          report), ``complexity_full`` (full score), ``openwind_url``.
+        - ``meta_warnings``: top-level notes ("3 fenêtres ignorées …").
+
         ## How it renders
 
         On hosts that support MCP Apps (Claude, Claude Desktop, ChatGPT, VS
         Code Copilot, Goose, Postman, MCPJam), the response is automatically
         accompanied by an interactive widget — the live openwind.fr/plan view
         served via the ``ui://openwind/plan-passage`` resource declared on
-        this tool's ``_meta``. Nothing to inject manually.
+        this tool's ``_meta``. The widget reads ``openwind_url`` from the
+        structured output and embeds the matching plan view as an iframe.
 
         On hosts without MCP Apps support (Cursor, Le Chat, terminal), present
         a short text summary of the result (route, ETA, complexity, warnings)


### PR DESCRIPTION
## Summary

Two issues from the user, both addressed:

### 1. The iframe shows nothing in Claude.ai

The widget was loading `https://openwind.fr/plan{{queryString}}` literally — `{{queryString}}` was a templating placeholder I invented in #74. The MCP Apps spec doesn't auto-fill it. The host pushes `structuredContent` to the iframe via postMessage (JSON-RPC dialect on the postMessage channel); the iframe must listen.

**Fix**: rewrites `_PLAN_WIDGET_HTML` as vanilla JS that:
- announces ready-state on load (sends `ui/ready`, `ui/initialize`, and a generic `ui-ready` — the spec name varies across hosts)
- listens for any incoming `message` and walks the data through known envelopes (`structuredContent`, `result`, `toolResult`, `params`, `content`, `data`, `payload`) to find an `openwind_url`
- in compare-windows mode, defaults to `windows[0].openwind_url`
- once found, swaps the placeholder for an `<iframe src=...>`
- otherwise keeps a clickable "Open in openwind.fr →" CTA (no blank page)

No external deps → sandbox CSP doesn't need to whitelist a CDN.

### 2. The LLM should default to compare-windows for trajets

User feedback: *"on a juste un peu plus de puissance de calcul mais pas plus de call API. […] beaucoup plus de valeur ajoutée dans cette comparaison de passage. […] dans la description des tools on ne peut pas aller dans ce truc là en disant 'use first compare' et 'then use plan to visualize' ?"*

**Fix**: rewrites the `plan_passage` docstring so the LLM sees an explicit classification:

1. Pure weather lookup at a point → `get_marine_forecast`
2. Trajet with FLEXIBLE date → `plan_passage` in compare-windows mode (default)
3. Trajet with PRECISE hour pinned → `plan_passage` single mode (drill-down)
4. Methodology Q → `read_me`

> Rule of thumb: if the user does NOT give an exact hour, prefer compare-windows.

Same API cost (cache prewarm), much more useful answer.

## Test plan

- [x] 20/20 mcp-core tests pass
- [x] `ruff check` clean
- [x] Resource serves `text/html;profile=mcp-app`, contains both `postMessage` and `openwind_url` markers
- [ ] Live: redeploy HF Space, retry in Claude.ai → expect openwind.fr/plan rendered inside the chat as an iframe with the right waypoints/departure
- [ ] Live: ask Claude "Marseille → Porquerolles ce week-end" → expect compare-windows mode invoked first (not single mode with arbitrary departure)