### PR TITLE
fix(hf-space): catch Open-Meteo timeouts → 503 instead of 500

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -22,6 +22,7 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
 from openwind_data.adapters.base import ForecastHorizonError
@@ -341,6 +342,11 @@ async def _api_passage(request: Request) -> JSONResponse:
             return JSONResponse({"error": str(exc)}, status_code=422)
         except ForecastHorizonError as exc:
             return JSONResponse({"error": str(exc)}, status_code=422)
+        except httpx.TimeoutException:
+            return JSONResponse(
+                {"error": "upstream weather service did not respond in time"},
+                status_code=503,
+            )
 
         # Sweep is partial-tolerant: estimate_passage_windows skips windows
         # that hit ForecastHorizonError. Compute the expected count to surface
@@ -420,6 +426,11 @@ async def _api_passage(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(exc)}, status_code=422)
     except ForecastHorizonError as exc:
         return JSONResponse({"error": str(exc)}, status_code=422)
+    except httpx.TimeoutException:
+        return JSONResponse(
+            {"error": "upstream weather service did not respond in time"},
+            status_code=503,
+        )
 
     complexity = score_complexity(passage)
 
@@ -490,6 +501,14 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(exc)}, status_code=422)
     except ForecastHorizonError as exc:
         return JSONResponse({"error": str(exc)}, status_code=422)
+    except httpx.TimeoutException:
+        # ETA solver does N iterations; any one of them can hit the upstream
+        # timeout. Surface a 503 so the web app shows the user a retry hint
+        # instead of a 500.
+        return JSONResponse(
+            {"error": "upstream weather service did not respond in time"},
+            status_code=503,
+        )
 
     complexity = score_complexity(plan.report)
 

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -26,6 +26,11 @@ export function friendlyError(raw: string): string {
   if (/sweep would produce \d+ windows/i.test(raw)) {
     return "Trop de créneaux à comparer. Réduisez la fenêtre ou augmentez le pas d'échantillonnage.";
   }
+  if (/upstream weather service did not respond in time/i.test(raw)) {
+    // Open-Meteo timed out (ReadTimeout / ConnectTimeout). Usually transient —
+    // HF Spaces' shared egress is jittery and Open-Meteo occasionally pauses.
+    return "Le service météo a mis trop de temps à répondre. Réessayez dans quelques instants.";
+  }
   if (/Erreur serveur 5\d\d/.test(raw) || /HTTP 5\d\d/.test(raw)) {
     return "Le serveur météo est indisponible. Réessayez dans quelques instants.";
   }


### PR DESCRIPTION
## Summary

`httpx.ReadTimeout` / `ConnectTimeout` from the Open-Meteo client were bubbling unhandled through `_api_passage` (single + sweep) and the new `_api_passage_by_eta` handlers, returning **500s** with raw stack traces in the HF logs. HF Spaces' shared egress is jittery enough that these fire in normal use.

- Add \`except httpx.TimeoutException\` to all three call sites; return **503** with a stable error string \`upstream weather service did not respond in time\`.
- Translate the 503 message in the web \`friendlyError\` so the user sees a French retry hint instead of \"Erreur serveur 503\".

## Validation

Patched \`OpenMeteoAdapter.fetch\` to raise \`ConnectTimeout\` and hit both endpoints with Starlette's TestClient — both now return 503 cleanly. Full suites still green: data-adapters 131 ✓, mcp-core 20 ✓, web vitest + tsc + vite build clean.

## Test plan

- [ ] Deploy and confirm a transient Open-Meteo timeout no longer surfaces as a 500 in HF logs.
- [ ] In the web app, force a slow network and confirm the user sees the French retry hint instead of a raw error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)