### PR TITLE
fix(adapters): restore hs_min_m in conditions_summary (lost in #69 squash)

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -117,6 +117,10 @@ def _build_conditions_summary(report: PassageReport) -> dict:
         "tws_min_kn": round(min(tws), 1),
         "tws_max_kn": round(max(tws), 1),
         "predominant_sail_angle": predominant,
+        # Both bounds so consumers (web table, MCP App widget) can render a
+        # range like "0.3-0.6m" instead of a single max value. PR #69 added
+        # hs_min_m but it was dropped by the squash-merge — restored here.
+        "hs_min_m": round(min(hs), 2) if hs else None,
         "hs_max_m": round(max(hs), 2) if hs else None,
     }
 

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -206,7 +206,8 @@ class TestPlanPassageSweep:
                 "conditions_summary", "warnings", "openwind_url"} <= w.keys()
         assert 1 <= w["complexity"]["level"] <= 5
         cs = w["conditions_summary"]
-        assert {"tws_min_kn", "tws_max_kn", "predominant_sail_angle", "hs_max_m"} <= cs.keys()
+        assert {"tws_min_kn", "tws_max_kn", "predominant_sail_angle",
+                "hs_min_m", "hs_max_m"} <= cs.keys()
         assert cs["predominant_sail_angle"] in ("pres", "travers", "largue", "portant")
 
     async def test_html_never_rendered_in_sweep(self) -> None:


### PR DESCRIPTION
## Summary

Discovered while end-to-end testing #80's Mer column: the live HF Space returns
`{tws_min_kn, tws_max_kn, predominant_sail_angle, hs_max_m}` — **no `hs_min_m`**.

Git archaeology shows the field was added in commits `887468f`/`594e123` on the original branch, but the squash-merge of PR #69 dropped it. So both the web compare table and the MCP App widget render single-value "0.5 m" instead of the intended range "0.3-0.6 m" — minor display loss, no crash thanks to defensive code.

## Fix

Re-add `hs_min_m: round(min(hs), 2) if hs else None` to `_build_conditions_summary` in [`packages/data-adapters/src/openwind_data/routing/passage.py`](packages/data-adapters/src/openwind_data/routing/passage.py).

Update the mcp-core test that asserts the keys to include `hs_min_m`.

## Test plan

- [x] 124/124 data-adapters tests pass
- [x] 20/20 mcp-core tests pass
- [x] `ruff check` clean
- [ ] Live: redeploy → call `plan_passage` in compare mode → `conditions_summary` includes both `hs_min_m` AND `hs_max_m`
- [ ] Widget Mer column renders ranges ("0.3-0.6 m") instead of single values