### PR TITLE
fix(mcp): use official ext-apps SDK from unpkg — fixes blank widget

### DIFF
--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -62,26 +62,34 @@ from .render import build_openwind_url
 PLAN_UI_RESOURCE_URI = "ui://openwind/plan-passage"
 PLAN_UI_MIME = "text/html;profile=mcp-app"
 PLAN_UI_FRAME_DOMAINS = ["https://openwind.fr"]
+# unpkg serves the official @modelcontextprotocol/ext-apps SDK bundle that
+# implements the ui/initialize -> ui/notifications/initialized handshake and
+# the ui/notifications/tool-result listener. Same CDN as the official
+# qr-server / say-server / threejs-server examples.
+PLAN_UI_RESOURCE_DOMAINS = ["https://unpkg.com"]
 
-# Body of the MCP Apps UI resource. Vanilla JS implementing the actual MCP
-# Apps spec handshake (per https://github.com/modelcontextprotocol/ext-apps,
-# spec rev 2026-01-26):
+# Body of the MCP Apps UI resource. Uses the official @modelcontextprotocol/
+# ext-apps SDK from unpkg — same pattern as the qr-server / say-server /
+# threejs-server reference examples in the ext-apps repo.
 #
-#   1. Iframe sends ``ui/initialize`` JSON-RPC request on load.
-#   2. Host responds (we ignore the body — we just need the handshake done).
-#   3. Host pushes ``ui/notifications/tool-result`` when the tool finishes,
-#      with the standard ``CallToolResult`` shape:
-#      ``{ structuredContent: { ...tool return... }, content: [...], ... }``
-#   4. We extract ``openwind_url`` (single mode) or ``windows[0].openwind_url``
-#      (sweep mode) and bind the iframe src.
+# Why the SDK (and not hand-rolled postMessage):
 #
-# Defensive fallback paths kept for shape variations across hosts
-# (Claude.ai vs Claude Desktop vs ChatGPT vs MCPJam may differ slightly).
+# The handshake has two messages, not one:
+#   1. ``ui/initialize`` REQUEST with ``params.appInfo`` (NOT clientInfo!) —
+#      different name from the core MCP ``initialize``.
+#   2. After the host responds, the iframe MUST send the
+#      ``ui/notifications/initialized`` notification before the host considers
+#      the view ready and starts pushing ``ui/notifications/tool-result``.
+#
+# Skipping (2) — or sending ``clientInfo`` instead of ``appInfo`` — leaves the
+# host in "view-not-ready" state forever, the iframe stays blank. Easier to
+# let the SDK handle that than to hand-roll it correctly.
 _PLAN_WIDGET_HTML = """<!doctype html>
 <html lang="fr">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>OpenWind</title>
   <style>
     html,body{margin:0;height:100%;background:#FAF7EE;color:#1A1A1A;
@@ -107,86 +115,45 @@ _PLAN_WIDGET_HTML = """<!doctype html>
       <a id="fallback" href="https://openwind.fr/plan" target="_blank" rel="noopener">openwind.fr →</a>
     </div>
   </div>
-  <script>
-  (function(){
-    var bound = false;
-    var nextId = 1;
+  <script type="module">
+    import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps";
 
-    function send(msg){
-      try { window.parent && window.parent.postMessage(msg, '*'); }
-      catch(e){}
+    function extractUrl(result) {
+      if (!result) return null;
+      const sc = result.structuredContent;
+      if (sc && typeof sc.openwind_url === 'string') return sc.openwind_url;
+      if (sc && Array.isArray(sc.windows) && sc.windows[0] && sc.windows[0].openwind_url) {
+        return sc.windows[0].openwind_url;
+      }
+      return null;
     }
 
-    function bindIframe(url){
-      if(bound) return;
-      bound = true;
-      var root = document.getElementById('root');
-      var iframe = document.createElement('iframe');
+    function bindIframe(url) {
+      const root = document.getElementById('root');
+      const iframe = document.createElement('iframe');
       iframe.src = url;
       iframe.title = 'OpenWind passage plan';
       iframe.allow = 'clipboard-write';
       iframe.referrerPolicy = 'no-referrer';
       root.innerHTML = '';
       root.appendChild(iframe);
+      const fb = document.getElementById('fallback');
+      if (fb) fb.href = url;
     }
 
-    function updateFallbackLink(url){
-      var a = document.getElementById('fallback');
-      if(a && url){ a.href = url; }
+    const app = new App({ name: "OpenWind Plan", version: "1.0.0" });
+
+    app.ontoolresult = (result) => {
+      const url = extractUrl(result);
+      if (url) bindIframe(url);
+    };
+
+    try {
+      await app.connect();
+    } catch (e) {
+      // Stay on the placeholder + clickable fallback — better than a hang.
+      console.error('[openwind] MCP App connect failed', e);
     }
-
-    // CallToolResult.structuredContent -> openwind_url, with sweep fallback
-    // and a few defensive lookups for older or alternate framings.
-    function extractUrl(payload){
-      if(!payload || typeof payload !== 'object') return null;
-      var sc = payload.structuredContent
-            || (payload.params && payload.params.structuredContent)
-            || (payload.result && payload.result.structuredContent)
-            || payload;
-      if(!sc) return null;
-      if(typeof sc.openwind_url === 'string') return sc.openwind_url;
-      if(Array.isArray(sc.windows) && sc.windows[0] && sc.windows[0].openwind_url){
-        return sc.windows[0].openwind_url;
-      }
-      return null;
-    }
-
-    window.addEventListener('message', function(ev){
-      var msg = ev.data;
-      if(!msg) return;
-      var method = msg.method;
-
-      // Spec method we care about: tool result delivered to the view.
-      if(method === 'ui/notifications/tool-result'
-         || method === 'notifications/tool-result'
-         || method === 'ui/tool-result'){
-        var url = extractUrl(msg.params || msg);
-        if(url){ bindIframe(url); updateFallbackLink(url); }
-        return;
-      }
-
-      // Some hosts may push the tool result as a plain message (non-JSON-RPC).
-      if(!method){
-        var url2 = extractUrl(msg);
-        if(url2){ bindIframe(url2); updateFallbackLink(url2); }
-      }
-    });
-
-    // Spec initialize handshake. Without it, several hosts won't push the
-    // tool-result notification.
-    function initialize(){
-      send({
-        jsonrpc: '2.0', id: nextId++, method: 'ui/initialize',
-        params: {
-          protocolVersion: '2026-01-26',
-          appCapabilities: {},
-          clientInfo: { name: 'openwind-plan-widget', version: '1' }
-        }
-      });
-    }
-    if(document.readyState === 'complete'){ initialize(); }
-    else { window.addEventListener('load', initialize); }
-  })();
   </script>
 </body>
 </html>
@@ -314,7 +281,16 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
         PLAN_UI_RESOURCE_URI,
         name="OpenWind plan widget",
         mime_type=PLAN_UI_MIME,
-        meta={"ui": {"csp": {"frameDomains": PLAN_UI_FRAME_DOMAINS}}},
+        meta={
+            "ui": {
+                "csp": {
+                    # Allow the inner iframe to load openwind.fr.
+                    "frameDomains": PLAN_UI_FRAME_DOMAINS,
+                    # Allow the SDK bundle (same CDN as the official examples).
+                    "resourceDomains": PLAN_UI_RESOURCE_DOMAINS,
+                }
+            }
+        },
     )
     def plan_widget_resource() -> str:
         """MCP Apps UI resource — iframe wrapper for openwind.fr/plan.


### PR DESCRIPTION
## Summary

User report after #77: *"ça ne marche toujours pas"* — even with the spec-compliant `ui/initialize` request, the widget stays blank. Chat shows the JSON tool result and `[This tool call rendered an interactive widget]` but no actual openwind.fr/plan iframe.

## Root cause

Two bugs in our hand-rolled handshake, found by reading the official SDK source (`@modelcontextprotocol/ext-apps`):

1. **Wrong field name**. We sent `clientInfo` but `McpUiInitializeRequest` ([`spec.types.ts:554-564`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/spec.types.ts)) requires `appInfo`. Different name from the core MCP `initialize` (which does use `clientInfo`). Strict-validating hosts reject our message and never reply.

2. **Missing follow-up notification**. After receiving the response to `ui/initialize`, the iframe MUST send a `ui/notifications/initialized` notification. Without it, the host considers the view un-initialized and never pushes `ui/notifications/tool-result`. The official `App.connect()` sends it automatically ([`app.ts:1980-1982`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app.ts)); we didn't.

→ handshake never completes → host never pushes the result → iframe stuck on loading placeholder forever.

## Fix: adopt the official SDK

Same pattern as the canonical `qr-server` / `say-server` / `threejs-server` reference examples. From `examples/qr-server/server.py:60-97`:

```html
<script type="module">
  import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps";
  const app = new App({ name: "OpenWind Plan", version: "1.0.0" });
  app.ontoolresult = (result) => { /* extract openwind_url, bind iframe */ };
  await app.connect();
</script>
```

`App.connect()` does the full handshake correctly with the right `appInfo` field and the follow-up `ui/notifications/initialized`. We keep our defensive `extractUrl()` helper since the structured content shape stays stable (single-mode `openwind_url` or sweep-mode `windows[0].openwind_url`).

## CSP

The SDK loads from unpkg.com → we add `resourceDomains`:

```python
meta={"ui": {"csp": {
    "frameDomains": ["https://openwind.fr"],     # inner iframe target
    "resourceDomains": ["https://unpkg.com"],    # SDK bundle
}}}
```

Per the spec ([`spec.types.ts:601-603`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/spec.types.ts)): *"All origins must be declared — including where your bundled JS/CSS is served from."*

## Test plan

- [x] 20/20 mcp-core tests pass
- [x] `ruff check` clean
- [x] Resource size 2.6 KB (was 3.9 KB — less hand-rolled code)
- [x] Verified resource contains `unpkg.com`, `OpenWind Plan`, `app.ontoolresult`, `app.connect`
- [ ] Live: redeploy HF Space, retry in Claude.ai → expect openwind.fr/plan rendered as iframe inside the widget