### PR TITLE
fix(web): leg-detail header — Vitesse absolue de X kn + colored build-up

### DIFF
--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -289,28 +289,28 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
 
   return (
     <div className="px-4 pb-4 pt-1">
-      {/* Section header */}
-      <div
-        className="mb-2 text-[10px] font-bold uppercase"
-        style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
-      >
-        Vitesse absolue
-      </div>
-
-      {/* Headline speed + cap */}
+      {/* Title with inline speed + cap on the right */}
       <div className="flex items-baseline justify-between mb-1.5">
-        <span
-          className="text-2xl font-bold tabular-nums"
-          style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
-        >
-          {leg.target_speed_kn.toFixed(1)} kn
-        </span>
+        <div className="flex items-baseline gap-1.5">
+          <span
+            className="text-[10px] font-bold uppercase"
+            style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
+          >
+            Vitesse absolue de
+          </span>
+          <span
+            className="text-base font-bold tabular-nums"
+            style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.01em" }}
+          >
+            {fmtFR1(leg.target_speed_kn)} kn
+          </span>
+        </div>
         <span className="text-[10px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
           cap {Math.round(leg.bearing_avg_deg)}°
         </span>
       </div>
 
-      {/* Build-up: polaire (+) / mer (−) / courant (±) → cible */}
+      {/* Build-up of the speed: polaire (+) / mer (−) / courant (±) */}
       <div
         className="text-[10px] tabular-nums leading-snug mb-2"
         style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
@@ -336,12 +336,6 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
             <span>courant</span>
           </div>
         )}
-        <div className="flex items-baseline gap-2 mt-0.5 pt-0.5" style={{ borderTop: "1px solid var(--ow-line)" }}>
-          <span className="w-10 tabular-nums font-semibold" style={{ color: "var(--ow-fg-0)" }}>
-            {fmtFR1(leg.target_speed_kn)}
-          </span>
-          <span style={{ color: "var(--ow-fg-1)" }}>kn</span>
-        </div>
       </div>
 
       {/* Compass diagram */}

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -310,29 +310,26 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
         </span>
       </div>
 
-      {/* Build-up of the speed: polaire (+) / mer (−) / courant (±) */}
+      {/* Build-up of the speed: polaire (+) / mer (−) / courant (±).
+          Each row picks up the matching arrow color from the boat diagram so
+          the eye links the number to its glyph. */}
       <div
         className="text-[10px] tabular-nums leading-snug mb-2"
-        style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+        style={{ fontFamily: "var(--ow-font-mono)" }}
       >
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline gap-2" style={{ color: COLORS.wind }}>
           <span className="w-10 tabular-nums">{fmtSigned1(leg.polar_after_eff_kn)}</span>
           <span>polaire</span>
         </div>
         {hasWaves && Math.abs(leg.wave_delta_kn) > 0.05 && (
-          <div className="flex items-baseline gap-2">
-            <span className="w-10 tabular-nums" style={{ color: "var(--ow-warn)" }}>{fmtSigned1(leg.wave_delta_kn)}</span>
+          <div className="flex items-baseline gap-2" style={{ color: COLORS.waves }}>
+            <span className="w-10 tabular-nums">{fmtSigned1(leg.wave_delta_kn)}</span>
             <span>mer</span>
           </div>
         )}
         {leg.current_delta_kn != null && Math.abs(leg.current_delta_kn) > 0.05 && (
-          <div className="flex items-baseline gap-2">
-            <span
-              className="w-10 tabular-nums"
-              style={{ color: leg.current_delta_kn >= 0 ? "var(--ow-ok)" : "var(--ow-warn)" }}
-            >
-              {fmtSigned1(leg.current_delta_kn)}
-            </span>
+          <div className="flex items-baseline gap-2" style={{ color: currentColor }}>
+            <span className="w-10 tabular-nums">{fmtSigned1(leg.current_delta_kn)}</span>
             <span>courant</span>
           </div>
         )}

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -289,7 +289,7 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
           <circle cx="8" cy="8" r="6" />
           <path d="M8 4 L8 8 L11 10" />
         </svg>
-        Conditions vues du bateau
+        Éléments considérés dans le calcul de la vitesse
       </div>
 
       {/* Speed + allure + cap */}
@@ -319,7 +319,7 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
           width={SIZE}
           height={SIZE}
           viewBox={`0 0 ${SIZE} ${SIZE}`}
-          aria-label="Conditions autour du bateau (vue Nord en haut)"
+          aria-label="Éléments considérés dans le calcul de la vitesse — vent, vagues, courant (vue Nord en haut)"
           style={{ overflow: "visible" }}
         >
           {/* Outer dashed dial */}

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -278,39 +278,70 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
   const [curLx, curLy] = currentAngle != null ? polarXY(currentLabelAngle, LABEL_R) : [0, 0];
   const curLabel = currentAngle != null ? labelLayout(currentLabelAngle) : { anchor: "middle" as const, dx: 0 };
 
+  // Build-up of the absolute (over-ground) target speed, shown as a small
+  // signed list under the headline number. Sign is explicit ("+", "−") on
+  // every line so the addition reads at a glance.
+  const fmtSigned1 = (n: number) => {
+    if (Math.abs(n) < 0.05) return "+0,0";
+    const sign = n > 0 ? "+" : "−";
+    return `${sign}${fmtFR1(Math.abs(n))}`;
+  };
+
   return (
     <div className="px-4 pb-4 pt-1">
       {/* Section header */}
       <div
-        className="flex items-center gap-1.5 mb-2 text-[10px] font-bold uppercase"
+        className="mb-2 text-[10px] font-bold uppercase"
         style={{ color: "var(--ow-accent)", letterSpacing: "0.1em" }}
       >
-        <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="8" cy="8" r="6" />
-          <path d="M8 4 L8 8 L11 10" />
-        </svg>
         Vitesse absolue
       </div>
 
-      {/* Speed + allure + cap */}
-      <div className="flex items-baseline justify-between mb-2">
-        <div className="flex items-baseline gap-3">
-          <span
-            className="text-2xl font-bold tabular-nums"
-            style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
-          >
-            {leg.target_speed_kn.toFixed(1)} kn
-          </span>
-          <span
-            className="text-xl font-bold"
-            style={{ color: "var(--ow-fg-0)", letterSpacing: "-0.01em", lineHeight: 1 }}
-          >
-            {leg.point_of_sail}
-          </span>
-        </div>
+      {/* Headline speed + cap */}
+      <div className="flex items-baseline justify-between mb-1.5">
+        <span
+          className="text-2xl font-bold tabular-nums"
+          style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)", letterSpacing: "-0.02em", lineHeight: 1 }}
+        >
+          {leg.target_speed_kn.toFixed(1)} kn
+        </span>
         <span className="text-[10px] tabular-nums" style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}>
           cap {Math.round(leg.bearing_avg_deg)}°
         </span>
+      </div>
+
+      {/* Build-up: polaire (+) / mer (−) / courant (±) → cible */}
+      <div
+        className="text-[10px] tabular-nums leading-snug mb-2"
+        style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        <div className="flex items-baseline gap-2">
+          <span className="w-10 tabular-nums">{fmtSigned1(leg.polar_after_eff_kn)}</span>
+          <span>polaire</span>
+        </div>
+        {hasWaves && Math.abs(leg.wave_delta_kn) > 0.05 && (
+          <div className="flex items-baseline gap-2">
+            <span className="w-10 tabular-nums" style={{ color: "var(--ow-warn)" }}>{fmtSigned1(leg.wave_delta_kn)}</span>
+            <span>mer</span>
+          </div>
+        )}
+        {leg.current_delta_kn != null && Math.abs(leg.current_delta_kn) > 0.05 && (
+          <div className="flex items-baseline gap-2">
+            <span
+              className="w-10 tabular-nums"
+              style={{ color: leg.current_delta_kn >= 0 ? "var(--ow-ok)" : "var(--ow-warn)" }}
+            >
+              {fmtSigned1(leg.current_delta_kn)}
+            </span>
+            <span>courant</span>
+          </div>
+        )}
+        <div className="flex items-baseline gap-2 mt-0.5 pt-0.5" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <span className="w-10 tabular-nums font-semibold" style={{ color: "var(--ow-fg-0)" }}>
+            {fmtFR1(leg.target_speed_kn)}
+          </span>
+          <span style={{ color: "var(--ow-fg-1)" }}>kn</span>
+        </div>
       </div>
 
       {/* Compass diagram */}

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -289,7 +289,7 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
           <circle cx="8" cy="8" r="6" />
           <path d="M8 4 L8 8 L11 10" />
         </svg>
-        Éléments considérés dans le calcul de la vitesse
+        Vitesse absolue
       </div>
 
       {/* Speed + allure + cap */}
@@ -319,7 +319,7 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
           width={SIZE}
           height={SIZE}
           viewBox={`0 0 ${SIZE} ${SIZE}`}
-          aria-label="Éléments considérés dans le calcul de la vitesse — vent, vagues, courant (vue Nord en haut)"
+          aria-label="Vitesse absolue — vent, vagues, courant autour du bateau (vue Nord en haut)"
           style={{ overflow: "visible" }}
         >
           {/* Outer dashed dial */}


### PR DESCRIPTION
## Summary

Suite de #102. Les 5 commits de polish sur le header du leg-detail (titre inline « Vitesse absolue de 3,2 kn » + build-up coloré + remove allure/clock icon) avaient bien été poussés sur la branche mais n'avaient pas été inclus dans le squash de #102 (probablement merge faite à un moment où GitHub n'avait vu que le 1er commit).

Cherry-pick + nouveau PR pour rattraper.

## Contenu

- Titre passe de « Conditions vues du bateau » → « Vitesse absolue de 3,2 kn » (inline avec la valeur)
- Horloge supprimée, allure (Près/Largue) supprimée à côté du nombre
- Build-up signé sous le titre :
  - `+5,0 polaire` (couleur vent)
  - `−1,0 mer` (couleur vagues, ambre)
  - `+0,3 courant` (couleur courant : vert/orange/bleu)
- Cap à droite préservé
- Lignes triviales (≤ 0,05 kn) cachées

## Test plan

- [x] tsc + build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)