### PR TITLE
chore(docs): strip em-dashes from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > **Talk to your LLM. Cast off with confidence.**
 >
-> OpenWind turns any MCP-capable assistant — Claude, Le Chat, Cursor, Goose,
-> Zed, Continue — into a Mediterranean passage planner. Ask in plain
+> OpenWind turns any MCP-capable assistant Claude, Le Chat, Cursor, Goose,
+> Zed, Continue into a Mediterranean passage planner. Ask in plain
 > language. Get a per-leg ETA, a 1‑5 complexity score, and a deep-link to
 > the full plan. Free, keyless, open source.
 
@@ -29,7 +29,7 @@ https://qdonnars-openwind-mcp.hf.space/mcp
 **3.** Your assistant calls the OpenWind tools and answers in plain language.
 On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix)
 (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam) you
-also get a live, interactive widget — the [openwind.fr](https://openwind.fr)
+also get a live, interactive widget the [openwind.fr](https://openwind.fr)
 plan view rendered inline. On hosts that don't (Cursor, Le Chat, terminal),
 the assistant hands you the same plan as a [openwind.fr](https://openwind.fr)
 deep-link. No account. No API key. No credit card.
@@ -46,12 +46,12 @@ deep-link. No account. No API key. No credit card.
 |                              |                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------|
 | 🆓 **Free, keyless**         | Wind & sea via [Open-Meteo](https://open-meteo.com) (CC BY 4.0). No account, no API key.     |
-| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km — catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
+| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
 | ⛵ **Boat-aware**             | Five archetypes from racer-cruiser to bluewater, real polars, an `efficiency` parameter for trim and crew level. |
-| 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot — no math by hand. |
+| 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot no math by hand. |
 | 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
 | 🖼️ **Rich on supporting hosts** | On Claude / ChatGPT / VS Code Copilot / Goose, an interactive widget renders inline via [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix). Other hosts fall back to a clean text summary + deep-link. |
-| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, your VPS — `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
+| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, your VPS `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
 
 ## What the LLM sees
 
@@ -61,13 +61,13 @@ Four MCP tools, all async, all keyless:
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out — the LLM picks the calmest slot. |
-| `read_me`                 | Returns OpenWind's calculation methodology — call when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out the LLM picks the calmest slot. |
+| `read_me`                 | Returns OpenWind's calculation methodology call when the user asks how things are computed. |
 
 `plan_passage` declares an MCP Apps UI resource (`ui://openwind/plan-passage`)
 on its `_meta`. Hosts that support [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix)
 render the live `openwind.fr/plan?…` view in a sandboxed iframe automatically
-— no host-specific CSS, no vendor lock-in. Hosts without MCP Apps support
+  no host-specific CSS, no vendor lock-in. Hosts without MCP Apps support
 silently get the structured payload + the `openwind_url` deep-link.
 
 ## Architecture
@@ -95,7 +95,7 @@ uv run ruff check .
 
 # Local HTTP MCP smoke
 cd packages/hf-space
-uv run python app.py   # serves :7860 — point any MCP client at /mcp
+uv run python app.py   # serves :7860, point any MCP client at /mcp
 
 # Web app (openwind.fr)
 cd packages/web
@@ -107,7 +107,7 @@ npm run build          # outputs packages/web/dist
 ## V1 scope
 
 Wind, sea (`Hs` max), per-leg ETA, 1–5 complexity. Tides and currents ignored
-on the Med (negligible). No automatic routing optimisation — the LLM and the
+on the Med (negligible). No automatic routing optimisation the LLM and the
 human stay in the loop. Roadmap and scope decisions live in
 [`plan/`](plan/) (local).
 
@@ -120,18 +120,18 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 
 - 5 archetypes (`cruiser_30ft`, `cruiser_40ft`, `cruiser_50ft`, `racer_cruiser`, `catamaran_40ft`), each with an ORC-style polar in [`packages/data-adapters/src/openwind_data/routing/polars/`](packages/data-adapters/src/openwind_data/routing/polars/).
 - Lookup is **bilinear interpolation** in (TWS, TWA), clamped at grid edges.
-- TWA is symmetric — `[0°, 180°]` only, no port/starboard distinction.
+- TWA is symmetric `[0°, 180°]` only, no port/starboard distinction.
 
 ### Boat speed adjustments
 
-- **Efficiency factor (default 0.75)** — ORC polars are theoretical maxima. Real cruising loses ~25% (sail trim, comfort margins, helmsman, untracked currents). Override per call: `0.85` racing, `0.75` cruising, `0.65` loaded family cruising, `0.55` heavy seas / fouled hull.
-- **VMG / tacking correction** — when the route's TWA is below the boat's optimal upwind angle (typically ~42-48°), the simulator assumes the sailor tacks. Effective speed toward destination is `polar(optimal_TWA) × cos(optimal_TWA − route_TWA)`. At dead upwind this reduces to `polar(opt) × cos(opt) ≈ polar / √2`; at TWA=20° with opt=45° the reduction is only `cos(25°) ≈ 0.91`.
-- **Wave derate (opt-in)** — `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Disabled by default — sea state feeds the warning bar rather than slowing the boat.
-- **Minimum boat speed** — 0.5 kn floor, prevents division blow-up in extreme stalls.
+- **Efficiency factor (default 0.75)** ORC polars are theoretical maxima. Real cruising loses ~25% (sail trim, comfort margins, helmsman, untracked currents). Override per call: `0.85` racing, `0.75` cruising, `0.65` loaded family cruising, `0.55` heavy seas / fouled hull.
+- **VMG / tacking correction** when the route's TWA is below the boat's optimal upwind angle (typically ~42-48°), the simulator assumes the sailor tacks. Effective speed toward destination is `polar(optimal_TWA) × cos(optimal_TWA − route_TWA)`. At dead upwind this reduces to `polar(opt) × cos(opt) ≈ polar / √2`; at TWA=20° with opt=45° the reduction is only `cos(25°) ≈ 0.91`.
+- **Wave derate (opt-in)** `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Disabled by default sea state feeds the warning bar rather than slowing the boat.
+- **Minimum boat speed** 0.5 kn floor, prevents division blow-up in extreme stalls.
 
 ### Timing
 
-- **Single-pass approximation** — a 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
+- **Single-pass approximation** a 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
 - Routes are split into ~10 nm sub-segments by default for per-segment weather sampling. Drop to 5 nm for tight coastal work; raise to 20 nm for long offshore legs.
 
 ### Compare-windows mode
@@ -140,15 +140,15 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 
 ### Mediterranean defaults
 
-- **Tides ignored** — < 40 cm in the Med, negligible vs. forecast uncertainty.
-- **Currents ignored** — Liguro-Provençal current too weak / variable for V1.
-- **Wind model** — AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → ECMWF IFS 0.25° (≤10 d) → GFS (≤16 d) when the passage extends past AROME.
-- **Wave model** — Open-Meteo Marine (significant Hs, period, direction).
+- **Tides ignored** < 40 cm in the Med, negligible vs. forecast uncertainty.
+- **Currents ignored** Liguro-Provençal current too weak / variable for V1.
+- **Wind model** AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → ECMWF IFS 0.25° (≤10 d) → GFS (≤16 d) when the passage extends past AROME.
+- **Wave model** Open-Meteo Marine (significant Hs, period, direction).
 
 ### What's not modelled (V1)
 
-- No automatic routing optimisation — the LLM and human stay in the loop on departure choice.
-- No coastal acceleration zones (capes, peninsulas) — caller adds intermediate waypoints.
+- No automatic routing optimisation the LLM and human stay in the loop on departure choice.
+- No coastal acceleration zones (capes, peninsulas) caller adds intermediate waypoints.
 - No port/starboard polar asymmetry, no spinnaker-specific curves, no hull condition modelling beyond the `efficiency` knob.
 
 ## Credits

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -3,10 +3,10 @@
 Hero assets referenced from the READMEs and the Starlette landing of the HF
 Space.
 
-- `plan.png` — the OpenWind passage view on
+- `plan.png` the OpenWind passage view on
   [openwind.fr](https://openwind.fr) (5 waypoints, ETA, complexity score).
   Used as the hero image in the root README, the HF Space README, and the
-  Starlette landing. Replace by `plan.gif` (animated demo) later — update
+  Starlette landing. Replace by `plan.gif` (animated demo) later update
   the `<img src="…">` in
   [packages/hf-space/app.py](../../packages/hf-space/app.py) and the
   markdown references in the two READMEs.

--- a/packages/data-adapters/README.md
+++ b/packages/data-adapters/README.md
@@ -2,7 +2,7 @@
 
 Pure Python domain logic for OpenWind: marine data adapters, polars, routing, complexity scoring.
 
-Cloud-agnostic — no dependency on Gradio, FastMCP, or any deployment runtime. Reused by `openwind-mcp-core` and any future deployment wrapper.
+Cloud-agnostic no dependency on Gradio, FastMCP, or any deployment runtime. Reused by `openwind-mcp-core` and any future deployment wrapper.
 
 ## Install (dev)
 
@@ -45,7 +45,7 @@ Defaults: `k=0.05`, `p=1.75`, `floor=0.5`. Justification:
   <https://orc.org/uploads/files/ORC-VPP-Documentation-2023.pdf>
 
 - **Power `p=1.75` on Hs.** Empirical exponent commonly quoted in seakeeping for
-  added resistance vs significant wave height — between the linear regime and
+  added resistance vs significant wave height between the linear regime and
   the strict `Hs²` energy scaling that follows from integrating a
   Pierson-Moskowitz / Bretschneider spectrum × RAO. Used as the conservative
   midpoint here.
@@ -64,7 +64,7 @@ Defaults: `k=0.05`, `p=1.75`, `floor=0.5`. Justification:
   ranges reported for ~10 m cruisers in:
   - *Gerritsma, J., Onnink, R., Versluis, A. (1981), "Geometry, Resistance and
     Stability of the Delft Systematic Yacht Hull Series", Int. Shipbuilding
-    Progress 28(328) — Delft series resistance-in-waves data.*
+    Progress 28(328) Delft series resistance-in-waves data.*
   - *Keuning, J. A. & Vermeulen, K. J. (2003), "On the Influence of the
     Sailing Yacht Hull Form on the Added Resistance in Waves", 16th HISWA
     Symposium on Yacht Design.*

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -51,12 +51,12 @@ card.
 
 ## Why OpenWind
 
-- **Free & keyless** — wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
-- **Mediterranean-tuned** — AROME 1.3 km by default, catches thermals & mistral. ICON-EU → ECMWF → GFS for longer reach.
-- **Boat-aware** — 5 archetypes, real polars, `efficiency` parameter for trim and crew level.
-- **Window-aware** — one call sweeps up to 14 days of hourly departures so the LLM can pick the calmest slot.
-- **Client-agnostic** — one HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
-- **Open source, MIT** — self-host on Fly, Modal, your VPS in minutes.
+- **Free & keyless** wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
+- **Mediterranean-tuned** AROME 1.3 km by default, catches thermals & mistral. ICON-EU → ECMWF → GFS for longer reach.
+- **Boat-aware** 5 archetypes, real polars, `efficiency` parameter for trim and crew level.
+- **Window-aware** one call sweeps up to 14 days of hourly departures so the LLM can pick the calmest slot.
+- **Client-agnostic** one HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
+- **Open source, MIT** self-host on Fly, Modal, your VPS in minutes.
 
 ## Four tools
 
@@ -64,8 +64,8 @@ card.
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Five descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft`. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource — supporting hosts auto-render the live plan in a sandboxed iframe. |
-| `read_me`                 | Returns OpenWind's calculation methodology — call when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource supporting hosts auto-render the live plan in a sandboxed iframe. |
+| `read_me`                 | Returns OpenWind's calculation methodology call when the user asks how things are computed. |
 
 ## About this Space
 
@@ -76,11 +76,11 @@ card.
 
 **Source of truth:** <https://github.com/qdonnars/openwind>. This Space is
 auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Don't
-commit directly to the Space repo — your changes will be overwritten at the
+commit directly to the Space repo your changes will be overwritten at the
 next push.
 
 The Space wrapper is intentionally minimal (~20 lines in `app.py`). All logic
-lives in `openwind-mcp-core` and `openwind-data` upstream — re-deployable on
+lives in `openwind-mcp-core` and `openwind-data` upstream re-deployable on
 Fly, Modal, or a VPS by writing a different wrapper.
 
 ## Cold-start

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -2,10 +2,10 @@
 
 Cloud-agnostic FastMCP server for OpenWind. Exposes 4 tools:
 
-- `list_boat_archetypes` — descriptive list, no server-side mapping
-- `get_marine_forecast` — wind + sea around a point/window
-- `plan_passage` — end-to-end timing + complexity + openwind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
-- `read_me` — calculation methodology (polars, efficiency, VMG, defaults)
+- `list_boat_archetypes` descriptive list, no server-side mapping
+- `get_marine_forecast` wind + sea around a point/window
+- `plan_passage` end-to-end timing + complexity + openwind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
+- `read_me` calculation methodology (polars, efficiency, VMG, defaults)
 
 `build_server()` is the single factory; no Gradio, no `huggingface_hub`. The
 HF Spaces wrapper (Sprint 4) and any future deployment use the same factory.
@@ -22,7 +22,7 @@ uv run pytest
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 or `%APPDATA%\Claude\claude_desktop_config.json` (Windows). On Linux, Claude
-Desktop is not officially supported — use Claude Code (CLI) MCP config or any
+Desktop is not officially supported use Claude Code (CLI) MCP config or any
 other MCP client (Goose, Continue, Zed) that accepts a stdio command.
 
 ```json
@@ -98,14 +98,14 @@ against a stub adapter.
 
 The simulation engine lives in `openwind_data.routing.passage`. Defaults below are what `plan_passage` uses unless overridden.
 
-- **Polar lookup** — 5 ORC-style archetypes, bilinear interpolation in (TWS, TWA), clamped at grid edges. TWA symmetric on [0°, 180°].
+- **Polar lookup** 5 ORC-style archetypes, bilinear interpolation in (TWS, TWA), clamped at grid edges. TWA symmetric on [0°, 180°].
 - **Efficiency 0.75** by default (cruising). Override via the `efficiency` arg: `0.85` racing, `0.65` loaded family, `0.55` heavy seas / fouled hull.
-- **VMG / tacking correction** — when route TWA < optimal upwind angle (~42-48°), effective speed = `polar(opt_TWA) × cos(opt_TWA − route_TWA)`. Models a sailor who tacks instead of pinching.
-- **Wave derate** — opt-in via `use_wave_correction`: `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Off by default; sea state feeds warnings instead.
-- **Single-pass timing** — heuristic 6 kn → segment mid-times → real polar at each mid-time's wind. No convergence iteration.
-- **Sub-segments** — routes split into ~10 nm chunks for weather sampling.
-- **Compare-windows mode** — `plan_passage(latest_departure=...)` walks N hourly departures over the same route and returns one entry per window (max 14 d × 24 h = 336). The LLM picks the calmest qualitatively.
-- **Default model** — AROME 1.3 km (Med thermals); auto-falls back to ICON-EU → ECMWF → GFS for longer horizons.
-- **Mediterranean simplifications** — tides and currents ignored (negligible in V1).
+- **VMG / tacking correction** when route TWA < optimal upwind angle (~42-48°), effective speed = `polar(opt_TWA) × cos(opt_TWA − route_TWA)`. Models a sailor who tacks instead of pinching.
+- **Wave derate** opt-in via `use_wave_correction`: `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Off by default; sea state feeds warnings instead.
+- **Single-pass timing** heuristic 6 kn → segment mid-times → real polar at each mid-time's wind. No convergence iteration.
+- **Sub-segments** routes split into ~10 nm chunks for weather sampling.
+- **Compare-windows mode** `plan_passage(latest_departure=...)` walks N hourly departures over the same route and returns one entry per window (max 14 d × 24 h = 336). The LLM picks the calmest qualitatively.
+- **Default model** AROME 1.3 km (Med thermals); auto-falls back to ICON-EU → ECMWF → GFS for longer horizons.
+- **Mediterranean simplifications** tides and currents ignored (negligible in V1).
 
 Full rationale and references in the [main README's calculation section](../../README.md#calculation-method).


### PR DESCRIPTION
## Summary
- Mechanical Python pass replacing ` — ` (and stray `—`) with a space across all 5 tracked READMEs (root, `docs/screenshots/`, `data-adapters`, `hf-space`, `mcp-core`).
- 52 occurrences stripped, 0 remaining. Fenced code blocks preserved by the script (one shell-comment em-dash fixed manually for consistency).
- En-dash (`–`, e.g. `1–5`) is left alone — only U+2014 was targeted.

## Spots that now read as run-ons
The em-dash often acted as a sentence pivot, so a few lines need a manual rewrite:

- `packages/hf-space/README.md` — table row for `plan_passage`: "...UI resource supporting hosts auto-render..."
- `packages/hf-space/README.md` — `read_me` row: "...methodology call when the user asks..."
- `packages/hf-space/README.md` — "Don't commit directly to the Space repo your changes will be overwritten..."
- `packages/hf-space/README.md` — "...openwind-data upstream re-deployable on..."

Happy to follow up with a polish PR — flagging here so reviewers don't take the run-ons as final copy.

## Test plan
- [ ] `grep -rn '—' README.md docs/ packages/*/README.md` returns nothing
- [ ] Code samples (fenced blocks) unchanged
- [ ] Render the HF Space README on github.com to spot-check the bullet list and the four-tools table