### PR TITLE
polish(web): make plan-page sidebar resize handle discoverable

### DIFF
--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -361,8 +361,8 @@ function ResizableDesktopSidebar({
 
   return (
     <div
-      className="hidden lg:flex shrink-0 border-l"
-      style={{ width: `${px}px`, background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
+      className="hidden lg:flex shrink-0"
+      style={{ width: `${px}px`, background: "var(--ow-bg-1)" }}
     >
       <div
         role="separator"
@@ -372,12 +372,16 @@ function ResizableDesktopSidebar({
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
-        className="shrink-0 flex items-center justify-center cursor-col-resize touch-none transition-colors hover:bg-[var(--ow-bg-2)]"
-        style={{ width: 8 }}
+        className="group shrink-0 flex items-center justify-center cursor-col-resize touch-none transition-colors hover:bg-[var(--ow-bg-2)]"
+        style={{
+          width: 12,
+          borderLeft: "1px solid var(--ow-line)",
+          borderRight: "1px solid var(--ow-line)",
+        }}
       >
         <span
-          className="block rounded-full"
-          style={{ width: 4, height: 36, background: "var(--ow-line-2)" }}
+          className="block rounded-full transition-colors group-hover:bg-[var(--ow-accent)]"
+          style={{ width: 4, height: 56, background: "var(--ow-fg-3)" }}
         />
       </div>
       <div className="flex-1 min-w-0 overflow-y-auto">{children}</div>


### PR DESCRIPTION
## Summary
The desktop sidebar resize from #81 shipped, but users couldn't find the handle. The 8 px hit zone with a tiny 4×36 grey dot looked like noise, not a control. This PR makes it obvious without being loud.

- Hit zone: 8 → **12 px** wide (still narrow, but easier to grab)
- Borders on both sides of the handle gutter so it reads as a distinct vertical strip, not dead space
- Pill: 36 → **56 px tall**, color upgraded from `--ow-line-2` to `--ow-fg-3` for contrast
- Hover state: pill turns accent-colored + gutter background lifts to `--ow-bg-2`

Same drag behavior — purely a discoverability fix.

## Test plan
- [ ] `cd packages/web && npx vite`, open the plan page on desktop (lg+ viewport)
- [ ] The handle is clearly visible at the left edge of the right-hand panel even at rest
- [ ] Hovering it turns the pill accent-colored and the gutter slightly lighter
- [ ] Drag still expands/contracts the panel and persists in localStorage on release
- [ ] Light + dark theme both look right

## Context
Reported live: "ne fonctionne pas de mon coté" — the feature was deployed (PR #81 merged, GH Pages live), but the affordance was invisible enough that the user thought it wasn't working.