### PR TITLE
fix(web): InfoModal renders behind map — portal to body

### DIFF
--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { InfoPanel } from "./InfoPanel";
 
 function InfoIcon() {
@@ -25,7 +26,9 @@ function InfoModal({ onClose }: { onClose: () => void }) {
     };
   }, [onClose]);
 
-  return (
+  // Portal the overlay to <body> so its z-index isn't trapped by a parent
+  // stacking context (the header uses backdrop-blur-lg, which creates one).
+  return createPortal(
     <div
       className="fixed inset-0 z-[1000] flex items-end lg:items-center justify-center animate-fade-in"
       onClick={onClose}
@@ -56,7 +59,8 @@ function InfoModal({ onClose }: { onClose: () => void }) {
         </button>
         <InfoPanel />
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
## Summary

Le modal « À propos » s'ouvrait derrière la carte Leaflet et les boutons flottants. Cause : il était rendu à l'intérieur du `<Header>` qui a `backdrop-blur-lg` → nouveau stacking context qui piège son `z-[1000]` localement. Une fois remonté au stacking context global du header (`z-30`), il passait sous la carte (`z-[400]`).

Fix : `createPortal(modal, document.body)` — le modal sort du stacking context du header et son `z-[1000]` redevient global. Le bouton reste dans le header.

## Test plan

- [x] tsc + build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)