### PR TITLE
fix(web): drop floating mobile hero overlay + Cplx tile

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -933,7 +933,7 @@ export function PlanSidebar({
 
       {/* Hero stats + segment bar */}
       <div className="px-4 py-3.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
-        <HeroStats passage={passage} complexity={complexity} />
+        <HeroStats passage={passage} />
       </div>
 
       {/* Warnings */}

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -1,7 +1,7 @@
 // Visual building blocks for the /plan right panel — keeps PlanSidebar.tsx
 // focused on state wiring while these components stay design-only.
 
-import type { ComplexityScore, PassageReport, SegmentReport } from "./types";
+import type { PassageReport, SegmentReport } from "./types";
 import { CX_COLORS, cxLevel } from "./types";
 
 // ── EmptyState ────────────────────────────────────────────────────────────────
@@ -230,23 +230,17 @@ function SegmentBar({ segments }: { segments: SegmentReport[] }) {
 
 export function HeroStats({
   passage,
-  complexity,
 }: {
   passage: PassageReport;
-  complexity: ComplexityScore;
 }) {
+  // Complexity isn't a tile any more — the colored segment bar below already
+  // tells the same story (per-leg wind buckets) without a redundant number.
   return (
     <div>
-      <div className="grid grid-cols-4 gap-3 mb-3">
+      <div className="grid grid-cols-3 gap-3 mb-3">
         <HeroCell label="Distance" value={passage.distance_nm.toFixed(1)} unit="nm" />
         <HeroCell label="Durée" value={fmtDuration(passage.duration_h)} />
         <HeroCell label="Arrivée" value={fmtTime(passage.arrival_time)} />
-        <HeroCell
-          label="Cplx"
-          value={String(complexity.level)}
-          unit="/5"
-          tone={complexity.level >= 4 ? "warn" : "default"}
-        />
       </div>
       <SegmentBar segments={passage.segments} />
       <div

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -12,7 +12,6 @@ import {
   type LastSimulation,
 } from "../plan/lastSimulation";
 import { type TimeAnchor } from "../plan/ModeToggle";
-import { CX_COLORS } from "../plan/types";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
@@ -47,39 +46,6 @@ function toTzAware(iso: string): string {
   const hh = String(Math.floor(abs / 60)).padStart(2, "0");
   const mm = String(abs % 60).padStart(2, "0");
   return `${iso}:00${sign}${hh}:${mm}`;
-}
-
-function fmtTime(iso: string) {
-  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-}
-function fmtDuration(h: number) {
-  const hrs = Math.floor(h);
-  const mins = Math.round((h - hrs) * 60);
-  return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
-}
-
-// Hero stats overlay — absolute, bottom of map, mobile only
-function PlanHeroStats({ passage, complexity }: { passage: PassageReport; complexity: ComplexityScore }) {
-  const stats = [
-    { label: "ETA", value: fmtTime(passage.arrival_time) },
-    { label: "Durée", value: fmtDuration(passage.duration_h) },
-    { label: "Dist", value: `${passage.distance_nm.toFixed(1)} nm` },
-    { label: "Cx", value: `${complexity.level}/5`, color: CX_COLORS[complexity.level] },
-  ];
-  return (
-    <div className="flex gap-1.5">
-      {stats.map(({ label, value, color }) => (
-        <div
-          key={label}
-          className="flex-1 rounded-xl px-2 py-1.5 text-center"
-          style={{ background: "var(--ow-surface-glass)", backdropFilter: "blur(8px)", border: "1px solid var(--ow-line-2)" }}
-        >
-          <div className="text-[9px] font-semibold uppercase tracking-wide" style={{ color: "var(--ow-fg-2)" }}>{label}</div>
-          <div className="text-xs font-bold tabular-nums leading-tight mt-0.5" style={{ color: color ?? "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>{value}</div>
-        </div>
-      ))}
-    </div>
-  );
 }
 
 // ── ResizableMobileDrawer ────────────────────────────────────────────────────
@@ -586,14 +552,6 @@ export function PlanPage() {
               >
                 {waypoints.length === 0 ? "Cliquez pour placer le départ" : "Cliquez pour tracer votre route"}
               </div>
-            </div>
-          )}
-          {/* Hero stats overlay — mobile only, floats above the drawer.
-              Hidden in compare mode (no single passage to summarise — the
-              windows table inside the drawer is the relevant view). */}
-          {passage && complexity && planMode === "single" && (
-            <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
-              <PlanHeroStats passage={passage} complexity={complexity} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Floating 4-tile overlay sur la carte mobile (ETA / DURÉE / DIST / CX) supprimé — c'était un doublon des hero stats déjà affichées dans le drawer
- Tuile « Cplx /5 » des hero stats supprimée — la barre segmentée colorée juste en-dessous porte déjà l'info complexité par tronçon. Grid passe de 4 à 3 colonnes (Distance / Durée / Arrivée)
- Nettoyage : `PlanHeroStats`, `fmtTime`/`fmtDuration` locaux, import `CX_COLORS` et prop `ComplexityScore` — tous devenus inutilisés

## Test plan

- [x] tsc + build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)