### PR TITLE
fix(web): current label avoids wind/wave collision

### DIFF
--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -250,21 +250,23 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
 
   // Each force gets its own label outside the dial at its own angle.
   // Wind & wave are spread by construction (30° angular offset). The current's
-  // angle is independent — when it lands within 40° of either wind or wave,
-  // pin its label opposite the wind direction so labels never share screen
-  // space. Two-line labels (caption + value) made the previous radial bump
-  // insufficient. The user is fine with the current label's position being
-  // arbitrary in this case; the on-dial flow field still shows the true
-  // flow direction.
+  // angle is independent — collision rules (user spec):
+  //   – close (<40°) to wind only   → label opposite the wind
+  //   – close (<40°) to wave only   → label opposite the wind (still ≥150° away)
+  //   – close to BOTH wind and wave → label perpendicular to the wind (+90°)
+  // The on-dial flow field still draws at the true current direction; only
+  // the textual annotation moves.
   const angularGap = (a: number, b: number): number => {
     const d = ((a - b + 540) % 360) - 180;
     return Math.abs(d);
   };
   let currentLabelAngle = currentAngle ?? 0;
   if (currentAngle != null) {
-    const tooCloseToWind = angularGap(currentAngle, windAngle) < 40;
-    const tooCloseToWave = angularGap(currentAngle, waveAngle) < 40;
-    if (tooCloseToWind || tooCloseToWave) {
+    const closeToWind = angularGap(currentAngle, windAngle) < 40;
+    const closeToWave = angularGap(currentAngle, waveAngle) < 40;
+    if (closeToWind && closeToWave) {
+      currentLabelAngle = (windAngle + 90) % 360;
+    } else if (closeToWind || closeToWave) {
       currentLabelAngle = (windAngle + 180) % 360;
     }
   }

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -250,27 +250,31 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
 
   // Each force gets its own label outside the dial at its own angle.
   // Wind & wave are spread by construction (30° angular offset). The current's
-  // angle is independent though — if it lands within 30° of either, push the
-  // current label radially outward so labels never share screen space. Keeps
-  // the angular position truthful (label still points at the real flow
-  // direction); only the distance from the dial changes.
+  // angle is independent — when it lands within 40° of either wind or wave,
+  // pin its label opposite the wind direction so labels never share screen
+  // space. Two-line labels (caption + value) made the previous radial bump
+  // insufficient. The user is fine with the current label's position being
+  // arbitrary in this case; the on-dial flow field still shows the true
+  // flow direction.
   const angularGap = (a: number, b: number): number => {
     const d = ((a - b + 540) % 360) - 180;
     return Math.abs(d);
   };
-  let currentLabelR = LABEL_R;
+  let currentLabelAngle = currentAngle ?? 0;
   if (currentAngle != null) {
-    const tooCloseToWind = angularGap(currentAngle, windAngle) < 30;
-    const tooCloseToWave = angularGap(currentAngle, waveAngle) < 30;
-    if (tooCloseToWind || tooCloseToWave) currentLabelR = LABEL_R + 28;
+    const tooCloseToWind = angularGap(currentAngle, windAngle) < 40;
+    const tooCloseToWave = angularGap(currentAngle, waveAngle) < 40;
+    if (tooCloseToWind || tooCloseToWave) {
+      currentLabelAngle = (windAngle + 180) % 360;
+    }
   }
 
   const [windLx, windLy] = polarXY(windAngle, LABEL_R);
   const windLabel = labelLayout(windAngle);
   const [waveLx, waveLy] = polarXY(waveAngle, LABEL_R);
   const waveLabel = labelLayout(waveAngle);
-  const [curLx, curLy] = currentAngle != null ? polarXY(currentAngle, currentLabelR) : [0, 0];
-  const curLabel = currentAngle != null ? labelLayout(currentAngle) : { anchor: "middle" as const, dx: 0 };
+  const [curLx, curLy] = currentAngle != null ? polarXY(currentLabelAngle, LABEL_R) : [0, 0];
+  const curLabel = currentAngle != null ? labelLayout(currentLabelAngle) : { anchor: "middle" as const, dx: 0 };
 
   return (
     <div className="px-4 pb-4 pt-1">


### PR DESCRIPTION
## Summary

Avant : quand le courant arrivait à <30° du vent ou des vagues, le label « Courant » se superposait avec « Hauteur vagues ». Le bump radial de 28 px ne suffisait plus depuis que les labels font 2 lignes (caption + valeur).

Après : quand le courant est à <40° du vent OU des vagues, le label part **à l'opposé du vent** (windAngle + 180°). Garanti ≥150° de distance angulaire avec les deux autres → collision impossible par construction. La flèche du flow field reste à la vraie direction.

User a explicitement validé que la position du label courant peut être arbitraire dans ce cas.

## Test plan

- [x] tsc + build OK
- [ ] Vérif visuelle : tracer un trajet où courant ≈ vent (typique zone de marin) → label courant doit s'afficher de l'autre côté du dial sans toucher les autres

🤖 Generated with [Claude Code](https://claude.com/claude-code)