### PR TITLE
feat(web): night icons, desktop day separators, plan UX polish

### DIFF
--- a/packages/web/src/api/openmeteo.ts
+++ b/packages/web/src/api/openmeteo.ts
@@ -12,7 +12,7 @@ const MODELS = [
 ];
 
 const PARAMS =
-  "hourly=wind_speed_10m,wind_direction_10m,wind_gusts_10m,weather_code&wind_speed_unit=kn&timezone=Europe/Paris&forecast_days=7";
+  "hourly=wind_speed_10m,wind_direction_10m,wind_gusts_10m,weather_code,is_day&wind_speed_unit=kn&timezone=Europe/Paris&forecast_days=7";
 
 const cache = new Map<string, { models: ModelForecast[]; fetchedAt: number }>();
 const CACHE_TTL = 30 * 60 * 1000;

--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -13,14 +13,14 @@ interface TimelineHeaderProps {
   visibleDay: string; // ISO date "2025-04-26" of leftmost visible day
 }
 
-function wmoIcon(code: number | null): string {
+function wmoIcon(code: number | null, isDay: boolean): string {
   if (code == null) return "";
-  if (code === 0) return "☀️";
-  if (code === 1) return "🌤️";
-  if (code === 2) return "⛅";
+  if (code === 0) return isDay ? "☀️" : "🌙";
+  if (code === 1) return isDay ? "🌤️" : "🌙";
+  if (code === 2) return isDay ? "⛅" : "☁️";
   if (code === 3) return "☁️";
   if (code === 45 || code === 48) return "🌫️";
-  if (code >= 51 && code <= 57) return "🌦️";
+  if (code >= 51 && code <= 57) return isDay ? "🌦️" : "🌧️";
   if (code >= 61 && code <= 67) return "🌧️";
   if (code >= 71 && code <= 77) return "🌨️";
   if (code >= 80 && code <= 82) return "🌧️";
@@ -56,6 +56,18 @@ export function TimelineHeader({
     return null;
   }
 
+  function isDayHour(timeStr: string): boolean {
+    for (const f of forecasts) {
+      const idx = f.hourly.time.indexOf(timeStr);
+      if (idx !== -1 && f.hourly.is_day?.[idx] != null) {
+        return f.hourly.is_day[idx] === 1;
+      }
+    }
+    // Fallback when is_day is missing: treat 07:00–20:59 as day.
+    const hour = parseInt(timeStr.slice(11, 13));
+    return hour >= 7 && hour < 21;
+  }
+
   // Mark the first column of each new day for subtle separators
   const dayStarts = new Set<string>();
   let prevDay = "";
@@ -64,18 +76,70 @@ export function TimelineHeader({
     if (day !== prevDay) { dayStarts.add(t); prevDay = day; }
   }
 
+  // Group consecutive hours by day for the desktop-only day-label row.
+  type DayGroup = { dayIso: string; count: number; weekday: string; dayNum: string };
+  const dayGroupsArr: DayGroup[] = [];
+  {
+    let curDay = "";
+    for (const t of times) {
+      const day = t.slice(0, 10);
+      if (day !== curDay) {
+        const [w, d] = formatStickyDay(day);
+        dayGroupsArr.push({ dayIso: day, count: 1, weekday: w, dayNum: d });
+        curDay = day;
+      } else {
+        dayGroupsArr[dayGroupsArr.length - 1].count++;
+      }
+    }
+  }
+
   const [weekday, dayNum] = formatStickyDay(visibleDay);
 
   return (
     <>
-      {/* Row 1: weather icons — sticky left spans both rows, shows day */}
+      {/* Row 0: per-day labels — desktop only, so mobile keeps its compact layout.
+          Each label cell is sticky-left so the leftmost day stays glued to the
+          left edge of the scroll viewport until the next day's cell crosses it. */}
+      <tr className="hidden lg:table-row">
+        <td
+          className="sticky left-0 z-30 min-w-[56px] border-r border-b"
+          style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
+        />
+        {dayGroupsArr.map((g, gi) => (
+          <td
+            key={g.dayIso}
+            colSpan={g.count}
+            className={`py-1 border-b ${gi > 0 ? 'ow-day-sep' : ''}`}
+            style={{
+              background: 'var(--ow-bg-1)',
+              borderColor: 'var(--ow-line-2)',
+              position: 'sticky',
+              left: 56,
+              zIndex: 19,
+            }}
+          >
+            <div className="pl-2 whitespace-nowrap">
+              <span className="text-[10px] font-bold uppercase tracking-widest" style={{ color: 'var(--ow-accent)' }}>
+                {g.weekday}
+              </span>
+              <span className="ml-1 text-[11px] font-bold tabular-nums" style={{ color: 'var(--ow-fg-0)' }}>
+                {g.dayNum}
+              </span>
+            </div>
+          </td>
+        ))}
+      </tr>
+
+      {/* Row 1: weather icons — sticky left spans both rows. The day badge here
+          is shown on mobile only; on desktop the per-day labels in Row 0 (sticky-left)
+          replace it so the date isn't written twice. */}
       <tr>
         <td
           rowSpan={2}
           className="sticky left-0 z-20 min-w-[56px] px-2 border-r border-b"
           style={{ background: 'var(--ow-bg-1)', borderColor: 'var(--ow-line-2)' }}
         >
-          <div className="flex flex-col items-center justify-center h-full leading-none gap-[2px]">
+          <div className="lg:hidden flex flex-col items-center justify-center h-full leading-none gap-[2px]">
             <span className="text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--ow-accent)' }}>
               {weekday}
             </span>
@@ -84,20 +148,22 @@ export function TimelineHeader({
             </span>
           </div>
         </td>
-        {times.map((t, i) => (
-          <td
-            key={i}
-            className="text-center p-0 ow-tbl-bg cursor-pointer leading-none"
-            style={{
-              fontSize: "13px",
-              lineHeight: "20px",
-              borderLeft: dayStarts.has(t) && i > 0 ? '1px solid var(--ow-line-2)' : undefined,
-            }}
-            onClick={() => onSelectHour(t)}
-          >
-            {wmoIcon(weatherCode(t))}
-          </td>
-        ))}
+        {times.map((t, i) => {
+          const isStart = dayStarts.has(t) && i > 0;
+          return (
+            <td
+              key={i}
+              className={`text-center p-0 ow-tbl-bg cursor-pointer leading-none ${isStart ? 'ow-day-sep' : ''}`}
+              style={{
+                fontSize: "13px",
+                lineHeight: "20px",
+              }}
+              onClick={() => onSelectHour(t)}
+            >
+              {wmoIcon(weatherCode(t), isDayHour(t))}
+            </td>
+          );
+        })}
       </tr>
 
       {/* Row 2: hour numbers — no sticky left (spanned by row above) */}
@@ -109,7 +175,7 @@ export function TimelineHeader({
             <th
               key={i}
               scope="col"
-              className={`text-[10px] lg:text-xs font-semibold py-1 cursor-pointer transition-colors relative border-b ${
+              className={`text-[10px] lg:text-xs font-semibold py-1 cursor-pointer transition-colors relative border-b ${isDayStart ? 'ow-day-sep' : ''} ${
                 t === selectedHour
                   ? "text-white bg-teal-600"
                   : isNow
@@ -118,7 +184,6 @@ export function TimelineHeader({
               }`}
               style={{
                 borderColor: 'var(--ow-line-2)',
-                borderLeft: isDayStart ? '1px solid var(--ow-line-2)' : undefined,
               }}
               onClick={() => onSelectHour(t)}
             >

--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -6,18 +6,21 @@ interface WindCellProps {
   direction: number | null;
   selected: boolean;
   isNow: boolean;
+  isDayStart?: boolean;
   onSelect: () => void;
 }
 
-export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }: WindCellProps) {
+export function WindCell({ speed, gusts, direction, selected, isNow, isDayStart, onSelect }: WindCellProps) {
+  // `isNow` border takes precedence over the day separator (the now marker is more salient).
   const nowBorder = isNow ? "border-l-2 border-l-teal-400" : "";
+  const daySepClass = !isNow && isDayStart ? "ow-day-sep" : "";
   const selectedStyle = selected ? "ring-2 ring-teal-400/70 ring-inset bg-teal-400/10" : "";
 
   if (speed == null) {
     return (
       <td
         role="cell"
-        className={`wind-cell ow-null-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center text-xs align-middle cursor-pointer ${nowBorder} ${selectedStyle}`}
+        className={`wind-cell ow-null-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center text-xs align-middle cursor-pointer ${nowBorder} ${daySepClass} ${selectedStyle}`}
         onClick={onSelect}
       >
         —
@@ -35,7 +38,7 @@ export function WindCell({ speed, gusts, direction, selected, isNow, onSelect }:
   return (
     <td
       role="cell"
-      className={`wind-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center align-middle p-0 cursor-pointer ${nowBorder} ${selectedStyle}`}
+      className={`wind-cell min-w-[36px] lg:min-w-[44px] h-10 lg:h-14 text-center align-middle p-0 cursor-pointer ${nowBorder} ${daySepClass} ${selectedStyle}`}
       style={{ backgroundColor: bg, color }}
       onClick={onSelect}
       aria-label={`${Math.round(speed)} knots${gusts != null ? `, gusts ${Math.round(gusts)}` : ""}${direction != null ? `, direction ${direction}°` : ""}`}

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -151,6 +151,16 @@ export function WindTable({
     );
   }, [forecasts]);
 
+  const dayStarts = useMemo(() => {
+    const set = new Set<string>();
+    let prev = "";
+    for (const t of masterTimeline) {
+      const day = t.slice(0, 10);
+      if (day !== prev) { set.add(t); prev = day; }
+    }
+    return set;
+  }, [masterTimeline]);
+
   const nowHour = nowParisHourPrefix();
 
   const updateVisibleDay = useCallback(() => {
@@ -248,6 +258,7 @@ export function WindTable({
                           direction={direction}
                           selected={t === selectedHour}
                           isNow={t.startsWith(nowHour)}
+                          isDayStart={dayStarts.has(t) && i > 0}
                           onSelect={() => onSelectHour(t)}
                         />
                       );

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -70,7 +70,7 @@ export function ThemeToggle() {
       title={`Switch to ${mode === 'dark' ? 'light' : 'dark'} theme`}
       aria-label={`Switch to ${mode === 'dark' ? 'light' : 'dark'} theme`}
     >
-      {mode === 'dark' ? <MoonIcon /> : <SunIcon />}
+      {mode === 'dark' ? <SunIcon /> : <MoonIcon />}
     </button>
   );
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -368,6 +368,16 @@ body {
   background: var(--ow-bg-2);
   color: var(--ow-fg-2);
 }
+/* Day separator: discreet on mobile, accent stripe on desktop so the eye
+   finds the day boundary without taking extra vertical space on phones. */
+.ow-day-sep {
+  border-left: 1px solid var(--ow-line-2);
+}
+@media (min-width: 1024px) {
+  .ow-day-sep {
+    border-left: 2px solid var(--ow-accent-line);
+  }
+}
 
 /* ── Theme-aware search ──────────────────────────────────────── */
 .ow-search-input {

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -139,10 +139,18 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     for (const m of markersRef.current) m.remove();
     markersRef.current = [];
 
+    // Finish-flag icon for the last waypoint (Lucide-style flag).
+    const flagSvg =
+      '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/>' +
+      '<line x1="4" y1="22" x2="4" y2="15"/>' +
+      '</svg>';
+
     waypoints.forEach(([lat, lon], i) => {
       const isFirst = i === 0;
       const isLast = i === waypoints.length - 1 && waypoints.length > 1;
-      const label = isFirst ? "▶" : isLast ? "■" : String(i);
+      // Number every waypoint 1..N so labels match the sidebar legs; last gets a flag.
+      const label = isLast ? flagSvg : String(i + 1);
       const bg = isFirst ? "#2dd4bf" : isLast ? "#e84118" : "#6b7280";
       const marker = L.marker([lat, lon], {
         icon: waypointIcon(label, bg, !!onWptDelete),

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -317,34 +317,17 @@ function SweepForm({
   earliest,
   latest,
   intervalHours,
-  targetEta,
   onEarliestChange,
   onLatestChange,
   onIntervalChange,
-  onTargetEtaChange,
-  resolvedTheme,
 }: {
   earliest: string;
   latest: string;
   intervalHours: number;
-  targetEta: string;
   onEarliestChange: (iso: string) => void;
   onLatestChange: (iso: string) => void;
   onIntervalChange: (h: number) => void;
-  onTargetEtaChange: (iso: string) => void;
-  resolvedTheme: "light" | "dark";
 }) {
-  const colorScheme = resolvedTheme === "light" ? "light" : "dark";
-  const [showEta, setShowEta] = useState(targetEta !== "");
-
-  // Bound target_eta to [now, now+14d] when shown — same horizon as the slider.
-  const { minIso, maxIso } = useMemo(() => {
-    const now = new Date();
-    now.setSeconds(0, 0);
-    const max = new Date(now.getTime() + SWEEP_HORIZON_DAYS * 86_400_000);
-    return { minIso: toLocalIsoMin(now), maxIso: toLocalIsoMin(max) };
-  }, []);
-
   // Convert ISO local strings <-> hours-from-now so the slider can drive them.
   const anchor = useMemo(() => {
     const d = new Date();
@@ -365,14 +348,6 @@ function SweepForm({
   const latestHours = Math.max(earliestHours + 1, isoToHours(latest));
 
   const validation = validateSweep(earliest, latest, intervalHours);
-
-  const inputStyle = {
-    background: "var(--ow-bg-2)",
-    color: "var(--ow-fg-0)",
-    border: "1px solid var(--ow-line-2)",
-    fontFamily: "var(--ow-font-mono)",
-    colorScheme,
-  } as const;
 
   return (
     <div className="space-y-3">
@@ -415,31 +390,6 @@ function SweepForm({
         </div>
       </div>
 
-      <div>
-        <button
-          type="button"
-          onClick={() => {
-            const next = !showEta;
-            setShowEta(next);
-            if (!next) onTargetEtaChange("");
-          }}
-          className="text-[10px] underline"
-          style={{ color: "var(--ow-fg-2)" }}
-        >
-          {showEta ? "Retirer l'heure d'arrivée souhaitée" : "+ Heure d'arrivée souhaitée (option)"}
-        </button>
-        {showEta && (
-          <input
-            type="datetime-local"
-            value={targetEta}
-            min={earliest || minIso}
-            max={maxIso}
-            onChange={(e) => onTargetEtaChange(e.target.value)}
-            className="w-full rounded-lg px-3 py-1.5 text-sm font-semibold tabular-nums mt-1.5"
-            style={inputStyle}
-          />
-        )}
-      </div>
     </div>
   );
 }
@@ -580,11 +530,9 @@ interface PlanSidebarProps {
   sweepEarliest: string;
   sweepLatest: string;
   sweepIntervalHours: number;
-  sweepTargetEta: string;
   onSweepEarliestChange: (iso: string) => void;
   onSweepLatestChange: (iso: string) => void;
   onSweepIntervalChange: (h: number) => void;
-  onSweepTargetEtaChange: (iso: string) => void;
   windows: PassageWindow[] | null;
   metaWarnings: string[];
   onCompareFetch: () => void;
@@ -611,11 +559,9 @@ export function PlanSidebar({
   sweepEarliest,
   sweepLatest,
   sweepIntervalHours,
-  sweepTargetEta,
   onSweepEarliestChange,
   onSweepLatestChange,
   onSweepIntervalChange,
-  onSweepTargetEtaChange,
   windows,
   metaWarnings,
   onCompareFetch,
@@ -658,34 +604,6 @@ export function PlanSidebar({
   if (mode === "compare" || !passage || !complexity) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
-        {/* Waypoint progress */}
-        <div className="flex items-center gap-3">
-          {[0, 1].map((i) => (
-            <div key={i} className="flex items-center gap-1.5">
-              <span
-                className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold"
-                style={{
-                  background: waypointCount > i ? (i === 0 ? "#2dd4bf" : "#e84118") : "var(--ow-bg-2)",
-                  color: waypointCount > i ? "#fff" : "var(--ow-fg-3)",
-                  border: `2px solid ${waypointCount > i ? "transparent" : "var(--ow-line-2)"}`,
-                }}
-              >
-                {i === 0 ? "▶" : "■"}
-              </span>
-              <span className="text-xs" style={{ color: waypointCount > i ? "var(--ow-fg-1)" : "var(--ow-fg-3)" }}>
-                {i === 0 ? "Départ" : "Arrivée"}
-              </span>
-            </div>
-          ))}
-        </div>
-
-        {/* Instruction */}
-        <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-2)" }}>
-          {waypointCount === 0
-            ? "Cliquez sur la carte pour placer votre point de départ."
-            : "Cliquez sur la carte pour placer votre point d'arrivée."}
-        </p>
-
         {/* Mode toggle */}
         <ModeToggle value={mode} onChange={onModeChange} />
 
@@ -697,12 +615,9 @@ export function PlanSidebar({
             earliest={sweepEarliest}
             latest={sweepLatest}
             intervalHours={sweepIntervalHours}
-            targetEta={sweepTargetEta}
             onEarliestChange={onSweepEarliestChange}
             onLatestChange={onSweepLatestChange}
             onIntervalChange={onSweepIntervalChange}
-            onTargetEtaChange={onSweepTargetEtaChange}
-            resolvedTheme={resolvedTheme}
           />
         )}
 

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -425,7 +425,6 @@ export function PlanPage() {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   });
   const [sweepInterval, setSweepInterval] = useState<number>(3);
-  const [sweepTargetEta, setSweepTargetEta] = useState("");
   const [windows, setWindows] = useState<PassageWindow[] | null>(null);
   const [metaWarnings, setMetaWarnings] = useState<string[]>([]);
 
@@ -494,7 +493,6 @@ export function PlanPage() {
         setSweepEarliest(cached.compare.sweepEarliest);
         setSweepLatest(cached.compare.sweepLatest);
         setSweepInterval(cached.compare.sweepIntervalHours);
-        setSweepTargetEta(cached.compare.sweepTargetEta ?? "");
         if (!cached.single || cached.single.departure !== departure) {
           setForecastUpdatedAt(cached.compare.forecastUpdatedAt);
         }
@@ -553,7 +551,6 @@ export function PlanPage() {
       latest: toTzAware(sweepLatest),
       archetype,
       intervalHours: sweepInterval,
-      targetEta: sweepTargetEta ? toTzAware(sweepTargetEta) : undefined,
     })
       .then((res) => {
         setWindows(res.windows);
@@ -574,7 +571,6 @@ export function PlanPage() {
             sweepEarliest,
             sweepLatest,
             sweepIntervalHours: sweepInterval,
-            sweepTargetEta: sweepTargetEta || undefined,
             windows: res.windows,
             metaWarnings: res.meta_warnings,
             forecastUpdatedAt: res.forecast_updated_at,
@@ -740,11 +736,9 @@ export function PlanPage() {
             sweepEarliest={sweepEarliest}
             sweepLatest={sweepLatest}
             sweepIntervalHours={sweepInterval}
-            sweepTargetEta={sweepTargetEta}
             onSweepEarliestChange={setSweepEarliest}
             onSweepLatestChange={setSweepLatest}
             onSweepIntervalChange={setSweepInterval}
-            onSweepTargetEtaChange={setSweepTargetEta}
             windows={windows}
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}
@@ -788,11 +782,9 @@ export function PlanPage() {
             sweepEarliest={sweepEarliest}
             sweepLatest={sweepLatest}
             sweepIntervalHours={sweepInterval}
-            sweepTargetEta={sweepTargetEta}
             onSweepEarliestChange={setSweepEarliest}
             onSweepLatestChange={setSweepLatest}
             onSweepIntervalChange={setSweepInterval}
-            onSweepTargetEtaChange={setSweepTargetEta}
             windows={windows}
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -12,6 +12,7 @@ export interface HourlyData {
   wind_direction_10m: (number | null)[];
   wind_gusts_10m: (number | null)[];
   weather_code: (number | null)[];
+  is_day?: (number | null)[];
 }
 
 export interface ModelForecast {


### PR DESCRIPTION
## Summary
- **Forecast table** : icônes de lune la nuit (via `is_day` Open-Meteo, fallback 7h-21h) ; séparateur de jours desktop renforcé (2px accent en header + body) ; nouvelle ligne desktop avec label par jour qui colle au bord gauche en `position: sticky` jusqu'à ce que le jour suivant prenne sa place. Mobile inchangé.
- **Theme toggle** : l'icône affichée représente désormais la cible (lune en light, soleil en dark).
- **Plan** : suppression de la légende ▶ Départ / ■ Arrivée et de l'instruction "Cliquez sur la carte…" ; waypoints renumérotés 1..N (cohérent avec la sidebar) ; dernier point en drapeau d'arrivée. Option "Heure d'arrivée souhaitée" retirée du formulaire compare (UI + props + cache).

## Test plan
- [x] `npx tsc --noEmit` (web) — pas d'erreur
- [x] `npx vitest run` (web) — 9/9
- [x] HMR validé en local (`http://localhost:5173/`)
- [ ] Vérifier sur desktop (≥1024px) que le label "TUE 5" reste collé en haut à gauche du tableau, remplacé par le suivant au scroll
- [ ] Vérifier sur mobile que le badge de date sticky de gauche est inchangé et que la ligne de jours desktop n'apparaît pas
- [ ] Vérifier sur la page plan : pas de légende ▶/■, waypoints numérotés 1..N, dernier en drapeau, mode comparer sans champ "heure d'arrivée souhaitée"
- [ ] Vérifier la nuit : icônes 🌙 sur les heures sans soleil, et que le toggle thème affiche 🌙 en clair / ☀️ en sombre

🤖 Generated with [Claude Code](https://claude.com/claude-code)