### PR TITLE
feat(web): consume MARC tide+current overlay, display ZH heights

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -144,6 +144,8 @@ function App() {
                   showWaves={showWaves}
                   showTides={showTides}
                   showCurrents={showCurrents}
+                  currentSource={marine?.current_source}
+                  marcResolutionM={marine?.marc_resolution_m}
                 />
               </div>
               <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">

--- a/packages/web/src/api/marine.test.ts
+++ b/packages/web/src/api/marine.test.ts
@@ -3,6 +3,9 @@ import {
   isCurrentsRelevant,
   isTidesRelevant,
   isWavesRelevant,
+  mergeMarcOverlay,
+  parisIsoToUtcMs,
+  type MarcOverlay,
 } from "./marine";
 import type { MarineHourly } from "../types";
 
@@ -83,5 +86,147 @@ describe("isWavesRelevant", () => {
 
   it("returns false when no Hs anywhere (no Marine coverage)", () => {
     expect(isWavesRelevant(emptyMarine())).toBe(false);
+  });
+});
+
+describe("parisIsoToUtcMs", () => {
+  it("CEST (summer): Paris midnight is 22:00 UTC the day before", () => {
+    // 2026-07-01 is well inside CEST (+02:00)
+    const ms = parisIsoToUtcMs("2026-07-01T00:00");
+    expect(new Date(ms).toISOString()).toBe("2026-06-30T22:00:00.000Z");
+  });
+
+  it("CET (winter): Paris midnight is 23:00 UTC the day before", () => {
+    // 2026-01-15 is well inside CET (+01:00)
+    const ms = parisIsoToUtcMs("2026-01-15T00:00");
+    expect(new Date(ms).toISOString()).toBe("2026-01-14T23:00:00.000Z");
+  });
+
+  it("CEST mid-day: 12:00 Paris = 10:00 UTC", () => {
+    const ms = parisIsoToUtcMs("2026-07-01T12:00");
+    expect(new Date(ms).toISOString()).toBe("2026-07-01T10:00:00.000Z");
+  });
+});
+
+function brestMarine(): MarineHourly {
+  // Brest, mid-July CEST (+02:00). Three Open-Meteo hours starting at 00:00
+  // local. The corresponding UTC instants are 2026-06-30T22:00Z, 23:00Z,
+  // 2026-07-01T00:00Z — that's what MARC would return.
+  return {
+    time: [
+      "2026-07-01T00:00",
+      "2026-07-01T01:00",
+      "2026-07-01T02:00",
+    ],
+    wave_height_m: [0.5, 0.6, 0.7],
+    wave_period_s: [6, 6, 7],
+    wave_direction_deg: [270, 270, 280],
+    current_speed_kn: [0.05, 0.04, 0.06], // SMOC at Brest port: near-zero
+    current_direction_to_deg: [180, 180, 180],
+    tide_height_m: [-1.5, 0.0, 1.5], // SMOC MSL reference
+  };
+}
+
+function brestMarcOverlay(): MarcOverlay {
+  // What the MARC endpoint would return for the brestMarine() window. Tide
+  // is in MSL (MARC's native output) — the merge step subtracts z0 to derive
+  // ZH. Currents are in kn (already converted server-side).
+  return {
+    covered: true,
+    current_source: "marc_finis_250m",
+    atlas_resolution_m: 250,
+    z0_hydro_m: -3.74,
+    times: [
+      "2026-06-30T22:00:00+00:00",
+      "2026-06-30T23:00:00+00:00",
+      "2026-07-01T00:00:00+00:00",
+    ],
+    tide_height_m: [2.1, 3.5, 5.2],
+    current_speed_kn: [0.4, 0.8, 1.2],
+    current_direction_to_deg: [90, 95, 100],
+  };
+}
+
+describe("mergeMarcOverlay", () => {
+  it("returns base data unchanged when overlay is null", () => {
+    const m = brestMarine();
+    const merged = mergeMarcOverlay(m, null);
+    expect(merged).toEqual(m);
+    expect(merged.tide_height_zh_m).toBeUndefined();
+    expect(merged.current_source).toBeUndefined();
+  });
+
+  it("returns base data unchanged when covered=false", () => {
+    const m = brestMarine();
+    const merged = mergeMarcOverlay(m, { covered: false });
+    expect(merged).toEqual(m);
+    expect(merged.tide_height_zh_m).toBeUndefined();
+  });
+
+  it("overrides tide and current at matching hours", () => {
+    const merged = mergeMarcOverlay(brestMarine(), brestMarcOverlay());
+    expect(merged.tide_height_m).toEqual([2.1, 3.5, 5.2]);
+    expect(merged.current_speed_kn).toEqual([0.4, 0.8, 1.2]);
+    expect(merged.current_direction_to_deg).toEqual([90, 95, 100]);
+  });
+
+  it("populates tide_height_zh_m as MSL minus z0_hydro_m (always ≥ 0 here)", () => {
+    const merged = mergeMarcOverlay(brestMarine(), brestMarcOverlay());
+    // z0 = -3.74 → ZH = MSL - (-3.74) = MSL + 3.74
+    expect(merged.tide_height_zh_m).not.toBeNull();
+    const zh = merged.tide_height_zh_m as (number | null)[];
+    expect(zh[0]).toBeCloseTo(2.1 + 3.74, 6);
+    expect(zh[1]).toBeCloseTo(3.5 + 3.74, 6);
+    expect(zh[2]).toBeCloseTo(5.2 + 3.74, 6);
+    // ZH heights at Brest are between ~2 m and ~9 m — what charts display.
+    for (const v of zh) expect(v).not.toBeNull();
+    expect(Math.min(...(zh as number[]))).toBeGreaterThan(0);
+  });
+
+  it("propagates current_source, marc_resolution_m, z0_hydro_m on the result", () => {
+    const merged = mergeMarcOverlay(brestMarine(), brestMarcOverlay());
+    expect(merged.current_source).toBe("marc_finis_250m");
+    expect(merged.marc_resolution_m).toBe(250);
+    expect(merged.z0_hydro_m).toBeCloseTo(-3.74, 6);
+  });
+
+  it("leaves SMOC values intact at unmatched hours (overlay shorter than OM)", () => {
+    const m = brestMarine();
+    const partial: MarcOverlay = {
+      covered: true,
+      current_source: "marc_finis_250m",
+      atlas_resolution_m: 250,
+      z0_hydro_m: -3.74,
+      // Only the first OM hour matches a MARC sample.
+      times: ["2026-06-30T22:00:00+00:00"],
+      tide_height_m: [2.1],
+      current_speed_kn: [0.4],
+      current_direction_to_deg: [90],
+    };
+    const merged = mergeMarcOverlay(m, partial);
+    expect(merged.tide_height_m[0]).toBe(2.1);
+    // Index 1 and 2 keep SMOC values.
+    expect(merged.tide_height_m[1]).toBe(0.0);
+    expect(merged.tide_height_m[2]).toBe(1.5);
+    // ZH array sized like OM, with nulls at unmatched hours.
+    const zh = merged.tide_height_zh_m as (number | null)[];
+    expect(zh[0]).toBeCloseTo(2.1 + 3.74, 6);
+    expect(zh[1]).toBeNull();
+    expect(zh[2]).toBeNull();
+  });
+});
+
+describe("isTidesRelevant with MARC ZH", () => {
+  it("uses ZH series when present (linear shift, same range)", () => {
+    const m = emptyMarine();
+    m.tide_height_m = [-1, 0, 1];
+    m.tide_height_zh_m = [2.0, 3.0, 4.0]; // same range = 2.0
+    expect(isTidesRelevant(m)).toBe(true);
+  });
+
+  it("returns false when ZH range below threshold (Mediterranean MARC zone hypothetical)", () => {
+    const m = emptyMarine();
+    m.tide_height_zh_m = [1.0, 1.1, 1.2]; // range = 0.20, below 0.5 m
+    expect(isTidesRelevant(m)).toBe(false);
   });
 });

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -18,6 +18,14 @@ const MARINE_VARS =
 // 1 nautical mile = 1852 m → 1 kn = 1.852 km/h.
 const KMH_TO_KN = 1 / 1.852;
 
+// MARC PREVIMER overlay served by our HF Space wrapper. Returns hourly tide
+// + current resampled from harmonic constants when the spot lies inside one
+// of the 7 published atlases (ATLNE, MANGA, FINIS, MANW, MANE, SUDBZH, AQUI).
+// Outside coverage the response carries ``covered: false`` and we keep the
+// Open-Meteo SMOC values.
+const MARC_URL =
+  "https://qdonnars-openwind-mcp.hf.space/api/v1/marine/marc";
+
 const cache = new Map<string, { data: MarineHourly; fetchedAt: number }>();
 const CACHE_TTL = 30 * 60 * 1000;
 
@@ -31,11 +39,149 @@ interface RawHourly {
   sea_level_height_msl?: (number | null)[];
 }
 
+export interface MarcOverlay {
+  covered: boolean;
+  current_source?: string;
+  atlas_resolution_m?: number;
+  z0_hydro_m?: number;
+  times?: string[];
+  tide_height_m?: (number | null)[];
+  current_speed_kn?: (number | null)[];
+  current_direction_to_deg?: (number | null)[];
+}
+
 function pad(arr: (number | null)[] | undefined, n: number): (number | null)[] {
   const out: (number | null)[] = new Array(n).fill(null);
   if (!arr) return out;
   for (let i = 0; i < Math.min(arr.length, n); i++) out[i] = arr[i] ?? null;
   return out;
+}
+
+// Open-Meteo returns timestamps as Europe/Paris wall-clock with no offset
+// suffix (e.g. "2026-05-08T00:00"). MARC returns ISO strings with explicit
+// offset. To align them we project both onto UTC ms-since-epoch.
+//
+// The trick: parse the naive string as if it were UTC, then ask Intl what
+// Paris wall-clock would be at that absolute instant. The diff is the Paris
+// offset for that day (handles DST without a tz library).
+export function parisIsoToUtcMs(parisIso: string): number {
+  const asUtc = new Date(parisIso + ":00Z");
+  const dtf = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of dtf.formatToParts(asUtc)) {
+    if (p.type !== "literal") parts[p.type] = p.value;
+  }
+  // Some engines emit "24" at the midnight rollover; coerce to 00.
+  const hour = parts.hour === "24" ? "00" : parts.hour;
+  const parisAsIfUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  const offsetMs = parisAsIfUtc - asUtc.getTime();
+  return asUtc.getTime() - offsetMs;
+}
+
+async function fetchMarcOverlay(
+  lat: number,
+  lon: number,
+  startUtcIso: string,
+  endUtcIso: string,
+): Promise<MarcOverlay | null> {
+  const url =
+    `${MARC_URL}?lat=${lat}&lon=${lon}` +
+    `&start=${encodeURIComponent(startUtcIso)}` +
+    `&end=${encodeURIComponent(endUtcIso)}` +
+    `&step_minutes=60`;
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) return null;
+    return (await resp.json()) as MarcOverlay;
+  } catch {
+    return null;
+  }
+}
+
+// Merge MARC overlay into the OM-shaped MarineHourly, index-by-index. Tide
+// and current arrays from MARC override SMOC on matching hours; uncovered or
+// non-matching hours keep SMOC. Always populates ``tide_height_zh_m`` when
+// MARC covers (chart-datum reference, always ≥ 0 — what nautical charts and
+// SHOM annuals display).
+export function mergeMarcOverlay(
+  data: MarineHourly,
+  overlay: MarcOverlay | null,
+): MarineHourly {
+  if (!overlay || !overlay.covered) return data;
+  if (
+    !overlay.times ||
+    !overlay.tide_height_m ||
+    !overlay.current_speed_kn ||
+    !overlay.current_direction_to_deg
+  ) {
+    return data;
+  }
+  const marcIdxByMinuteMs = new Map<number, number>();
+  for (let i = 0; i < overlay.times.length; i++) {
+    const ms = Date.parse(overlay.times[i]);
+    if (Number.isFinite(ms)) {
+      marcIdxByMinuteMs.set(Math.floor(ms / 60000) * 60000, i);
+    }
+  }
+
+  const n = data.time.length;
+  const tideMsl = data.tide_height_m.slice();
+  const tideZh: (number | null)[] = new Array(n).fill(null);
+  const speed = data.current_speed_kn.slice();
+  const dirTo = data.current_direction_to_deg.slice();
+  const z0 = overlay.z0_hydro_m;
+
+  for (let i = 0; i < n; i++) {
+    const utcMs = parisIsoToUtcMs(data.time[i]);
+    const key = Math.floor(utcMs / 60000) * 60000;
+    const j = marcIdxByMinuteMs.get(key);
+    if (j == null) continue;
+    const tm = overlay.tide_height_m[j];
+    const sp = overlay.current_speed_kn[j];
+    const dr = overlay.current_direction_to_deg[j];
+    if (tm != null) {
+      tideMsl[i] = tm;
+      if (z0 != null) tideZh[i] = tm - z0;
+    }
+    if (sp != null) speed[i] = sp;
+    if (dr != null) dirTo[i] = dr;
+  }
+
+  return {
+    ...data,
+    tide_height_m: tideMsl,
+    tide_height_zh_m: tideZh,
+    current_speed_kn: speed,
+    current_direction_to_deg: dirTo,
+    z0_hydro_m: z0,
+    current_source: overlay.current_source,
+    marc_resolution_m: overlay.atlas_resolution_m,
+  };
+}
+
+// 7-day UTC window anchored at "today 00:00 Europe/Paris" — matches the OM
+// forecast horizon so MARC and SMOC align hour-for-hour after merge.
+function marcWindow(): [string, string] {
+  const now = new Date();
+  const dayParis = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric", month: "2-digit", day: "2-digit",
+  }).format(now);
+  const startMs = parisIsoToUtcMs(`${dayParis}T00:00`);
+  const endMs = startMs + 7 * 24 * 3600 * 1000;
+  return [new Date(startMs).toISOString(), new Date(endMs).toISOString()];
 }
 
 export async function fetchMarine(lat: number, lon: number): Promise<MarineHourly | null> {
@@ -47,18 +193,26 @@ export async function fetchMarine(lat: number, lon: number): Promise<MarineHourl
   const url =
     `${MARINE_URL}?latitude=${lat}&longitude=${lon}` +
     `&hourly=${MARINE_VARS}&timezone=Europe/Paris&forecast_days=7`;
-  let raw: { hourly?: RawHourly };
+  const [startIso, endIso] = marcWindow();
+  let raw: { hourly?: RawHourly } | null;
+  let overlay: MarcOverlay | null = null;
   try {
-    const resp = await fetch(url);
-    if (!resp.ok) return null;
-    raw = await resp.json();
+    const [omResp, marcOverlay] = await Promise.all([
+      fetch(url).then(async (r) =>
+        r.ok ? ((await r.json()) as { hourly?: RawHourly }) : null,
+      ),
+      fetchMarcOverlay(lat, lon, startIso, endIso),
+    ]);
+    if (!omResp) return null;
+    raw = omResp;
+    overlay = marcOverlay;
   } catch {
     return null;
   }
   const h = raw.hourly;
   if (!h || !h.time) return null;
   const n = h.time.length;
-  const data: MarineHourly = {
+  const baseData: MarineHourly = {
     time: h.time,
     wave_height_m: pad(h.wave_height, n),
     wave_period_s: pad(h.wave_period, n),
@@ -69,6 +223,7 @@ export async function fetchMarine(lat: number, lon: number): Promise<MarineHourl
     current_direction_to_deg: pad(h.ocean_current_direction, n),
     tide_height_m: pad(h.sea_level_height_msl, n),
   };
+  const data = mergeMarcOverlay(baseData, overlay);
   cache.set(key, { data, fetchedAt: Date.now() });
   return data;
 }
@@ -82,7 +237,10 @@ export function isCurrentsRelevant(marine: MarineHourly | null): boolean {
 
 export function isTidesRelevant(marine: MarineHourly | null): boolean {
   if (!marine) return false;
-  const valid = marine.tide_height_m.filter((v): v is number => v != null);
+  // Prefer ZH (chart-datum) heights when MARC covers — same range as MSL since
+  // ZH is a linear shift by z0, so the threshold check is unchanged.
+  const series = marine.tide_height_zh_m ?? marine.tide_height_m;
+  const valid = series.filter((v): v is number => v != null);
   if (valid.length === 0) return false;
   return Math.max(...valid) - Math.min(...valid) >= TIDE_RANGE_RELEVANCE_THRESHOLD_M;
 }

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -17,18 +17,27 @@ interface RowConfig {
   unit: string;
 }
 
-const ROWS_PER_METRIC: Record<MarineMetric, RowConfig[]> = {
-  waves: [
-    { kind: "hs", label: "Hs", unit: "m" },
-    { kind: "wave_dir", label: "Dir", unit: "°" },
-    { kind: "wave_period", label: "T", unit: "s" },
-  ],
-  tides: [{ kind: "tide", label: "Tide", unit: "m" }],
-  currents: [
-    { kind: "current", label: "Curr.", unit: "kn" },
-    { kind: "current_dir", label: "Dir", unit: "°" },
-  ],
-};
+function rowsForMetric(
+  metric: MarineMetric,
+  marine: MarineHourly,
+): RowConfig[] {
+  const tideUnit = marine.tide_height_zh_m != null ? "m ZH" : "m";
+  switch (metric) {
+    case "waves":
+      return [
+        { kind: "hs", label: "Hs", unit: "m" },
+        { kind: "wave_dir", label: "Dir", unit: "°" },
+        { kind: "wave_period", label: "T", unit: "s" },
+      ];
+    case "tides":
+      return [{ kind: "tide", label: "Tide", unit: tideUnit }];
+    case "currents":
+      return [
+        { kind: "current", label: "Curr.", unit: "kn" },
+        { kind: "current_dir", label: "Dir", unit: "°" },
+      ];
+  }
+}
 
 const CELL_W = 36;
 
@@ -195,16 +204,23 @@ function MarineCell({
       break;
     }
     case "tide": {
-      value = marine.tide_height_m[timeIdx];
+      // Prefer the ZH (chart-datum) series when MARC covers — always ≥ 0,
+      // matches what nautical charts display. Fall back to MSL elsewhere.
+      const zh = marine.tide_height_zh_m;
+      const useZh = zh != null;
+      const series = useZh ? zh : marine.tide_height_m;
+      value = series[timeIdx];
       if (value != null) {
         level = tidesLevel(Math.abs(value));
-        display = (value >= 0 ? "+" : "") + value.toFixed(1);
+        display = useZh
+          ? value.toFixed(1)
+          : (value >= 0 ? "+" : "") + value.toFixed(1);
         if (prevTide != null) {
           const delta = value - prevTide;
           if (delta > 0.01) trend = 1;
           else if (delta < -0.01) trend = -1;
         }
-        aria = `Tide ${display} m${trend > 0 ? ", rising" : trend < 0 ? ", falling" : ""}`;
+        aria = `Tide ${display} m${useZh ? " ZH" : ""}${trend > 0 ? ", rising" : trend < 0 ? ", falling" : ""}`;
       }
       break;
     }
@@ -424,7 +440,11 @@ export function MarineTable({
     return () => el.removeEventListener("scroll", checkScrollEnd);
   }, [checkScrollEnd]);
 
-  const rows = ROWS_PER_METRIC[metric];
+  const rows = rowsForMetric(metric, marine);
+  // The series powering the rising/falling indicator follows the same source
+  // as the displayed cell (ZH when MARC covers, MSL otherwise). Linear shift
+  // doesn't change the sign of deltas, but we keep the references consistent.
+  const tideSeries = marine.tide_height_zh_m ?? marine.tide_height_m;
 
   return (
     <div className="animate-fade-in">
@@ -474,7 +494,7 @@ export function MarineTable({
                     const prevIdx = prevT != null ? timeIndex.get(prevT) : undefined;
                     const prevTide =
                       row.kind === "tide" && prevIdx != null
-                        ? marine.tide_height_m[prevIdx]
+                        ? tideSeries[prevIdx]
                         : null;
                     return (
                       <MarineCell

--- a/packages/web/src/components/MetricPills.tsx
+++ b/packages/web/src/components/MetricPills.tsx
@@ -7,6 +7,11 @@ interface PillsProps {
   showWaves: boolean;
   showTides: boolean;
   showCurrents: boolean;
+  // ``"marc_<atlas>_<res>m"`` when MARC PREVIMER overrides tide+current; we
+  // use this to drive a small "MARC <res>" badge on the Tides/Currents pills
+  // so users know the precision they're getting.
+  currentSource?: string;
+  marcResolutionM?: number;
 }
 
 interface PillDef {
@@ -14,6 +19,14 @@ interface PillDef {
   label: string;
   visible: boolean;
   icon: ReactNode;
+  badge?: string;
+}
+
+// Render the resolution as the unit a sailor would expect: 250 m, 700 m, 2 km.
+function formatMarcBadge(resolutionM: number | undefined): string {
+  if (resolutionM == null) return "MARC";
+  if (resolutionM >= 1000) return `MARC ${(resolutionM / 1000).toFixed(0)} km`;
+  return `MARC ${resolutionM} m`;
 }
 
 // Wind: stacked airflow lines (mirrors the brand mark in Header).
@@ -55,12 +68,16 @@ export function MetricPills({
   showWaves,
   showTides,
   showCurrents,
+  currentSource,
+  marcResolutionM,
 }: PillsProps) {
+  const marcActive = currentSource != null && currentSource.startsWith("marc_");
+  const marcBadge = marcActive ? formatMarcBadge(marcResolutionM) : undefined;
   const pills: PillDef[] = [
     { view: "wind", label: "Wind", visible: true, icon: WindIcon },
     { view: "waves", label: "Waves", visible: showWaves, icon: WavesIcon },
-    { view: "tides", label: "Tides", visible: showTides, icon: TidesIcon },
-    { view: "currents", label: "Currents", visible: showCurrents, icon: CurrentsIcon },
+    { view: "tides", label: "Tides", visible: showTides, icon: TidesIcon, badge: marcBadge },
+    { view: "currents", label: "Currents", visible: showCurrents, icon: CurrentsIcon, badge: marcBadge },
   ];
   const visible = pills.filter((p) => p.visible);
   if (visible.length <= 1) return null;
@@ -88,6 +105,18 @@ export function MetricPills({
           >
             <span aria-hidden className="shrink-0">{p.icon}</span>
             <span>{p.label}</span>
+            {p.badge && (
+              <span
+                className="ml-0.5 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider rounded"
+                style={{
+                  background: active ? "var(--ow-accent)" : "var(--ow-line-2)",
+                  color: active ? "#fff" : "var(--ow-fg-2)",
+                }}
+                title={`Source: ${p.badge}`}
+              >
+                {p.badge}
+              </span>
+            )}
           </button>
         );
       })}

--- a/packages/web/src/components/TideChart.tsx
+++ b/packages/web/src/components/TideChart.tsx
@@ -105,8 +105,13 @@ export function TideChart({
     return () => el.removeEventListener("scroll", checkScrollEnd);
   }, [checkScrollEnd]);
 
-  // Tide curve geometry
-  const tides = marine.tide_height_m;
+  // Tide curve geometry. Prefer the chart-datum (ZH) series when MARC covers
+  // the spot — that's what nautical charts and SHOM annuals display, and it's
+  // always ≥ 0 so users don't see negative heights at low tide.
+  const useZh = marine.tide_height_zh_m != null;
+  const tides = useZh ? (marine.tide_height_zh_m as (number | null)[]) : marine.tide_height_m;
+  const refLabel = useZh ? "ZH" : "MSL";
+  const unitLabel = useZh ? "m ZH" : "m";
   const valid = tides.filter((v): v is number => v != null);
   const hasData = valid.length >= 2;
   const tideMin = hasData ? Math.min(...valid) : -1;
@@ -191,7 +196,7 @@ export function TideChart({
                       className="text-[8px] font-medium"
                       style={{ color: "var(--ow-fg-2)" }}
                     >
-                      m
+                      {unitLabel}
                     </span>
                   </div>
                 </td>
@@ -238,19 +243,38 @@ export function TideChart({
                       ) : null,
                     )}
 
-                    {/* Mean-water-level reference line (zero of the dataset) — only
-                        when 0 is inside the displayed range so it actually shows up. */}
+                    {/* Reference line (zero of the dataset). In ZH mode this is
+                        chart datum / lowest astronomical tide; in MSL mode it's
+                        mean sea level. Drawn only when 0 is inside the displayed
+                        range. */}
                     {tideMin <= 0 && tideMax >= 0 && (
-                      <line
-                        x1={0}
-                        y1={yForTide(0)}
-                        x2={svgWidth}
-                        y2={yForTide(0)}
-                        stroke="var(--ow-fg-3)"
-                        strokeWidth={1}
-                        strokeDasharray="3 3"
-                        opacity={0.4}
-                      />
+                      <>
+                        <line
+                          x1={0}
+                          y1={yForTide(0)}
+                          x2={svgWidth}
+                          y2={yForTide(0)}
+                          stroke="var(--ow-fg-3)"
+                          strokeWidth={1}
+                          strokeDasharray="3 3"
+                          opacity={0.4}
+                        />
+                        <text
+                          x={4}
+                          y={yForTide(0) - 3}
+                          fontSize="9"
+                          fill="var(--ow-fg-2)"
+                          opacity={0.7}
+                          style={{
+                            paintOrder: "stroke",
+                            stroke: "var(--ow-bg-0)",
+                            strokeWidth: 3,
+                            strokeLinejoin: "round",
+                          }}
+                        >
+                          {refLabel}
+                        </text>
+                      </>
                     )}
 
                     {hasData && (
@@ -292,7 +316,9 @@ export function TideChart({
                         const onRight = selectedIdx <= tides.length - 4;
                         const labelX = onRight ? sx + 9 : sx - 9;
                         const labelAnchor = onRight ? "start" : "end";
-                        const labelText = `${sh >= 0 ? "+" : ""}${sh.toFixed(2)} m`;
+                        const labelText = useZh
+                          ? `${sh.toFixed(2)} m`
+                          : `${sh >= 0 ? "+" : ""}${sh.toFixed(2)} m`;
                         return (
                           <>
                             <line
@@ -339,7 +365,9 @@ export function TideChart({
                       const x = xForIdx(e.idx);
                       const y = yForTide(h);
                       const time = formatHour(masterTimeline[e.idx], timezoneMode);
-                      const heightLabel = `${h >= 0 ? "+" : ""}${h.toFixed(2)} m`;
+                      const heightLabel = useZh
+                        ? `${h.toFixed(2)} m`
+                        : `${h >= 0 ? "+" : ""}${h.toFixed(2)} m`;
                       const labelY = e.type === "high" ? y - 10 : y + 18;
                       return (
                         <g key={`ext-${e.idx}`}>

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -27,7 +27,25 @@ export interface MarineHourly {
   wave_direction_deg: (number | null)[];
   current_speed_kn: (number | null)[];
   current_direction_to_deg: (number | null)[];
+  // Tide height in MSL reference (Open-Meteo SMOC). Always populated when SMOC
+  // covers the spot. Negative values are normal (water below mean sea level).
   tide_height_m: (number | null)[];
+  // Tide height in ZH (Zéro Hydrographique / chart datum) reference. Populated
+  // only when MARC PREVIMER covers the spot. Always ≥ 0 by construction (chart
+  // datum is the lowest astronomical tide), so it matches what nautical charts,
+  // SHOM annuals and tide gauges display.
+  tide_height_zh_m?: (number | null)[];
+  // Z0 used to convert tide_height_m → tide_height_zh_m
+  // (zh = msl - z0_hydro_m). Single scalar per spot. Present only when MARC
+  // covers the spot.
+  z0_hydro_m?: number;
+  // Provenance of tide+current data. ``"openmeteo_smoc"`` for the default
+  // Open-Meteo path; ``"marc_<atlas>_<resolution>"`` (e.g. ``marc_finis_250m``)
+  // when MARC overrides. Used to drive a small badge on the active pill.
+  current_source?: string;
+  // Resolution in metres of the MARC atlas used. Surfaces in the badge: 250 m
+  // (FINIS), 700 m (MANGA, MANW, MANE, SUDBZH, AQUI), 2000 m (ATLNE).
+  marc_resolution_m?: number;
 }
 
 // Surfacing thresholds, mirror of openwind_data.adapters.base. Below these,


### PR DESCRIPTION
## Summary

Phase 3 of the MARC integration: the web app now consumes the HF Space MARC endpoint alongside Open-Meteo, so users at Brest, Saint-Malo or any other Atlantic French coast spot inside the 7 published atlases see chart-datum tides and Ifremer-grade currents directly in the browser.

- `fetchMarine()` calls Open-Meteo and `https://qdonnars-openwind-mcp.hf.space/api/v1/marine/marc` in parallel; on coverage, MARC overrides tide and current per matching hour.
- New `tide_height_zh_m` field is computed as `tide_height_m - z0_hydro_m` and surfaced in `TideChart` and `MarineTable`. Always positive, matches what SHOM annuals and nautical charts display, no more negative values at low tide.
- `MetricPills` shows a `MARC 250 m` / `MARC 700 m` / `MARC 2 km` badge on the Tides and Currents pills when MARC covers, so users know the precision they're getting.
- Falls back gracefully to Open-Meteo SMOC outside MARC coverage (covered=false, network error, HTTP error).

Expected at Brest (FINIS, z0 = -3.74 m): tide curve in roughly +2 to +9 m ZH instead of -1.5 to +1.5 m MSL, with a `MARC 250 m` badge on the active pill.

## Test plan

- [x] 32 vitest tests pass, including 11 new tests covering merge, ZH transform, partial overlap, Paris/UTC conversion in CET and CEST.
- [x] `tsc -b` clean, `vite build` succeeds (442 kB / 131 kB gzip), lint count unchanged from main.
- [ ] Local `npm run dev` smoke at Brest: tide values in ZH range, `MARC 250 m` badge visible.
- [ ] Smoke at a Med spot (Marseille): no badge, MSL values as before.
- [ ] Smoke at a non-coverage Atlantic spot (offshore Gascogne): no badge, SMOC fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)