### PR TITLE
feat(web): /plan right-panel redesign — clickable leg with build-up

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -182,6 +182,8 @@ class SegmentReport:
     # ``"marc_finis_250m"``) when MARC PREVIMER atlas data overrides Open-Meteo
     # in covered zones. ``None`` when no current data is available.
     current_source: str | None = None
+    gust_kn: float | None = None
+    wave_period_s: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -406,6 +408,7 @@ async def _estimate_with_model(
         # state and ground-track corrections, even if wave correction is off.
         sea_pt = _closest_sea_point(bundle.sea.points, mid_time)
         hs_m = sea_pt.wave_height_m if sea_pt else None
+        tp_s = sea_pt.wave_period_s if sea_pt else None
         cur_kn = sea_pt.current_speed_kn if sea_pt else None
         cur_to = sea_pt.current_direction_to_deg if sea_pt else None
         cur_src = sea_pt.current_source if sea_pt else None
@@ -440,6 +443,8 @@ async def _estimate_with_model(
                 current_direction_to_deg=cur_to,
                 sog_kn=sog,
                 current_source=cur_src,
+                gust_kn=wp.gust_kn,
+                wave_period_s=tp_s,
             )
         )
 
@@ -544,6 +549,7 @@ async def _estimate_backward_with_model(
             effective_polar = polar_speed
         sea_pt = _closest_sea_point(bundle.sea.points, mid_time)
         hs_m = sea_pt.wave_height_m if sea_pt else None
+        tp_s = sea_pt.wave_period_s if sea_pt else None
         cur_kn = sea_pt.current_speed_kn if sea_pt else None
         cur_to = sea_pt.current_direction_to_deg if sea_pt else None
         cur_src = sea_pt.current_source if sea_pt else None
@@ -576,6 +582,8 @@ async def _estimate_backward_with_model(
                 current_source=cur_src,
                 current_direction_to_deg=cur_to,
                 sog_kn=sog,
+                gust_kn=wp.gust_kn,
+                wave_period_s=tp_s,
             )
         )
         end_time = seg_start

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -41,12 +41,16 @@ class StubAdapter:
         hs_m: float | None = None,
         current_kn: float | None = None,
         current_to_deg: float | None = None,
+        gust_kn: float | None = None,
+        wave_period_s: float | None = None,
     ) -> None:
         self.tws_kn = tws_kn
         self.twd_deg = twd_deg
         self.hs_m = hs_m
         self.current_kn = current_kn
         self.current_to_deg = current_to_deg
+        self.gust_kn = gust_kn
+        self.wave_period_s = wave_period_s
         self.calls: list[tuple[float, float, datetime, datetime]] = []
 
     async def fetch(
@@ -67,14 +71,17 @@ class StubAdapter:
                     time=t,
                     speed_kn=self.tws_kn,
                     direction_deg=self.twd_deg,
-                    gust_kn=None,
+                    gust_kn=self.gust_kn,
                 )
             )
             t = t + timedelta(hours=1)
         wind = {m: WindSeries(model=m, points=tuple(points)) for m in models}
         sea_points: list[SeaPoint] = []
         emit_sea = (
-            self.hs_m is not None or self.current_kn is not None or self.current_to_deg is not None
+            self.hs_m is not None
+            or self.current_kn is not None
+            or self.current_to_deg is not None
+            or self.wave_period_s is not None
         )
         if emit_sea:
             t = start
@@ -83,7 +90,7 @@ class StubAdapter:
                     SeaPoint(
                         time=t,
                         wave_height_m=self.hs_m,
-                        wave_period_s=None,
+                        wave_period_s=self.wave_period_s,
                         wave_direction_deg=None,
                         wind_wave_height_m=None,
                         swell_wave_height_m=None,
@@ -241,6 +248,20 @@ class TestEstimatePassage:
                 "battleship",
                 adapter=adapter,
             )
+
+    async def test_gust_and_wave_period_propagated_to_segments(self) -> None:
+        # Web "Comment c'est calculé" build-up surfaces gust_kn and wave_period_s
+        # alongside Hs — verify both ride through the full pipeline.
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=180.0, hs_m=1.4, gust_kn=22.0, wave_period_s=4.5)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=10.0,
+        )
+        assert all(seg.gust_kn == 22.0 for seg in report.segments)
+        assert all(seg.wave_period_s == 4.5 for seg in report.segments)
 
     async def test_segments_continuous_in_time(self) -> None:
         adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)

--- a/packages/web/src/design/tokens.css
+++ b/packages/web/src/design/tokens.css
@@ -11,6 +11,7 @@
   --ow-bg-0: #030712;        /* deepest bg (gray-950) */
   --ow-bg-1: #0d1117;        /* surface panel */
   --ow-bg-2: #161b22;        /* elevated surface */
+  --ow-bg-3: #1f2632;        /* hover / inset (used by /plan only) */
 
   /* Foreground */
   --ow-fg-0: #e8eaf0;        /* primary text */
@@ -83,6 +84,10 @@
   --ow-warn: #fbbf24;
   --ow-warn-soft: rgba(251, 191, 36, 0.12);
   --ow-warn-line: rgba(251, 191, 36, 0.25);
+  --ow-ok: #34d399;
+  --ow-ok-soft: rgba(52, 211, 153, 0.12);
+  --ow-ok-line: rgba(52, 211, 153, 0.25);
+  --ow-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
 
   /* Map */
   --ow-map-sea-0: #0B1A2E;
@@ -95,6 +100,7 @@
   --ow-bg-0: #f4f6fb;
   --ow-bg-1: #ffffff;
   --ow-bg-2: #e8ecf3;
+  --ow-bg-3: #dde3ed;
 
   --ow-fg-0: #0d1117;
   --ow-fg-1: #3a4250;
@@ -167,4 +173,8 @@
   --ow-warn: #fbbf24;
   --ow-warn-soft: rgba(251, 191, 36, 0.12);
   --ow-warn-line: rgba(251, 191, 36, 0.25);
+  --ow-ok: #0e9f8f;
+  --ow-ok-soft: rgba(14, 159, 143, 0.12);
+  --ow-ok-line: rgba(14, 159, 143, 0.40);
+  --ow-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08);
 }

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,0 +1,315 @@
+import type { AggregatedLeg } from "./aggregateLegs";
+
+// "Comment c'est calculé" — expanded leg detail. Layout:
+//   1. Build-up of the target speed: polar → wave penalty → current → target
+//   2. Four mini-tiles: polar pose, observed wind, sea sensitivity, current
+// Numbers come from `aggregateLegs` (segment-level math weighted by distance,
+// so the column sums match the displayed target).
+
+const fmtKn = (kn: number, signed = false): string => {
+  const r = Math.abs(kn) < 0.05 ? 0 : kn; // hide tiny rounding flips
+  if (!signed) return `${r.toFixed(1)} kn`;
+  const sign = r > 0 ? "+" : r < 0 ? "−" : "";
+  return `${sign}${Math.abs(r).toFixed(1)} kn`;
+};
+
+function compass16(deg: number): string {
+  const dirs = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+  return dirs[Math.round(((deg % 360) + 360) % 360 / 22.5) % 16];
+}
+
+// ── Inline icons (kept tiny, design uses 11px line-art) ────────────────────────
+function Icon({ name, size = 11, color = "currentColor" }: { name: "gauge" | "sail" | "wind" | "alert" | "route"; size?: number; color?: string }) {
+  const stroke = { width: 1.6, color };
+  const common = { width: size, height: size, viewBox: "0 0 16 16", fill: "none", stroke: stroke.color, strokeWidth: stroke.width, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
+  switch (name) {
+    case "gauge":
+      return (<svg {...common}><path d="M3 12a5 5 0 0 1 10 0" /><path d="M8 12 11 8" /><circle cx="8" cy="12" r="0.7" fill={color} /></svg>);
+    case "sail":
+      return (<svg {...common}><path d="M8 2v11" /><path d="M8 2c-2.5 1 -4 5 -4 11h4z" /><path d="M2 14h12" /></svg>);
+    case "wind":
+      return (<svg {...common}><path d="M3 6h7a2 2 0 1 0-2-2" /><path d="M3 10h10a2 2 0 1 1-2 2" /></svg>);
+    case "alert":
+      return (<svg {...common}><path d="M8 2 14 13H2z" /><path d="M8 7v3" /><circle cx="8" cy="12" r="0.5" fill={color} /></svg>);
+    case "route":
+      return (<svg {...common}><path d="M3 12c2-4 5-1 7-3 1-1 2-3 3-3" /><circle cx="3" cy="12" r="1.4" fill={color} stroke="none" /><circle cx="13" cy="6" r="1.4" fill={color} stroke="none" /></svg>);
+  }
+}
+
+// ── Build-up rows ─────────────────────────────────────────────────────────────
+function BuildUpRow({
+  label,
+  sub,
+  value,
+  tone,
+}: {
+  label: string;
+  sub: string;
+  value: string;
+  tone: "base" | "pos" | "neg" | "total";
+}) {
+  const colorMap: Record<typeof tone, string> = {
+    base: "var(--ow-fg-1)",
+    pos: "var(--ow-ok)",
+    neg: "var(--ow-warn)",
+    total: "var(--ow-accent)",
+  };
+  return (
+    <div className="flex items-center gap-2 mt-1">
+      <div className="flex-1 min-w-0">
+        <div className="text-[11px]" style={{ color: "var(--ow-fg-0)", fontWeight: tone === "total" ? 600 : 500 }}>
+          {label}
+        </div>
+        <div className="text-[9px] mt-0.5" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+          {sub}
+        </div>
+      </div>
+      <span
+        className="text-xs font-semibold tabular-nums"
+        style={{ color: colorMap[tone], fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.01em" }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ── Mini visualizations ───────────────────────────────────────────────────────
+function PolarMini({ twa }: { twa: number }) {
+  const r = 16, cx = 20, cy = 20;
+  // TWA is a relative angle (0..180). Place it on the right hemisphere of a half-circle.
+  const a = Math.min(180, Math.max(0, Math.abs(twa) > 180 ? 360 - Math.abs(twa) : Math.abs(twa)));
+  const angle = ((a - 90) * Math.PI) / 180;
+  const tx = cx + Math.cos(angle) * r;
+  const ty = cy + Math.sin(angle) * r;
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" aria-hidden="true">
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" />
+      <path
+        d={`M ${cx} ${cy - r} A ${r} ${r} 0 0 1 ${cx + r} ${cy}`}
+        stroke="var(--ow-accent)"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <line x1={cx} y1={cy} x2={tx} y2={ty} stroke="var(--ow-accent)" strokeWidth="1.5" />
+      <circle cx={tx} cy={ty} r="2.2" fill="var(--ow-accent)" />
+    </svg>
+  );
+}
+
+function CompassArrow({ deg, label }: { deg: number; label: string }) {
+  // True wind direction is "from" — flip to "to" for the arrow tip.
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <svg width="26" height="26" viewBox="0 0 26 26" style={{ transform: `rotate(${deg + 180}deg)` }} aria-hidden="true">
+        <line x1="13" y1="5" x2="13" y2="20" stroke="var(--ow-fg-1)" strokeWidth="1.6" strokeLinecap="round" />
+        <path d="M13 5 L9 10 M13 5 L17 10" stroke="var(--ow-fg-1)" strokeWidth="1.6" strokeLinecap="round" fill="none" />
+      </svg>
+      <span className="text-[8px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>{label}</span>
+    </div>
+  );
+}
+
+function WaveMini({ steep }: { steep: boolean }) {
+  // Tighter wavelength when steep (Hs/Tp high) — visual cue, not to scale.
+  const path = steep
+    ? "M0 13 Q 4 4 8 13 T 16 13 T 24 13 T 32 13 T 40 13"
+    : "M0 13 Q 6 6 12 13 T 24 13 T 36 13 T 48 13";
+  return (
+    <svg width="40" height="20" viewBox="0 0 40 20" aria-hidden="true">
+      <path d={path} stroke="var(--ow-warn)" strokeWidth="1.5" fill="none" />
+    </svg>
+  );
+}
+
+function CurrentArrow({ relative }: { relative: "portant" | "contraire" | "travers" }) {
+  const color = relative === "portant" ? "var(--ow-ok)" : relative === "contraire" ? "var(--ow-warn)" : "var(--ow-fg-1)";
+  // travers: short side-line; portant: forward arrow; contraire: backward arrow
+  if (relative === "travers") {
+    return (
+      <svg width="40" height="20" viewBox="0 0 40 20" aria-hidden="true">
+        <path d="M2 10 L38 10" stroke={color} strokeWidth="1.5" fill="none" />
+        <path d="M22 6 L18 10 L22 14" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      width="40"
+      height="20"
+      viewBox="0 0 40 20"
+      aria-hidden="true"
+      style={{ transform: relative === "contraire" ? "scaleX(-1)" : "none" }}
+    >
+      <path d="M2 10 Q 11 4 22 10 T 40 10" stroke={color} strokeWidth="1.5" fill="none" />
+      <path d="M34 7 L40 10 L34 13" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ── Factor tile (the 4 cards) ─────────────────────────────────────────────────
+function FactorTile({
+  icon,
+  title,
+  metric,
+  caption,
+  tone,
+  extra,
+}: {
+  icon: "sail" | "wind" | "alert" | "route";
+  title: string;
+  metric: string;
+  caption: string;
+  tone?: "warn" | "ok";
+  extra?: React.ReactNode;
+}) {
+  const accent = tone === "warn" ? "var(--ow-warn)" : tone === "ok" ? "var(--ow-ok)" : "var(--ow-fg-0)";
+  return (
+    <div
+      className="rounded-lg p-2.5"
+      style={{ background: "var(--ow-bg-1)", border: "1px solid var(--ow-line)" }}
+    >
+      <div className="flex items-center gap-1.5 mb-1.5" style={{ color: "var(--ow-fg-2)" }}>
+        <Icon name={icon} size={11} />
+        <span className="text-[9px] font-bold uppercase tracking-widest">{title}</span>
+      </div>
+      <div className="flex items-end justify-between gap-1.5">
+        <div className="min-w-0">
+          <div
+            className="text-[15px] font-bold tabular-nums leading-none"
+            style={{ color: accent, fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em" }}
+          >
+            {metric}
+          </div>
+          <div className="text-[9px] mt-1 leading-tight" style={{ color: "var(--ow-fg-2)" }}>
+            {caption}
+          </div>
+        </div>
+        {extra && <div className="shrink-0">{extra}</div>}
+      </div>
+    </div>
+  );
+}
+
+// ── Main card ─────────────────────────────────────────────────────────────────
+export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; archetypeLabel: string }) {
+  const twa = Math.round(Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg));
+  const tws = Math.round(leg.tws_avg_kn);
+  const effPct = Math.round(leg.efficiency * 100);
+
+  // Sea direction relative to the boat (hs_avg_m null → no sea data)
+  const seaDir = leg.sea_direction; // "face" | "travers" | "arrière" | null
+  const tpStr = leg.tp_avg_s != null ? ` · Tp ${leg.tp_avg_s.toFixed(1)} s` : "";
+  const seaSub = leg.hs_avg_m != null
+    ? `Hs ${leg.hs_avg_m.toFixed(1)} m${tpStr}${seaDir ? ` · de ${seaDir}` : ""}`
+    : "Pas de donnée vagues";
+
+  // Current sub-text
+  const curSub = (() => {
+    if (leg.current_speed_kn == null || leg.current_relative == null) return "Pas de donnée courant";
+    const speed = leg.current_speed_kn.toFixed(1);
+    const rel = leg.current_relative;
+    return `${speed} kn ${rel}`;
+  })();
+  const gustStr = leg.gust_max_kn != null ? `rafales ${Math.round(leg.gust_max_kn)} kn · ` : "";
+
+  // Steepness heuristic: short period for the height = steep mer courte.
+  const steepSea = leg.hs_avg_m != null && leg.tp_avg_s != null && leg.hs_avg_m / leg.tp_avg_s > 0.3;
+
+  return (
+    <div className="px-4 pb-3 pt-1">
+      {/* Section label */}
+      <div
+        className="flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase"
+        style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
+      >
+        <Icon name="gauge" size={11} color="var(--ow-accent)" />
+        Comment c'est calculé
+      </div>
+
+      {/* Build-up card */}
+      <div
+        className="rounded-lg p-3 mb-2.5"
+        style={{ background: "var(--ow-bg-1)", border: "1px solid var(--ow-line)" }}
+      >
+        <div
+          className="text-[9px] mb-1.5 font-bold uppercase tracking-widest"
+          style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+        >
+          Vitesse cible · build-up
+        </div>
+        <BuildUpRow
+          label="Polaire bateau"
+          sub={`${archetypeLabel} · TWA ${twa}° / TWS ${tws} kn · efficacité ${effPct}%`}
+          value={fmtKn(leg.polar_after_eff_kn, true)}
+          tone="base"
+        />
+        {Math.abs(leg.wave_delta_kn) > 0.05 && (
+          <BuildUpRow
+            label="Pénalité vagues"
+            sub={
+              leg.hs_avg_m != null
+                ? `Hs ${leg.hs_avg_m.toFixed(1)} m${tpStr}${seaDir ? ` · de ${seaDir}` : ""}`
+                : "—"
+            }
+            value={fmtKn(leg.wave_delta_kn, true)}
+            tone="neg"
+          />
+        )}
+        {leg.current_delta_kn != null && Math.abs(leg.current_delta_kn) > 0.05 && (
+          <BuildUpRow
+            label="Courant"
+            sub={
+              leg.current_speed_kn != null
+                ? `${leg.current_speed_kn.toFixed(1)} kn ${leg.current_relative ?? ""}`.trim()
+                : "—"
+            }
+            value={fmtKn(leg.current_delta_kn, true)}
+            tone={leg.current_delta_kn >= 0 ? "pos" : "neg"}
+          />
+        )}
+        <div className="h-px my-1.5" style={{ background: "var(--ow-line)" }} />
+        <BuildUpRow
+          label="Cible retenue"
+          sub="utilisée pour la durée"
+          value={fmtKn(leg.target_speed_kn)}
+          tone="total"
+        />
+      </div>
+
+      {/* 4 factor tiles */}
+      <div className="grid grid-cols-2 gap-2">
+        <FactorTile
+          icon="sail"
+          title="Finesse bateau"
+          metric={`${leg.polar_after_eff_kn.toFixed(1)} kn`}
+          caption={`${leg.point_of_sail.toLowerCase()} · TWA ${twa}°`}
+          extra={<PolarMini twa={leg.twa_avg_deg} />}
+        />
+        <FactorTile
+          icon="wind"
+          title="Vent vu"
+          metric={`${tws} kn`}
+          caption={`${gustStr}${leg.point_of_sail.toLowerCase()}`}
+          extra={<CompassArrow deg={leg.twd_avg_deg} label={compass16(leg.twd_avg_deg)} />}
+        />
+        <FactorTile
+          icon="alert"
+          title="Sensibilité vagues"
+          metric={leg.hs_avg_m != null ? fmtKn(leg.wave_delta_kn, true) : "—"}
+          caption={seaSub}
+          tone="warn"
+          extra={leg.hs_avg_m != null ? <WaveMini steep={steepSea} /> : null}
+        />
+        <FactorTile
+          icon="route"
+          title="Courant"
+          metric={leg.current_delta_kn != null ? fmtKn(leg.current_delta_kn, true) : "—"}
+          caption={curSub}
+          tone={leg.current_delta_kn != null && leg.current_delta_kn >= 0 ? "ok" : "warn"}
+          extra={leg.current_relative ? <CurrentArrow relative={leg.current_relative} /> : null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/plan/ModeToggle.tsx
+++ b/packages/web/src/plan/ModeToggle.tsx
@@ -5,42 +5,86 @@ export type PlanMode = "single" | "compare";
 // (server.estimate_passage_for_arrival via /api/v1/passage-by-eta).
 export type TimeAnchor = "departure" | "arrival";
 
+// Per-mode accent palette — picked up by tab icons so the two modes feel
+// distinct at a glance (cyan = simulate, amber = compare windows).
+const MODE_ACCENT: Record<PlanMode, string> = {
+  single: "var(--ow-accent)",
+  compare: "#F4C25C",
+};
+
+const MODE_META: Record<PlanMode, { title: string; sub: string; icon: "route" | "clock" }> = {
+  single: { title: "Simuler ma route", sub: "Combien de temps pour ce trajet ?", icon: "route" },
+  compare: { title: "Comparer les fenêtres", sub: "Quand partir ?", icon: "clock" },
+};
+
+function ModeIcon({ name, size = 12, color }: { name: "route" | "clock"; size?: number; color: string }) {
+  if (name === "clock") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="8" cy="8" r="6.5" />
+        <path d="M8 4.5V8l2.5 1.5" />
+      </svg>
+    );
+  }
+  // route: a wavy path with two waypoint dots
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 12c2-4 5-1 7-3 1-1 2-3 3-3" />
+      <circle cx="3" cy="12" r="1.5" fill={color} stroke="none" />
+      <circle cx="13" cy="6" r="1.5" fill={color} stroke="none" />
+    </svg>
+  );
+}
+
 export function ModeToggle({
   value,
   onChange,
+  locked = false,
 }: {
   value: PlanMode;
   onChange: (m: PlanMode) => void;
+  /** When true, shows both tabs dimmed and inactive (used for the empty state). */
+  locked?: boolean;
 }) {
   return (
     <div
-      className="flex p-1 rounded-xl text-xs font-semibold"
-      style={{ background: "var(--ow-bg-2)", border: "1px solid var(--ow-line-2)" }}
+      className="grid grid-cols-2 gap-0.5 p-[3px] rounded-lg"
+      style={{ background: "var(--ow-bg-2)", border: "1px solid var(--ow-line)" }}
       role="tablist"
       aria-label="Mode de planification"
     >
-      {(
-        [
-          ["single", "Simuler ma route"],
-          ["compare", "Comparer les fenêtres"],
-        ] as const
-      ).map(([m, label]) => {
-        const active = value === m;
+      {(["single", "compare"] as const).map((m) => {
+        const meta = MODE_META[m];
+        const active = !locked && value === m;
+        const dim = locked;
         return (
           <button
             key={m}
             type="button"
             role="tab"
             aria-selected={active}
-            onClick={() => onChange(m)}
-            className="flex-1 px-3 py-1.5 rounded-lg transition-colors"
+            onClick={() => !locked && onChange(m)}
+            disabled={locked}
+            className="text-left transition-all"
             style={{
+              padding: "8px 10px",
               background: active ? "var(--ow-bg-1)" : "transparent",
-              color: active ? "var(--ow-fg-0)" : "var(--ow-fg-2)",
-              boxShadow: active ? "var(--ow-shadow-soft)" : "none",
+              border: active ? "1px solid var(--ow-line-2)" : "1px solid transparent",
+              borderRadius: 6,
+              boxShadow: active ? "var(--ow-shadow-sm)" : "none",
+              opacity: dim ? 0.4 : 1,
+              cursor: locked ? "default" : "pointer",
             }}
           >
-            {label}
+            <div className="flex items-center gap-1.5 mb-0.5">
+              <ModeIcon name={meta.icon} size={11} color={active ? MODE_ACCENT[m] : "var(--ow-fg-2)"} />
+              <span className="text-xs font-semibold" style={{ color: active ? "var(--ow-fg-0)" : "var(--ow-fg-1)" }}>
+                {meta.title}
+              </span>
+            </div>
+            <div className="text-[10px] leading-tight" style={{ color: "var(--ow-fg-2)" }}>
+              {meta.sub}
+            </div>
           </button>
         );
       })}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from "react";
 import { useTheme } from "../design/theme";
 import type { PassageReport, ComplexityScore, SegmentReport, Archetype, PassageWindow } from "./types";
-import { aggregateLegs } from "./aggregateLegs";
+import { aggregateLegs, type AggregatedLeg } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
 import { WindowsTable } from "./WindowsTable";
 import { ModeToggle, TimeAnchorToggle, type PlanMode, type TimeAnchor } from "./ModeToggle";
+import { LegDetailCard } from "./LegDetailCard";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -526,6 +527,98 @@ function ArchetypeSelector({
   );
 }
 
+// ── LegList ──────────────────────────────────────────────────────────────────
+// Click-to-expand list of legs, with the "Comment c'est calculé" build-up
+// rendered inline for the open leg.
+
+function LegRow({
+  leg,
+  index,
+  expanded,
+  archetypeLabel,
+  onToggle,
+}: {
+  leg: AggregatedLeg;
+  index: number;
+  expanded: boolean;
+  archetypeLabel: string;
+  onToggle: () => void;
+}) {
+  const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
+  const tws = Math.round(leg.tws_avg_kn);
+  return (
+    <div style={{ borderBottom: "1px solid var(--ow-line)", background: expanded ? "var(--ow-bg-2)" : "transparent" }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-2.5 px-4 py-2.5 text-left"
+        aria-expanded={expanded}
+      >
+        <span
+          className="shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-[11px] font-bold tabular-nums"
+          style={{ background: CX_COLORS[cx], color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
+        >
+          {index + 1}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-semibold truncate" style={{ color: "var(--ow-fg-0)" }}>
+            Tronçon {index + 1}
+          </div>
+          <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+            {leg.distance_nm.toFixed(1)} nm · {leg.point_of_sail} · {tws} kn
+          </div>
+        </div>
+        <span className="text-[11px] tabular-nums shrink-0" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
+          {new Date(leg.end_time).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}
+        </span>
+        <span
+          aria-hidden="true"
+          className="inline-flex"
+          style={{
+            color: expanded ? "var(--ow-accent)" : "var(--ow-fg-3)",
+            transform: expanded ? "rotate(180deg)" : "none",
+            transition: "transform 150ms ease, color 150ms ease",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 6l5 5 5-5" />
+          </svg>
+        </span>
+      </button>
+      {expanded && <LegDetailCard leg={leg} archetypeLabel={archetypeLabel} />}
+    </div>
+  );
+}
+
+function LegList({ legs, archetypeLabel }: { legs: AggregatedLeg[]; archetypeLabel: string }) {
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  return (
+    <div>
+      <div
+        className="flex items-center justify-between px-4 pt-3 pb-1.5 text-[10px] uppercase tracking-widest font-bold"
+        style={{ color: "var(--ow-fg-2)" }}
+      >
+        Segments
+        <span className="text-[9px] font-medium normal-case tracking-normal" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
+          cliquez pour détailler
+        </span>
+      </div>
+      <div style={{ borderTop: "1px solid var(--ow-line)" }}>
+        {legs.map((leg, i) => (
+          <LegRow
+            key={i}
+            leg={leg}
+            index={i}
+            expanded={openIdx === i}
+            archetypeLabel={archetypeLabel}
+            onToggle={() => setOpenIdx((cur) => (cur === i ? null : i))}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ── PlanSidebar ───────────────────────────────────────────────────────────────
 
 interface PlanSidebarProps {
@@ -787,49 +880,16 @@ export function PlanSidebar({
         </div>
       )}
 
-      {/* Legs — one row per user waypoint segment */}
+      {/* Legs — click any row to see the "Comment c'est calculé" build-up */}
       {(() => {
-        const legs = aggregateLegs(passage.segments, waypoints);
+        const legs = aggregateLegs(passage.segments, waypoints, passage.efficiency);
+        const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
+        const archetypeLabel = archetype?.name ?? currentArchetypeSlug;
+        // LegList has its own padding; cancel the page's px-4 so the rows
+        // stretch edge-to-edge like the design.
         return (
-          <div>
-            <div className="flex items-center gap-2 mb-1 px-1 text-[9px]" style={{ color: "var(--ow-fg-3)" }}>
-              <span className="w-5 shrink-0" />
-              <span className="flex-1 grid grid-cols-5 gap-1">
-                <span>Heure</span>
-                <span>Allure</span>
-                <span>Vent</span>
-                <span>Mer</span>
-                <span className="text-right">Vitesse</span>
-              </span>
-            </div>
-            <div className="space-y-1">
-              {legs.map((leg, i) => {
-                const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
-                const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
-                  ? `${Math.round(leg.tws_min)} kn`
-                  : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
-                const seaLabel = leg.hs_avg_m == null
-                  ? "—"
-                  : `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction}`;
-                return (
-                  <div key={i} className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-bg-2)" }}>
-                    <span
-                      className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
-                      style={{ background: CX_COLORS[cx], color: "#fff" }}
-                    >
-                      {i + 1}
-                    </span>
-                    <div className="flex-1 grid grid-cols-5 gap-1 tabular-nums" style={{ fontFamily: "var(--ow-font-mono)" }}>
-                      <span style={{ color: "var(--ow-fg-1)" }}>{fmtTime(leg.end_time)}</span>
-                      <span style={{ color: "var(--ow-fg-0)" }}>{leg.point_of_sail}</span>
-                      <span style={{ color: "var(--ow-fg-1)" }}>{windLabel}</span>
-                      <span style={{ color: "var(--ow-fg-1)" }}>{seaLabel}</span>
-                      <span className="text-right" style={{ color: "var(--ow-fg-0)" }}>{leg.boat_speed_kn.toFixed(1)} kn</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+          <div className="-mx-4">
+            <LegList legs={legs} archetypeLabel={archetypeLabel} />
           </div>
         );
       })()}

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -1,19 +1,44 @@
 import type { SegmentReport } from "./types";
 
 export interface AggregatedLeg {
+  // ── Distances & timing (carried from the segment span) ─────────────────────
   distance_nm: number;
+  end_time: string;
+
+  // ── Wind summary ──────────────────────────────────────────────────────────
   tws_min: number;
   tws_max: number;
-  boat_speed_kn: number;
-  end_time: string;
+  tws_avg_kn: number;
+  twa_avg_deg: number; // signed -180..180 like SegmentReport.twa_deg
+  twd_avg_deg: number; // 0..360 (true wind direction)
+  gust_max_kn: number | null;
   point_of_sail: string;
-  // Mean significant wave height (m) over the leg, distance-weighted. null if
-  // no Hs data was available for any sub-segment.
+
+  // ── Boat speed build-up (all in knots) ────────────────────────────────────
+  // Distance-weighted means computed per-segment then averaged, so the
+  // build-up adds up exactly: polar_after_eff_kn + wave_delta_kn (≤ 0)
+  // ≈ boat_speed_kn, and boat_speed_kn + current_delta_kn = target_speed_kn.
+  polar_after_eff_kn: number; // polar lookup × passage efficiency (no waves, no current)
+  wave_delta_kn: number; // ≤ 0 — loss from wave_derate
+  current_delta_kn: number | null; // signed — gain when along, loss when against; null without current data
+  boat_speed_kn: number; // STW (polar × efficiency × derate)
+  target_speed_kn: number; // SOG when current modelled, else STW — used for duration
+  efficiency: number; // passage-wide constant, for display
+
+  // ── Sea state ─────────────────────────────────────────────────────────────
   hs_avg_m: number | null;
+  hs_max_m: number | null;
+  tp_avg_s: number | null;
   // Where the sea hits the boat relative to its course: "face", "travers",
   // "arrière", or null if Hs is null. Approximated from TWA (Med swell mostly
   // tracks wind in the absence of distant ocean swell).
   sea_direction: "face" | "travers" | "arrière" | null;
+
+  // ── Current ───────────────────────────────────────────────────────────────
+  current_speed_kn: number | null;
+  current_direction_to_deg: number | null;
+  // Sign of current_delta_kn translated to a sailor-friendly label.
+  current_relative: "portant" | "contraire" | "travers" | null;
 }
 
 function circularMeanDeg(angles: number[]): number {
@@ -40,9 +65,16 @@ function twaToSeaDirection(twa: number): "face" | "travers" | "arrière" {
   return "arrière";
 }
 
+function classifyCurrent(deltaKn: number, currentSpeedKn: number | null): "portant" | "contraire" | "travers" {
+  // |delta| / current_speed ~ |cos(angle)|. > 0.5 → mostly along (portant or contraire); < 0.5 → mostly travers.
+  if (currentSpeedKn != null && currentSpeedKn > 0 && Math.abs(deltaKn) / currentSpeedKn < 0.5) return "travers";
+  return deltaKn >= 0 ? "portant" : "contraire";
+}
+
 export function aggregateLegs(
   segments: SegmentReport[],
   waypoints: [number, number][],
+  efficiency = 0.75,
 ): AggregatedLeg[] {
   if (waypoints.length < 2 || segments.length === 0) return [];
 
@@ -63,25 +95,72 @@ export function aggregateLegs(
   return legStarts.slice(0, -1).map((start, li) => {
     const segs = segments.slice(start, legStarts[li + 1]);
     const totalDist = segs.reduce((s, seg) => s + seg.distance_nm, 0);
-    const twsVals = segs.map((s) => s.tws_kn);
-    const avgSpeed = segs.reduce((s, seg) => s + seg.boat_speed_kn * seg.distance_nm, 0) / totalDist;
-    const avgTwa = circularMeanDeg(segs.map((s) => s.twa_deg));
+    const wsum = (pick: (s: SegmentReport) => number): number =>
+      segs.reduce((acc, seg) => acc + pick(seg) * seg.distance_nm, 0) / totalDist;
 
+    // Wind aggregates
+    const twsVals = segs.map((s) => s.tws_kn);
+    const tws_avg_kn = wsum((s) => s.tws_kn);
+    const twa_avg_deg = circularMeanDeg(segs.map((s) => s.twa_deg));
+    const twd_avg_deg = circularMeanDeg(segs.map((s) => s.twd_deg));
+    const gusts = segs.map((s) => s.gust_kn).filter((g): g is number => g != null);
+    const gust_max_kn = gusts.length > 0 ? Math.max(...gusts) : null;
+
+    // Speed build-up (per-segment, then weighted averaged so the additions stay coherent)
+    const polar_after_eff_kn = wsum((s) => s.polar_speed_kn * efficiency);
+    const boat_speed_kn = wsum((s) => s.boat_speed_kn);
+    const wave_delta_kn = boat_speed_kn - polar_after_eff_kn; // ≤ 0
+
+    // Current — only if every segment in the leg has SOG (avoid mixing)
+    const allHaveSog = segs.every((s) => s.sog_kn != null);
+    const current_delta_kn = allHaveSog ? wsum((s) => (s.sog_kn as number) - s.boat_speed_kn) : null;
+    const target_speed_kn = allHaveSog ? wsum((s) => s.sog_kn as number) : boat_speed_kn;
+
+    // Current speed/direction (max speed for "worst case", circular mean direction)
+    const curSpeeds = segs.map((s) => s.current_speed_kn).filter((v): v is number => v != null);
+    const current_speed_kn = curSpeeds.length > 0 ? Math.max(...curSpeeds) : null;
+    const curDirs = segs.map((s) => s.current_direction_to_deg).filter((v): v is number => v != null);
+    const current_direction_to_deg = curDirs.length > 0 ? circularMeanDeg(curDirs) : null;
+    const current_relative = current_delta_kn != null
+      ? classifyCurrent(current_delta_kn, current_speed_kn)
+      : null;
+
+    // Sea state
     const hsSegs = segs.filter((s) => s.hs_m != null);
     const hsTotalDist = hsSegs.reduce((s, seg) => s + seg.distance_nm, 0);
-    const hsAvg = hsTotalDist > 0
+    const hs_avg_m = hsTotalDist > 0
       ? hsSegs.reduce((s, seg) => s + (seg.hs_m as number) * seg.distance_nm, 0) / hsTotalDist
+      : null;
+    const hs_max_m = hsSegs.length > 0 ? Math.max(...hsSegs.map((s) => s.hs_m as number)) : null;
+    const tpSegs = segs.filter((s) => s.wave_period_s != null);
+    const tpTotalDist = tpSegs.reduce((s, seg) => s + seg.distance_nm, 0);
+    const tp_avg_s = tpTotalDist > 0
+      ? tpSegs.reduce((s, seg) => s + (seg.wave_period_s as number) * seg.distance_nm, 0) / tpTotalDist
       : null;
 
     return {
       distance_nm: totalDist,
+      end_time: segs[segs.length - 1].end_time,
       tws_min: Math.min(...twsVals),
       tws_max: Math.max(...twsVals),
-      boat_speed_kn: avgSpeed,
-      end_time: segs[segs.length - 1].end_time,
-      point_of_sail: twaToPointOfSail(avgTwa),
-      hs_avg_m: hsAvg,
-      sea_direction: hsAvg == null ? null : twaToSeaDirection(avgTwa),
+      tws_avg_kn,
+      twa_avg_deg,
+      twd_avg_deg,
+      gust_max_kn,
+      point_of_sail: twaToPointOfSail(twa_avg_deg),
+      polar_after_eff_kn,
+      wave_delta_kn,
+      current_delta_kn,
+      boat_speed_kn,
+      target_speed_kn,
+      efficiency,
+      hs_avg_m,
+      hs_max_m,
+      tp_avg_s,
+      sea_direction: hs_avg_m == null ? null : twaToSeaDirection(twa_avg_deg),
+      current_speed_kn,
+      current_direction_to_deg,
+      current_relative,
     };
   });
 }

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -18,6 +18,12 @@ export interface SegmentReport {
   duration_h: number;
   hs_m: number | null;
   wave_derate_factor: number;
+  current_speed_kn?: number | null;
+  current_direction_to_deg?: number | null;
+  sog_kn?: number | null;
+  current_source?: string | null;
+  gust_kn?: number | null;
+  wave_period_s?: number | null;
 }
 
 export interface PassageReport {


### PR DESCRIPTION
## Summary

- Refonte de l'onglet droit `/plan` : chaque tronçon est cliquable et déploie une carte « Comment c'est calculé » (build-up de la vitesse cible + 4 mini-tuiles).
- Onglets Simuler/Comparer revus avec sous-titre (« Combien de temps ? » / « Quand partir ? »), accent dédié par mode.
- `SegmentReport` enrichi de 2 champs optionnels (`gust_kn`, `wave_period_s`) propagés depuis les adaptateurs vers le frontend, alimentent les sub-lignes du build-up.

## Build-up de la vitesse cible

Build-up qui s'additionne strictement (per-segment math, pondéré par distance) :

```
Polaire bateau (× efficacité)   +X.X kn
Pénalité vagues                 −X.X kn  (si Hs)
Courant                         ±X.X kn  (si SOG)
─────────────────────────────────────────
Cible retenue                    Y.Y kn  (utilisée pour la durée)
```

## Décisions hors-scope (validées avec l'utilisateur avant impl)

- ❌ Ligne « Sécurité (réduction) · Risée >25 kn » du design **abandonnée** — n'existe pas dans notre moteur (pas de safety reduction modélisé).
- ❌ Bandeau « Confiance ECMWF + GFS » **abandonné** — un seul modèle (AROME), pas de multi-model agreement.
- ✅ Tp + rafales remontés au SegmentReport (vrais signaux marins).

## Fichiers

**Backend** (data-adapters)
- `passage.py` : `SegmentReport.gust_kn` + `wave_period_s`, propagation forward + backward
- `test_passage.py` : `StubAdapter` étendu, nouveau test de propagation

**Frontend** (web/plan)
- `LegDetailCard.tsx` (nouveau) : la carte zoom (build-up + 4 mini-tuiles)
- `aggregateLegs.ts` : exposes `polar_after_eff_kn`, `wave_delta_kn`, `current_delta_kn`, `target_speed_kn`, `gust_max_kn`, `tp_avg_s`, `current_relative` ; rétro-compatible avec CompactDrawer mobile
- `ModeToggle.tsx` : grille 2 colonnes avec sous-titre, support `locked`
- `PlanSidebar.tsx` : nouveau `LegList` cliquable
- `types.ts` : miroir backend
- `tokens.css` : `--ow-ok`, `--ow-bg-3`, `--ow-shadow-sm` (dark + light)

## Hors périmètre

- App.tsx / explore (page initiale) intacts — refonte limitée à `/plan`
- Header mobile inchangé (demande explicite)
- Mode picker en grandes cartes, empty state avec sketch route, bouton « Modifier » récap compact : reportés (non demandés)

## Test plan

- [x] `pytest packages/data-adapters` : 170 passed (1 nouveau)
- [x] `pytest packages/mcp-core` : 20 passed
- [x] `ruff check src` clean
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `npm run build` OK (pas de régression de taille bundle)
- [ ] Smoke MCP live `plan_passage` Marseille → Porquerolles (sub-agent en cours)
- [ ] Vérif visuelle : ouvrir `/plan`, tracer 2+ waypoints, cliquer un tronçon, vérifier que le build-up s'additionne correctement (Polaire − Vagues + Courant = Cible)
- [ ] Vérif visuelle bis : tronçon sans courant (Med côte) → ligne Courant absente, Cible = Polaire − Vagues

🤖 Generated with [Claude Code](https://claude.com/claude-code)