### PR TITLE
refacto(complexity): wind/sea warnings as min-max range, drop bare max

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/complexity.py
+++ b/packages/data-adapters/src/openwind_data/routing/complexity.py
@@ -62,6 +62,20 @@ def _lower_bound(level: int, bands: tuple[tuple[float, int, str], ...]) -> float
     return 0.0  # pragma: no cover
 
 
+def _compact_range(values: list[float], decimals: int) -> str:
+    """`"30"` for {30}, `"25-30"` for the spread, rounded to `decimals` digits.
+
+    Reporting a single max obscured how the conditions actually played out:
+    "TWS max 30 kn" reads like one moment of stress, when the affected stretch
+    might have been steady at 25-30 kn. The range is more informative for both
+    the LLM (decision-making) and the human reader.
+    """
+    rounded = sorted({round(v, decimals) for v in values})
+    if len(rounded) == 1:
+        return f"{rounded[0]:.{decimals}f}"
+    return f"{rounded[0]:.{decimals}f}-{rounded[-1]:.{decimals}f}"
+
+
 @dataclass(frozen=True, slots=True)
 class ComplexityWarning:
     kind: Literal["wind", "sea"]
@@ -126,10 +140,11 @@ def score_complexity(
         threshold = _lower_bound(wind_level, _WIND_BANDS)
         affected = tuple(i for i, s in enumerate(passage.segments) if s.tws_kn >= threshold)
         affected_nm = sum(passage.segments[i].distance_nm for i in affected)
+        tws_range = _compact_range([passage.segments[i].tws_kn for i in affected], 0)
         warnings.append(ComplexityWarning(
             kind="wind",
             level=wind_level,
-            message=f"Vent {wind_label} : TWS max {tws_max:.0f} kn sur {affected_nm:.0f} nm",
+            message=f"Vent {wind_label} : TWS {tws_range} kn sur {affected_nm:.0f} nm",
             affected_segments=affected,
         ))
     if sea_level is not None and sea_level >= 3 and max_hs_m is not None:
@@ -144,10 +159,16 @@ def score_complexity(
         if not affected_sea:
             affected_sea = tuple(range(len(passage.segments)))
         affected_sea_nm = sum(passage.segments[i].distance_nm for i in affected_sea)
+        affected_hs = [
+            passage.segments[i].hs_m
+            for i in affected_sea
+            if passage.segments[i].hs_m is not None
+        ]
+        hs_range = _compact_range(affected_hs, 1) if affected_hs else f"{max_hs_m:.1f}"
         warnings.append(ComplexityWarning(
             kind="sea",
             level=sea_level,
-            message=f"Mer {sea_label} : Hs max {max_hs_m:.1f} m sur {affected_sea_nm:.0f} nm",
+            message=f"Mer {sea_label} : Hs {hs_range} m sur {affected_sea_nm:.0f} nm",
             affected_segments=affected_sea,
         ))
 

--- a/packages/data-adapters/tests/test_complexity.py
+++ b/packages/data-adapters/tests/test_complexity.py
@@ -119,8 +119,10 @@ class TestWarnings:
         assert w.level == 3
         assert isinstance(w, ComplexityWarning)
         assert 0 in w.affected_segments
-        # Message reports affected route distance, not segment count.
+        # Single affected segment → no range, just the value, plus affected nm.
+        assert "TWS 18 kn" in w.message
         assert "5 nm" in w.message
+        assert "max" not in w.message
         assert "segment" not in w.message
 
     def test_wind_warning_identifies_hot_segments(self) -> None:
@@ -129,15 +131,27 @@ class TestWarnings:
         assert len(s.warnings) == 1
         w = s.warnings[0]
         assert w.affected_segments == (1,)
-        # Single 5 nm segment affected → "sur 5 nm".
+        assert "TWS 26 kn" in w.message
         assert "5 nm" in w.message
+
+    def test_wind_warning_reports_min_max_range(self) -> None:
+        # Multiple affected segments at level 5 with different TWS values →
+        # message must report the range, not a single max.
+        s = score_complexity(_make_passage([26.0, 28.0, 30.0]))
+        assert len(s.warnings) == 1
+        w = s.warnings[0]
+        assert w.kind == "wind"
+        assert w.affected_segments == (0, 1, 2)
+        assert "TWS 26-30 kn" in w.message
+        assert "15 nm" in w.message
 
     def test_sea_warning_at_level_4(self) -> None:
         s = score_complexity(_make_passage([5.0]), max_hs_m=2.5)
         sea_w = [w for w in s.warnings if w.kind == "sea"]
         assert len(sea_w) == 1
         assert sea_w[0].level == 4  # 2.5 m falls in level 4 (2–3 m band)
-        assert "2.5" in sea_w[0].message
+        assert "Hs 2.5 m" in sea_w[0].message
+        assert "max" not in sea_w[0].message
 
     def test_no_sea_warning_without_max_hs(self) -> None:
         s = score_complexity(_make_passage([18.0]))
@@ -157,15 +171,28 @@ class TestWarnings:
         sea_w = [w for w in s.warnings if w.kind == "sea"]
         assert len(sea_w) == 1
         assert sea_w[0].affected_segments == (1,)
+        assert "Hs 1.6 m" in sea_w[0].message
         assert "5 nm" in sea_w[0].message
-        assert "1.6" in sea_w[0].message  # max_hs_m derived from segments
+
+    def test_sea_warning_reports_min_max_range(self) -> None:
+        # Three segments with Hs >= 1.0 m and varying values → range expected.
+        s = score_complexity(
+            _make_passage([10.0, 10.0, 10.0], hs_per_segment=[1.2, 1.6, 1.9])
+        )
+        sea_w = [w for w in s.warnings if w.kind == "sea"]
+        assert len(sea_w) == 1
+        assert sea_w[0].affected_segments == (0, 1, 2)
+        assert "Hs 1.2-1.9 m" in sea_w[0].message
+        assert "15 nm" in sea_w[0].message
 
     def test_sea_warning_uses_full_route_when_only_max_hs_provided(self) -> None:
         # No per-segment Hs but caller passes route-level max → warning falls
-        # back to the whole route distance (3 segs x 5 nm = 15 nm).
+        # back to the whole route distance (3 segs x 5 nm = 15 nm) and reports
+        # the override value alone (no range data available).
         s = score_complexity(_make_passage([10.0, 10.0, 10.0]), max_hs_m=2.5)
         sea_w = [w for w in s.warnings if w.kind == "sea"]
         assert len(sea_w) == 1
+        assert "Hs 2.5 m" in sea_w[0].message
         assert "15 nm" in sea_w[0].message
 
 


### PR DESCRIPTION
## Summary

`Vent très fort : TWS max 30 kn sur 24 nm` reads like one moment of stress: the user can not tell whether the affected stretch was steady at 25-30 kn or barely brushed the threshold once. Switch both axes to a compact range over the affected segments.

- Wind: `Vent très fort : TWS 25-30 kn sur 24 nm`
- Sea : `Mer agitée : Hs 1.5-1.9 m sur 33 nm`
- Single-value cases collapse to one number (`TWS 18 kn`, `Hs 1.6 m`).

Sea fallback when the caller passed only a route-level `max_hs_m` and no per-segment Hs is preserved: report that single value (no spread to draw from).

## Test plan

- [x] `uv run pytest` green in `packages/data-adapters` (138 tests).
- [x] New tests pin the range format on both axes (`TWS 26-30 kn`, `Hs 1.2-1.9 m`).
- [ ] Eyeball the plan page UX after merge: warning rows should now show ranges instead of bare maxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)