### PR TITLE
fix(marc): recover endpoint + C-grid + Z0 fixes lost in PR #95 squash

### DIFF
--- a/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
+++ b/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
@@ -108,13 +108,19 @@ def _tile_path(atlas: AtlasMeta, lat: float, lon: float) -> Path:
     )
 
 
-def _nearest_cell_in_tile(df: pl.DataFrame, lat: float, lon: float) -> int | None:
-    """Return index of metric-nearest cell, or None if the tile is empty.
+def _nearest_cell_in_tile(
+    df: pl.DataFrame, lat: float, lon: float, required_col: str | None = None
+) -> int | None:
+    """Return index of metric-nearest cell, or None if no valid cell qualifies.
 
     Uses local-tangent-plane distance: degrees-lon are scaled by cos(lat) so
-    we don't bias toward longitudinal neighbours at high latitude. This
-    matters for the cell-distance threshold check (a 0.05° lon-only neighbour
-    at 48°N is 3.7 km away, not 5.5 km that an angular-only metric implies).
+    we don't bias toward longitudinal neighbours at high latitude. When
+    ``required_col`` is given, only cells with a finite value in that column
+    are considered — this matters for currents because MARC's Arakawa C-grid
+    offsets U and V by half a step from XE, so the metric-nearest XE cell can
+    have an on-land U face (NaN) even when XE itself is valid sea. ~50 cells
+    in FINIS exhibit this; routing through a slightly further cell with
+    finite U/V is a sub-resolution shift, well within harmonic precision.
     """
     lats = df["lat"].to_numpy()
     lons = df["lon"].to_numpy()
@@ -122,6 +128,11 @@ def _nearest_cell_in_tile(df: pl.DataFrame, lat: float, lon: float) -> int | Non
         return None
     cos_lat = np.cos(np.deg2rad(lat))
     d2 = ((lats - lat) ** 2) + ((lons - lon) * cos_lat) ** 2
+    if required_col is not None and required_col in df.columns:
+        valid = np.isfinite(df[required_col].to_numpy())
+        if not valid.any():
+            return None
+        d2 = np.where(valid, d2, np.inf)
     return int(np.argmin(d2))
 
 
@@ -171,24 +182,29 @@ class MarcAtlasRegistry:
     # Tolerance for "the nearest cell is close enough to be considered valid".
     # Coverage polygons are bbox-only at build time, so the bbox can extend
     # beyond actual sea cells (e.g. ATLNE bbox includes parts of the Med where
-    # the model has no valid cells). We require the nearest cell to be within
-    # ~1.5x the atlas resolution, expressed in degrees at the query lat.
+    # the model has no valid cells).
     _MAX_CELL_DISTANCE_M = 5000.0  # 5 km, generous
 
-    def _cell_within_distance(
-        self, atlas: AtlasMeta, df: pl.DataFrame, lat: float, lon: float
+    def _cell_with_finite(
+        self,
+        atlas: AtlasMeta,
+        df: pl.DataFrame,
+        lat: float,
+        lon: float,
+        required_col: str | None = None,
     ) -> int | None:
-        idx = _nearest_cell_in_tile(df, lat, lon)
+        """Return idx of the nearest cell within distance threshold whose
+        ``required_col`` is finite (when given). Returns None if the closest
+        valid cell is beyond max(5 km, 5x atlas resolution) of the query.
+        """
+        idx = _nearest_cell_in_tile(df, lat, lon, required_col=required_col)
         if idx is None:
             return None
-        cell_lat = float(df["lat"][idx])
-        cell_lon = float(df["lon"][idx])
-        # Convert degrees to metres at the query latitude.
+        cell_lat = float(df["lat"].to_numpy()[idx])
+        cell_lon = float(df["lon"].to_numpy()[idx])
         dlat_m = (cell_lat - lat) * 111_000
         dlon_m = (cell_lon - lon) * 111_000 * np.cos(np.deg2rad(lat))
         d_m = np.hypot(dlat_m, dlon_m)
-        # Allow up to max(5 km, 5x resolution) — generous so we don't reject
-        # legitimate MARC cells across small gaps in coverage.
         threshold = max(self._MAX_CELL_DISTANCE_M, 5.0 * atlas.resolution_m)
         return idx if d_m <= threshold else None
 
@@ -207,33 +223,49 @@ class MarcAtlasRegistry:
             df = _read_tile(str(_tile_path(atlas, lat, lon)))
             if df is None or df.height == 0:
                 continue
-            if self._cell_within_distance(atlas, df, lat, lon) is not None:
+            # Use the unfiltered metric-nearest as the coverage signal; the
+            # variable-specific lookup happens at predict time.
+            if self._cell_with_finite(atlas, df, lat, lon, required_col=None) is not None:
                 return atlas
         return None
 
     def cell_at(self, lat: float, lon: float) -> CellPrediction | None:
-        """Return the nearest valid cell across the best covering atlas, or None."""
+        """Return the nearest cells (per-variable) across the best covering atlas.
+
+        MARC's Arakawa C-grid stores XE / U / V on offset half-step grids.
+        The metric-nearest XE cell may have an on-land U or V face (NaN);
+        in that case we fall back to the nearest cell whose U / V is finite.
+        Anchor lat/lon and z0 come from the height cell.
+        """
         atlas = self.covers(lat, lon)
         if atlas is None:
             return None
-        path = _tile_path(atlas, lat, lon)
-        df = _read_tile(str(path))
+        df = _read_tile(str(_tile_path(atlas, lat, lon)))
         if df is None or df.height == 0:
             return None
-        idx = self._cell_within_distance(atlas, df, lat, lon)
-        if idx is None:
+        # Per-variable nearest cell with finite data. M2 is the canonical
+        # proxy (always present in every MARC atlas).
+        h_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_h_amp")
+        u_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_u_amp")
+        v_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_v_amp")
+        anchor = h_idx if h_idx is not None else (u_idx if u_idx is not None else v_idx)
+        if anchor is None:
             return None
-        cell_lat = float(df["lat"][idx])
-        cell_lon = float(df["lon"][idx])
-        z0_hydro = df.get_column("z0_hydro_m")[idx] if "z0_hydro_m" in df.columns else None
+        cell_lat = float(df["lat"].to_numpy()[anchor])
+        cell_lon = float(df["lon"].to_numpy()[anchor])
+        z0_hydro = (
+            df.get_column("z0_hydro_m").to_numpy()[anchor] if "z0_hydro_m" in df.columns else None
+        )
         return CellPrediction(
             atlas_name=atlas.name,
             lat=cell_lat,
             lon=cell_lon,
-            z0_hydro_m=float(z0_hydro) if z0_hydro is not None and np.isfinite(z0_hydro) else None,
-            h_constants=_extract_constants(df, idx, "h"),
-            u_constants=_extract_constants(df, idx, "u"),
-            v_constants=_extract_constants(df, idx, "v"),
+            z0_hydro_m=(
+                float(z0_hydro) if z0_hydro is not None and np.isfinite(z0_hydro) else None
+            ),
+            h_constants=_extract_constants(df, h_idx, "h") if h_idx is not None else {},
+            u_constants=_extract_constants(df, u_idx, "u") if u_idx is not None else {},
+            v_constants=_extract_constants(df, v_idx, "v") if v_idx is not None else {},
         )
 
     def predict_height(self, lat: float, lon: float, t: datetime) -> tuple[float, str] | None:

--- a/packages/hf-space/Dockerfile
+++ b/packages/hf-space/Dockerfile
@@ -19,23 +19,15 @@ RUN pip install /app/data-adapters /app/mcp-core "uvicorn[standard]>=0.30" \
 # need an HF token with read access. On HF Spaces, define the secret in
 # Settings -> Variables and secrets -> Secrets:
 #   HF_TOKEN  (User Access Token with read scope on Qdonnars/openwind-tidal-atlas)
-# Runtime reads it back via MARC_ATLAS_DIR (set below).
-ARG HF_DATASET_ID=Qdonnars/openwind-tidal-atlas
+# Runtime reads it back via MARC_ATLAS_DIR (set below). The fetch script falls
+# back gracefully (creates an empty MARC_ATLAS_DIR, runtime uses Open-Meteo
+# SMOC only) when the secret is absent.
+ENV HF_DATASET_ID=Qdonnars/openwind-tidal-atlas
 ENV MARC_ATLAS_DIR=/app/data/marc-atlas
+COPY fetch_marc_dataset.py /tmp/fetch_marc_dataset.py
 RUN --mount=type=secret,id=HF_TOKEN,required=false \
-    bash -c '\
-if [ -f /run/secrets/HF_TOKEN ]; then \
-    export HF_TOKEN="$(cat /run/secrets/HF_TOKEN)"; \
-    python -c "import os; from huggingface_hub import snapshot_download; \
-               snapshot_download(\"${HF_DATASET_ID}\", repo_type=\"dataset\", \
-                                 local_dir=\"${MARC_ATLAS_DIR}\", token=os.environ[\"HF_TOKEN\"])"; \
-    echo \"MARC dataset cached at ${MARC_ATLAS_DIR}\"; \
-    ls \"${MARC_ATLAS_DIR}\"; \
-else \
-    echo \"WARNING: no HF_TOKEN secret mounted; skipping MARC dataset download\"; \
-    echo \"plan_passage will fall back to Open-Meteo SMOC only\"; \
-    mkdir -p \"${MARC_ATLAS_DIR}\"; \
-fi'
+    sh -c 'if [ -f /run/secrets/HF_TOKEN ]; then export HF_TOKEN="$(cat /run/secrets/HF_TOKEN)"; fi; \
+           python /tmp/fetch_marc_dataset.py'
 
 COPY app.py /app/app.py
 

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import dataclasses
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
 from openwind_data.adapters.base import ForecastHorizonError
+from openwind_data.currents.marc_atlas import MarcAtlasRegistry
 from openwind_data.routing.archetypes import list_archetypes_metadata
 from openwind_data.routing.complexity import score_complexity
 from openwind_data.routing.geometry import Point
@@ -508,6 +509,122 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     })
 
 
+# Module-level MARC registry — loaded once at import. Empty registry when
+# MARC_ATLAS_DIR is unset or the dataset wasn't pulled (build without
+# HF_TOKEN secret), so the overlay endpoint silently returns covered=false.
+_MARC_REGISTRY = MarcAtlasRegistry.from_directory(
+    os.environ.get("MARC_ATLAS_DIR", "")
+)
+
+
+async def _api_marc_overlay(request: Request) -> JSONResponse:
+    """Return MARC PREVIMER currents and tide-height predictions for a point.
+
+    Designed as a low-overhead overlay on top of Open-Meteo Marine: the web
+    client calls Open-Meteo direct from the browser (per-IP scaling, no
+    backend bottleneck) and in parallel calls this endpoint. When ``covered``
+    is true, the client overrides Open-Meteo currents and tide_height_m with
+    the MARC values; otherwise (Mediterranean, open ocean, polar regions),
+    the client keeps the Open-Meteo response unchanged.
+
+    Query params:
+      ``lat``, ``lon`` -- required floats.
+      ``start``, ``end`` -- required ISO-8601 timestamps (UTC assumed).
+      ``step_minutes`` -- optional, default 60 (hourly series).
+
+    Response shape (always 200 to avoid client-side 404 noise):
+      ``{"covered": false}`` when outside MARC coverage.
+      ``{"covered": true, "current_source": "marc_finis_250m",
+         "atlas_resolution_m": 250, "z0_hydro_m": -3.85, "times": [...],
+         "current_speed_kn": [...], "current_direction_to_deg": [...],
+         "tide_height_m": [...]}`` when covered.
+
+    Cache: 1 day (predictions are deterministic harmonics, time-series only
+    differs per requested ``[start, end, step]``).
+    """
+    try:
+        lat = float(request.query_params["lat"])
+        lon = float(request.query_params["lon"])
+        start = datetime.fromisoformat(request.query_params["start"])
+        end = datetime.fromisoformat(request.query_params["end"])
+    except (KeyError, ValueError, TypeError) as exc:
+        return JSONResponse(
+            {"error": f"missing or invalid query params (lat, lon, start, end): {exc}"},
+            status_code=422,
+        )
+    step_minutes = 60
+    if "step_minutes" in request.query_params:
+        try:
+            step_minutes = int(request.query_params["step_minutes"])
+        except ValueError:
+            return JSONResponse(
+                {"error": "step_minutes must be an integer"}, status_code=422
+            )
+        if step_minutes < 5 or step_minutes > 360:
+            return JSONResponse(
+                {"error": "step_minutes must be between 5 and 360"}, status_code=422
+            )
+
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=UTC)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=UTC)
+    if end <= start:
+        return JSONResponse({"error": "end must be after start"}, status_code=422)
+    span_days = (end - start).total_seconds() / 86400
+    if span_days > 30:
+        return JSONResponse(
+            {"error": "time window must be at most 30 days"}, status_code=422
+        )
+
+    if not _MARC_REGISTRY.atlases:
+        return JSONResponse(
+            {"covered": False, "reason": "no MARC dataset loaded on this Space"},
+            headers={"Cache-Control": "public, max-age=300"},
+        )
+
+    cell = _MARC_REGISTRY.cell_at(lat, lon)
+    if cell is None:
+        return JSONResponse(
+            {"covered": False},
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    n_steps = int((end - start).total_seconds() // (step_minutes * 60)) + 1
+    times = [start + timedelta(minutes=step_minutes * i) for i in range(n_steps)]
+
+    h_result = _MARC_REGISTRY.predict_height_series(lat, lon, times)
+    c_result = _MARC_REGISTRY.predict_current_series(lat, lon, times)
+
+    payload: dict[str, Any] = {
+        "covered": True,
+        "current_source": (h_result[1] if h_result else c_result[2]).lower()
+        if (h_result or c_result)
+        else None,
+        "atlas_resolution_m": next(
+            (a.resolution_m for a in _MARC_REGISTRY.atlases if a.name == cell.atlas_name),
+            None,
+        ),
+        "z0_hydro_m": cell.z0_hydro_m,
+        "times": [t.isoformat() for t in times],
+    }
+    if h_result is not None:
+        payload["tide_height_m"] = [round(float(v), 4) for v in h_result[0]]
+    if c_result is not None:
+        speeds, dirs, _ = c_result
+        payload["current_speed_kn"] = [round(float(v), 4) for v in speeds]
+        payload["current_direction_to_deg"] = [round(float(v), 2) for v in dirs]
+    # Map the source label to "marc_<atlas>_<res>m" pattern used elsewhere.
+    if cell.atlas_name and payload["atlas_resolution_m"]:
+        payload["current_source"] = (
+            f"marc_{cell.atlas_name.lower()}_{payload['atlas_resolution_m']}m"
+        )
+    return JSONResponse(
+        payload,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
 def main() -> None:
     server = build_server()
     server.settings.transport_security = TransportSecuritySettings(
@@ -531,6 +648,7 @@ def main() -> None:
             Route("/api/v1/archetypes", _api_archetypes, methods=["GET"]),
             Route("/api/v1/passage", _api_passage, methods=["POST"]),
             Route("/api/v1/passage-by-eta", _api_passage_by_eta, methods=["POST"]),
+            Route("/api/v1/marine/marc", _api_marc_overlay, methods=["GET"]),
             Mount("/", app=mcp_app),
         ],
         middleware=[

--- a/packages/hf-space/fetch_marc_dataset.py
+++ b/packages/hf-space/fetch_marc_dataset.py
@@ -1,0 +1,40 @@
+"""Pull MARC PREVIMER atlases from the HF Dataset at Docker build time.
+
+Reads ``HF_TOKEN`` (mounted as a build secret), ``HF_DATASET_ID`` and
+``MARC_ATLAS_DIR`` from the environment. Falls back gracefully (no MARC
+data, runtime uses Open-Meteo SMOC) if the token is absent — this lets
+contributors build the image without an HF account.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    target = os.environ.get("MARC_ATLAS_DIR", "/app/data/marc-atlas")
+    dataset_id = os.environ.get("HF_DATASET_ID", "Qdonnars/openwind-tidal-atlas")
+    token = os.environ.get("HF_TOKEN")
+
+    if not token:
+        print("WARNING: HF_TOKEN not set, skipping MARC dataset download")
+        print("plan_passage will fall back to Open-Meteo SMOC only")
+        os.makedirs(target, exist_ok=True)
+        return
+
+    from huggingface_hub import snapshot_download
+
+    print(f"Fetching {dataset_id} -> {target}")
+    snapshot_download(dataset_id, repo_type="dataset", local_dir=target, token=token)
+    atlases = sorted(p for p in os.listdir(target) if not p.startswith("."))
+    print(f"MARC dataset cached at {target}")
+    print(f"Atlases: {atlases}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"ERROR fetching MARC dataset: {exc}", file=sys.stderr)
+        # Don't fail the build — runtime will fall back to Open-Meteo SMOC.
+        os.makedirs(os.environ.get("MARC_ATLAS_DIR", "/app/data/marc-atlas"), exist_ok=True)

--- a/scripts/build_marc_atlas.py
+++ b/scripts/build_marc_atlas.py
@@ -338,9 +338,20 @@ def compute_z0_hydro(
         a2d, p2d = constants_per_cell[rn]
         amp_mat[:, j] = a2d.ravel()[flat_idx]
         phase_mat[:, j] = p2d.ravel()[flat_idx]
-    bad_cell = ~np.all(np.isfinite(amp_mat) & np.isfinite(phase_mat), axis=1)
-    amp_mat[bad_cell] = 0.0
-    phase_mat[bad_cell] = 0.0
+    # Per-cell NaN handling: replace any NaN with 0 (constituent contributes
+    # nothing to the prediction at that cell). A cell is only flagged ``bad``
+    # — and its z0 set to NaN — when M2 is missing (no usable tide signal at
+    # all). Earlier versions required ALL constituents to be finite, which
+    # bizarrely excluded otherwise-valid coastal cells where one minor
+    # constituent had a NaN due to grid edge effects.
+    nan_mask = ~(np.isfinite(amp_mat) & np.isfinite(phase_mat))
+    amp_mat[nan_mask] = 0.0
+    phase_mat[nan_mask] = 0.0
+    if "M2" in {cn for _, cn in keep}:
+        m2_col = next(j for j, (_, cn) in enumerate(keep) if cn == "M2")
+        bad_cell = nan_mask[:, m2_col]
+    else:
+        bad_cell = np.zeros(n_cells, dtype=bool)
 
     n_samples = nodal_cycle_years * 365 * 24 // sample_hours
     base = datetime(2010, 1, 1, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

PR #95 squash-merged into ``25f9b53`` only contained the changes from the FIRST commit on the feature branch, dropping two follow-up commits that landed on the branch *after* the PR was opened. The HF Space deployment was already validated live (verified end-to-end with `z0_hydro_m = -3.74 m` at Brest), but `main` itself doesn't reflect that state.

This PR cherry-picks the two missing commits as-is:

1. **fix(hf-space) — fetch_marc_dataset.py** (commit ``e832b8a``)
   The original Dockerfile used a ``bash -c`` heredoc that double-escaped quotes, causing the post-download verification step to fail with ``ls: cannot access '"/app/data/marc-atlas"'``. Replaces the heredoc with a small Python script that handles both authenticated and no-token cases.

2. **feat(marc) — runtime endpoint + C-grid + Z0 fixes** (commit ``7c2afeb``)
   - HF Space REST endpoint ``/api/v1/marine/marc`` for the web app to overlay MARC currents/tide on top of Open-Meteo (per-IP scaling preserved on Open-Meteo).
   - ``marc_atlas.cell_at`` C-grid fix: MARS2D's Arakawa C-grid stores XE / U / V on offset half-step grids; the metric-nearest XE cell can have an on-land U or V face (NaN). ``cell_at`` now picks the nearest *finite* cell per variable. Without this, ``predict_current`` returned None at coastal cells like Brest port.
   - Build script Z0 fix: ``compute_z0_hydro`` previously required ALL constituents to be finite at a cell; FINIS specifically came out with all-NaN Z0. Replaces NaNs with 0 (constituent contributes nothing) and only flags a cell as bad when M2 itself is missing.

## Test plan

- [x] data-adapters tests pass (20/20 currents).
- [x] mcp-core tests pass (20/20).
- [x] Live verified before this recovery PR: GET ``https://qdonnars-openwind-mcp.hf.space/api/v1/marine/marc?lat=48.3829&lon=-4.4950&start=2024-06-15T00:00:00Z&end=2024-06-15T03:00:00Z`` returns ``z0_hydro_m: -3.7396``, ``current_source: marc_finis_250m``, finite tide and current arrays.
- [ ] After merge: confirm ``sync-hf-space.yml`` reflects the same content as already deployed (no actual changes to redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)