### PR TITLE
feat(web): /plan right-panel — empty / picker / récap compact / hero stats

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,23 +1,15 @@
 import { useMemo, useState } from "react";
 import { useTheme } from "../design/theme";
-import type { PassageReport, ComplexityScore, SegmentReport, Archetype, PassageWindow } from "./types";
+import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "./types";
 import { aggregateLegs, type AggregatedLeg } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
 import { WindowsTable } from "./WindowsTable";
 import { ModeToggle, TimeAnchorToggle, type PlanMode, type TimeAnchor } from "./ModeToggle";
 import { LegDetailCard } from "./LegDetailCard";
+import { EmptyState, ModePicker, HeroStats, Warn, RecapButton } from "./PlanStates";
+import { useHasChosenMode } from "./useChosenMode";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
-
-function fmtDuration(h: number): string {
-  const hrs = Math.floor(h);
-  const mins = Math.round((h - hrs) * 60);
-  return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
-}
-
-function fmtTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-}
 
 // Format a Date as "YYYY-MM-DDTHH:MM" (local, naive — the format datetime-local expects).
 function toLocalIso(d: Date): string {
@@ -414,58 +406,6 @@ function SweepForm({
   );
 }
 
-// ── ComplexityBadge ───────────────────────────────────────────────────────────
-
-function ComplexityBadge({ level, label }: { level: number; label: string }) {
-  return (
-    <div
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-sm font-bold"
-      style={{ background: CX_COLORS[level] + "22", color: CX_COLORS[level], border: `1px solid ${CX_COLORS[level]}55` }}
-    >
-      <span className="w-2.5 h-2.5 rounded-full" style={{ background: CX_COLORS[level] }} />
-      {level}/5 — {label}
-    </div>
-  );
-}
-
-// ── ComplexityBar ─────────────────────────────────────────────────────────────
-
-function ComplexityBar({ segments }: { segments: SegmentReport[] }) {
-  const total = segments.reduce((s, seg) => s + seg.distance_nm, 0);
-  return (
-    <div className="flex h-2.5 rounded-full overflow-hidden gap-[1px]" role="progressbar">
-      {segments.map((seg, i) => (
-        <div
-          key={i}
-          style={{
-            width: `${(seg.distance_nm / total) * 100}%`,
-            background: CX_COLORS[cxLevel(seg.tws_kn)],
-            minWidth: 2,
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-// ── SegmentLegend ─────────────────────────────────────────────────────────────
-
-function SegmentLegend() {
-  const items: [number, string][] = [
-    [1, "< 10 kn"], [2, "10–15"], [3, "15–20"], [4, "20–25"], [5, "> 25"],
-  ];
-  return (
-    <div className="hidden lg:flex items-center gap-2 text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
-      {items.map(([lvl, label]) => (
-        <div key={lvl} className="flex items-center gap-1">
-          <span className="w-2.5 h-2.5 rounded-sm" style={{ background: CX_COLORS[lvl] }} />
-          {label}
-        </div>
-      ))}
-    </div>
-  );
-}
-
 // ── ArchetypeSelector ─────────────────────────────────────────────────────────
 
 function ArchetypeSelector({
@@ -689,6 +629,21 @@ export function PlanSidebar({
     ? validateSweep(sweepEarliest, sweepLatest, sweepIntervalHours)
     : { ok: true } as SweepValidation;
   const canCalculate = waypointCount >= 2 && (mode === "single" || sweepValid.ok);
+  const [hasChosenMode, markChosen] = useHasChosenMode();
+  const [isEditingParams, setIsEditingParams] = useState(false);
+
+  // Wrap the parent handler so picking via tabs ALSO dismisses the picker on
+  // future visits. Same effect when the user clicks one of the big cards.
+  const handleModeChange = (m: PlanMode) => {
+    markChosen();
+    onModeChange(m);
+  };
+
+  // Show the mode picker when: 2+ waypoints placed, user has never chosen a
+  // mode in this browser, and no result is showing yet (single passage or
+  // compare windows). After first choice it gets out of the way for good.
+  const showModePicker =
+    waypointCount >= 2 && !hasChosenMode && !passage && !(windows && windows.length > 0);
 
   if (isLoading) {
     return (
@@ -707,7 +662,8 @@ export function PlanSidebar({
   if (error) {
     return (
       <div className="p-4">
-        <div className="rounded-xl p-4 text-sm" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)", border: "1px solid var(--ow-err-line)" }}>
+        <ModeToggle value={mode} onChange={handleModeChange} locked={waypointCount < 2} />
+        <div className="mt-4 rounded-xl p-4 text-sm" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)", border: "1px solid var(--ow-err-line)" }}>
           <p className="font-semibold mb-1">Erreur</p>
           <p className="leading-relaxed">{error}</p>
         </div>
@@ -715,16 +671,34 @@ export function PlanSidebar({
     );
   }
 
-  // In compare mode we always show the form + (optional) windows table,
-  // even if a single-mode `passage` is also in memory. That way toggling
-  // back to single shows the cached single result without a re-fetch.
-  if (mode === "compare" || !passage || !complexity) {
+  // ── Empty state: no waypoints yet ─────────────────────────────────────────
+  if (waypointCount < 2) {
+    return (
+      <div className="p-4 animate-fade-in">
+        <ModeToggle value={mode} onChange={handleModeChange} locked />
+        <EmptyState />
+      </div>
+    );
+  }
+
+  // ── Mode picker: 2+ waypoints, no choice yet ──────────────────────────────
+  if (showModePicker) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
-        {/* Mode toggle */}
-        <ModeToggle value={mode} onChange={onModeChange} />
+        <ModeToggle value={mode} onChange={handleModeChange} locked />
+        <ModePicker onPick={handleModeChange} />
+      </div>
+    );
+  }
 
-        {/* Departure (single) or sweep form (compare) */}
+  // ── Form state (compare always; single before any result) ─────────────────
+  if (mode === "compare" || !passage || !complexity) {
+    const accent = mode === "compare" ? "#F4C25C" : "var(--ow-accent)";
+    const ctaInk = mode === "compare" ? "#3a2a08" : "#fff";
+    return (
+      <div className="p-4 space-y-4 animate-fade-in">
+        <ModeToggle value={mode} onChange={handleModeChange} />
+
         {mode === "single" ? (
           <div className="space-y-2">
             <TimeAnchorToggle value={timeAnchor} onChange={onTimeAnchorChange} />
@@ -746,21 +720,19 @@ export function PlanSidebar({
           />
         )}
 
-        {/* Archetype */}
         <ArchetypeSelector
           currentSlug={currentArchetypeSlug}
           archetypes={archetypes}
           onChange={onArchetypeChange}
         />
 
-        {/* Calculate button */}
         <button
           onClick={mode === "single" ? onRefetch : onCompareFetch}
           disabled={!canCalculate}
           className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold transition-all"
           style={{
-            background: canCalculate ? "var(--ow-accent)" : "var(--ow-bg-2)",
-            color: canCalculate ? "#fff" : "var(--ow-fg-3)",
+            background: canCalculate ? accent : "var(--ow-bg-2)",
+            color: canCalculate ? ctaInk : "var(--ow-fg-3)",
             border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line-2)"}`,
             cursor: canCalculate ? "pointer" : "not-allowed",
           }}
@@ -773,14 +745,10 @@ export function PlanSidebar({
             : `${waypointCount}/2 waypoints`}
         </button>
 
-        {/* Windows table — shown after a successful compare-mode fetch */}
         {mode === "compare" && windows && windows.length > 0 && (
           <div className="space-y-2">
             {metaWarnings.map((m, i) => (
-              <p key={i} className="text-[11px] rounded-lg px-3 py-1.5"
-                 style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)" }}>
-                {m}
-              </p>
+              <Warn key={i}>{m}</Warn>
             ))}
             <div className="rounded-xl overflow-hidden border" style={{ borderColor: "var(--ow-line)" }}>
               <WindowsTable windows={windows} onSelect={onWindowSelect} />
@@ -794,109 +762,84 @@ export function PlanSidebar({
     );
   }
 
+  // ── Filled state: single mode with a result ───────────────────────────────
   const hasWarnings = (complexity.warnings?.length ?? 0) > 0 || passage.warnings.length > 0;
+  const recapDate = new Date(departure).toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
+  const recapTime = new Date(departure).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+  const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
+  const archetypeLabel = archetype?.name ?? currentArchetypeSlug;
 
   return (
-    <div className="p-4 space-y-4 animate-fade-in">
-      {/* Mode toggle — always visible so the user can switch back to compare */}
-      <ModeToggle value={mode} onChange={onModeChange} />
-
-      {/* Recalculate — grows when stale */}
-      <button
-        onClick={onRefetch}
-        className={`w-full flex items-center justify-center gap-2 rounded-xl font-bold transition-all ${isStale ? "py-3 text-base" : "py-1.5 text-xs"}`}
-        style={{
-          background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
-          color: isStale ? "#fff" : "var(--ow-fg-2)",
-          border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
-        }}
-      >
-        <svg width={isStale ? 16 : 12} height={isStale ? 16 : 12} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M13.5 2.5A7 7 0 1 0 14.5 9"/><path d="M14 1v4h-4"/>
-        </svg>
-        Recalculer
-      </button>
-
-      {/* Time anchor + slider — both editable in the result view too. */}
-      <TimeAnchorToggle value={timeAnchor} onChange={onTimeAnchorChange} />
-      <DepartureSlider
-        value={departure}
-        onChange={onDepartureChange}
-        resolvedTheme={resolvedTheme}
-        anchor={timeAnchor}
-      />
-
-      {/* Archetype dropdown */}
-      <ArchetypeSelector
-        currentSlug={currentArchetypeSlug}
-        archetypes={archetypes}
-        onChange={onArchetypeChange}
-      />
-
-      {/* Stats grid */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
-        {[
-          { label: "Distance", value: `${passage.distance_nm.toFixed(1)} nm` },
-          { label: "Durée", value: fmtDuration(passage.duration_h) },
-          { label: "Arrivée", value: fmtTime(passage.arrival_time) },
-        ].map(({ label, value }) => (
-          <div key={label} className="rounded-xl p-3" style={{ background: "var(--ow-bg-2)" }}>
-            <p className="text-[9px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>{label}</p>
-            <p className="text-sm font-bold tabular-nums" style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>{value}</p>
-          </div>
-        ))}
-        <div className="rounded-xl p-3" style={{ background: "var(--ow-bg-2)" }}>
-          <p className="text-[9px] uppercase tracking-widest mb-1 font-semibold" style={{ color: "var(--ow-fg-2)" }}>Complexité</p>
-          <p className="text-sm font-bold" style={{ color: CX_COLORS[complexity.level], fontFamily: "var(--ow-font-mono)" }}>
-            {complexity.level}/5 — {complexity.label}
-          </p>
-        </div>
+    <div className="animate-fade-in">
+      {/* Mode tabs */}
+      <div className="px-4 pt-4 pb-3" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+        <ModeToggle value={mode} onChange={handleModeChange} />
       </div>
 
-      {/* Complexity bar */}
-      <div className="space-y-1.5">
-        <ComplexityBar segments={passage.segments} />
-        <SegmentLegend />
+      {/* Recalculer bar */}
+      <div className="px-4 py-2.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+        <button
+          onClick={onRefetch}
+          className="w-full flex items-center justify-center gap-2 rounded-md py-1.5 text-xs font-semibold transition-all"
+          style={{
+            background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
+            color: isStale ? "#fff" : "var(--ow-fg-1)",
+            border: `1px solid ${isStale ? "transparent" : "var(--ow-line)"}`,
+          }}
+        >
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M13.5 2.5A7 7 0 1 0 14.5 9" /><path d="M14 1v4h-4" />
+          </svg>
+          {isStale ? "Recalculer" : "Recalculer"}
+        </button>
       </div>
 
-      {/* Complexity badge */}
-      <ComplexityBadge level={complexity.level} label={complexity.label} />
-
-      {/* Warnings */}
-      {hasWarnings && (
-        <div className="space-y-1.5">
-          {complexity.warnings?.map((w, i) => (
-            <div key={i} className="flex items-start gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)", border: "1px solid var(--ow-warn-line)" }}>
-              <span className="shrink-0 mt-0.5">⚠</span>
-              <span>{w.message}</span>
-            </div>
-          ))}
-          {passage.warnings.map((w, i) => (
-            <div key={`pw-${i}`} className="flex items-start gap-2 rounded-lg px-3 py-2 text-xs" style={{ background: "var(--ow-warn-soft)", color: "var(--ow-warn)", border: "1px solid var(--ow-warn-line)" }}>
-              <span className="shrink-0 mt-0.5">⚠</span>
-              <span>{w}</span>
-            </div>
-          ))}
+      {/* Récap compact: click to edit departure / archetype inline */}
+      <RecapButton
+        primary={`${recapDate.charAt(0).toUpperCase() + recapDate.slice(1)} · ${recapTime}`}
+        secondary={archetypeLabel}
+        isOpen={isEditingParams}
+        onClick={() => setIsEditingParams((v) => !v)}
+      />
+      {isEditingParams && (
+        <div className="px-4 py-3 space-y-3" style={{ borderBottom: "1px solid var(--ow-line)", background: "var(--ow-bg-2)" }}>
+          <TimeAnchorToggle value={timeAnchor} onChange={onTimeAnchorChange} />
+          <DepartureSlider
+            value={departure}
+            onChange={onDepartureChange}
+            resolvedTheme={resolvedTheme}
+            anchor={timeAnchor}
+          />
+          <ArchetypeSelector
+            currentSlug={currentArchetypeSlug}
+            archetypes={archetypes}
+            onChange={onArchetypeChange}
+          />
         </div>
       )}
 
-      {/* Legs — click any row to see the "Comment c'est calculé" build-up */}
+      {/* Hero stats + segment bar */}
+      <div className="px-4 py-3.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+        <HeroStats passage={passage} complexity={complexity} />
+      </div>
+
+      {/* Warnings */}
+      {hasWarnings && (
+        <div className="px-4 py-2.5 space-y-1.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+          {complexity.warnings?.map((w, i) => <Warn key={i}>{w.message}</Warn>)}
+          {passage.warnings.map((w, i) => <Warn key={`pw-${i}`}>{w}</Warn>)}
+        </div>
+      )}
+
+      {/* Legs — click any row to see the build-up */}
       {(() => {
         const legs = aggregateLegs(passage.segments, waypoints, passage.efficiency);
-        const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
-        const archetypeLabel = archetype?.name ?? currentArchetypeSlug;
-        // LegList has its own padding; cancel the page's px-4 so the rows
-        // stretch edge-to-edge like the design.
-        return (
-          <div className="-mx-4">
-            <LegList legs={legs} archetypeLabel={archetypeLabel} />
-          </div>
-        );
+        return <LegList legs={legs} archetypeLabel={archetypeLabel} />;
       })()}
 
       {/* Footer */}
       {forecastUpdatedAt && (
-        <p className="text-[10px] pt-1 border-t" style={{ color: "var(--ow-fg-2)", borderColor: "var(--ow-line)" }}>
+        <p className="px-4 py-2 text-[10px]" style={{ color: "var(--ow-fg-2)", borderTop: "1px solid var(--ow-line)" }}>
           Données fraîches au {new Date(forecastUpdatedAt).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })} · Open-Meteo.com (CC BY 4.0)
         </p>
       )}

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -1,0 +1,342 @@
+// Visual building blocks for the /plan right panel — keeps PlanSidebar.tsx
+// focused on state wiring while these components stay design-only.
+
+import type { ComplexityScore, PassageReport, SegmentReport } from "./types";
+import { CX_COLORS, cxLevel } from "./types";
+
+// ── EmptyState ────────────────────────────────────────────────────────────────
+// Shown when fewer than 2 waypoints are placed: invites the user to draw a
+// route on the map. The mode tabs above are dimmed (locked) until placement.
+
+export function RouteSketch() {
+  return (
+    <svg viewBox="0 0 280 100" className="w-full" style={{ maxHeight: 110 }} aria-hidden="true">
+      <defs>
+        <pattern id="ow-dots-bg" width="8" height="8" patternUnits="userSpaceOnUse">
+          <circle cx="1" cy="1" r="0.6" fill="var(--ow-line-2)" />
+        </pattern>
+      </defs>
+      <rect width="280" height="100" fill="url(#ow-dots-bg)" opacity="0.6" />
+      <path
+        d="M30 70 Q 90 30 150 50 T 250 30"
+        stroke="var(--ow-accent)"
+        strokeWidth="2"
+        fill="none"
+        strokeDasharray="4 4"
+      />
+      <circle cx="30" cy="70" r="6" fill="var(--ow-accent)" stroke="var(--ow-bg-1)" strokeWidth="2" />
+      <circle cx="250" cy="30" r="6" fill="#FF7A59" stroke="var(--ow-bg-1)" strokeWidth="2" />
+      <text x="30" y="88" fontSize="9" fill="var(--ow-fg-2)" fontFamily="var(--ow-font-mono)" textAnchor="middle">A</text>
+      <text x="250" y="14" fontSize="9" fill="var(--ow-fg-2)" fontFamily="var(--ow-font-mono)" textAnchor="middle">B</text>
+    </svg>
+  );
+}
+
+export function EmptyState() {
+  return (
+    <div className="px-2 py-6 flex flex-col gap-4">
+      <RouteSketch />
+      <div>
+        <div
+          className="text-base font-semibold mb-1.5 leading-snug"
+          style={{ color: "var(--ow-fg-0)", letterSpacing: "-0.01em" }}
+        >
+          Tracez votre trajet
+        </div>
+        <div className="text-xs leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>
+          Cliquez sur la carte pour placer un départ et une arrivée. Vous pourrez ensuite simuler le temps du trajet ou comparer plusieurs créneaux de départ.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── ModePicker ────────────────────────────────────────────────────────────────
+// Once 2 waypoints are placed and no mode has been chosen yet (first-time
+// flow), surface the 2 big "narrative" cards rather than the bare tab toggle.
+
+function PickerIcon({ name, color }: { name: "route" | "clock"; color: string }) {
+  if (name === "clock") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="8" cy="8" r="6.5" />
+        <path d="M8 4.5V8l2.5 1.5" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 12c2-4 5-1 7-3 1-1 2-3 3-3" />
+      <circle cx="3" cy="12" r="1.5" fill={color} stroke="none" />
+      <circle cx="13" cy="6" r="1.5" fill={color} stroke="none" />
+    </svg>
+  );
+}
+
+function BigCard({
+  icon,
+  accent,
+  title,
+  body,
+  example,
+  onClick,
+}: {
+  icon: "route" | "clock";
+  accent: string;
+  title: string;
+  body: string;
+  example: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-xl px-4 py-3.5 transition-all"
+      style={{ background: "var(--ow-bg-2)", border: "1px solid var(--ow-line)" }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        <span
+          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
+          style={{ background: accent, color: "#0B1A14" }}
+        >
+          <PickerIcon name={icon} color="#0B1A14" />
+        </span>
+        <div
+          className="text-sm font-semibold"
+          style={{ color: "var(--ow-fg-0)", letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </div>
+        <span className="ml-auto" aria-hidden="true">
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--ow-fg-2)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M6 3l5 5-5 5" />
+          </svg>
+        </span>
+      </div>
+      <div className="text-xs leading-relaxed mb-1.5" style={{ color: "var(--ow-fg-1)" }}>
+        {body}
+      </div>
+      <div className="text-[10px] italic" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+        {example}
+      </div>
+    </button>
+  );
+}
+
+export function ModePicker({
+  onPick,
+}: {
+  onPick: (m: "single" | "compare") => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div
+        className="text-base font-semibold"
+        style={{ color: "var(--ow-fg-0)", letterSpacing: "-0.005em" }}
+      >
+        Que voulez-vous faire&nbsp;?
+      </div>
+      <BigCard
+        icon="route"
+        accent="var(--ow-accent)"
+        title="Simuler ma route"
+        body="Vous savez quand partir. OpenWind calcule le temps du trajet, l'ETA et les conditions sur chaque segment."
+        example="Ex. — « Si je pars samedi 17:00, j'arrive quand ? »"
+        onClick={() => onPick("single")}
+      />
+      <BigCard
+        icon="clock"
+        accent="#F4C25C"
+        title="Comparer les fenêtres"
+        body="Vous savez où aller. OpenWind teste plusieurs heures de départ et classe les créneaux par confort."
+        example="Ex. — « Quel est le meilleur départ entre samedi et lundi ? »"
+        onClick={() => onPick("compare")}
+      />
+    </div>
+  );
+}
+
+// ── HeroStats + SegmentBar ────────────────────────────────────────────────────
+// 4-cell stats row with a segmented complexity bar underneath; matches the
+// design's "Sim filled" header block.
+
+function fmtDuration(h: number): string {
+  const hrs = Math.floor(h);
+  const mins = Math.round((h - hrs) * 60);
+  if (hrs === 0) return `${mins}m`;
+  if (mins === 0) return `${hrs}h`;
+  return `${hrs}h${String(mins).padStart(2, "0")}`;
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function HeroCell({
+  label,
+  value,
+  unit,
+  tone,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  tone?: "warn" | "accent" | "default";
+}) {
+  const color =
+    tone === "warn" ? "var(--ow-warn)" :
+    tone === "accent" ? "var(--ow-accent)" :
+    "var(--ow-fg-0)";
+  return (
+    <div>
+      <div className="text-[9px] uppercase tracking-widest font-bold mb-1" style={{ color: "var(--ow-fg-2)" }}>
+        {label}
+      </div>
+      <div className="flex items-baseline gap-1">
+        <span
+          className="text-xl font-bold tabular-nums"
+          style={{ color, letterSpacing: "-0.02em", lineHeight: 1, fontFamily: "var(--ow-font-mono)" }}
+        >
+          {value}
+        </span>
+        {unit && (
+          <span className="text-[10px]" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+            {unit}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SegmentBar({ segments }: { segments: SegmentReport[] }) {
+  const total = segments.reduce((s, seg) => s + seg.distance_nm, 0);
+  return (
+    <div className="flex h-2 rounded-sm overflow-hidden gap-[1px]" role="progressbar" aria-label="Distribution du vent par segment">
+      {segments.map((seg, i) => (
+        <div
+          key={i}
+          style={{
+            width: `${(seg.distance_nm / total) * 100}%`,
+            background: CX_COLORS[cxLevel(seg.tws_kn)],
+            minWidth: 2,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function HeroStats({
+  passage,
+  complexity,
+}: {
+  passage: PassageReport;
+  complexity: ComplexityScore;
+}) {
+  return (
+    <div>
+      <div className="grid grid-cols-4 gap-3 mb-3">
+        <HeroCell label="Distance" value={passage.distance_nm.toFixed(1)} unit="nm" />
+        <HeroCell label="Durée" value={fmtDuration(passage.duration_h)} />
+        <HeroCell label="Arrivée" value={fmtTime(passage.arrival_time)} />
+        <HeroCell
+          label="Cplx"
+          value={String(complexity.level)}
+          unit="/5"
+          tone={complexity.level >= 4 ? "warn" : "default"}
+        />
+      </div>
+      <SegmentBar segments={passage.segments} />
+      <div
+        className="flex justify-between mt-1.5 text-[9px] tabular-nums"
+        style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        <span>&lt;10 · 10–15 · 15–20 · 20–25 · &gt;25 kn</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Warn ──────────────────────────────────────────────────────────────────────
+// Single-line warning row matching the design's "Warn" component (alert icon
+// + soft warn background).
+
+export function Warn({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[11px] leading-tight"
+      style={{
+        background: "var(--ow-warn-soft)",
+        border: "1px solid var(--ow-warn-line)",
+        color: "var(--ow-fg-1)",
+      }}
+    >
+      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="var(--ow-warn)" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+        <path d="M8 2 14 13H2z" />
+        <path d="M8 7v3" />
+        <circle cx="8" cy="12" r="0.5" fill="var(--ow-warn)" />
+      </svg>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+// ── RecapButton ───────────────────────────────────────────────────────────────
+// Compact summary of the active form (departure time / archetype) with a
+// "Modifier" affordance. Click toggles the inline editor below.
+
+export function RecapButton({
+  primary,
+  secondary,
+  isOpen,
+  onClick,
+}: {
+  primary: string;
+  secondary: string;
+  isOpen: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-2.5 px-4 py-2.5 transition-colors"
+      style={{
+        background: "var(--ow-bg-2)",
+        borderTop: "1px solid var(--ow-line)",
+        borderBottom: "1px solid var(--ow-line)",
+        textAlign: "left",
+      }}
+      aria-expanded={isOpen}
+    >
+      <span
+        className="text-xs font-bold tabular-nums"
+        style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        {primary}
+      </span>
+      <span className="text-[10px]" style={{ color: "var(--ow-fg-3)" }}>·</span>
+      <span className="text-[11px] font-medium" style={{ color: "var(--ow-fg-1)" }}>
+        {secondary}
+      </span>
+      <span className="ml-auto flex items-center gap-1 text-[10px] font-semibold" style={{ color: "var(--ow-fg-1)" }}>
+        {isOpen ? "Fermer" : "Modifier"}
+        <svg
+          width="9"
+          height="9"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ transform: isOpen ? "rotate(180deg)" : "none", transition: "transform 150ms ease" }}
+        >
+          <path d="M3 6l5 5 5-5" />
+        </svg>
+      </span>
+    </button>
+  );
+}

--- a/packages/web/src/plan/useChosenMode.ts
+++ b/packages/web/src/plan/useChosenMode.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+const KEY = "openwind:plan:hasChosenMode";
+
+// Tracks whether the user has explicitly picked a mode at least once
+// (Simuler / Comparer). Used to show the mode-picker cards on first visit
+// only — once a choice has been made, the regular form takes over.
+
+export function useHasChosenMode(): [boolean, () => void] {
+  const [chosen, setChosen] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    if (!chosen) return;
+    try {
+      window.localStorage.setItem(KEY, "true");
+    } catch {
+      // ignore (private mode, full storage)
+    }
+  }, [chosen]);
+
+  return [chosen, () => setChosen(true)];
+}


### PR DESCRIPTION
## Summary

Suite de #98 (mergée) pour finir la refonte de l'onglet droit `/plan`. Apporte les 6 morceaux du design qui avaient été sous-scopés dans la première passe.

| Élément | Fichier | Statut |
|---|---|---|
| Empty state (sketch + invite) | `PlanStates.tsx::EmptyState` | ✅ |
| Mode picker (2 grandes cartes) | `PlanStates.tsx::ModePicker` | ✅ first-visit, localStorage flag |
| Récap compact + Modifier | `PlanStates.tsx::RecapButton` | ✅ collapsible inline editor |
| Recalculer bar | `PlanSidebar.tsx` filled view | ✅ accent quand stale |
| Hero stats 4-col + segment bar | `PlanStates.tsx::HeroStats` | ✅ |
| Warnings stylés | `PlanStates.tsx::Warn` | ✅ alert icon + warn-soft |

## Flux d'états

```
waypointCount < 2          → ModeTabs locked + EmptyState
waypointCount ≥ 2 + first  → ModeTabs locked + ModePicker (2 cartes)
mode = compare OU !passage → ModeTabs + form (slider/sweep) + CTA accent
mode = single + passage    → ModeTabs + Recalculer + RécapButton + HeroStats + Warnings + LegList + footer
```

## Comportement nouveau

- **Mode picker first-time** : flag `openwind:plan:hasChosenMode` en localStorage. Une fois cliqué (carte ou onglet), le picker disparaît pour toujours sur ce navigateur.
- **Récap compact collapsible** : la date + bateau apparaissent dans un bandeau cliquable. Click → l'éditeur inline (slider, time anchor, archetype) se déplie. Re-click → se referme. Évite d'avoir le slider plein-format en permanence quand on consulte les résultats.
- **CTA per-mode color** : le bouton « Calculer le passage » est cyan en mode Simuler, le bouton « Comparer les créneaux » est jaune-amber en mode Comparer (cohérent avec les onglets).

## Hors scope

- App.tsx / explore inchangés (page initiale, demande explicite)
- Header mobile inchangé (demande explicite)
- CompactDrawer mobile : conserve l'apparence existante (le design a sa propre bottom-sheet progressive qu'on n'a pas encore implémentée)
- Pas de changement backend / MCP — purement frontend

## Test plan

- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `npm run build` OK (459 kB / 60 kB CSS — +5 kB JS pour les nouveaux composants)
- [x] `eslint src/plan/` : seules erreurs pré-existantes (validateSweep export, WindowsTable dynamic components — pas miennes)
- [ ] Vérif visuelle : tracer 0 → 1 → 2 waypoints, le panneau passe de Empty → Mode picker
- [ ] Vérif visuelle : cliquer une carte → flag set, picker ne réapparaît plus, on passe au form
- [ ] Vérif visuelle : calculer un passage → filled view avec récap + hero + segment bar
- [ ] Vérif visuelle : cliquer le récap « Modifier » → slider + archetype apparaissent en dessous
- [ ] Vérif visuelle : passer en mode compare → CTA jaune
- [ ] Vérif visuelle : tronçon cliqué → carte build-up se déploie (régression check vs #98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)