### PR TITLE
feat(web): /plan boat compass + mobile parity + diagram polish

### DIFF
--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -1,14 +1,13 @@
-import { useEffect, useState } from "react";
 import type { Spot } from "../types";
 import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";
-import { InfoPanel } from "./InfoPanel";
+import { InfoButton } from "./InfoButton";
 
 
 interface HeaderProps {
   onSelectSpot: (spot: Spot) => void;
-  canSave: boolean;
-  onSave: () => void;
+  canSave?: boolean;
+  onSave?: () => void;
 }
 
 function WindIcon() {
@@ -21,114 +20,34 @@ function WindIcon() {
   );
 }
 
-function InfoIcon() {
+export function Header({ onSelectSpot, canSave = false, onSave }: HeaderProps) {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="16" x2="12" y2="12" />
-      <line x1="12" y1="8" x2="12.01" y2="8" />
-    </svg>
-  );
-}
-
-function InfoModal({ onClose }: { onClose: () => void }) {
-  // Close on Escape; restore body scroll on unmount.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      document.body.style.overflow = prevOverflow;
-    };
-  }, [onClose]);
-
-  return (
-    <div
-      className="fixed inset-0 z-[1000] flex items-end lg:items-center justify-center animate-fade-in"
-      onClick={onClose}
-      style={{ background: "rgba(0,0,0,0.6)" }}
-      role="dialog"
-      aria-modal="true"
-      aria-label="À propos d'OpenWind"
+    <header
+      className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6"
+      style={{ background: 'var(--ow-surface-glass)', borderBottom: '1px solid var(--ow-accent-line)' }}
     >
-      <div
-        className="relative w-full lg:max-w-2xl max-h-[92vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          background: "var(--ow-bg-0)",
-          border: "1px solid var(--ow-line)",
-        }}
-      >
-        <button
-          onClick={onClose}
-          aria-label="Fermer"
-          className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center text-base font-semibold transition-colors"
-          style={{
-            background: "var(--ow-bg-1)",
-            color: "var(--ow-fg-1)",
-            border: "1px solid var(--ow-line)",
-          }}
-        >
-          ✕
-        </button>
-        <InfoPanel />
-      </div>
-    </div>
-  );
-}
-
-export function Header({
-  onSelectSpot,
-  canSave,
-  onSave,
-}: HeaderProps) {
-  const [showInfo, setShowInfo] = useState(false);
-  return (
-    <>
-      <header
-        className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6"
-        style={{ background: 'var(--ow-surface-glass)', borderBottom: '1px solid var(--ow-accent-line)' }}
-      >
-        <div className="flex items-center gap-3 max-w-screen-2xl mx-auto">
-          <div className="flex items-center gap-2 shrink-0">
-            <WindIcon />
-            <h1 className="hidden sm:block text-xl font-extrabold tracking-tight">
-              <span style={{ color: 'var(--ow-fg-0)' }}>Open</span>
-              <span style={{ color: 'var(--ow-accent)' }}>Wind</span>
-            </h1>
-          </div>
-          <div className="flex-1 flex justify-center">
-            <SpotSearch onSelect={onSelectSpot} />
-          </div>
-          {canSave && (
-            <button
-              onClick={onSave}
-              className="shrink-0 min-h-[44px] px-4 rounded-xl bg-teal-500/15 text-teal-300 text-sm font-semibold hover:bg-teal-500/25 active:bg-teal-500/35 active:scale-95 transition-all whitespace-nowrap border border-teal-500/30"
-            >
-              + Save
-            </button>
-          )}
-          <button
-            onClick={() => setShowInfo(true)}
-            aria-label="À propos d'OpenWind"
-            title="À propos"
-            className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 active:scale-95"
-            style={{
-              background: 'var(--ow-accent-soft)',
-              color: 'var(--ow-accent)',
-              border: '1px solid var(--ow-accent-line)',
-            }}
-          >
-            <InfoIcon />
-          </button>
-          <ThemeToggle />
+      <div className="flex items-center gap-3 max-w-screen-2xl mx-auto">
+        <div className="flex items-center gap-2 shrink-0">
+          <WindIcon />
+          <h1 className="hidden sm:block text-xl font-extrabold tracking-tight">
+            <span style={{ color: 'var(--ow-fg-0)' }}>Open</span>
+            <span style={{ color: 'var(--ow-accent)' }}>Wind</span>
+          </h1>
         </div>
-      </header>
-      {showInfo && <InfoModal onClose={() => setShowInfo(false)} />}
-    </>
+        <div className="flex-1 flex justify-center">
+          <SpotSearch onSelect={onSelectSpot} />
+        </div>
+        {canSave && (
+          <button
+            onClick={onSave}
+            className="shrink-0 min-h-[44px] px-4 rounded-xl bg-teal-500/15 text-teal-300 text-sm font-semibold hover:bg-teal-500/25 active:bg-teal-500/35 active:scale-95 transition-all whitespace-nowrap border border-teal-500/30"
+          >
+            + Save
+          </button>
+        )}
+        <InfoButton />
+        <ThemeToggle />
+      </div>
+    </header>
   );
 }

--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { InfoPanel } from "./InfoPanel";
+
+function InfoIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="11" x2="12" y2="17" />
+      <line x1="12" y1="7" x2="12.01" y2="7" />
+    </svg>
+  );
+}
+
+function InfoModal({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[1000] flex items-end lg:items-center justify-center animate-fade-in"
+      onClick={onClose}
+      style={{ background: "rgba(0,0,0,0.6)" }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="À propos d'OpenWind"
+    >
+      <div
+        className="relative w-full lg:max-w-2xl max-h-[92vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--ow-bg-0)",
+          border: "1px solid var(--ow-line)",
+        }}
+      >
+        <button
+          onClick={onClose}
+          aria-label="Fermer"
+          className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center text-base font-semibold transition-colors"
+          style={{
+            background: "var(--ow-bg-1)",
+            color: "var(--ow-fg-1)",
+            border: "1px solid var(--ow-line)",
+          }}
+        >
+          ✕
+        </button>
+        <InfoPanel />
+      </div>
+    </div>
+  );
+}
+
+export function InfoButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="À propos d'OpenWind"
+        title="À propos"
+        className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 active:scale-95"
+        style={{
+          background: "var(--ow-accent-soft)",
+          color: "var(--ow-accent)",
+          border: "1px solid var(--ow-accent-line)",
+        }}
+      >
+        <InfoIcon />
+      </button>
+      {open && <InfoModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -78,6 +78,20 @@ export function InfoPanel() {
             (SMOC pour les courants), CC BY 4.0
           </li>
           <li>
+            Atlas haute résolution courants &amp; marée (Atlantique, passes
+            critiques) :{" "}
+            <a
+              href="https://marc.ifremer.fr/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+              style={{ color: "var(--ow-accent)" }}
+            >
+              IFREMER MARC PREVIMER
+            </a>{" "}
+            (250 m / 2 km)
+          </li>
+          <li>
             Cartographie :{" "}
             <a
               href="https://www.openstreetmap.org/"

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -218,29 +218,6 @@ function CardinalMarkers() {
   );
 }
 
-function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" | "windDouble" | "wave"; label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1.5 text-[10px]" style={{ color: "var(--ow-fg-1)" }}>
-      {swatch === "windDouble" ? (
-        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
-          <line x1="2" y1="3" x2="13" y2="3" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
-          <line x1="2" y1="7" x2="13" y2="7" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
-          <path d="M 13 1 L 18 5 L 13 9" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      ) : swatch === "arrow" ? (
-        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
-          <line x1="2" y1="5" x2="14" y2="5" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
-          <path d="M 11 2 L 16 5 L 11 8" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      ) : (
-        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
-          <path d="M 1 5 Q 5 1 9 5 T 17 5" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />
-        </svg>
-      )}
-      <span>{label}</span>
-    </span>
-  );
-}
 
 // ── Main component ────────────────────────────────────────────────────────────
 export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
@@ -353,34 +330,42 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
           {/* Wind arrow (double-shaft, distinctive) */}
           <WindArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} />
 
-          {/* Wind label at wind direction */}
+          {/* Wind label — caption above the value, same color & font as the arrow */}
           <text
             x={windLx + windLabel.dx}
-            y={windLy}
+            y={windLy - 7}
             textAnchor={windLabel.anchor}
             dominantBaseline="middle"
-            fontSize="12"
             fill={COLORS.wind}
-            style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
+            style={{ fontFamily: "var(--ow-font-mono)" }}
           >
-            {windLine}
+            <tspan fontSize="9" fontWeight="500">
+              {leg.gust_max_kn != null && leg.gust_max_kn > tws + 1 ? "Vent (rafales)" : "Vent"}
+            </tspan>
+            <tspan x={windLx + windLabel.dx} dy="13" fontSize="12" fontWeight="700">
+              {windLine}
+            </tspan>
           </text>
 
           {/* Waves wavy line at wave direction (offset 30° from wind so they
-              never share a shaft), with its own label */}
+              never share a shaft), with its own captioned label */}
           {hasWaves && (
             <>
               <WaveMark angleDeg={waveAngle} color={COLORS.waves} />
               <text
                 x={waveLx + waveLabel.dx}
-                y={waveLy}
+                y={waveLy - 7}
                 textAnchor={waveLabel.anchor}
                 dominantBaseline="middle"
-                fontSize="12"
                 fill={COLORS.waves}
-                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
+                style={{ fontFamily: "var(--ow-font-mono)" }}
               >
-                {waveLine}
+                <tspan fontSize="9" fontWeight="500">
+                  {leg.tp_avg_s != null ? "Hauteur vagues (période)" : "Hauteur vagues"}
+                </tspan>
+                <tspan x={waveLx + waveLabel.dx} dy="13" fontSize="12" fontWeight="700">
+                  {waveLine}
+                </tspan>
               </text>
             </>
           )}
@@ -391,27 +376,20 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
               <CurrentFlowField flowAngleDeg={currentAngle} color={currentColor} />
               <text
                 x={curLx + curLabel.dx}
-                y={curLy}
+                y={curLy - 7}
                 textAnchor={curLabel.anchor}
                 dominantBaseline="middle"
-                fontSize="12"
                 fill={currentColor}
-                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
+                style={{ fontFamily: "var(--ow-font-mono)" }}
               >
-                {leg.current_speed_kn?.toFixed(1) ?? "—"} kn
+                <tspan fontSize="9" fontWeight="500">Courant</tspan>
+                <tspan x={curLx + curLabel.dx} dy="13" fontSize="12" fontWeight="700">
+                  {leg.current_speed_kn != null ? `${leg.current_speed_kn.toFixed(1).replace(".", ",")} kn` : "— kn"}
+                </tspan>
               </text>
             </>
           )}
         </svg>
-      </div>
-
-      {/* Color legend — only the forces we're drawing */}
-      <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center mt-1 mb-1">
-        <LegendItem color={COLORS.wind} swatch="windDouble" label="Vent" />
-        {hasWaves && <LegendItem color={COLORS.waves} swatch="wave" label="Vagues" />}
-        {currentAngle != null && (
-          <LegendItem color={currentColor} swatch="arrow" label="Courant" />
-        )}
       </div>
     </div>
   );

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,8 +1,7 @@
 import type { AggregatedLeg } from "./aggregateLegs";
 
-// "Comment c'est calculé" — expanded leg detail. Layout:
-//   1. Build-up of the target speed: polar → wave penalty → current → target
-//   2. Four mini-tiles: polar pose, observed wind, sea sensitivity, current
+// "Comment c'est calculé" — expanded leg detail. The card lays out the speed
+// build-up that flows: polar (× efficiency) − wave penalty + current = target.
 // Numbers come from `aggregateLegs` (segment-level math weighted by distance,
 // so the column sums match the displayed target).
 
@@ -13,27 +12,14 @@ const fmtKn = (kn: number, signed = false): string => {
   return `${sign}${Math.abs(r).toFixed(1)} kn`;
 };
 
-function compass16(deg: number): string {
-  const dirs = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
-  return dirs[Math.round(((deg % 360) + 360) % 360 / 22.5) % 16];
-}
-
-// ── Inline icons (kept tiny, design uses 11px line-art) ────────────────────────
-function Icon({ name, size = 11, color = "currentColor" }: { name: "gauge" | "sail" | "wind" | "alert" | "route"; size?: number; color?: string }) {
-  const stroke = { width: 1.6, color };
-  const common = { width: size, height: size, viewBox: "0 0 16 16", fill: "none", stroke: stroke.color, strokeWidth: stroke.width, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
-  switch (name) {
-    case "gauge":
-      return (<svg {...common}><path d="M3 12a5 5 0 0 1 10 0" /><path d="M8 12 11 8" /><circle cx="8" cy="12" r="0.7" fill={color} /></svg>);
-    case "sail":
-      return (<svg {...common}><path d="M8 2v11" /><path d="M8 2c-2.5 1 -4 5 -4 11h4z" /><path d="M2 14h12" /></svg>);
-    case "wind":
-      return (<svg {...common}><path d="M3 6h7a2 2 0 1 0-2-2" /><path d="M3 10h10a2 2 0 1 1-2 2" /></svg>);
-    case "alert":
-      return (<svg {...common}><path d="M8 2 14 13H2z" /><path d="M8 7v3" /><circle cx="8" cy="12" r="0.5" fill={color} /></svg>);
-    case "route":
-      return (<svg {...common}><path d="M3 12c2-4 5-1 7-3 1-1 2-3 3-3" /><circle cx="3" cy="12" r="1.4" fill={color} stroke="none" /><circle cx="13" cy="6" r="1.4" fill={color} stroke="none" /></svg>);
-  }
+function GaugeIcon({ size = 11, color = "currentColor" }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 12a5 5 0 0 1 10 0" />
+      <path d="M8 12 11 8" />
+      <circle cx="8" cy="12" r="0.7" fill={color} />
+    </svg>
+  );
 }
 
 // ── Build-up rows ─────────────────────────────────────────────────────────────
@@ -74,123 +60,6 @@ function BuildUpRow({
   );
 }
 
-// ── Mini visualizations ───────────────────────────────────────────────────────
-function PolarMini({ twa }: { twa: number }) {
-  const r = 16, cx = 20, cy = 20;
-  // TWA is a relative angle (0..180). Place it on the right hemisphere of a half-circle.
-  const a = Math.min(180, Math.max(0, Math.abs(twa) > 180 ? 360 - Math.abs(twa) : Math.abs(twa)));
-  const angle = ((a - 90) * Math.PI) / 180;
-  const tx = cx + Math.cos(angle) * r;
-  const ty = cy + Math.sin(angle) * r;
-  return (
-    <svg width="40" height="40" viewBox="0 0 40 40" aria-hidden="true">
-      <circle cx={cx} cy={cy} r={r} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" />
-      <path
-        d={`M ${cx} ${cy - r} A ${r} ${r} 0 0 1 ${cx + r} ${cy}`}
-        stroke="var(--ow-accent)"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <line x1={cx} y1={cy} x2={tx} y2={ty} stroke="var(--ow-accent)" strokeWidth="1.5" />
-      <circle cx={tx} cy={ty} r="2.2" fill="var(--ow-accent)" />
-    </svg>
-  );
-}
-
-function CompassArrow({ deg, label }: { deg: number; label: string }) {
-  // True wind direction is "from" — flip to "to" for the arrow tip.
-  return (
-    <div className="flex flex-col items-center gap-0.5">
-      <svg width="26" height="26" viewBox="0 0 26 26" style={{ transform: `rotate(${deg + 180}deg)` }} aria-hidden="true">
-        <line x1="13" y1="5" x2="13" y2="20" stroke="var(--ow-fg-1)" strokeWidth="1.6" strokeLinecap="round" />
-        <path d="M13 5 L9 10 M13 5 L17 10" stroke="var(--ow-fg-1)" strokeWidth="1.6" strokeLinecap="round" fill="none" />
-      </svg>
-      <span className="text-[8px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>{label}</span>
-    </div>
-  );
-}
-
-function WaveMini({ steep }: { steep: boolean }) {
-  // Tighter wavelength when steep (Hs/Tp high) — visual cue, not to scale.
-  const path = steep
-    ? "M0 13 Q 4 4 8 13 T 16 13 T 24 13 T 32 13 T 40 13"
-    : "M0 13 Q 6 6 12 13 T 24 13 T 36 13 T 48 13";
-  return (
-    <svg width="40" height="20" viewBox="0 0 40 20" aria-hidden="true">
-      <path d={path} stroke="var(--ow-warn)" strokeWidth="1.5" fill="none" />
-    </svg>
-  );
-}
-
-function CurrentArrow({ relative }: { relative: "portant" | "contraire" | "travers" }) {
-  const color = relative === "portant" ? "var(--ow-ok)" : relative === "contraire" ? "var(--ow-warn)" : "var(--ow-fg-1)";
-  // travers: short side-line; portant: forward arrow; contraire: backward arrow
-  if (relative === "travers") {
-    return (
-      <svg width="40" height="20" viewBox="0 0 40 20" aria-hidden="true">
-        <path d="M2 10 L38 10" stroke={color} strokeWidth="1.5" fill="none" />
-        <path d="M22 6 L18 10 L22 14" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  return (
-    <svg
-      width="40"
-      height="20"
-      viewBox="0 0 40 20"
-      aria-hidden="true"
-      style={{ transform: relative === "contraire" ? "scaleX(-1)" : "none" }}
-    >
-      <path d="M2 10 Q 11 4 22 10 T 40 10" stroke={color} strokeWidth="1.5" fill="none" />
-      <path d="M34 7 L40 10 L34 13" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-// ── Factor tile (the 4 cards) ─────────────────────────────────────────────────
-function FactorTile({
-  icon,
-  title,
-  metric,
-  caption,
-  tone,
-  extra,
-}: {
-  icon: "sail" | "wind" | "alert" | "route";
-  title: string;
-  metric: string;
-  caption: string;
-  tone?: "warn" | "ok";
-  extra?: React.ReactNode;
-}) {
-  const accent = tone === "warn" ? "var(--ow-warn)" : tone === "ok" ? "var(--ow-ok)" : "var(--ow-fg-0)";
-  return (
-    <div
-      className="rounded-lg p-2.5"
-      style={{ background: "var(--ow-bg-1)", border: "1px solid var(--ow-line)" }}
-    >
-      <div className="flex items-center gap-1.5 mb-1.5" style={{ color: "var(--ow-fg-2)" }}>
-        <Icon name={icon} size={11} />
-        <span className="text-[9px] font-bold uppercase tracking-widest">{title}</span>
-      </div>
-      <div className="flex items-end justify-between gap-1.5">
-        <div className="min-w-0">
-          <div
-            className="text-[15px] font-bold tabular-nums leading-none"
-            style={{ color: accent, fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em" }}
-          >
-            {metric}
-          </div>
-          <div className="text-[9px] mt-1 leading-tight" style={{ color: "var(--ow-fg-2)" }}>
-            {caption}
-          </div>
-        </div>
-        {extra && <div className="shrink-0">{extra}</div>}
-      </div>
-    </div>
-  );
-}
-
 // ── Main card ─────────────────────────────────────────────────────────────────
 export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; archetypeLabel: string }) {
   const twa = Math.round(Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg));
@@ -200,21 +69,13 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
   // Sea direction relative to the boat (hs_avg_m null → no sea data)
   const seaDir = leg.sea_direction; // "face" | "travers" | "arrière" | null
   const tpStr = leg.tp_avg_s != null ? ` · Tp ${leg.tp_avg_s.toFixed(1)} s` : "";
-  const seaSub = leg.hs_avg_m != null
-    ? `Hs ${leg.hs_avg_m.toFixed(1)} m${tpStr}${seaDir ? ` · de ${seaDir}` : ""}`
-    : "Pas de donnée vagues";
 
-  // Current sub-text
-  const curSub = (() => {
-    if (leg.current_speed_kn == null || leg.current_relative == null) return "Pas de donnée courant";
-    const speed = leg.current_speed_kn.toFixed(1);
-    const rel = leg.current_relative;
-    return `${speed} kn ${rel}`;
-  })();
-  const gustStr = leg.gust_max_kn != null ? `rafales ${Math.round(leg.gust_max_kn)} kn · ` : "";
-
-  // Steepness heuristic: short period for the height = steep mer courte.
-  const steepSea = leg.hs_avg_m != null && leg.tp_avg_s != null && leg.hs_avg_m / leg.tp_avg_s > 0.3;
+  // Wind sub-line: surface gust whenever it's meaningfully above TWS so the
+  // sailor sees the volatility the build-up doesn't otherwise expose.
+  const gustNote =
+    leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
+      ? ` · rafales ${Math.round(leg.gust_max_kn)} kn`
+      : "";
 
   return (
     <div className="px-4 pb-3 pt-1">
@@ -223,13 +84,13 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         className="flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase"
         style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
       >
-        <Icon name="gauge" size={11} color="var(--ow-accent)" />
+        <GaugeIcon size={11} color="var(--ow-accent)" />
         Comment c'est calculé
       </div>
 
       {/* Build-up card */}
       <div
-        className="rounded-lg p-3 mb-2.5"
+        className="rounded-lg p-3"
         style={{ background: "var(--ow-bg-1)", border: "1px solid var(--ow-line)" }}
       >
         <div
@@ -240,7 +101,7 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         </div>
         <BuildUpRow
           label="Polaire bateau"
-          sub={`${archetypeLabel} · TWA ${twa}° / TWS ${tws} kn · efficacité ${effPct}%`}
+          sub={`${archetypeLabel} · TWA ${twa}° / TWS ${tws} kn${gustNote} · efficacité ${effPct}%`}
           value={fmtKn(leg.polar_after_eff_kn, true)}
           tone="base"
         />
@@ -274,40 +135,6 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
           sub="utilisée pour la durée"
           value={fmtKn(leg.target_speed_kn)}
           tone="total"
-        />
-      </div>
-
-      {/* 4 factor tiles */}
-      <div className="grid grid-cols-2 gap-2">
-        <FactorTile
-          icon="sail"
-          title="Finesse bateau"
-          metric={`${leg.polar_after_eff_kn.toFixed(1)} kn`}
-          caption={`${leg.point_of_sail.toLowerCase()} · TWA ${twa}°`}
-          extra={<PolarMini twa={leg.twa_avg_deg} />}
-        />
-        <FactorTile
-          icon="wind"
-          title="Vent vu"
-          metric={`${tws} kn`}
-          caption={`${gustStr}${leg.point_of_sail.toLowerCase()}`}
-          extra={<CompassArrow deg={leg.twd_avg_deg} label={compass16(leg.twd_avg_deg)} />}
-        />
-        <FactorTile
-          icon="alert"
-          title="Sensibilité vagues"
-          metric={leg.hs_avg_m != null ? fmtKn(leg.wave_delta_kn, true) : "—"}
-          caption={seaSub}
-          tone="warn"
-          extra={leg.hs_avg_m != null ? <WaveMini steep={steepSea} /> : null}
-        />
-        <FactorTile
-          icon="route"
-          title="Courant"
-          metric={leg.current_delta_kn != null ? fmtKn(leg.current_delta_kn, true) : "—"}
-          caption={curSub}
-          tone={leg.current_delta_kn != null && leg.current_delta_kn >= 0 ? "ok" : "warn"}
-          extra={leg.current_relative ? <CurrentArrow relative={leg.current_relative} /> : null}
         />
       </div>
     </div>

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,141 +1,243 @@
 import type { AggregatedLeg } from "./aggregateLegs";
 
-// "Comment c'est calculé" — expanded leg detail. The card lays out the speed
-// build-up that flows: polar (× efficiency) − wave penalty + current = target.
-// Numbers come from `aggregateLegs` (segment-level math weighted by distance,
-// so the column sums match the displayed target).
+// "Comment c'est calculé" — top-down boat compass showing where wind, waves
+// and current come from relative to the boat's heading. The boat sits in the
+// middle pointing up (= its course); each force has a labelled arrow around it.
+//
+// Numbers come from `aggregateLegs` (segment-level math weighted by distance).
 
-const fmtKn = (kn: number, signed = false): string => {
-  const r = Math.abs(kn) < 0.05 ? 0 : kn; // hide tiny rounding flips
-  if (!signed) return `${r.toFixed(1)} kn`;
-  const sign = r > 0 ? "+" : r < 0 ? "−" : "";
-  return `${sign}${Math.abs(r).toFixed(1)} kn`;
-};
+const SIZE = 240;
+const CENTER = SIZE / 2;
+const COMPASS_R = 88;
+const ARROW_TIP_R = 56;   // wind/wave tip closes in toward the boat
+const ARROW_TAIL_R = 86;
+const CURRENT_TAIL_R = 38;
+const CURRENT_TIP_R = 84;
+const LABEL_R = 102;
 
-function GaugeIcon({ size = 11, color = "currentColor" }: { size?: number; color?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 12a5 5 0 0 1 10 0" />
-      <path d="M8 12 11 8" />
-      <circle cx="8" cy="12" r="0.7" fill={color} />
-    </svg>
-  );
+const COMPASS_16 = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"] as const;
+const compass16 = (deg: number): string =>
+  COMPASS_16[Math.round((((deg % 360) + 360) % 360) / 22.5) % 16];
+
+// 0° = up (12 o'clock), increasing clockwise. Returns [x, y] in SVG coords.
+function polarXY(angleDeg: number, r: number): [number, number] {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return [CENTER + Math.cos(rad) * r, CENTER + Math.sin(rad) * r];
 }
 
-// ── Build-up rows ─────────────────────────────────────────────────────────────
-function BuildUpRow({
-  label,
-  sub,
-  value,
-  tone,
+// Anchor a label so it stays readable on either side of the dial.
+function textAnchor(angleDeg: number): "start" | "middle" | "end" {
+  const a = ((angleDeg % 360) + 360) % 360;
+  if (a < 20 || a > 340) return "middle";
+  if (a > 160 && a < 200) return "middle";
+  return a < 180 ? "start" : "end";
+}
+
+function ForceArrow({
+  fromR,
+  toR,
+  angleDeg,
+  color,
+  width = 2,
 }: {
-  label: string;
-  sub: string;
-  value: string;
-  tone: "base" | "pos" | "neg" | "total";
+  fromR: number;
+  toR: number;
+  angleDeg: number;
+  color: string;
+  width?: number;
 }) {
-  const colorMap: Record<typeof tone, string> = {
-    base: "var(--ow-fg-1)",
-    pos: "var(--ow-ok)",
-    neg: "var(--ow-warn)",
-    total: "var(--ow-accent)",
-  };
+  const [x1, y1] = polarXY(angleDeg, fromR);
+  const [x2, y2] = polarXY(angleDeg, toR);
+  // Build a small arrowhead at (x2, y2) pointing in the direction (fromR → toR).
+  const dirRad = Math.atan2(y2 - y1, x2 - x1);
+  const head = 7;
+  const wing = 4;
+  const hx1 = x2 - Math.cos(dirRad) * head + Math.sin(dirRad) * wing;
+  const hy1 = y2 - Math.sin(dirRad) * head - Math.cos(dirRad) * wing;
+  const hx2 = x2 - Math.cos(dirRad) * head - Math.sin(dirRad) * wing;
+  const hy2 = y2 - Math.sin(dirRad) * head + Math.cos(dirRad) * wing;
   return (
-    <div className="flex items-center gap-2 mt-1">
-      <div className="flex-1 min-w-0">
-        <div className="text-[11px]" style={{ color: "var(--ow-fg-0)", fontWeight: tone === "total" ? 600 : 500 }}>
-          {label}
-        </div>
-        <div className="text-[9px] mt-0.5" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-          {sub}
-        </div>
-      </div>
-      <span
-        className="text-xs font-semibold tabular-nums"
-        style={{ color: colorMap[tone], fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.01em" }}
-      >
-        {value}
-      </span>
-    </div>
+    <g>
+      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={width} strokeLinecap="round" />
+      <path d={`M ${hx1} ${hy1} L ${x2} ${y2} L ${hx2} ${hy2}`} stroke={color} strokeWidth={width} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+    </g>
   );
 }
 
-// ── Main card ─────────────────────────────────────────────────────────────────
+// A wavy line drawn along the chord at the given angle — visually distinct
+// from straight arrows so the eye knows it's the swell.
+function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
+  const [tipX, tipY] = polarXY(angleDeg, ARROW_TIP_R + 4);
+  const [tailX, tailY] = polarXY(angleDeg, ARROW_TAIL_R - 4);
+  // Build a wavy path between tail and tip with 3 oscillations.
+  const dx = tipX - tailX;
+  const dy = tipY - tailY;
+  const len = Math.hypot(dx, dy);
+  const ux = dx / len, uy = dy / len; // unit along
+  const nx = -uy, ny = ux;            // unit normal
+  const amp = 3;
+  const N = 18;
+  const points: string[] = [];
+  for (let i = 0; i <= N; i++) {
+    const t = i / N;
+    const ax = tailX + ux * len * t;
+    const ay = tailY + uy * len * t;
+    const o = Math.sin(t * Math.PI * 3) * amp;
+    points.push(`${ax + nx * o},${ay + ny * o}`);
+  }
+  return <polyline points={points.join(" ")} stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />;
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; archetypeLabel: string }) {
-  const twa = Math.round(Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg));
+  // Wind: TWA is unsigned (0..180) in our model — show wind on the starboard
+  // side by convention so port/starboard ambiguity doesn't lie about the trim.
+  const twa = Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg);
+  const windAngle = twa; // 0..180, wind comes from this side of the bow
   const tws = Math.round(leg.tws_avg_kn);
-  const effPct = Math.round(leg.efficiency * 100);
-
-  // Sea direction relative to the boat (hs_avg_m null → no sea data)
-  const seaDir = leg.sea_direction; // "face" | "travers" | "arrière" | null
-  const tpStr = leg.tp_avg_s != null ? ` · Tp ${leg.tp_avg_s.toFixed(1)} s` : "";
-
-  // Wind sub-line: surface gust whenever it's meaningfully above TWS so the
-  // sailor sees the volatility the build-up doesn't otherwise expose.
   const gustNote =
     leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
-      ? ` · rafales ${Math.round(leg.gust_max_kn)} kn`
+      ? ` · raf. ${Math.round(leg.gust_max_kn)}`
       : "";
 
+  // Waves: in absence of a propagated wave_direction, assume waves track the
+  // wind (Med wind-wave dominant). Slight offset to visually separate wave
+  // from wind arrows.
+  const waveAngle = windAngle + 4;
+  const hasWaves = leg.hs_avg_m != null;
+
+  // Current: relative direction from boat bow = (current_to - bearing).
+  // The arrow points OUTWARD (current pushes the boat in that direction).
+  let currentAngle: number | null = null;
+  if (leg.current_direction_to_deg != null) {
+    const rel = ((leg.current_direction_to_deg - leg.bearing_avg_deg) % 360 + 360) % 360;
+    currentAngle = rel;
+  }
+  const currentColor =
+    leg.current_relative === "portant" ? "var(--ow-ok)" :
+    leg.current_relative === "contraire" ? "var(--ow-warn)" :
+    "var(--ow-fg-1)";
+
+  // Label positions
+  const [windLx, windLy] = polarXY(windAngle, LABEL_R);
+  const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
+  const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, LABEL_R) : [0, 0];
+
   return (
-    <div className="px-4 pb-3 pt-1">
-      {/* Section label */}
+    <div className="px-4 pb-4 pt-1">
+      {/* Section header */}
       <div
-        className="flex items-center gap-1.5 mb-2.5 text-[10px] font-bold uppercase"
+        className="flex items-center gap-1.5 mb-2 text-[10px] font-bold uppercase"
         style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
       >
-        <GaugeIcon size={11} color="var(--ow-accent)" />
-        Comment c'est calculé
+        <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="8" cy="8" r="6" />
+          <path d="M8 4 L8 8 L11 10" />
+        </svg>
+        Conditions vues du bateau
       </div>
 
-      {/* Build-up card */}
-      <div
-        className="rounded-lg p-3"
-        style={{ background: "var(--ow-bg-1)", border: "1px solid var(--ow-line)" }}
-      >
-        <div
-          className="text-[9px] mb-1.5 font-bold uppercase tracking-widest"
-          style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+      {/* Speed pill */}
+      <div className="flex items-baseline gap-2 mb-2">
+        <span
+          className="text-2xl font-bold tabular-nums"
+          style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
         >
-          Vitesse cible · build-up
-        </div>
-        <BuildUpRow
-          label="Polaire bateau"
-          sub={`${archetypeLabel} · TWA ${twa}° / TWS ${tws} kn${gustNote} · efficacité ${effPct}%`}
-          value={fmtKn(leg.polar_after_eff_kn, true)}
-          tone="base"
-        />
-        {Math.abs(leg.wave_delta_kn) > 0.05 && (
-          <BuildUpRow
-            label="Pénalité vagues"
-            sub={
-              leg.hs_avg_m != null
-                ? `Hs ${leg.hs_avg_m.toFixed(1)} m${tpStr}${seaDir ? ` · de ${seaDir}` : ""}`
-                : "—"
-            }
-            value={fmtKn(leg.wave_delta_kn, true)}
-            tone="neg"
-          />
-        )}
-        {leg.current_delta_kn != null && Math.abs(leg.current_delta_kn) > 0.05 && (
-          <BuildUpRow
-            label="Courant"
-            sub={
-              leg.current_speed_kn != null
-                ? `${leg.current_speed_kn.toFixed(1)} kn ${leg.current_relative ?? ""}`.trim()
-                : "—"
-            }
-            value={fmtKn(leg.current_delta_kn, true)}
-            tone={leg.current_delta_kn >= 0 ? "pos" : "neg"}
-          />
-        )}
-        <div className="h-px my-1.5" style={{ background: "var(--ow-line)" }} />
-        <BuildUpRow
-          label="Cible retenue"
-          sub="utilisée pour la durée"
-          value={fmtKn(leg.target_speed_kn)}
-          tone="total"
-        />
+          {leg.target_speed_kn.toFixed(1)} kn
+        </span>
+        <span className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
+          vitesse cible
+        </span>
+      </div>
+
+      {/* Compass diagram */}
+      <div className="flex justify-center">
+        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} aria-label="Conditions autour du bateau">
+          {/* Outer dashed dial */}
+          <circle cx={CENTER} cy={CENTER} r={COMPASS_R} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" strokeDasharray="2 4" />
+
+          {/* Cap (heading) tick at top */}
+          <line x1={CENTER} y1={CENTER - COMPASS_R - 4} x2={CENTER} y2={CENTER - COMPASS_R + 4} stroke="var(--ow-fg-2)" strokeWidth="1.5" />
+          <text x={CENTER} y={CENTER - COMPASS_R - 8} textAnchor="middle" fontSize="9" fill="var(--ow-fg-2)" style={{ fontFamily: "var(--ow-font-mono)" }}>
+            cap {Math.round(leg.bearing_avg_deg)}°
+          </text>
+
+          {/* Boat hull pointing up */}
+          <g transform={`translate(${CENTER} ${CENTER})`}>
+            <path
+              d="M 0 -28 Q -11 -14 -11 12 Q -11 24 0 30 Q 11 24 11 12 Q 11 -14 0 -28 Z"
+              fill="var(--ow-bg-2)"
+              stroke="var(--ow-fg-0)"
+              strokeWidth="1.6"
+            />
+            {/* centerline */}
+            <line x1="0" y1="-22" x2="0" y2="26" stroke="var(--ow-fg-2)" strokeWidth="0.8" />
+            {/* mast dot */}
+            <circle cx="0" cy="-2" r="2" fill="var(--ow-accent)" />
+          </g>
+
+          {/* Wind arrow: tail on dial, tip near boat (wind comes from the angle) */}
+          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color="var(--ow-fg-0)" />
+          <text
+            x={windLx}
+            y={windLy}
+            textAnchor={textAnchor(windAngle)}
+            dominantBaseline="middle"
+            fontSize="10"
+            fill="var(--ow-fg-0)"
+            style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+          >
+            <tspan>{tws} kn{gustNote}</tspan>
+            <tspan x={windLx} dy="11" fill="var(--ow-fg-2)">{compass16(leg.twd_avg_deg)}</tspan>
+          </text>
+
+          {/* Waves wavy line — same hemisphere as wind, slight angular offset */}
+          {hasWaves && (
+            <>
+              <WaveMark angleDeg={waveAngle} color="var(--ow-warn)" />
+              <text
+                x={waveLx}
+                y={waveLy + 18}
+                textAnchor={textAnchor(waveAngle)}
+                dominantBaseline="middle"
+                fontSize="10"
+                fill="var(--ow-warn)"
+                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+              >
+                <tspan>Hs {leg.hs_avg_m!.toFixed(1)} m</tspan>
+                <tspan x={waveLx} dy="11" fill="var(--ow-fg-2)" fontWeight="500">
+                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : "—"}
+                </tspan>
+              </text>
+            </>
+          )}
+
+          {/* Current: arrow pushes outward in the direction water flows */}
+          {currentAngle != null && (
+            <>
+              <ForceArrow fromR={CURRENT_TAIL_R} toR={CURRENT_TIP_R} angleDeg={currentAngle} color={currentColor} />
+              <text
+                x={curLx}
+                y={curLy}
+                textAnchor={textAnchor(currentAngle)}
+                dominantBaseline="middle"
+                fontSize="10"
+                fill={currentColor}
+                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+              >
+                <tspan>{leg.current_speed_kn?.toFixed(1) ?? "—"} kn</tspan>
+                <tspan x={curLx} dy="11" fill="var(--ow-fg-2)" fontWeight="500">
+                  {leg.current_relative ?? ""}
+                </tspan>
+              </text>
+            </>
+          )}
+        </svg>
+      </div>
+
+      {/* Footer line: who and how */}
+      <div className="text-[10px] mt-2 leading-relaxed" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+        Polaire {archetypeLabel} · TWA {Math.round(twa)}° · efficacité {Math.round(leg.efficiency * 100)}%
       </div>
     </div>
   );

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -130,17 +130,24 @@ function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
   const ux = dx / len, uy = dy / len;
   const nx = -uy, ny = ux;
   const amp = 3.2;
-  const N = 18;
+  // Reserve a straight section just before the tip so the arrowhead reads as
+  // a clean chevron (not jammed into the last sinusoid bump).
+  const TAIL_STRAIGHT = 10;
+  const wavyEnd = len - TAIL_STRAIGHT;
+  const N = 16;
   const points: string[] = [];
   for (let i = 0; i <= N; i++) {
     const t = i / N;
-    const ax = tailX + ux * len * t;
-    const ay = tailY + uy * len * t;
-    const o = Math.sin(t * Math.PI * 3) * amp;
-    points.push(`${ax + nx * o},${ay + ny * o}`);
+    const dist = wavyEnd * t;
+    const o = Math.sin(t * Math.PI * 3) * amp * (1 - t * 0.5); // taper amp toward the tip
+    points.push(`${tailX + ux * dist + nx * o},${tailY + uy * dist + ny * o}`);
   }
-  // Arrowhead at the inner end (tip) so the wave reads as "coming toward the boat".
-  const HEAD = 6, WING = 3.5;
+  // Continue with a straight segment to the tip.
+  points.push(`${tipX},${tipY}`);
+
+  // Arrowhead at the tip — drawn along the radial direction, so it lands on
+  // the straight tail section above and reads as a clean ▶.
+  const HEAD = 7, WING = 4;
   const hx1 = tipX - ux * HEAD + nx * WING;
   const hy1 = tipY - uy * HEAD + ny * WING;
   const hx2 = tipX - ux * HEAD - nx * WING;
@@ -265,11 +272,27 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
     COLORS.currentTravers;
 
   // Each force gets its own label outside the dial at its own angle.
+  // Wind & wave are spread by construction (30° angular offset). The current's
+  // angle is independent though — if it lands within 30° of either, push the
+  // current label radially outward so labels never share screen space. Keeps
+  // the angular position truthful (label still points at the real flow
+  // direction); only the distance from the dial changes.
+  const angularGap = (a: number, b: number): number => {
+    const d = ((a - b + 540) % 360) - 180;
+    return Math.abs(d);
+  };
+  let currentLabelR = LABEL_R;
+  if (currentAngle != null) {
+    const tooCloseToWind = angularGap(currentAngle, windAngle) < 30;
+    const tooCloseToWave = angularGap(currentAngle, waveAngle) < 30;
+    if (tooCloseToWind || tooCloseToWave) currentLabelR = LABEL_R + 28;
+  }
+
   const [windLx, windLy] = polarXY(windAngle, LABEL_R);
   const windLabel = labelLayout(windAngle);
   const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
   const waveLabel = labelLayout(waveAngle);
-  const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, LABEL_R) : [0, 0];
+  const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, currentLabelR) : [0, 0];
   const curLabel = currentAngle != null ? labelLayout(currentAngle) : { anchor: "middle" as const, dx: 0 };
 
   return (

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,19 +1,29 @@
 import type { AggregatedLeg } from "./aggregateLegs";
 
-// "Comment c'est calculé" — top-down boat compass showing where wind, waves
-// and current come from relative to the boat's heading. The boat sits in the
-// middle pointing up (= its course); each force has a labelled arrow around it.
+// "Conditions vues du bateau" — top-down boat compass showing where wind,
+// waves and current come from relative to the boat's heading. The boat sits in
+// the middle pointing up (= its course); each force has a labelled marker.
 //
-// Numbers come from `aggregateLegs` (segment-level math weighted by distance).
+// Color code: white = wind, amber = waves, green/orange/grey = current
+// (favourable / against / cross). Keep this aligned with the legend at the
+// bottom of the card.
 
-const SIZE = 240;
+const SIZE = 280;
 const CENTER = SIZE / 2;
-const COMPASS_R = 88;
-const ARROW_TIP_R = 56;   // wind/wave tip closes in toward the boat
-const ARROW_TAIL_R = 86;
+const COMPASS_R = 96;
+const ARROW_TAIL_R = 92;
+const ARROW_TIP_R = 56;
 const CURRENT_TAIL_R = 38;
-const CURRENT_TIP_R = 84;
-const LABEL_R = 102;
+const CURRENT_TIP_R = 88;
+const LABEL_R = 116;
+
+const COLORS = {
+  wind: "var(--ow-fg-0)",
+  waves: "var(--ow-warn)",
+  currentPortant: "var(--ow-ok)",
+  currentContraire: "#fb923c", // distinct from waves' amber so the eye doesn't merge them
+  currentTravers: "var(--ow-fg-1)",
+};
 
 const COMPASS_16 = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"] as const;
 const compass16 = (deg: number): string =>
@@ -25,12 +35,14 @@ function polarXY(angleDeg: number, r: number): [number, number] {
   return [CENTER + Math.cos(rad) * r, CENTER + Math.sin(rad) * r];
 }
 
-// Anchor a label so it stays readable on either side of the dial.
-function textAnchor(angleDeg: number): "start" | "middle" | "end" {
+// Pick label anchor + small dx so a force label outside the dial reads clean.
+function labelLayout(angleDeg: number): { anchor: "start" | "middle" | "end"; dx: number } {
   const a = ((angleDeg % 360) + 360) % 360;
-  if (a < 20 || a > 340) return "middle";
-  if (a > 160 && a < 200) return "middle";
-  return a < 180 ? "start" : "end";
+  if (a < 15 || a > 345) return { anchor: "middle", dx: 0 };
+  if (a > 165 && a < 195) return { anchor: "middle", dx: 0 };
+  return a < 180
+    ? { anchor: "start", dx: 4 }   // right hemisphere → label flows right
+    : { anchor: "end", dx: -4 };   // left hemisphere → label flows left
 }
 
 function ForceArrow({
@@ -48,7 +60,6 @@ function ForceArrow({
 }) {
   const [x1, y1] = polarXY(angleDeg, fromR);
   const [x2, y2] = polarXY(angleDeg, toR);
-  // Build a small arrowhead at (x2, y2) pointing in the direction (fromR → toR).
   const dirRad = Math.atan2(y2 - y1, x2 - x1);
   const head = 7;
   const wing = 4;
@@ -59,23 +70,29 @@ function ForceArrow({
   return (
     <g>
       <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={width} strokeLinecap="round" />
-      <path d={`M ${hx1} ${hy1} L ${x2} ${y2} L ${hx2} ${hy2}`} stroke={color} strokeWidth={width} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d={`M ${hx1} ${hy1} L ${x2} ${y2} L ${hx2} ${hy2}`}
+        stroke={color}
+        strokeWidth={width}
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </g>
   );
 }
 
-// A wavy line drawn along the chord at the given angle — visually distinct
-// from straight arrows so the eye knows it's the swell.
+// Wavy line tangent to the radius at `angleDeg`. Drawn outside the boat,
+// pointing toward the dial — visually distinct from straight arrows.
 function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
-  const [tipX, tipY] = polarXY(angleDeg, ARROW_TIP_R + 4);
+  const [tipX, tipY] = polarXY(angleDeg, ARROW_TIP_R + 8);
   const [tailX, tailY] = polarXY(angleDeg, ARROW_TAIL_R - 4);
-  // Build a wavy path between tail and tip with 3 oscillations.
   const dx = tipX - tailX;
   const dy = tipY - tailY;
   const len = Math.hypot(dx, dy);
-  const ux = dx / len, uy = dy / len; // unit along
-  const nx = -uy, ny = ux;            // unit normal
-  const amp = 3;
+  const ux = dx / len, uy = dy / len;
+  const nx = -uy, ny = ux;
+  const amp = 3.2;
   const N = 18;
   const points: string[] = [];
   for (let i = 0; i <= N; i++) {
@@ -85,7 +102,58 @@ function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
     const o = Math.sin(t * Math.PI * 3) * amp;
     points.push(`${ax + nx * o},${ay + ny * o}`);
   }
-  return <polyline points={points.join(" ")} stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />;
+  return <polyline points={points.join(" ")} stroke={color} strokeWidth="1.7" fill="none" strokeLinecap="round" />;
+}
+
+// ── Top-down hull silhouette ─────────────────────────────────────────────────
+// Pointed bow at top, gentle widening to midship, flat transom at the bottom.
+// Path is centred on (0,0) so it can be translated to the SVG centre.
+function BoatHull() {
+  return (
+    <g>
+      {/* Hull outline */}
+      <path
+        d="
+          M 0 -34
+          C -8 -28, -14 -16, -14 -2
+          C -14 8, -14 16, -13 22
+          L 13 22
+          C 14 16, 14 8, 14 -2
+          C 14 -16, 8 -28, 0 -34
+          Z
+        "
+        fill="var(--ow-bg-2)"
+        stroke="var(--ow-fg-0)"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+      {/* Centerline (suggests the keel/mast axis) */}
+      <line x1="0" y1="-26" x2="0" y2="20" stroke="var(--ow-fg-2)" strokeWidth="0.8" />
+      {/* Mast (small dot just forward of midship) */}
+      <circle cx="0" cy="-4" r="2.2" fill="var(--ow-accent)" />
+      {/* Tiny bow indicator triangle to reinforce the heading direction */}
+      <path d="M 0 -34 L -3 -28 L 3 -28 Z" fill="var(--ow-fg-0)" stroke="none" />
+    </g>
+  );
+}
+
+// ── Legend ────────────────────────────────────────────────────────────────────
+function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" | "wave"; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[10px]" style={{ color: "var(--ow-fg-1)" }}>
+      {swatch === "arrow" ? (
+        <svg width="20" height="8" viewBox="0 0 20 8" aria-hidden="true">
+          <line x1="2" y1="4" x2="14" y2="4" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+          <path d="M 11 1 L 16 4 L 11 7" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ) : (
+        <svg width="20" height="8" viewBox="0 0 20 8" aria-hidden="true">
+          <path d="M 1 4 Q 5 0 9 4 T 17 4" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />
+        </svg>
+      )}
+      <span>{label}</span>
+    </span>
+  );
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
@@ -93,7 +161,7 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
   // Wind: TWA is unsigned (0..180) in our model — show wind on the starboard
   // side by convention so port/starboard ambiguity doesn't lie about the trim.
   const twa = Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg);
-  const windAngle = twa; // 0..180, wind comes from this side of the bow
+  const windAngle = twa;
   const tws = Math.round(leg.tws_avg_kn);
   const gustNote =
     leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
@@ -101,27 +169,28 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
       : "";
 
   // Waves: in absence of a propagated wave_direction, assume waves track the
-  // wind (Med wind-wave dominant). Slight offset to visually separate wave
-  // from wind arrows.
-  const waveAngle = windAngle + 4;
+  // wind (Med wind-wave dominant). Place on the opposite hemisphere when the
+  // wind is forward (TWA < 30°) so the two labels never stack vertically.
+  const waveAngle = windAngle < 30 ? -windAngle - 18 : windAngle + 22;
   const hasWaves = leg.hs_avg_m != null;
 
   // Current: relative direction from boat bow = (current_to - bearing).
-  // The arrow points OUTWARD (current pushes the boat in that direction).
-  let currentAngle: number | null = null;
-  if (leg.current_direction_to_deg != null) {
-    const rel = ((leg.current_direction_to_deg - leg.bearing_avg_deg) % 360 + 360) % 360;
-    currentAngle = rel;
-  }
+  // Arrow points OUTWARD (current pushes the boat in that direction).
+  const currentAngle = leg.current_direction_to_deg != null
+    ? ((leg.current_direction_to_deg - leg.bearing_avg_deg) % 360 + 360) % 360
+    : null;
   const currentColor =
-    leg.current_relative === "portant" ? "var(--ow-ok)" :
-    leg.current_relative === "contraire" ? "var(--ow-warn)" :
-    "var(--ow-fg-1)";
+    leg.current_relative === "portant" ? COLORS.currentPortant :
+    leg.current_relative === "contraire" ? COLORS.currentContraire :
+    COLORS.currentTravers;
 
   // Label positions
   const [windLx, windLy] = polarXY(windAngle, LABEL_R);
+  const windLabel = labelLayout(windAngle);
   const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
+  const waveLabel = labelLayout(waveAngle);
   const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, LABEL_R) : [0, 0];
+  const curLabel = currentAngle != null ? labelLayout(currentAngle) : { anchor: "middle" as const, dx: 0 };
 
   return (
     <div className="px-4 pb-4 pt-1">
@@ -156,77 +225,77 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
           {/* Outer dashed dial */}
           <circle cx={CENTER} cy={CENTER} r={COMPASS_R} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" strokeDasharray="2 4" />
 
-          {/* Cap (heading) tick at top */}
-          <line x1={CENTER} y1={CENTER - COMPASS_R - 4} x2={CENTER} y2={CENTER - COMPASS_R + 4} stroke="var(--ow-fg-2)" strokeWidth="1.5" />
-          <text x={CENTER} y={CENTER - COMPASS_R - 8} textAnchor="middle" fontSize="9" fill="var(--ow-fg-2)" style={{ fontFamily: "var(--ow-font-mono)" }}>
+          {/* Cap (heading) tick + label at top */}
+          <line x1={CENTER} y1={CENTER - COMPASS_R - 6} x2={CENTER} y2={CENTER - COMPASS_R + 4} stroke="var(--ow-fg-2)" strokeWidth="1.5" />
+          <text
+            x={CENTER}
+            y={CENTER - COMPASS_R - 12}
+            textAnchor="middle"
+            fontSize="9"
+            fill="var(--ow-fg-2)"
+            style={{ fontFamily: "var(--ow-font-mono)" }}
+          >
             cap {Math.round(leg.bearing_avg_deg)}°
           </text>
 
-          {/* Boat hull pointing up */}
+          {/* Boat hull pointing up (its course = true bearing) */}
           <g transform={`translate(${CENTER} ${CENTER})`}>
-            <path
-              d="M 0 -28 Q -11 -14 -11 12 Q -11 24 0 30 Q 11 24 11 12 Q 11 -14 0 -28 Z"
-              fill="var(--ow-bg-2)"
-              stroke="var(--ow-fg-0)"
-              strokeWidth="1.6"
-            />
-            {/* centerline */}
-            <line x1="0" y1="-22" x2="0" y2="26" stroke="var(--ow-fg-2)" strokeWidth="0.8" />
-            {/* mast dot */}
-            <circle cx="0" cy="-2" r="2" fill="var(--ow-accent)" />
+            <BoatHull />
           </g>
 
-          {/* Wind arrow: tail on dial, tip near boat (wind comes from the angle) */}
-          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color="var(--ow-fg-0)" />
+          {/* Wind arrow + label */}
+          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} />
           <text
-            x={windLx}
+            x={windLx + windLabel.dx}
             y={windLy}
-            textAnchor={textAnchor(windAngle)}
+            textAnchor={windLabel.anchor}
             dominantBaseline="middle"
-            fontSize="10"
-            fill="var(--ow-fg-0)"
+            fontSize="11"
+            fill={COLORS.wind}
             style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
           >
             <tspan>{tws} kn{gustNote}</tspan>
-            <tspan x={windLx} dy="11" fill="var(--ow-fg-2)">{compass16(leg.twd_avg_deg)}</tspan>
+            <tspan x={windLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
+              {compass16(leg.twd_avg_deg)}
+            </tspan>
           </text>
 
-          {/* Waves wavy line — same hemisphere as wind, slight angular offset */}
+          {/* Waves wavy line + label (offset hemisphere from wind) */}
           {hasWaves && (
             <>
-              <WaveMark angleDeg={waveAngle} color="var(--ow-warn)" />
+              <WaveMark angleDeg={waveAngle} color={COLORS.waves} />
               <text
-                x={waveLx}
-                y={waveLy + 18}
-                textAnchor={textAnchor(waveAngle)}
+                x={waveLx + waveLabel.dx}
+                y={waveLy}
+                textAnchor={waveLabel.anchor}
                 dominantBaseline="middle"
-                fontSize="10"
-                fill="var(--ow-warn)"
+                fontSize="11"
+                fill={COLORS.waves}
                 style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
               >
                 <tspan>Hs {leg.hs_avg_m!.toFixed(1)} m</tspan>
-                <tspan x={waveLx} dy="11" fill="var(--ow-fg-2)" fontWeight="500">
-                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : "—"}
+                <tspan x={waveLx + waveLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
+                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : leg.sea_direction ?? ""}
                 </tspan>
               </text>
             </>
           )}
 
-          {/* Current: arrow pushes outward in the direction water flows */}
+          {/* Current arrow + label (points outward — direction the water flows) */}
           {currentAngle != null && (
             <>
               <ForceArrow fromR={CURRENT_TAIL_R} toR={CURRENT_TIP_R} angleDeg={currentAngle} color={currentColor} />
               <text
-                x={curLx}
+                x={curLx + curLabel.dx}
                 y={curLy}
-                textAnchor={textAnchor(currentAngle)}
+                textAnchor={curLabel.anchor}
                 dominantBaseline="middle"
-                fontSize="10"
+                fontSize="11"
                 fill={currentColor}
                 style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
               >
                 <tspan>{leg.current_speed_kn?.toFixed(1) ?? "—"} kn</tspan>
-                <tspan x={curLx} dy="11" fill="var(--ow-fg-2)" fontWeight="500">
+                <tspan x={curLx + curLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
                   {leg.current_relative ?? ""}
                 </tspan>
               </text>
@@ -235,8 +304,17 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         </svg>
       </div>
 
+      {/* Color legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center mt-1 mb-2">
+        <LegendItem color={COLORS.wind} swatch="arrow" label="Vent" />
+        <LegendItem color={COLORS.waves} swatch="wave" label="Vagues" />
+        <LegendItem color={COLORS.currentPortant} swatch="arrow" label="Courant portant" />
+        <LegendItem color={COLORS.currentContraire} swatch="arrow" label="contraire" />
+        <LegendItem color={COLORS.currentTravers} swatch="arrow" label="travers" />
+      </div>
+
       {/* Footer line: who and how */}
-      <div className="text-[10px] mt-2 leading-relaxed" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+      <div className="text-[10px] mt-1 leading-relaxed text-center" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
         Polaire {archetypeLabel} · TWA {Math.round(twa)}° · efficacité {Math.round(leg.efficiency * 100)}%
       </div>
     </div>

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -8,14 +8,14 @@ import type { AggregatedLeg } from "./aggregateLegs";
 //   white = vent, amber wavy = vagues,
 //   green/orange/grey arrow = courant (portant / contraire / travers).
 
-const SIZE = 280;
+const SIZE = 320;
 const CENTER = SIZE / 2;
-const COMPASS_R = 96;
-const ARROW_TAIL_R = 92;
-const ARROW_TIP_R = 56;
+const COMPASS_R = 104;
+const ARROW_TAIL_R = 100;
+const ARROW_TIP_R = 58;
 const CURRENT_TAIL_R = 38;
-const CURRENT_TIP_R = 88;
-const LABEL_R = 116;
+const CURRENT_TIP_R = 92;
+const LABEL_R = 122;
 
 const COLORS = {
   wind: "var(--ow-fg-0)",
@@ -24,10 +24,6 @@ const COLORS = {
   currentContraire: "#fb923c", // distinct from waves' amber so the eye doesn't merge them
   currentTravers: "var(--ow-fg-1)",
 };
-
-const COMPASS_16 = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"] as const;
-const compass16 = (deg: number): string =>
-  COMPASS_16[Math.round((((deg % 360) + 360) % 360) / 22.5) % 16];
 
 // 0° = up (12 o'clock), increasing clockwise. Returns [x, y] in SVG coords.
 function polarXY(angleDeg: number, r: number): [number, number] {
@@ -180,19 +176,20 @@ function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" |
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
-export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; archetypeLabel: string }) {
+export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
   // Absolute compass bearings — boat is rotated to its actual heading and
   // every force sits at its true direction on the North-up dial.
   const windAngle = leg.twd_avg_deg;     // wind comes FROM this compass bearing
   const waveAngle = leg.twd_avg_deg + 6; // small offset; Med assumption (wind = waves)
   const tws = Math.round(leg.tws_avg_kn);
-  const gustNote =
+  const windLine =
     leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
-      ? ` · raf. ${Math.round(leg.gust_max_kn)}`
-      : "";
-
-  // For sailing context, surface TWA in the footer (built from twd-bearing).
-  const twa = Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg);
+      ? `${tws} (${Math.round(leg.gust_max_kn)}) kn`
+      : `${tws} kn`;
+  const fmtFR1 = (n: number) => n.toFixed(1).replace(".", ",");
+  const waveLine = leg.hs_avg_m != null
+    ? `${fmtFR1(leg.hs_avg_m)} m${leg.tp_avg_s != null ? ` (${Math.round(leg.tp_avg_s)} s)` : ""}`
+    : "";
   const hasWaves = leg.hs_avg_m != null;
 
   // Current arrow points OUTWARD from the boat in the direction water flows.
@@ -223,27 +220,36 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         Conditions vues du bateau
       </div>
 
-      {/* Speed pill + heading caption */}
+      {/* Speed + allure + cap */}
       <div className="flex items-baseline justify-between mb-2">
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline gap-3">
           <span
             className="text-2xl font-bold tabular-nums"
             style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
           >
             {leg.target_speed_kn.toFixed(1)} kn
           </span>
-          <span className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
-            vitesse cible
+          <span
+            className="text-xl font-bold"
+            style={{ color: "var(--ow-fg-0)", letterSpacing: "-0.01em", lineHeight: 1 }}
+          >
+            {leg.point_of_sail}
           </span>
         </div>
         <span className="text-[10px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-          cap {Math.round(leg.bearing_avg_deg)}° {compass16(leg.bearing_avg_deg)}
+          cap {Math.round(leg.bearing_avg_deg)}°
         </span>
       </div>
 
       {/* Compass diagram */}
       <div className="flex justify-center">
-        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} aria-label="Conditions autour du bateau (vue Nord en haut)">
+        <svg
+          width={SIZE}
+          height={SIZE}
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          aria-label="Conditions autour du bateau (vue Nord en haut)"
+          style={{ overflow: "visible" }}
+        >
           {/* Outer dashed dial */}
           <circle cx={CENTER} cy={CENTER} r={COMPASS_R} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" strokeDasharray="2 4" />
 
@@ -255,8 +261,8 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
             <BoatHull />
           </g>
 
-          {/* Wind arrow */}
-          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} />
+          {/* Wind arrow — drawn thicker than the rest so it reads first */}
+          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} width={3} />
 
           {/* Waves wavy line, slightly offset so it doesn't overlap the wind shaft */}
           {hasWaves && <WaveMark angleDeg={waveAngle} color={COLORS.waves} />}
@@ -264,27 +270,17 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
           {/* Combined wind + wave label, stacked rows, single anchor outside the dial */}
           <text
             x={windWaveLx + windLabel.dx}
-            y={windWaveLy - (hasWaves ? 12 : 0)}
+            y={windWaveLy - (hasWaves ? 10 : 0)}
             textAnchor={windLabel.anchor}
             dominantBaseline="middle"
-            fontSize="11"
+            fontSize="12"
             fill={COLORS.wind}
-            style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+            style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
           >
-            <tspan>{tws} kn{gustNote}</tspan>
-            <tspan x={windWaveLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
-              {compass16(leg.twd_avg_deg)}
+            <tspan>{windLine}</tspan>
+            <tspan x={windWaveLx + windLabel.dx} dy="13" fill={COLORS.waves} fontWeight="600">
+              {hasWaves ? waveLine : ""}
             </tspan>
-            {hasWaves && (
-              <>
-                <tspan x={windWaveLx + windLabel.dx} dy="14" fill={COLORS.waves} fontWeight="600">
-                  Hs {leg.hs_avg_m!.toFixed(1)} m
-                </tspan>
-                <tspan x={windWaveLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
-                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : ""}
-                </tspan>
-              </>
-            )}
           </text>
 
           {/* Current arrow (water flows toward `current_direction_to_deg`) */}
@@ -310,18 +306,19 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         </svg>
       </div>
 
-      {/* Color legend */}
-      <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center mt-1 mb-2">
+      {/* Color legend — current entry only when a current is actually drawn */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center mt-1 mb-1">
         <LegendItem color={COLORS.wind} swatch="arrow" label="Vent" />
-        <LegendItem color={COLORS.waves} swatch="wave" label="Vagues" />
-        <LegendItem color={COLORS.currentPortant} swatch="arrow" label="Courant portant" />
-        <LegendItem color={COLORS.currentContraire} swatch="arrow" label="contraire" />
-        <LegendItem color={COLORS.currentTravers} swatch="arrow" label="travers" />
-      </div>
-
-      {/* Footer line */}
-      <div className="text-[10px] mt-1 leading-relaxed text-center" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-        Polaire {archetypeLabel} · TWA {Math.round(twa)}° · efficacité {Math.round(leg.efficiency * 100)}%
+        {hasWaves && <LegendItem color={COLORS.waves} swatch="wave" label="Vagues" />}
+        {currentAngle != null && leg.current_relative === "portant" && (
+          <LegendItem color={COLORS.currentPortant} swatch="arrow" label="Courant portant" />
+        )}
+        {currentAngle != null && leg.current_relative === "contraire" && (
+          <LegendItem color={COLORS.currentContraire} swatch="arrow" label="Courant contraire" />
+        )}
+        {currentAngle != null && leg.current_relative === "travers" && (
+          <LegendItem color={COLORS.currentTravers} swatch="arrow" label="Courant travers" />
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,12 +1,12 @@
 import type { AggregatedLeg } from "./aggregateLegs";
 
-// "Conditions vues du bateau" — top-down boat compass showing where wind,
-// waves and current come from relative to the boat's heading. The boat sits in
-// the middle pointing up (= its course); each force has a labelled marker.
+// "Conditions vues du bateau" — North-up compass with the boat rotated to its
+// true heading. Wind / waves / current sit at their absolute compass bearings
+// around the dial; the boat points where it's going.
 //
-// Color code: white = wind, amber = waves, green/orange/grey = current
-// (favourable / against / cross). Keep this aligned with the legend at the
-// bottom of the card.
+// Color code (also rendered in the legend below the diagram):
+//   white = vent, amber wavy = vagues,
+//   green/orange/grey arrow = courant (portant / contraire / travers).
 
 const SIZE = 280;
 const CENTER = SIZE / 2;
@@ -41,8 +41,8 @@ function labelLayout(angleDeg: number): { anchor: "start" | "middle" | "end"; dx
   if (a < 15 || a > 345) return { anchor: "middle", dx: 0 };
   if (a > 165 && a < 195) return { anchor: "middle", dx: 0 };
   return a < 180
-    ? { anchor: "start", dx: 4 }   // right hemisphere → label flows right
-    : { anchor: "end", dx: -4 };   // left hemisphere → label flows left
+    ? { anchor: "start", dx: 4 }
+    : { anchor: "end", dx: -4 };
 }
 
 function ForceArrow({
@@ -82,8 +82,6 @@ function ForceArrow({
   );
 }
 
-// Wavy line tangent to the radius at `angleDeg`. Drawn outside the boat,
-// pointing toward the dial — visually distinct from straight arrows.
 function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
   const [tipX, tipY] = polarXY(angleDeg, ARROW_TIP_R + 8);
   const [tailX, tailY] = polarXY(angleDeg, ARROW_TAIL_R - 4);
@@ -105,13 +103,11 @@ function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
   return <polyline points={points.join(" ")} stroke={color} strokeWidth="1.7" fill="none" strokeLinecap="round" />;
 }
 
-// ── Top-down hull silhouette ─────────────────────────────────────────────────
-// Pointed bow at top, gentle widening to midship, flat transom at the bottom.
-// Path is centred on (0,0) so it can be translated to the SVG centre.
+// Top-down hull silhouette — pointed bow up, flat transom at the bottom.
+// Drawn centred on (0,0) so it can be translated + rotated by bearing.
 function BoatHull() {
   return (
     <g>
-      {/* Hull outline */}
       <path
         d="
           M 0 -34
@@ -127,17 +123,44 @@ function BoatHull() {
         strokeWidth="1.6"
         strokeLinejoin="round"
       />
-      {/* Centerline (suggests the keel/mast axis) */}
       <line x1="0" y1="-26" x2="0" y2="20" stroke="var(--ow-fg-2)" strokeWidth="0.8" />
-      {/* Mast (small dot just forward of midship) */}
       <circle cx="0" cy="-4" r="2.2" fill="var(--ow-accent)" />
-      {/* Tiny bow indicator triangle to reinforce the heading direction */}
       <path d="M 0 -34 L -3 -28 L 3 -28 Z" fill="var(--ow-fg-0)" stroke="none" />
     </g>
   );
 }
 
-// ── Legend ────────────────────────────────────────────────────────────────────
+// Cardinal direction markers (N, E, S, W) just outside the dial.
+function CardinalMarkers() {
+  const items: { label: string; deg: number }[] = [
+    { label: "N", deg: 0 },
+    { label: "E", deg: 90 },
+    { label: "S", deg: 180 },
+    { label: "W", deg: 270 },
+  ];
+  return (
+    <g>
+      {items.map(({ label, deg }) => {
+        const [x, y] = polarXY(deg, COMPASS_R + 14);
+        return (
+          <text
+            key={label}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize="10"
+            fill="var(--ow-fg-3)"
+            style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+          >
+            {label}
+          </text>
+        );
+      })}
+    </g>
+  );
+}
+
 function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" | "wave"; label: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-[10px]" style={{ color: "var(--ow-fg-1)" }}>
@@ -158,37 +181,31 @@ function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" |
 
 // ── Main component ────────────────────────────────────────────────────────────
 export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; archetypeLabel: string }) {
-  // Wind: TWA is unsigned (0..180) in our model — show wind on the starboard
-  // side by convention so port/starboard ambiguity doesn't lie about the trim.
-  const twa = Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg);
-  const windAngle = twa;
+  // Absolute compass bearings — boat is rotated to its actual heading and
+  // every force sits at its true direction on the North-up dial.
+  const windAngle = leg.twd_avg_deg;     // wind comes FROM this compass bearing
+  const waveAngle = leg.twd_avg_deg + 6; // small offset; Med assumption (wind = waves)
   const tws = Math.round(leg.tws_avg_kn);
   const gustNote =
     leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
       ? ` · raf. ${Math.round(leg.gust_max_kn)}`
       : "";
 
-  // Waves: in absence of a propagated wave_direction, assume waves track the
-  // wind (Med wind-wave dominant). Place on the opposite hemisphere when the
-  // wind is forward (TWA < 30°) so the two labels never stack vertically.
-  const waveAngle = windAngle < 30 ? -windAngle - 18 : windAngle + 22;
+  // For sailing context, surface TWA in the footer (built from twd-bearing).
+  const twa = Math.abs(leg.twa_avg_deg) > 180 ? 360 - Math.abs(leg.twa_avg_deg) : Math.abs(leg.twa_avg_deg);
   const hasWaves = leg.hs_avg_m != null;
 
-  // Current: relative direction from boat bow = (current_to - bearing).
-  // Arrow points OUTWARD (current pushes the boat in that direction).
-  const currentAngle = leg.current_direction_to_deg != null
-    ? ((leg.current_direction_to_deg - leg.bearing_avg_deg) % 360 + 360) % 360
-    : null;
+  // Current arrow points OUTWARD from the boat in the direction water flows.
+  const currentAngle = leg.current_direction_to_deg ?? null;
   const currentColor =
     leg.current_relative === "portant" ? COLORS.currentPortant :
     leg.current_relative === "contraire" ? COLORS.currentContraire :
     COLORS.currentTravers;
 
-  // Label positions
-  const [windLx, windLy] = polarXY(windAngle, LABEL_R);
+  // Combined wind+wave label sits outside the dial at the wind direction
+  // (waves track wind in our current model). Stacked rows, color-coded.
+  const [windWaveLx, windWaveLy] = polarXY(windAngle, LABEL_R);
   const windLabel = labelLayout(windAngle);
-  const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
-  const waveLabel = labelLayout(waveAngle);
   const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, LABEL_R) : [0, 0];
   const curLabel = currentAngle != null ? labelLayout(currentAngle) : { anchor: "middle" as const, dx: 0 };
 
@@ -206,48 +223,48 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         Conditions vues du bateau
       </div>
 
-      {/* Speed pill */}
-      <div className="flex items-baseline gap-2 mb-2">
-        <span
-          className="text-2xl font-bold tabular-nums"
-          style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
-        >
-          {leg.target_speed_kn.toFixed(1)} kn
-        </span>
-        <span className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
-          vitesse cible
+      {/* Speed pill + heading caption */}
+      <div className="flex items-baseline justify-between mb-2">
+        <div className="flex items-baseline gap-2">
+          <span
+            className="text-2xl font-bold tabular-nums"
+            style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
+          >
+            {leg.target_speed_kn.toFixed(1)} kn
+          </span>
+          <span className="text-[10px]" style={{ color: "var(--ow-fg-2)" }}>
+            vitesse cible
+          </span>
+        </div>
+        <span className="text-[10px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
+          cap {Math.round(leg.bearing_avg_deg)}° {compass16(leg.bearing_avg_deg)}
         </span>
       </div>
 
       {/* Compass diagram */}
       <div className="flex justify-center">
-        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} aria-label="Conditions autour du bateau">
+        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} aria-label="Conditions autour du bateau (vue Nord en haut)">
           {/* Outer dashed dial */}
           <circle cx={CENTER} cy={CENTER} r={COMPASS_R} fill="none" stroke="var(--ow-line-2)" strokeWidth="1" strokeDasharray="2 4" />
 
-          {/* Cap (heading) tick + label at top */}
-          <line x1={CENTER} y1={CENTER - COMPASS_R - 6} x2={CENTER} y2={CENTER - COMPASS_R + 4} stroke="var(--ow-fg-2)" strokeWidth="1.5" />
-          <text
-            x={CENTER}
-            y={CENTER - COMPASS_R - 12}
-            textAnchor="middle"
-            fontSize="9"
-            fill="var(--ow-fg-2)"
-            style={{ fontFamily: "var(--ow-font-mono)" }}
-          >
-            cap {Math.round(leg.bearing_avg_deg)}°
-          </text>
+          {/* Cardinal markers */}
+          <CardinalMarkers />
 
-          {/* Boat hull pointing up (its course = true bearing) */}
-          <g transform={`translate(${CENTER} ${CENTER})`}>
+          {/* Boat hull rotated to its true bearing */}
+          <g transform={`translate(${CENTER} ${CENTER}) rotate(${leg.bearing_avg_deg})`}>
             <BoatHull />
           </g>
 
-          {/* Wind arrow + label */}
+          {/* Wind arrow */}
           <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} />
+
+          {/* Waves wavy line, slightly offset so it doesn't overlap the wind shaft */}
+          {hasWaves && <WaveMark angleDeg={waveAngle} color={COLORS.waves} />}
+
+          {/* Combined wind + wave label, stacked rows, single anchor outside the dial */}
           <text
-            x={windLx + windLabel.dx}
-            y={windLy}
+            x={windWaveLx + windLabel.dx}
+            y={windWaveLy - (hasWaves ? 12 : 0)}
             textAnchor={windLabel.anchor}
             dominantBaseline="middle"
             fontSize="11"
@@ -255,33 +272,22 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
             style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
           >
             <tspan>{tws} kn{gustNote}</tspan>
-            <tspan x={windLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
+            <tspan x={windWaveLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
               {compass16(leg.twd_avg_deg)}
             </tspan>
+            {hasWaves && (
+              <>
+                <tspan x={windWaveLx + windLabel.dx} dy="14" fill={COLORS.waves} fontWeight="600">
+                  Hs {leg.hs_avg_m!.toFixed(1)} m
+                </tspan>
+                <tspan x={windWaveLx + windLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
+                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : ""}
+                </tspan>
+              </>
+            )}
           </text>
 
-          {/* Waves wavy line + label (offset hemisphere from wind) */}
-          {hasWaves && (
-            <>
-              <WaveMark angleDeg={waveAngle} color={COLORS.waves} />
-              <text
-                x={waveLx + waveLabel.dx}
-                y={waveLy}
-                textAnchor={waveLabel.anchor}
-                dominantBaseline="middle"
-                fontSize="11"
-                fill={COLORS.waves}
-                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
-              >
-                <tspan>Hs {leg.hs_avg_m!.toFixed(1)} m</tspan>
-                <tspan x={waveLx + waveLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
-                  {leg.tp_avg_s != null ? `Tp ${leg.tp_avg_s.toFixed(1)} s` : leg.sea_direction ?? ""}
-                </tspan>
-              </text>
-            </>
-          )}
-
-          {/* Current arrow + label (points outward — direction the water flows) */}
+          {/* Current arrow (water flows toward `current_direction_to_deg`) */}
           {currentAngle != null && (
             <>
               <ForceArrow fromR={CURRENT_TAIL_R} toR={CURRENT_TIP_R} angleDeg={currentAngle} color={currentColor} />
@@ -313,7 +319,7 @@ export function LegDetailCard({ leg, archetypeLabel }: { leg: AggregatedLeg; arc
         <LegendItem color={COLORS.currentTravers} swatch="arrow" label="travers" />
       </div>
 
-      {/* Footer line: who and how */}
+      {/* Footer line */}
       <div className="text-[10px] mt-1 leading-relaxed text-center" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
         Polaire {archetypeLabel} · TWA {Math.round(twa)}° · efficacité {Math.round(leg.efficiency * 100)}%
       </div>

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -13,16 +13,14 @@ const CENTER = SIZE / 2;
 const COMPASS_R = 104;
 const ARROW_TAIL_R = 100;
 const ARROW_TIP_R = 58;
-const CURRENT_TAIL_R = 38;
-const CURRENT_TIP_R = 92;
 const LABEL_R = 122;
 
 const COLORS = {
   wind: "var(--ow-fg-0)",
   waves: "var(--ow-warn)",
   currentPortant: "var(--ow-ok)",
-  currentContraire: "#fb923c", // distinct from waves' amber so the eye doesn't merge them
-  currentTravers: "var(--ow-fg-1)",
+  currentContraire: "#fb923c",  // distinct from waves' amber
+  currentTravers: "#3b82f6",    // blue-500 — clearly visible in both themes (grey washed out in light)
 };
 
 // 0° = up (12 o'clock), increasing clockwise. Returns [x, y] in SVG coords.
@@ -41,39 +39,84 @@ function labelLayout(angleDeg: number): { anchor: "start" | "middle" | "end"; dx
     : { anchor: "end", dx: -4 };
 }
 
-function ForceArrow({
+// Double-shaft arrow for the wind — two parallel lines so the eye can pick
+// it out among the wavy line and the current flow field. The shaft stops a
+// few px short of the tip so the lines don't poke through the arrowhead.
+function WindArrow({
   fromR,
   toR,
   angleDeg,
   color,
-  width = 2,
 }: {
   fromR: number;
   toR: number;
   angleDeg: number;
   color: string;
-  width?: number;
 }) {
   const [x1, y1] = polarXY(angleDeg, fromR);
   const [x2, y2] = polarXY(angleDeg, toR);
   const dirRad = Math.atan2(y2 - y1, x2 - x1);
-  const head = 7;
-  const wing = 4;
+  const perpRad = dirRad + Math.PI / 2;
+  const off = 2.6;
+  const ox = Math.cos(perpRad) * off;
+  const oy = Math.sin(perpRad) * off;
+  const tipBack = 8;
+  const sx = x2 - Math.cos(dirRad) * tipBack;
+  const sy = y2 - Math.sin(dirRad) * tipBack;
+  const head = 10, wing = 5.5;
   const hx1 = x2 - Math.cos(dirRad) * head + Math.sin(dirRad) * wing;
   const hy1 = y2 - Math.sin(dirRad) * head - Math.cos(dirRad) * wing;
   const hx2 = x2 - Math.cos(dirRad) * head - Math.sin(dirRad) * wing;
   const hy2 = y2 - Math.sin(dirRad) * head + Math.cos(dirRad) * wing;
   return (
-    <g>
-      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={width} strokeLinecap="round" />
-      <path
-        d={`M ${hx1} ${hy1} L ${x2} ${y2} L ${hx2} ${hy2}`}
-        stroke={color}
-        strokeWidth={width}
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+    <g stroke={color} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round">
+      <line x1={x1 + ox} y1={y1 + oy} x2={sx + ox} y2={sy + oy} />
+      <line x1={x1 - ox} y1={y1 - oy} x2={sx - ox} y2={sy - oy} />
+      <path d={`M ${hx1} ${hy1} L ${x2} ${y2} L ${hx2} ${hy2}`} />
+    </g>
+  );
+}
+
+// Current flow field — short fine arrows distributed around the boat, all
+// pointing in the direction the water flows. Visually evokes a river current
+// (the user's red drawing).
+function CurrentFlowField({ flowAngleDeg, color }: { flowAngleDeg: number; color: string }) {
+  const flowRad = ((flowAngleDeg - 90) * Math.PI) / 180;
+  const fx = Math.cos(flowRad), fy = Math.sin(flowRad);
+  const px = -fy, py = fx; // perpendicular unit
+  const lineLen = 38;       // longer than before so the field reads as flow, not many small arrows
+  const HEAD = 4, WING = 2.2; // smaller arrowhead so the flow stays subtle
+  const positions: Array<[number, number]> = [];
+  // 2 rows of 3 lines either side of the boat — quieter than the prior 3×3 grid.
+  const perpOffsets = [-58, 58];
+  const alongOffsets = [-46, 0, 46];
+  for (const a of alongOffsets) {
+    for (const p of perpOffsets) {
+      positions.push([CENTER + fx * a + px * p, CENTER + fy * a + py * p]);
+    }
+  }
+
+  return (
+    <g stroke={color} strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round" opacity="0.5">
+      {positions.map(([cx, cy], i) => {
+        const distC = Math.hypot(cx - CENTER, cy - CENTER);
+        if (distC > COMPASS_R - 4) return null;
+        if (distC < 30) return null; // keep clear of the hull
+        const tailX = cx - fx * lineLen / 2;
+        const tailY = cy - fy * lineLen / 2;
+        const tipX = cx + fx * lineLen / 2;
+        const tipY = cy + fy * lineLen / 2;
+        const hx1 = tipX - fx * HEAD + px * WING;
+        const hy1 = tipY - fy * HEAD + py * WING;
+        const hx2 = tipX - fx * HEAD - px * WING;
+        const hy2 = tipY - fy * HEAD - py * WING;
+        return (
+          <g key={i}>
+            <line x1={tailX} y1={tailY} x2={tipX} y2={tipY} />
+            <path d={`M ${hx1} ${hy1} L ${tipX} ${tipY} L ${hx2} ${hy2}`} />
+          </g>
+        );
+      })}
     </g>
   );
 }
@@ -96,7 +139,18 @@ function WaveMark({ angleDeg, color }: { angleDeg: number; color: string }) {
     const o = Math.sin(t * Math.PI * 3) * amp;
     points.push(`${ax + nx * o},${ay + ny * o}`);
   }
-  return <polyline points={points.join(" ")} stroke={color} strokeWidth="1.7" fill="none" strokeLinecap="round" />;
+  // Arrowhead at the inner end (tip) so the wave reads as "coming toward the boat".
+  const HEAD = 6, WING = 3.5;
+  const hx1 = tipX - ux * HEAD + nx * WING;
+  const hy1 = tipY - uy * HEAD + ny * WING;
+  const hx2 = tipX - ux * HEAD - nx * WING;
+  const hy2 = tipY - uy * HEAD - ny * WING;
+  return (
+    <g stroke={color} strokeWidth="1.7" fill="none" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points={points.join(" ")} />
+      <path d={`M ${hx1} ${hy1} L ${tipX} ${tipY} L ${hx2} ${hy2}`} />
+    </g>
+  );
 }
 
 // Top-down hull silhouette — pointed bow up, flat transom at the bottom.
@@ -157,17 +211,23 @@ function CardinalMarkers() {
   );
 }
 
-function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" | "wave"; label: string }) {
+function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" | "windDouble" | "wave"; label: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-[10px]" style={{ color: "var(--ow-fg-1)" }}>
-      {swatch === "arrow" ? (
-        <svg width="20" height="8" viewBox="0 0 20 8" aria-hidden="true">
-          <line x1="2" y1="4" x2="14" y2="4" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
-          <path d="M 11 1 L 16 4 L 11 7" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      {swatch === "windDouble" ? (
+        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
+          <line x1="2" y1="3" x2="13" y2="3" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+          <line x1="2" y1="7" x2="13" y2="7" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+          <path d="M 13 1 L 18 5 L 13 9" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ) : swatch === "arrow" ? (
+        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
+          <line x1="2" y1="5" x2="14" y2="5" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+          <path d="M 11 2 L 16 5 L 11 8" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       ) : (
-        <svg width="20" height="8" viewBox="0 0 20 8" aria-hidden="true">
-          <path d="M 1 4 Q 5 0 9 4 T 17 4" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />
+        <svg width="22" height="10" viewBox="0 0 22 10" aria-hidden="true">
+          <path d="M 1 5 Q 5 1 9 5 T 17 5" stroke={color} strokeWidth="1.6" fill="none" strokeLinecap="round" />
         </svg>
       )}
       <span>{label}</span>
@@ -178,9 +238,14 @@ function LegendItem({ color, swatch, label }: { color: string; swatch: "arrow" |
 // ── Main component ────────────────────────────────────────────────────────────
 export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
   // Absolute compass bearings — boat is rotated to its actual heading and
-  // every force sits at its true direction on the North-up dial.
-  const windAngle = leg.twd_avg_deg;     // wind comes FROM this compass bearing
-  const waveAngle = leg.twd_avg_deg + 6; // small offset; Med assumption (wind = waves)
+  // every force sits at its true direction on the North-up dial. Waves
+  // track wind in our current Med model; we offset the wave marker by a
+  // fixed 30° so the two arrows never share a shaft. Robust by construction:
+  // 30° is the minimum gap that keeps labels (≈ 50-60 px wide at LABEL_R)
+  // from overlapping at 12 pt. Picking the offset away from the boat's bow
+  // also avoids stacking wave on top of the boat hull.
+  const windAngle = leg.twd_avg_deg;
+  const waveAngle = leg.twd_avg_deg + 30;
   const tws = Math.round(leg.tws_avg_kn);
   const windLine =
     leg.gust_max_kn != null && leg.gust_max_kn > tws + 1
@@ -199,10 +264,11 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
     leg.current_relative === "contraire" ? COLORS.currentContraire :
     COLORS.currentTravers;
 
-  // Combined wind+wave label sits outside the dial at the wind direction
-  // (waves track wind in our current model). Stacked rows, color-coded.
-  const [windWaveLx, windWaveLy] = polarXY(windAngle, LABEL_R);
+  // Each force gets its own label outside the dial at its own angle.
+  const [windLx, windLy] = polarXY(windAngle, LABEL_R);
   const windLabel = labelLayout(windAngle);
+  const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
+  const waveLabel = labelLayout(waveAngle);
   const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, LABEL_R) : [0, 0];
   const curLabel = currentAngle != null ? labelLayout(currentAngle) : { anchor: "middle" as const, dx: 0 };
 
@@ -261,63 +327,67 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
             <BoatHull />
           </g>
 
-          {/* Wind arrow — drawn thicker than the rest so it reads first */}
-          <ForceArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} width={3} />
+          {/* Wind arrow (double-shaft, distinctive) */}
+          <WindArrow fromR={ARROW_TAIL_R} toR={ARROW_TIP_R} angleDeg={windAngle} color={COLORS.wind} />
 
-          {/* Waves wavy line, slightly offset so it doesn't overlap the wind shaft */}
-          {hasWaves && <WaveMark angleDeg={waveAngle} color={COLORS.waves} />}
-
-          {/* Combined wind + wave label, stacked rows, single anchor outside the dial */}
+          {/* Wind label at wind direction */}
           <text
-            x={windWaveLx + windLabel.dx}
-            y={windWaveLy - (hasWaves ? 10 : 0)}
+            x={windLx + windLabel.dx}
+            y={windLy}
             textAnchor={windLabel.anchor}
             dominantBaseline="middle"
             fontSize="12"
             fill={COLORS.wind}
             style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
           >
-            <tspan>{windLine}</tspan>
-            <tspan x={windWaveLx + windLabel.dx} dy="13" fill={COLORS.waves} fontWeight="600">
-              {hasWaves ? waveLine : ""}
-            </tspan>
+            {windLine}
           </text>
 
-          {/* Current arrow (water flows toward `current_direction_to_deg`) */}
+          {/* Waves wavy line at wave direction (offset 30° from wind so they
+              never share a shaft), with its own label */}
+          {hasWaves && (
+            <>
+              <WaveMark angleDeg={waveAngle} color={COLORS.waves} />
+              <text
+                x={waveLx + waveLabel.dx}
+                y={waveLy}
+                textAnchor={waveLabel.anchor}
+                dominantBaseline="middle"
+                fontSize="12"
+                fill={COLORS.waves}
+                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
+              >
+                {waveLine}
+              </text>
+            </>
+          )}
+
+          {/* Current flow field — short fine arrows around the boat */}
           {currentAngle != null && (
             <>
-              <ForceArrow fromR={CURRENT_TAIL_R} toR={CURRENT_TIP_R} angleDeg={currentAngle} color={currentColor} />
+              <CurrentFlowField flowAngleDeg={currentAngle} color={currentColor} />
               <text
                 x={curLx + curLabel.dx}
                 y={curLy}
                 textAnchor={curLabel.anchor}
                 dominantBaseline="middle"
-                fontSize="11"
+                fontSize="12"
                 fill={currentColor}
-                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 600 }}
+                style={{ fontFamily: "var(--ow-font-mono)", fontWeight: 700 }}
               >
-                <tspan>{leg.current_speed_kn?.toFixed(1) ?? "—"} kn</tspan>
-                <tspan x={curLx + curLabel.dx} dy="12" fill="var(--ow-fg-2)" fontWeight="500">
-                  {leg.current_relative ?? ""}
-                </tspan>
+                {leg.current_speed_kn?.toFixed(1) ?? "—"} kn
               </text>
             </>
           )}
         </svg>
       </div>
 
-      {/* Color legend — current entry only when a current is actually drawn */}
+      {/* Color legend — only the forces we're drawing */}
       <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center mt-1 mb-1">
-        <LegendItem color={COLORS.wind} swatch="arrow" label="Vent" />
+        <LegendItem color={COLORS.wind} swatch="windDouble" label="Vent" />
         {hasWaves && <LegendItem color={COLORS.waves} swatch="wave" label="Vagues" />}
-        {currentAngle != null && leg.current_relative === "portant" && (
-          <LegendItem color={COLORS.currentPortant} swatch="arrow" label="Courant portant" />
-        )}
-        {currentAngle != null && leg.current_relative === "contraire" && (
-          <LegendItem color={COLORS.currentContraire} swatch="arrow" label="Courant contraire" />
-        )}
-        {currentAngle != null && leg.current_relative === "travers" && (
-          <LegendItem color={COLORS.currentTravers} swatch="arrow" label="Courant travers" />
+        {currentAngle != null && (
+          <LegendItem color={currentColor} swatch="arrow" label="Courant" />
         )}
       </div>
     </div>

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -17,6 +17,8 @@ interface PlanMapProps {
   onWptAdd?: (afterIdx: number, lat: number, lon: number) => void;
   onWptDelete?: (idx: number) => void;
   onMapClick?: (lat: number, lon: number) => void;
+  /** Inclusive-exclusive range of segment indices to highlight (selected leg). */
+  highlightedSegmentRange?: [number, number] | null;
 }
 
 function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon {
@@ -32,13 +34,14 @@ function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon 
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick, highlightedSegmentRange }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const polylinesRef = useRef<L.Polyline[]>([]);
+  const highlightLineRef = useRef<L.Polyline | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const dragLineRef = useRef<L.Polyline | null>(null);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
@@ -262,6 +265,36 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       polylinesRef.current.push(line);
     });
   }, [waypoints, segments, isStale]);
+
+  // Selected-leg highlight overlay — drawn on top of the colored segments,
+  // using the brand accent color so it pops against the wind palette.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (highlightLineRef.current) {
+      highlightLineRef.current.remove();
+      highlightLineRef.current = null;
+    }
+    if (!highlightedSegmentRange || !segments || segments.length === 0) return;
+    const [s, e] = highlightedSegmentRange;
+    if (s < 0 || e <= s || s >= segments.length) return;
+    const slice = segments.slice(s, Math.min(e, segments.length));
+    if (slice.length === 0) return;
+    const path: L.LatLngExpression[] = [
+      L.latLng(slice[0].start.lat, slice[0].start.lon),
+      ...slice.map((seg) => L.latLng(seg.end.lat, seg.end.lon)),
+    ];
+    const accent = resolvedTheme === "light" ? "#0f766e" : "#2dd4bf";
+    const overlay = L.polyline(path, {
+      color: accent,
+      weight: 10,
+      opacity: 0.85,
+      lineCap: "round",
+      lineJoin: "round",
+    }).addTo(map);
+    overlay.bringToFront();
+    highlightLineRef.current = overlay;
+  }, [highlightedSegmentRange, segments, resolvedTheme]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 });

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -555,7 +555,7 @@ function LegList({ legs, archetypeLabel }: { legs: AggregatedLeg[]; archetypeLab
         className="px-4 pb-1.5 text-[9px]"
         style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
       >
-        <span className="ml-[34px]">allure · vent · mer · distance</span>
+        <span className="ml-[34px]">allure · vent · vagues · distance</span>
         <span className="float-right">vitesse cible</span>
       </div>
       <div style={{ borderTop: "1px solid var(--ow-line)" }}>

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -475,13 +475,11 @@ function LegRow({
   leg,
   index,
   expanded,
-  archetypeLabel,
   onToggle,
 }: {
   leg: AggregatedLeg;
   index: number;
   expanded: boolean;
-  archetypeLabel: string;
   onToggle: () => void;
 }) {
   const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
@@ -533,12 +531,12 @@ function LegRow({
           </svg>
         </span>
       </button>
-      {expanded && <LegDetailCard leg={leg} archetypeLabel={archetypeLabel} />}
+      {expanded && <LegDetailCard leg={leg} />}
     </div>
   );
 }
 
-function LegList({ legs, archetypeLabel }: { legs: AggregatedLeg[]; archetypeLabel: string }) {
+function LegList({ legs }: { legs: AggregatedLeg[] }) {
   const [openIdx, setOpenIdx] = useState<number | null>(null);
   return (
     <div>
@@ -565,7 +563,6 @@ function LegList({ legs, archetypeLabel }: { legs: AggregatedLeg[]; archetypeLab
             leg={leg}
             index={i}
             expanded={openIdx === i}
-            archetypeLabel={archetypeLabel}
             onToggle={() => setOpenIdx((cur) => (cur === i ? null : i))}
           />
         ))}
@@ -908,7 +905,7 @@ export function PlanSidebar({
       {/* Legs — click any row to see the build-up */}
       {(() => {
         const legs = aggregateLegs(passage.segments, waypoints, passage.efficiency);
-        return <LegList legs={legs} archetypeLabel={archetypeLabel} />;
+        return <LegList legs={legs} />;
       })()}
 
       {/* Footer */}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -543,13 +543,20 @@ function LegList({ legs, archetypeLabel }: { legs: AggregatedLeg[]; archetypeLab
   return (
     <div>
       <div
-        className="flex items-center justify-between px-4 pt-3 pb-1.5 text-[10px] uppercase tracking-widest font-bold"
+        className="flex items-center justify-between px-4 pt-3 pb-1 text-[10px] uppercase tracking-widest font-bold"
         style={{ color: "var(--ow-fg-2)" }}
       >
         Segments
         <span className="text-[9px] font-medium normal-case tracking-normal" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
           cliquez pour détailler
         </span>
+      </div>
+      <div
+        className="px-4 pb-1.5 text-[9px]"
+        style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        <span className="ml-[34px]">allure · vent · mer · distance</span>
+        <span className="float-right">vitesse cible</span>
       </div>
       <div style={{ borderTop: "1px solid var(--ow-line)" }}>
         {legs.map((leg, i) => (

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -614,6 +614,9 @@ interface PlanSidebarProps {
   /** Selected leg index in the filled view (drives the map highlight). */
   selectedLegIdx: number | null;
   onSelectedLegChange: (idx: number | null) => void;
+  /** Mobile-only: pop the bottom drawer up to a readable height when the
+   *  user picks a mode (no-op on desktop). */
+  onExpandDrawer?: () => void;
 }
 
 export function PlanSidebar({
@@ -647,6 +650,7 @@ export function PlanSidebar({
   onWindowSelect,
   selectedLegIdx,
   onSelectedLegChange,
+  onExpandDrawer,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
   const sweepValid = mode === "compare"
@@ -710,7 +714,12 @@ export function PlanSidebar({
     return (
       <div className="p-4 space-y-4 animate-fade-in">
         <ModeToggle value={mode} onChange={handleModeChange} locked />
-        <ModePicker onPick={handleModeChange} />
+        <ModePicker
+          onPick={(m) => {
+            handleModeChange(m);
+            onExpandDrawer?.();
+          }}
+        />
       </div>
     );
   }

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -486,6 +486,8 @@ function LegRow({
 }) {
   const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
   const tws = Math.round(leg.tws_avg_kn);
+  const fmtHM = (iso: string) =>
+    new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
   return (
     <div style={{ borderBottom: "1px solid var(--ow-line)", background: expanded ? "var(--ow-bg-2)" : "transparent" }}>
       <button
@@ -507,9 +509,12 @@ function LegRow({
           <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
             {leg.distance_nm.toFixed(1)} nm · {leg.point_of_sail} · {tws} kn
           </div>
+          <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
+            {fmtHM(leg.start_time)} → {fmtHM(leg.end_time)}
+          </div>
         </div>
-        <span className="text-[11px] tabular-nums shrink-0" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
-          {new Date(leg.end_time).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}
+        <span className="text-[11px] tabular-nums shrink-0 font-semibold" style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>
+          {leg.target_speed_kn.toFixed(1)} kn
         </span>
         <span
           aria-hidden="true"
@@ -691,7 +696,82 @@ export function PlanSidebar({
     );
   }
 
-  // ── Form state (compare always; single before any result) ─────────────────
+  const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
+  const archetypeLabel = archetype?.name ?? currentArchetypeSlug;
+
+  // ── Filled compare view: results loaded, inputs collapsed into a recap ────
+  if (mode === "compare" && windows && windows.length > 0) {
+    const fmtShort = (iso: string) =>
+      new Date(iso).toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
+    const fmtClock = (iso: string) =>
+      new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+    const recapPrimary = `${fmtShort(sweepEarliest)} ${fmtClock(sweepEarliest)} → ${fmtShort(sweepLatest)} ${fmtClock(sweepLatest)}`;
+    const recapSecondary = `pas ${sweepIntervalHours}h · ${archetypeLabel}`;
+
+    return (
+      <div className="animate-fade-in">
+        <div className="px-4 pt-4 pb-3" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+          <ModeToggle value={mode} onChange={handleModeChange} />
+        </div>
+
+        <div className="px-4 py-2.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+          <button
+            onClick={onCompareFetch}
+            disabled={!canCalculate}
+            className="w-full flex items-center justify-center gap-2 rounded-md py-1.5 text-xs font-semibold transition-all"
+            style={{
+              background: canCalculate ? "#F4C25C" : "var(--ow-bg-2)",
+              color: canCalculate ? "#3a2a08" : "var(--ow-fg-3)",
+              border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line)"}`,
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M13.5 2.5A7 7 0 1 0 14.5 9" /><path d="M14 1v4h-4" />
+            </svg>
+            Recalculer
+          </button>
+        </div>
+
+        <RecapButton
+          primary={recapPrimary}
+          secondary={recapSecondary}
+          isOpen={isEditingParams}
+          onClick={() => setIsEditingParams((v) => !v)}
+        />
+        {isEditingParams && (
+          <div className="px-4 py-3 space-y-3" style={{ borderBottom: "1px solid var(--ow-line)", background: "var(--ow-bg-2)" }}>
+            <SweepForm
+              earliest={sweepEarliest}
+              latest={sweepLatest}
+              intervalHours={sweepIntervalHours}
+              onEarliestChange={onSweepEarliestChange}
+              onLatestChange={onSweepLatestChange}
+              onIntervalChange={onSweepIntervalChange}
+            />
+            <ArchetypeSelector
+              currentSlug={currentArchetypeSlug}
+              archetypes={archetypes}
+              onChange={onArchetypeChange}
+            />
+          </div>
+        )}
+
+        {metaWarnings.length > 0 && (
+          <div className="px-4 py-2.5 space-y-1.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+            {metaWarnings.map((m, i) => <Warn key={i}>{m}</Warn>)}
+          </div>
+        )}
+
+        <WindowsTable windows={windows} onSelect={onWindowSelect} />
+
+        <p className="px-4 py-2 text-[10px]" style={{ color: "var(--ow-fg-3)", borderTop: "1px solid var(--ow-line)" }}>
+          {windows.length} fenêtre{windows.length > 1 ? "s" : ""} comparée{windows.length > 1 ? "s" : ""} · cliquez sur une ligne pour ouvrir la simulation détaillée
+        </p>
+      </div>
+    );
+  }
+
+  // ── Form state (compare without windows; single before any result) ────────
   if (mode === "compare" || !passage || !complexity) {
     const accent = mode === "compare" ? "#F4C25C" : "var(--ow-accent)";
     const ctaInk = mode === "compare" ? "#3a2a08" : "#fff";
@@ -744,20 +824,6 @@ export function PlanSidebar({
             ? mode === "single" ? "Calculer le passage" : "Comparer les créneaux"
             : `${waypointCount}/2 waypoints`}
         </button>
-
-        {mode === "compare" && windows && windows.length > 0 && (
-          <div className="space-y-2">
-            {metaWarnings.map((m, i) => (
-              <Warn key={i}>{m}</Warn>
-            ))}
-            <div className="rounded-xl overflow-hidden border" style={{ borderColor: "var(--ow-line)" }}>
-              <WindowsTable windows={windows} onSelect={onWindowSelect} />
-            </div>
-            <p className="text-[10px]" style={{ color: "var(--ow-fg-3)" }}>
-              {windows.length} fenêtre{windows.length > 1 ? "s" : ""} comparée{windows.length > 1 ? "s" : ""} · cliquez sur une ligne pour ouvrir la simulation détaillée
-            </p>
-          </div>
-        )}
       </div>
     );
   }
@@ -766,8 +832,6 @@ export function PlanSidebar({
   const hasWarnings = (complexity.warnings?.length ?? 0) > 0 || passage.warnings.length > 0;
   const recapDate = new Date(departure).toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
   const recapTime = new Date(departure).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-  const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
-  const archetypeLabel = archetype?.name ?? currentArchetypeSlug;
 
   return (
     <div className="animate-fade-in">

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -471,6 +471,11 @@ function ArchetypeSelector({
 // Click-to-expand list of legs, with the "Comment c'est calculé" build-up
 // rendered inline for the open leg.
 
+// Shared 4-column template for the leg sub-line — kept as a constant so the
+// sidebar's legend header and every row use the same widths and the values
+// (allure / vent / vagues / distance) line up vertically across rows.
+const SEG_SUBLINE_COLS = "minmax(50px,0.7fr) minmax(40px,0.5fr) minmax(82px,1fr) minmax(44px,0.5fr)";
+
 function LegRow({
   leg,
   index,
@@ -486,7 +491,7 @@ function LegRow({
   const tws = Math.round(leg.tws_avg_kn);
   const seaPart = leg.hs_avg_m != null
     ? `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction ?? ""}`.trim()
-    : null;
+    : "—";
   const fmtHM = (iso: string) =>
     new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
   return (
@@ -507,8 +512,14 @@ function LegRow({
           <div className="text-xs font-semibold truncate" style={{ color: "var(--ow-fg-0)" }}>
             Tronçon {index + 1}
           </div>
-          <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-            {leg.point_of_sail} · {tws} kn{seaPart ? ` · ${seaPart}` : ""} · {leg.distance_nm.toFixed(1)} nm
+          <div
+            className="grid gap-2 mt-0.5 text-[10px] tabular-nums"
+            style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)", gridTemplateColumns: SEG_SUBLINE_COLS }}
+          >
+            <span className="truncate">{leg.point_of_sail}</span>
+            <span>{tws} kn</span>
+            <span className="truncate">{seaPart}</span>
+            <span>{leg.distance_nm.toFixed(1)} nm</span>
           </div>
           <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
             {fmtHM(leg.start_time)} → {fmtHM(leg.end_time)}
@@ -557,11 +568,21 @@ function LegList({
         </span>
       </div>
       <div
-        className="px-4 pb-1.5 text-[9px]"
+        className="flex items-center gap-2.5 px-4 pb-1.5 text-[9px]"
         style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
       >
-        <span className="ml-[34px]">allure · vent · vagues · distance</span>
-        <span className="float-right">vitesse cible</span>
+        <span className="shrink-0 w-6" />
+        <div
+          className="flex-1 min-w-0 grid gap-2"
+          style={{ gridTemplateColumns: SEG_SUBLINE_COLS }}
+        >
+          <span>allure</span>
+          <span>vent</span>
+          <span>vagues</span>
+          <span>distance</span>
+        </div>
+        <span className="shrink-0">vitesse cible</span>
+        <span className="shrink-0 w-[14px]" />
       </div>
       <div style={{ borderTop: "1px solid var(--ow-line)" }}>
         {legs.map((leg, i) => (

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -486,6 +486,9 @@ function LegRow({
 }) {
   const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
   const tws = Math.round(leg.tws_avg_kn);
+  const seaPart = leg.hs_avg_m != null
+    ? `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction ?? ""}`.trim()
+    : null;
   const fmtHM = (iso: string) =>
     new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
   return (
@@ -507,7 +510,7 @@ function LegRow({
             Tronçon {index + 1}
           </div>
           <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-            {leg.distance_nm.toFixed(1)} nm · {leg.point_of_sail} · {tws} kn
+            {leg.point_of_sail} · {tws} kn{seaPart ? ` · ${seaPart}` : ""} · {leg.distance_nm.toFixed(1)} nm
           </div>
           <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
             {fmtHM(leg.start_time)} → {fmtHM(leg.end_time)}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -536,8 +536,15 @@ function LegRow({
   );
 }
 
-function LegList({ legs }: { legs: AggregatedLeg[] }) {
-  const [openIdx, setOpenIdx] = useState<number | null>(null);
+function LegList({
+  legs,
+  openIdx,
+  onOpenChange,
+}: {
+  legs: AggregatedLeg[];
+  openIdx: number | null;
+  onOpenChange: (idx: number | null) => void;
+}) {
   return (
     <div>
       <div
@@ -563,7 +570,7 @@ function LegList({ legs }: { legs: AggregatedLeg[] }) {
             leg={leg}
             index={i}
             expanded={openIdx === i}
-            onToggle={() => setOpenIdx((cur) => (cur === i ? null : i))}
+            onToggle={() => onOpenChange(openIdx === i ? null : i)}
           />
         ))}
       </div>
@@ -604,6 +611,9 @@ interface PlanSidebarProps {
   metaWarnings: string[];
   onCompareFetch: () => void;
   onWindowSelect?: (w: PassageWindow) => void;
+  /** Selected leg index in the filled view (drives the map highlight). */
+  selectedLegIdx: number | null;
+  onSelectedLegChange: (idx: number | null) => void;
 }
 
 export function PlanSidebar({
@@ -635,6 +645,8 @@ export function PlanSidebar({
   metaWarnings,
   onCompareFetch,
   onWindowSelect,
+  selectedLegIdx,
+  onSelectedLegChange,
 }: PlanSidebarProps) {
   const { resolvedTheme } = useTheme();
   const sweepValid = mode === "compare"
@@ -905,7 +917,13 @@ export function PlanSidebar({
       {/* Legs — click any row to see the build-up */}
       {(() => {
         const legs = aggregateLegs(passage.segments, waypoints, passage.efficiency);
-        return <LegList legs={legs} />;
+        return (
+          <LegList
+            legs={legs}
+            openIdx={selectedLegIdx}
+            onOpenChange={onSelectedLegChange}
+          />
+        );
       })()}
 
       {/* Footer */}

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -12,6 +12,7 @@ export interface AggregatedLeg {
   tws_avg_kn: number;
   twa_avg_deg: number; // signed -180..180 like SegmentReport.twa_deg
   twd_avg_deg: number; // 0..360 (true wind direction)
+  bearing_avg_deg: number; // 0..360 (boat course, true)
   gust_max_kn: number | null;
   point_of_sail: string;
 
@@ -104,6 +105,7 @@ export function aggregateLegs(
     const tws_avg_kn = wsum((s) => s.tws_kn);
     const twa_avg_deg = circularMeanDeg(segs.map((s) => s.twa_deg));
     const twd_avg_deg = circularMeanDeg(segs.map((s) => s.twd_deg));
+    const bearing_avg_deg = circularMeanDeg(segs.map((s) => s.bearing_deg));
     const gusts = segs.map((s) => s.gust_kn).filter((g): g is number => g != null);
     const gust_max_kn = gusts.length > 0 ? Math.max(...gusts) : null;
 
@@ -148,6 +150,7 @@ export function aggregateLegs(
       tws_avg_kn,
       twa_avg_deg,
       twd_avg_deg,
+      bearing_avg_deg,
       gust_max_kn,
       point_of_sail: twaToPointOfSail(twa_avg_deg),
       polar_after_eff_kn,

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -3,6 +3,7 @@ import type { SegmentReport } from "./types";
 export interface AggregatedLeg {
   // ── Distances & timing (carried from the segment span) ─────────────────────
   distance_nm: number;
+  start_time: string;
   end_time: string;
 
   // ── Wind summary ──────────────────────────────────────────────────────────
@@ -140,6 +141,7 @@ export function aggregateLegs(
 
     return {
       distance_nm: totalDist,
+      start_time: segs[0].start_time,
       end_time: segs[segs.length - 1].end_time,
       tws_min: Math.min(...twsVals),
       tws_max: Math.max(...twsVals),

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -58,6 +58,29 @@ function twaToPointOfSail(twa: number): string {
   return "Arrière";
 }
 
+// Inclusive-exclusive segment ranges per user-waypoint leg. Shared between
+// the sidebar (drives the click-to-expand list) and the map (drives the
+// highlight overlay when a leg is selected).
+export function computeLegSegmentRanges(
+  segments: { start: { lat: number; lon: number } }[],
+  waypoints: [number, number][],
+): Array<[number, number]> {
+  if (waypoints.length < 2 || segments.length === 0) return [];
+  const legStarts: number[] = [0];
+  for (let w = 1; w < waypoints.length - 1; w++) {
+    const [wlat, wlon] = waypoints[w];
+    let best = legStarts[legStarts.length - 1] + 1;
+    let bestD = Infinity;
+    for (let i = best; i < segments.length; i++) {
+      const d = Math.hypot(segments[i].start.lat - wlat, segments[i].start.lon - wlon);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    legStarts.push(best);
+  }
+  legStarts.push(segments.length);
+  return legStarts.slice(0, -1).map((s, i) => [s, legStarts[i + 1]]);
+}
+
 function twaToSeaDirection(twa: number): "face" | "travers" | "arrière" {
   // 3-bucket split (vs 4 for point_of_sail) — sailors call out sea state in
   // coarser terms than sail trim.

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -11,9 +11,9 @@ import {
   waypointsEqual,
   type LastSimulation,
 } from "../plan/lastSimulation";
-import { ModeToggle, type PlanMode, type TimeAnchor } from "../plan/ModeToggle";
-import { cxLevel, CX_COLORS } from "../plan/types";
-import { aggregateLegs, computeLegSegmentRanges } from "../plan/aggregateLegs";
+import { type TimeAnchor } from "../plan/ModeToggle";
+import { CX_COLORS } from "../plan/types";
+import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
@@ -58,14 +58,6 @@ function fmtDuration(h: number) {
   return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
 }
 
-function RefetchIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M13.5 2.5A7 7 0 1 0 14.5 9" /><path d="M14 1v4h-4" />
-    </svg>
-  );
-}
-
 // Hero stats overlay — absolute, bottom of map, mobile only
 function PlanHeroStats({ passage, complexity }: { passage: PassageReport; complexity: ComplexityScore }) {
   const stats = [
@@ -86,134 +78,6 @@ function PlanHeroStats({ passage, complexity }: { passage: PassageReport; comple
           <div className="text-xs font-bold tabular-nums leading-tight mt-0.5" style={{ color: color ?? "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>{value}</div>
         </div>
       ))}
-    </div>
-  );
-}
-
-// Compact drawer — replaces sidebar on mobile
-function CompactDrawer({
-  passage,
-  complexity,
-  waypoints,
-  isLoading,
-  error,
-  isStale,
-  onRefetch,
-  mode,
-  onModeChange,
-}: {
-  passage: PassageReport | null;
-  complexity: ComplexityScore | null;
-  waypoints: [number, number][];
-  isLoading: boolean;
-  error: string | null;
-  isStale: boolean;
-  onRefetch: () => void;
-  mode: PlanMode;
-  onModeChange: (m: PlanMode) => void;
-}) {
-  // Mode toggle is always visible at the top so the user can swap between
-  // Simuler / Comparer even when single-mode results are showing.
-  const header = (
-    <div className="px-3 pt-3 pb-2" style={{ background: "var(--ow-bg-1)" }}>
-      <ModeToggle value={mode} onChange={onModeChange} />
-    </div>
-  );
-
-  if (isLoading) {
-    return (
-      <div>
-        {header}
-        <div className="p-3 space-y-2 animate-fade-in">
-          {[0, 1, 2].map((i) => <div key={i} className="skeleton h-9 rounded-lg" />)}
-        </div>
-      </div>
-    );
-  }
-  if (error) {
-    return (
-      <div>
-        {header}
-        <div className="p-3">
-          <p className="text-xs rounded-lg px-3 py-2" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)" }}>{error}</p>
-        </div>
-      </div>
-    );
-  }
-  if (!passage || !complexity) return header;
-
-  const legs = aggregateLegs(passage.segments, waypoints);
-
-  return (
-    <div>
-      {header}
-      {/* Sticky header */}
-      <div
-        className="sticky top-0 z-10 flex items-center gap-2 px-3 py-2 border-b"
-        style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
-      >
-        <span className="text-xs font-semibold flex-1" style={{ color: "var(--ow-fg-1)" }}>
-          {legs.length} tronçon{legs.length > 1 ? "s" : ""} · {passage.distance_nm.toFixed(1)} nm
-        </span>
-        {isStale && (
-          <span className="text-[10px] font-medium shrink-0" style={{ color: "var(--ow-warn)" }}>⚠ Obsolète</span>
-        )}
-        <button
-          onClick={onRefetch}
-          className="shrink-0 flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-semibold transition-colors"
-          style={{
-            background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
-            color: isStale ? "#fff" : "var(--ow-fg-2)",
-            border: `1px solid ${isStale ? "transparent" : "var(--ow-line-2)"}`,
-          }}
-        >
-          <RefetchIcon />
-          Recalculer
-        </button>
-      </div>
-
-      {/* Column legend — mirrors the desktop sidebar so the row format is legible */}
-      <div
-        className="flex items-center gap-2 px-3 py-1 text-[9px]"
-        style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
-      >
-        <span className="shrink-0 w-5" />
-        <span className="flex-1">allure · vent · vagues · vitesse</span>
-        <span className="shrink-0">heure</span>
-      </div>
-
-      {/* Leg rows */}
-      <div>
-        {legs.map((leg, i) => {
-          const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
-          const windLabel = Math.round(leg.tws_min) === Math.round(leg.tws_max)
-            ? `${Math.round(leg.tws_min)} kn`
-            : `${Math.round(leg.tws_min)}–${Math.round(leg.tws_max)} kn`;
-          const seaLabel = leg.hs_avg_m == null
-            ? null
-            : `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction}`;
-          return (
-            <div
-              key={i}
-              className="flex items-center gap-2 px-3 py-2.5 border-b text-xs"
-              style={{ borderColor: "var(--ow-line)" }}
-            >
-              <span
-                className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-bold text-[10px]"
-                style={{ background: CX_COLORS[cx], color: "#fff" }}
-              >
-                {i + 1}
-              </span>
-              <span className="flex-1 tabular-nums" style={{ color: "var(--ow-fg-1)", fontFamily: "var(--ow-font-mono)" }}>
-                {leg.point_of_sail} · {windLabel}{seaLabel ? ` · ${seaLabel}` : ""} · {leg.boat_speed_kn.toFixed(1)} kn
-              </span>
-              <span className="tabular-nums shrink-0" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
-                {fmtTime(leg.end_time)}
-              </span>
-            </div>
-          );
-        })}
-      </div>
     </div>
   );
 }
@@ -724,8 +588,10 @@ export function PlanPage() {
               </div>
             </div>
           )}
-          {/* Hero stats overlay — mobile only, floats above compact drawer */}
-          {passage && complexity && (
+          {/* Hero stats overlay — mobile only, floats above the drawer.
+              Hidden in compare mode (no single passage to summarise — the
+              windows table inside the drawer is the relevant view). */}
+          {passage && complexity && planMode === "single" && (
             <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
               <PlanHeroStats passage={passage} complexity={complexity} />
             </div>
@@ -772,53 +638,39 @@ export function PlanPage() {
 
       {/* Mobile drawer — below map. User-resizable via the handle bar at the top. */}
       <ResizableMobileDrawer ref={drawerRef} defaultVh={passage ? 38 : 60}>
-        {passage && complexity && planMode === "single" ? (
-          <CompactDrawer
-            passage={passage}
-            complexity={complexity}
-            waypoints={waypoints}
-            isLoading={isLoading}
-            error={apiError}
-            isStale={isStale}
-            onRefetch={handleRefetch}
-            mode={planMode}
-            onModeChange={handleModeChange}
-          />
-        ) : (
-          <PlanSidebar
-            passage={passage}
-            complexity={complexity}
-            isLoading={isLoading}
-            error={apiError}
-            archetypes={archetypes}
-            currentArchetypeSlug={archetype}
-            onArchetypeChange={handleArchetypeChange}
-            departure={departure}
-            onDepartureChange={handleDepartureChange}
-            isStale={isStale}
-            onRefetch={handleRefetch}
-            forecastUpdatedAt={forecastUpdatedAt}
-            waypointCount={waypoints.length}
-            waypoints={waypoints}
-            timeAnchor={timeAnchor}
-            onTimeAnchorChange={handleTimeAnchorChange}
-            mode={planMode}
-            onModeChange={handleModeChange}
-            sweepEarliest={sweepEarliest}
-            sweepLatest={sweepLatest}
-            sweepIntervalHours={sweepInterval}
-            onSweepEarliestChange={setSweepEarliest}
-            onSweepLatestChange={setSweepLatest}
-            onSweepIntervalChange={setSweepInterval}
-            windows={windows}
-            metaWarnings={metaWarnings}
-            onCompareFetch={doFetchWindows}
-            onWindowSelect={handleWindowSelect}
-            selectedLegIdx={selectedLegIdx}
-            onSelectedLegChange={setSelectedLegIdx}
-            onExpandDrawer={() => drawerRef.current?.expand()}
-          />
-        )}
+        <PlanSidebar
+          passage={passage}
+          complexity={complexity}
+          isLoading={isLoading}
+          error={apiError}
+          archetypes={archetypes}
+          currentArchetypeSlug={archetype}
+          onArchetypeChange={handleArchetypeChange}
+          departure={departure}
+          onDepartureChange={handleDepartureChange}
+          isStale={isStale}
+          onRefetch={handleRefetch}
+          forecastUpdatedAt={forecastUpdatedAt}
+          waypointCount={waypoints.length}
+          waypoints={waypoints}
+          timeAnchor={timeAnchor}
+          onTimeAnchorChange={handleTimeAnchorChange}
+          mode={planMode}
+          onModeChange={handleModeChange}
+          sweepEarliest={sweepEarliest}
+          sweepLatest={sweepLatest}
+          sweepIntervalHours={sweepInterval}
+          onSweepEarliestChange={setSweepEarliest}
+          onSweepLatestChange={setSweepLatest}
+          onSweepIntervalChange={setSweepInterval}
+          windows={windows}
+          metaWarnings={metaWarnings}
+          onCompareFetch={doFetchWindows}
+          onWindowSelect={handleWindowSelect}
+          selectedLegIdx={selectedLegIdx}
+          onSelectedLegChange={setSelectedLegIdx}
+          onExpandDrawer={() => drawerRef.current?.expand()}
+        />
       </ResizableMobileDrawer>
     </div>
   );

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -5,6 +5,7 @@ import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError } from "../api/passage";
 import { ThemeToggle } from "../design/theme";
 import { SpotSearch } from "../components/SpotSearch";
+import { InfoButton } from "../components/InfoButton";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import {
   loadLastSimulation,
@@ -14,7 +15,7 @@ import {
 } from "../plan/lastSimulation";
 import { ModeToggle, type PlanMode, type TimeAnchor } from "../plan/ModeToggle";
 import { cxLevel, CX_COLORS } from "../plan/types";
-import { aggregateLegs } from "../plan/aggregateLegs";
+import { aggregateLegs, computeLegSegmentRanges } from "../plan/aggregateLegs";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
@@ -439,6 +440,11 @@ export function PlanPage() {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   });
   const [sweepInterval, setSweepInterval] = useState<number>(3);
+  // Selected leg for the sidebar's expanded "Comment c'est calculé" — also
+  // drives the highlight overlay on the map. Cleared whenever the route or
+  // its segments change so we never highlight stale ranges.
+  const [selectedLegIdx, setSelectedLegIdx] = useState<number | null>(null);
+  useEffect(() => { setSelectedLegIdx(null); }, [waypoints, passage]);
   const [windows, setWindows] = useState<PassageWindow[] | null>(null);
   const [metaWarnings, setMetaWarnings] = useState<string[]>([]);
 
@@ -695,6 +701,7 @@ export function PlanPage() {
         </div>
         <div className="flex items-center gap-1">
           <CopyLinkButton />
+          <InfoButton />
           <ThemeToggle />
         </div>
       </header>
@@ -712,6 +719,11 @@ export function PlanPage() {
             onWptAdd={waypoints.length >= 2 ? handleWptAdd : undefined}
             onWptDelete={handleWptDelete}
             onMapClick={handleMapClick}
+            highlightedSegmentRange={
+              selectedLegIdx != null && passage
+                ? computeLegSegmentRanges(passage.segments as { start: { lat: number; lon: number } }[], waypoints)[selectedLegIdx] ?? null
+                : null
+            }
           />
           {/* Back-to-explore FAB — mirrors the compass FAB on the home map */}
           <a
@@ -772,6 +784,8 @@ export function PlanPage() {
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}
             onWindowSelect={handleWindowSelect}
+            selectedLegIdx={selectedLegIdx}
+            onSelectedLegChange={setSelectedLegIdx}
           />
         </ResizableDesktopSidebar>
       </div>
@@ -820,6 +834,8 @@ export function PlanPage() {
             metaWarnings={metaWarnings}
             onCompareFetch={doFetchWindows}
             onWindowSelect={handleWindowSelect}
+            selectedLegIdx={selectedLegIdx}
+            onSelectedLegChange={setSelectedLegIdx}
           />
         )}
       </ResizableMobileDrawer>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
@@ -172,6 +172,16 @@ function CompactDrawer({
         </button>
       </div>
 
+      {/* Column legend — mirrors the desktop sidebar so the row format is legible */}
+      <div
+        className="flex items-center gap-2 px-3 py-1 text-[9px]"
+        style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        <span className="shrink-0 w-5" />
+        <span className="flex-1">allure · vent · vagues · vitesse</span>
+        <span className="shrink-0">heure</span>
+      </div>
+
       {/* Leg rows */}
       <div>
         {legs.map((leg, i) => {
@@ -212,18 +222,24 @@ function CompactDrawer({
 // User-resizable bottom drawer: a 4 px grab-handle at the top responds to
 // pointer drag (mouse or touch) and adjusts the drawer height in vh. The
 // chosen height persists in localStorage so reload feels stable.
+//
+// Exposes an imperative `.expand()` so callers (e.g. the mode-picker click)
+// can pop the drawer up to a sensible reading height when the panel content
+// gets richer.
 
 const DRAWER_HEIGHT_KEY = "ow_drawer_vh_v1";
 const DRAWER_MIN_VH = 12;
 const DRAWER_MAX_VH = 90;
+const DRAWER_EXPANDED_VH = 75;
 
-function ResizableMobileDrawer({
-  defaultVh,
-  children,
-}: {
+interface DrawerHandle {
+  expand: () => void;
+}
+
+const ResizableMobileDrawer = forwardRef<DrawerHandle, {
   defaultVh: number;
   children: React.ReactNode;
-}) {
+}>(function ResizableMobileDrawer({ defaultVh, children }, ref) {
   const [vh, setVh] = useState<number>(() => {
     try {
       const raw = localStorage.getItem(DRAWER_HEIGHT_KEY);
@@ -238,6 +254,16 @@ function ResizableMobileDrawer({
   function persist(next: number) {
     try { localStorage.setItem(DRAWER_HEIGHT_KEY, String(next)); } catch { /* best-effort */ }
   }
+
+  useImperativeHandle(ref, () => ({
+    expand: () => {
+      setVh((prev) => {
+        const next = Math.max(prev, DRAWER_EXPANDED_VH);
+        if (next !== prev) persist(next);
+        return next;
+      });
+    },
+  }), []);
 
   function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
     e.preventDefault();
@@ -283,7 +309,7 @@ function ResizableMobileDrawer({
       <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
     </div>
   );
-}
+});
 
 // ── ResizableDesktopSidebar ──────────────────────────────────────────────────
 // Desktop equivalent of ResizableMobileDrawer: vertical grab-handle on the left
@@ -372,6 +398,7 @@ function ResizableDesktopSidebar({
 
 export function PlanPage() {
   const mapRef = useRef<PlanMapHandle>(null);
+  const drawerRef = useRef<DrawerHandle>(null);
   const initialParsed = parsePlanUrl(window.location.search);
 
   const [waypoints, setWaypoints] = useState<[number, number][]>(
@@ -738,12 +765,13 @@ export function PlanPage() {
             onWindowSelect={handleWindowSelect}
             selectedLegIdx={selectedLegIdx}
             onSelectedLegChange={setSelectedLegIdx}
+            onExpandDrawer={() => drawerRef.current?.expand()}
           />
         </ResizableDesktopSidebar>
       </div>
 
       {/* Mobile drawer — below map. User-resizable via the handle bar at the top. */}
-      <ResizableMobileDrawer defaultVh={passage ? 38 : 60}>
+      <ResizableMobileDrawer ref={drawerRef} defaultVh={passage ? 38 : 60}>
         {passage && complexity && planMode === "single" ? (
           <CompactDrawer
             passage={passage}
@@ -788,6 +816,7 @@ export function PlanPage() {
             onWindowSelect={handleWindowSelect}
             selectedLegIdx={selectedLegIdx}
             onSelectedLegChange={setSelectedLegIdx}
+            onExpandDrawer={() => drawerRef.current?.expand()}
           />
         )}
       </ResizableMobileDrawer>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -3,9 +3,7 @@ import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError } from "../api/passage";
-import { ThemeToggle } from "../design/theme";
-import { SpotSearch } from "../components/SpotSearch";
-import { InfoButton } from "../components/InfoButton";
+import { Header } from "../components/Header";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import {
   loadLastSimulation,
@@ -207,39 +205,6 @@ function CompactDrawer({
         })}
       </div>
     </div>
-  );
-}
-
-// ── CopyLinkButton ────────────────────────────────────────────────────────────
-
-function CopyLinkButton() {
-  const [copied, setCopied] = useState(false);
-  async function copy() {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-    } catch {
-      const el = document.createElement("textarea");
-      el.value = window.location.href;
-      document.body.appendChild(el);
-      el.select();
-      document.execCommand("copy");
-      document.body.removeChild(el);
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-  return (
-    <button
-      onClick={copy}
-      className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
-      style={{
-        background: copied ? "var(--ow-accent-soft)" : "var(--ow-bg-2)",
-        color: copied ? "var(--ow-accent)" : "var(--ow-fg-1)",
-        border: "1px solid var(--ow-line-2)",
-      }}
-    >
-      {copied ? "Copié ✓" : "🔗"}
-    </button>
   );
 }
 
@@ -689,22 +654,9 @@ export function PlanPage() {
       className="h-screen flex flex-col overflow-hidden"
       style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
     >
-      {/* Header */}
-      <header
-        className="shrink-0 h-12 flex items-center px-3 gap-2 border-b"
-        style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line)" }}
-      >
-        <div className="flex-1 flex justify-center px-1">
-          <SpotSearch
-            onSelect={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
-          />
-        </div>
-        <div className="flex items-center gap-1">
-          <CopyLinkButton />
-          <InfoButton />
-          <ThemeToggle />
-        </div>
-      </header>
+      <Header
+        onSelectSpot={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
+      />
 
       {/* Body */}
       <div className="flex-1 min-h-0 flex flex-col lg:flex-row">


### PR DESCRIPTION
## Summary

Suite de #100. Polish complet de la vue détail des segments + alignement mobile/desktop.

**Diagramme bateau (vue dépliée du segment)**
- Vue Nord-haut : la coque tourne vers son cap réel (N/E/S/W marqués), vent / vagues / courant aux vrais angles compas
- Vent : flèche **double-trait** (la plus visible), distinctif vs vagues et courant
- Vagues : wavy line ambre avec **flèche au bout**, décalée de 30° du vent par construction (jamais sur le même axe)
- Courant : **flow field** discret de fines flèches autour du bateau (pas une seule grosse), couleur sémantique (vert portant / orange contraire / bleu travers)
- Anti-overlap : si le label courant est à <30° du vent, push radial automatique vers l'extérieur
- Chaque label = caption + valeur, dans la couleur de la flèche : « Vent (rafales) / 18 (23) kn », « Hauteur vagues (période) / 1,2 m (5 s) », « Courant / 0,8 kn »
- Coque silhouette top-down avec étrave pointue + tableau plat à l'arrière

**Map ↔ sidebar**
- Click sur un tronçon → overlay accent par-dessus les segments correspondants sur la carte. Sélection auto-clear quand les waypoints/passage changent

**Mobile parity**
- `CompactDrawer` supprimé, le drawer mobile utilise désormais le même `PlanSidebar` que desktop : Recalculer, Récap collapsible, HeroStats, warnings, segments cliquables avec boat compass
- Auto-expand du drawer (75 vh) quand l'utilisateur clique une carte du mode picker
- Les 4 tuiles flottantes ETA/DURÉE/DIST/CX cachées en mode compare

**Sidebar polish**
- Sous-ligne segment en grid 4 colonnes (allure · vent · vagues · distance) → valeurs alignées verticalement entre tronçons
- Speed pill « 5,8 kn Près » (allure en gros à côté), cap en degrés seuls
- Header /plan unifié avec celui de l'explore (logo OpenWind + search + InfoButton + theme)

**Sources**
- InfoPanel mentionne maintenant IFREMER MARC PREVIMER pour les atlas haute résolution courants/marée

## Test plan

- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `npm run build` OK (459 kB)
- [x] Smoke MCP non requis (changements purement frontend)
- [ ] Vérif visuelle desktop : tracer 2+ waypoints → mode picker → form → résultats → click segment → compass + highlight carte
- [ ] Vérif visuelle mobile : même parcours dans le drawer, drawer s'agrandit après pick mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)