### PR TITLE
refacto(adapters): single-pass backward ETA solver

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -55,10 +55,6 @@ ROUGH_SEA_HS_M = 2.5     # >= 2.5m: "forte mer" warning
 PREWARM_MIN_SPEED_KN = 2.0  # conservative floor to upper-bound passage duration for cache prewarm
 MAX_SWEEP_WINDOWS = 336  # 14 days x 24h hard cap
 
-# ETA-driven solver defaults — see `estimate_passage_for_arrival`.
-DEFAULT_ETA_TOLERANCE = timedelta(minutes=10)
-DEFAULT_ETA_MAX_ITERATIONS = 4
-
 # Wave derate — see README "References" section for sources.
 WAVE_DERATE_K = 0.05
 WAVE_DERATE_P = 1.75
@@ -164,17 +160,15 @@ class PassageReport:
 class EtaPassagePlan:
     """Result of an ETA-driven passage solve.
 
-    The solver iterates `estimate_passage` to find a departure that lands
-    arrival within `tolerance` of `target_arrival`. `residual_seconds` is
-    `target - actual`: positive means we still arrive too early, negative
-    too late. `converged` is False when the iteration cap was reached.
+    Backward-resolved: each segment's end_time is fixed (the next segment's
+    start, or `target_arrival` for the last segment), and its duration is
+    computed from the wind sampled at a heuristic mid-time. So
+    `report.arrival_time == target_arrival` exactly by construction (modulo
+    timedelta microsecond drift).
     """
 
     report: PassageReport
     target_arrival: datetime
-    iterations: int
-    residual_seconds: float
-    converged: bool
 
 
 def _closest_wind_point(points: tuple[WindPoint, ...], target: datetime) -> WindPoint:
@@ -393,6 +387,139 @@ async def _estimate_with_model(
     )
 
 
+async def _estimate_backward_with_model(
+    waypoints: list[Point],
+    target_arrival: datetime,
+    boat_archetype: str,
+    *,
+    efficiency: float,
+    segment_length_nm: float,
+    adapter: MarineDataAdapter | None,
+    model: str,
+    heuristic_speed_kn: float,
+    use_wave_correction: bool,
+) -> PassageReport:
+    """Mirror of `_estimate_with_model` anchored at arrival, solving backward.
+
+    Walks segments from last to first: each segment's end_time is fixed (the
+    next segment's start_time, or `target_arrival` for the last segment), and
+    its actual duration is computed from the wind sampled at a mid-time guess.
+    By construction, the resulting report has `arrival_time == target_arrival`
+    exactly (modulo timedelta microsecond drift), so no fixed-point iteration
+    is needed. Mid-time guesses use `heuristic_speed_kn` like the forward path,
+    same temporal-correlation argument applies.
+    """
+    polar = get_polar(boat_archetype)
+    segments = segment_route(waypoints, segment_length_nm)
+    target_utc = target_arrival.astimezone(UTC)
+
+    heuristic_speed_kn = max(heuristic_speed_kn, MIN_BOAT_SPEED_KN)
+    seg_mid_times: list[datetime] = [target_utc] * len(segments)
+    cumulative_back = timedelta(0)
+    for idx in range(len(segments) - 1, -1, -1):
+        seg_h = segments[idx].distance_nm / heuristic_speed_kn
+        seg_mid_times[idx] = target_utc - cumulative_back - timedelta(hours=seg_h / 2)
+        cumulative_back += timedelta(hours=seg_h)
+
+    seg_mid_points = [midpoint(s.start, s.end) for s in segments]
+
+    own_adapter = adapter is None
+    fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
+    try:
+        bundles = await asyncio.gather(
+            *[
+                fetch_adapter.fetch(
+                    pt.lat,
+                    pt.lon,
+                    mid - WIND_FETCH_WINDOW / 2,
+                    mid + WIND_FETCH_WINDOW / 2,
+                    models=[model],
+                )
+                for pt, mid in zip(seg_mid_points, seg_mid_times, strict=True)
+            ]
+        )
+    finally:
+        if own_adapter and hasattr(fetch_adapter, "aclose"):
+            await fetch_adapter.aclose()  # pragma: no cover
+
+    # Backward pass: walk segments in reverse, anchoring end_time at arrival.
+    reverse_reports: list[SegmentReport] = []
+    end_time = target_utc
+    min_boat_speed = float("inf")
+    for seg, mid_time, bundle in zip(
+        reversed(segments), reversed(seg_mid_times), reversed(bundles), strict=True
+    ):
+        wind_series = bundle.wind_by_model.get(model)
+        if wind_series is None or not wind_series.points:
+            raise ForecastHorizonError(model, mid_time)
+        wp = _closest_wind_point(wind_series.points, mid_time)
+        twa = normalize_twa(twd=wp.direction_deg, course=seg.bearing_deg)
+        polar_speed = lookup_polar(polar, wp.speed_kn, twa)
+        opt_twa, opt_polar_speed = best_vmg_upwind(polar, wp.speed_kn)
+        if twa < opt_twa:
+            effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
+        else:
+            effective_polar = polar_speed
+        hs_m = _closest_sea_hs(bundle.sea.points, mid_time)
+        derate = 1.0
+        if use_wave_correction and hs_m is not None:
+            derate = wave_derate(hs_m, twa)
+        boat_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
+        seg_duration = timedelta(hours=seg.distance_nm / boat_speed)
+        seg_start = end_time - seg_duration
+        min_boat_speed = min(min_boat_speed, boat_speed)
+        reverse_reports.append(
+            SegmentReport(
+                start=seg.start,
+                end=seg.end,
+                distance_nm=seg.distance_nm,
+                bearing_deg=seg.bearing_deg,
+                start_time=seg_start,
+                end_time=end_time,
+                tws_kn=wp.speed_kn,
+                twd_deg=wp.direction_deg,
+                twa_deg=twa,
+                polar_speed_kn=polar_speed,
+                boat_speed_kn=boat_speed,
+                duration_h=seg_duration.total_seconds() / 3600.0,
+                hs_m=hs_m,
+                wave_derate_factor=derate,
+            )
+        )
+        end_time = seg_start
+
+    reports = list(reversed(reverse_reports))
+    departure = reports[0].start_time
+    duration = target_utc - departure
+
+    warnings: list[str] = []
+    max_tws = max(r.tws_kn for r in reports)
+    if max_tws >= STRONG_WIND_THRESHOLD_KN:
+        warnings.append(f"vent fort: TWS max {max_tws:.0f} kn (≥{STRONG_WIND_THRESHOLD_KN:.0f})")
+    if min_boat_speed < LIGHT_WIND_THRESHOLD_KN:
+        warnings.append(f"vent faible: vitesse mini {min_boat_speed:.1f} kn : passage très lent")
+    hs_values = [r.hs_m for r in reports if r.hs_m is not None]
+    if hs_values:
+        hs_max = max(hs_values)
+        if hs_max >= ROUGH_SEA_HS_M:
+            warnings.append(f"forte mer: Hs max {hs_max:.1f} m (≥{ROUGH_SEA_HS_M:.1f})")
+        elif hs_max >= MODERATE_SEA_HS_M:
+            warnings.append(f"mer formée: Hs max {hs_max:.1f} m (≥{MODERATE_SEA_HS_M:.1f})")
+
+    total_distance = sum(s.distance_nm for s in segments)
+    return PassageReport(
+        archetype=boat_archetype,
+        departure_time=departure,
+        arrival_time=target_utc,
+        duration_h=duration.total_seconds() / 3600.0,
+        distance_nm=total_distance,
+        efficiency=efficiency,
+        model=model,
+        segments=tuple(reports),
+        warnings=tuple(warnings),
+    )
+
+
 async def estimate_passage_windows(
     waypoints: list[Point],
     earliest_departure: datetime,
@@ -528,80 +655,76 @@ async def estimate_passage_for_arrival(
     target_arrival: datetime,
     boat_archetype: str,
     *,
-    tolerance: timedelta = DEFAULT_ETA_TOLERANCE,
-    max_iterations: int = DEFAULT_ETA_MAX_ITERATIONS,
     efficiency: float = 0.75,
     segment_length_nm: float = 10.0,
     adapter: MarineDataAdapter | None = None,
-    model: str = DEFAULT_MODEL,
+    model: str = AUTO_MODEL,
     heuristic_speed_kn: float = HEURISTIC_SPEED_KN,
     use_wave_correction: bool = False,
 ) -> EtaPassagePlan:
     """Inverse of `estimate_passage`: solve for a departure given a target arrival.
 
-    Fixed-point iteration: guess `departure = target_arrival - distance/heuristic_speed`,
-    simulate, shift `departure` by the residual `target - actual_arrival`, repeat
-    until `|residual| <= tolerance` or `max_iterations` is reached. Converges in
-    1-3 steps under typical Mediterranean wind variability because the wind window
-    we hit at the corrected departure is close to the previous one.
+    Single-pass backward resolution: walks segments from last to first, anchoring
+    each segment's end_time at the next one's start (or `target_arrival` for the
+    last segment) and computing its actual duration from the wind sampled at a
+    heuristic mid-time. Returns a plan whose `report.arrival_time` equals
+    `target_arrival` exactly by construction, so no iteration / tolerance /
+    convergence logic is needed.
 
     Args:
         waypoints: ordered list of route waypoints (>=2 points).
         target_arrival: timezone-aware datetime; the arrival we want to hit.
         boat_archetype: one of the registry names.
-        tolerance: residual under which a solution counts as converged.
-        max_iterations: cap on solver steps. Solutions return with `converged=False`
-            beyond this cap; caller decides whether to retry or surface as-is.
-        Other args: forwarded to `estimate_passage`.
+        efficiency: multiplier on polar speeds (see `estimate_passage`).
+        segment_length_nm: sub-segment length for weather sampling.
+        adapter: any `MarineDataAdapter` (defaults to a fresh `OpenMeteoAdapter`).
+        model: wind model name; ``"auto"`` tries AROME → ICON → GFS in order.
+        heuristic_speed_kn: speed used to lay out per-segment mid-time guesses.
+        use_wave_correction: if True, multiply boat speed by `wave_derate(Hs, TWA)`.
 
     Raises:
-        ValueError: target_arrival naive, max_iterations < 1, or tolerance <= 0.
-        ForecastHorizonError: from `estimate_passage` if the inferred departure
-            falls outside the model's forecast horizon. Caller should retry with
-            a different `model` or accept the failure.
+        ValueError: if `target_arrival` is naive.
+        ForecastHorizonError: if no model in the (auto-)chain covers the resolved
+            passage window.
     """
     if target_arrival.tzinfo is None:
         raise ValueError("target_arrival must be timezone-aware")
-    if max_iterations < 1:
-        raise ValueError("max_iterations must be >= 1")
-    if tolerance.total_seconds() <= 0:
-        raise ValueError("tolerance must be positive")
+    if not 0.0 < efficiency <= 1.0:
+        raise ValueError("efficiency must be in (0, 1]")
 
     target_utc = target_arrival.astimezone(UTC)
-    segments = segment_route(waypoints, segment_length_nm)
-    total_nm = sum(s.distance_nm for s in segments)
-    departure = target_utc - timedelta(hours=total_nm / heuristic_speed_kn)
 
-    last_report: PassageReport | None = None
-    for i in range(1, max_iterations + 1):
-        report = await estimate_passage(
-            waypoints,
-            departure,
-            boat_archetype,
-            efficiency=efficiency,
-            segment_length_nm=segment_length_nm,
-            adapter=adapter,
-            model=model,
-            heuristic_speed_kn=heuristic_speed_kn,
-            use_wave_correction=use_wave_correction,
-        )
-        last_report = report
-        residual = target_utc - report.arrival_time
-        if abs(residual) <= tolerance:
-            return EtaPassagePlan(
-                report=report,
-                target_arrival=target_utc,
-                iterations=i,
-                residual_seconds=residual.total_seconds(),
-                converged=True,
-            )
-        departure = departure + residual
+    if model == AUTO_MODEL:
+        last_err: ForecastHorizonError | None = None
+        for candidate in AUTO_FALLBACK_CHAIN:
+            try:
+                report = await _estimate_backward_with_model(
+                    waypoints,
+                    target_utc,
+                    boat_archetype,
+                    efficiency=efficiency,
+                    segment_length_nm=segment_length_nm,
+                    adapter=adapter,
+                    model=candidate,
+                    heuristic_speed_kn=heuristic_speed_kn,
+                    use_wave_correction=use_wave_correction,
+                )
+                return EtaPassagePlan(report=report, target_arrival=target_utc)
+            except ForecastHorizonError as exc:
+                last_err = exc
+                continue
+        assert last_err is not None
+        raise last_err
 
-    assert last_report is not None  # max_iterations >= 1 guarantees at least one pass
-    return EtaPassagePlan(
-        report=last_report,
-        target_arrival=target_utc,
-        iterations=max_iterations,
-        residual_seconds=(target_utc - last_report.arrival_time).total_seconds(),
-        converged=False,
+    report = await _estimate_backward_with_model(
+        waypoints,
+        target_utc,
+        boat_archetype,
+        efficiency=efficiency,
+        segment_length_nm=segment_length_nm,
+        adapter=adapter,
+        model=model,
+        heuristic_speed_kn=heuristic_speed_kn,
+        use_wave_correction=use_wave_correction,
     )
+    return EtaPassagePlan(report=report, target_arrival=target_utc)

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -17,7 +17,6 @@ from openwind_data.adapters.base import (
 from openwind_data.routing.archetypes import get_polar, lookup_polar
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import (
-    DEFAULT_ETA_TOLERANCE,
     LIGHT_WIND_THRESHOLD_KN,
     MAX_SWEEP_WINDOWS,
     MODERATE_SEA_HS_M,
@@ -799,10 +798,10 @@ class TestSeaStateWarnings:
 class TestEstimatePassageForArrival:
     """ETA-driven solver: given a target arrival, find the right departure."""
 
-    async def test_converges_under_constant_wind(self) -> None:
-        # Constant wind in time → first iteration's residual fully predicts the
-        # second iteration's correction. Should converge on iteration 2 (the
-        # initial heuristic-speed guess is off, the corrected one lands exactly).
+    async def test_arrival_lands_exactly_on_target(self) -> None:
+        # Backward resolution anchors the last segment's end_time at target,
+        # so arrival must equal target to microsecond precision (the only
+        # drift comes from cumulative timedelta arithmetic, sub-microsecond).
         adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
         target = datetime(2026, 5, 1, 14, 0, tzinfo=UTC)
         plan = await estimate_passage_for_arrival(
@@ -812,20 +811,15 @@ class TestEstimatePassageForArrival:
             adapter=adapter,
             segment_length_nm=10.0,
         )
-        assert plan.converged is True
         assert plan.target_arrival == target
-        assert abs(plan.residual_seconds) <= DEFAULT_ETA_TOLERANCE.total_seconds()
-        # Arrival lands within tolerance of target
-        assert (
-            abs((plan.report.arrival_time - target).total_seconds())
-            <= DEFAULT_ETA_TOLERANCE.total_seconds()
-        )
-        # And departure + duration = arrival (sanity)
+        assert plan.report.arrival_time == target
+        # And departure + duration ≈ arrival (sanity)
         expected_arrival = plan.report.departure_time + timedelta(hours=plan.report.duration_h)
-        assert abs((plan.report.arrival_time - expected_arrival).total_seconds()) < 1.0
+        assert abs((plan.report.arrival_time - expected_arrival).total_seconds()) < 1e-3
 
-    async def test_iteration_count_is_small(self) -> None:
-        # Constant wind → fixed-point converges in <=3 iterations.
+    async def test_segments_chain_continuously_to_target(self) -> None:
+        # End-to-end: each segment's end_time equals the next segment's
+        # start_time, the last segment's end_time equals target.
         adapter = StubAdapter(tws_kn=12.0, twd_deg=180.0)
         target = datetime(2026, 5, 1, 16, 0, tzinfo=UTC)
         plan = await estimate_passage_for_arrival(
@@ -835,8 +829,23 @@ class TestEstimatePassageForArrival:
             adapter=adapter,
             segment_length_nm=10.0,
         )
-        assert plan.iterations <= 3
-        assert plan.converged
+        for s1, s2 in pairwise(plan.report.segments):
+            assert s1.end_time == s2.start_time
+        assert plan.report.segments[-1].end_time == target
+        assert plan.report.segments[0].start_time == plan.report.departure_time
+
+    async def test_one_fetch_per_segment(self) -> None:
+        # Backward solver issues one fetch per segment, no iteration multiplier.
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        target = datetime(2026, 5, 1, 14, 0, tzinfo=UTC)
+        plan = await estimate_passage_for_arrival(
+            [MARSEILLE, PORQUEROLLES],
+            target,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=10.0,
+        )
+        assert len(adapter.calls) == len(plan.report.segments)
 
     async def test_naive_target_rejected(self) -> None:
         adapter = StubAdapter()
@@ -848,48 +857,16 @@ class TestEstimatePassageForArrival:
                 adapter=adapter,
             )
 
-    async def test_invalid_max_iterations_rejected(self) -> None:
+    async def test_invalid_efficiency_rejected(self) -> None:
         adapter = StubAdapter()
-        with pytest.raises(ValueError, match="max_iterations"):
+        with pytest.raises(ValueError, match="efficiency"):
             await estimate_passage_for_arrival(
                 [MARSEILLE, PORQUEROLLES],
                 datetime(2026, 5, 1, 14, 0, tzinfo=UTC),
                 "cruiser_40ft",
                 adapter=adapter,
-                max_iterations=0,
+                efficiency=0.0,
             )
-
-    async def test_non_positive_tolerance_rejected(self) -> None:
-        adapter = StubAdapter()
-        with pytest.raises(ValueError, match="tolerance"):
-            await estimate_passage_for_arrival(
-                [MARSEILLE, PORQUEROLLES],
-                datetime(2026, 5, 1, 14, 0, tzinfo=UTC),
-                "cruiser_40ft",
-                adapter=adapter,
-                tolerance=timedelta(0),
-            )
-
-    async def test_did_not_converge_returns_last_with_flag(self) -> None:
-        # Single iteration cannot converge from the heuristic-speed guess
-        # (HEURISTIC_SPEED_KN=6.0 vs cruiser_40ft beam-reach ~5 kn at 10 kn TWS).
-        # Force it: max_iterations=1 + tight tolerance → expect converged=False.
-        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
-        target = datetime(2026, 5, 1, 14, 0, tzinfo=UTC)
-        plan = await estimate_passage_for_arrival(
-            [MARSEILLE, PORQUEROLLES],
-            target,
-            "cruiser_40ft",
-            adapter=adapter,
-            segment_length_nm=10.0,
-            max_iterations=1,
-            tolerance=timedelta(seconds=30),
-        )
-        assert plan.converged is False
-        assert plan.iterations == 1
-        # The residual is reported in seconds, and matches target - actual.
-        actual_residual = (target - plan.report.arrival_time).total_seconds()
-        assert plan.residual_seconds == pytest.approx(actual_residual, abs=1e-6)
 
     async def test_target_arrival_with_local_tz_converted_to_utc(self) -> None:
         # A non-UTC tzinfo should be normalized; target_arrival on the result

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -478,22 +478,13 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     except (TypeError, ValueError) as exc:
         return JSONResponse({"error": f"invalid efficiency: {exc}"}, status_code=422)
 
-    from datetime import timedelta as _td
-    kwargs: dict[str, Any] = {"efficiency": efficiency, "model": "auto"}
-    if "tolerance_minutes" in body:
-        try:
-            kwargs["tolerance"] = _td(minutes=float(body["tolerance_minutes"]))
-        except (TypeError, ValueError) as exc:
-            return JSONResponse({"error": f"invalid tolerance_minutes: {exc}"}, status_code=422)
-    if "max_iterations" in body:
-        try:
-            kwargs["max_iterations"] = int(body["max_iterations"])
-        except (TypeError, ValueError) as exc:
-            return JSONResponse({"error": f"invalid max_iterations: {exc}"}, status_code=422)
-
     try:
         plan = await estimate_passage_for_arrival(
-            waypoints, target_arrival, body["archetype"], **kwargs,
+            waypoints,
+            target_arrival,
+            body["archetype"],
+            efficiency=efficiency,
+            model="auto",
         )
     except KeyError as exc:
         return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
@@ -502,9 +493,6 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     except ForecastHorizonError as exc:
         return JSONResponse({"error": str(exc)}, status_code=422)
     except httpx.TimeoutException:
-        # ETA solver does N iterations; any one of them can hit the upstream
-        # timeout. Surface a 503 so the web app shows the user a retry hint
-        # instead of a 500.
         return JSONResponse(
             {"error": "upstream weather service did not respond in time"},
             status_code=503,
@@ -515,12 +503,7 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     return JSONResponse({
         "passage": _to_json(plan.report),
         "complexity": _to_json(complexity),
-        "eta": {
-            "target_arrival": plan.target_arrival.isoformat(),
-            "iterations": plan.iterations,
-            "residual_seconds": plan.residual_seconds,
-            "converged": plan.converged,
-        },
+        "eta": {"target_arrival": plan.target_arrival.isoformat()},
         "forecast_updated_at": datetime.now(UTC).isoformat(),
     })
 

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -96,8 +96,6 @@ export async function fetchPassageByEta(params: {
   targetArrival: string;
   archetype: string;
   efficiency?: number;
-  toleranceMinutes?: number;
-  maxIterations?: number;
 }): Promise<PassageByEtaResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -105,8 +103,6 @@ export async function fetchPassageByEta(params: {
     archetype: params.archetype,
     efficiency: params.efficiency ?? 0.75,
   };
-  if (params.toleranceMinutes !== undefined) body["tolerance_minutes"] = params.toleranceMinutes;
-  if (params.maxIterations !== undefined) body["max_iterations"] = params.maxIterations;
 
   const res = await fetch(`${API_BASE}/api/v1/passage-by-eta`, {
     method: "POST",

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -62,9 +62,6 @@ export interface PassageResponse {
 
 export interface EtaSolveMeta {
   target_arrival: string;       // ISO-8601 UTC
-  iterations: number;
-  residual_seconds: number;     // target - actual; positive = arrived too early
-  converged: boolean;
 }
 
 export interface PassageByEtaResponse extends PassageResponse {


### PR DESCRIPTION
## Summary

- Replace the fixed-point iterator in `estimate_passage_for_arrival` with a single-pass **backward resolution**. Each segment's `end_time` is anchored (at `target_arrival` for the last segment, at the next segment's `start_time` for earlier ones), and its actual duration is computed from the wind sampled at a heuristic mid-time guess. So `report.arrival_time == target_arrival` exactly by construction, no iteration / tolerance / convergence logic needed.
- Cost: 1 fetch per segment, vs up to 4× before. Same precision as the forward solver (the heuristic-speed bias on mid-time is identical and well within forecast temporal correlation).
- Drops the now-meaningless API surface: `EtaPassagePlan.{iterations, residual_seconds, converged}` fields, `tolerance` / `max_iterations` params, `DEFAULT_ETA_TOLERANCE` / `DEFAULT_ETA_MAX_ITERATIONS` constants, and the matching HF-space request fields (`tolerance_minutes`, `max_iterations`) and response keys (`eta.iterations`, `eta.residual_seconds`, `eta.converged`). Web `EtaSolveMeta` and `fetchPassageByEta` params slimmed to match.

## Test plan

- [x] `pytest packages/data-adapters` (132 passed)
- [x] `pytest packages/mcp-core` (20 passed)
- [x] `tsc --noEmit` on `packages/web` (clean)
- [x] `ruff check` on `passage.py` (clean)
- [x] Live smoke against real Open-Meteo, target arrival 2026-05-04 18:00 +02:00:
  - Marseille → Porquerolles: arrival drift 0.000000 s, AROME, 1.1 s
  - Marseille → Ajaccio (target 2026-05-06): arrival drift 0.000000 s, AUTO falls back to ICON-EU, 7.4 s for 18 fetches
  - Segment chain: every `segments[i].end_time == segments[i+1].start_time`, first anchor on `departure_time`, last anchor exactly on `target_arrival`
- [ ] Re-run smoke after rebase on top of PR #90 (cap heuristic) to confirm 10-segment cap kicks in for the long route

🤖 Generated with [Claude Code](https://claude.com/claude-code)