### PR TITLE
feat(web): center home map on user position at first visit

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -74,6 +74,30 @@ function App() {
     };
   }, [spot]);
 
+  // First-visit geolocation: if the user has no saved spots and we landed on
+  // the Marseille fallback, ask the browser for their position. Granted →
+  // center on them and load forecasts there. Denied / error → silent, keep
+  // the default. Returning users with custom spots keep their chosen spot.
+  useEffect(() => {
+    if (customSpots.length > 0) return;
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setSpot({
+          name: "Ma position",
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+        });
+      },
+      () => {
+        // Permission denied or unavailable — keep RADE_MARSEILLE.
+      },
+      { timeout: 8000, maximumAge: 5 * 60 * 1000 },
+    );
+  // Run once on mount; the customSpots check covers the returning-user case.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // If the active view's data becomes irrelevant for the new spot (e.g. moving
   // from Atlantic to Med drops Tides/Currents below threshold), fall back to Wind.
   const showWaves = isWavesRelevant(marine);


### PR DESCRIPTION
## Summary

- First-visit geolocation: if a user lands on the app with no saved spots, the browser is asked for their current position. Granted → map centers on **Ma position** and forecasts load there. Denied or unavailable → silent fallback to the Marseille default.
- Returning users with custom spots are not prompted (their first custom spot still hydrates the initial view).
- One-shot lookup with `timeout: 8s, maximumAge: 5min` so we never burn battery and never hang the app on a slow GPS fix.

## Test plan

- [ ] Clear localStorage, reload → browser prompts for location.
  - [ ] Allow → map pans to your position, **Ma position** shows in the spot pill, forecasts load for that lat/lon.
  - [ ] Block → no prompt error visible, map stays on Marseille, app behaves normally.
- [ ] With a custom spot already saved, reload → no prompt, custom spot still loads as before.
- [ ] On a browser without `navigator.geolocation` (very rare) → silent fallback to Marseille.

🤖 Generated with [Claude Code](https://claude.com/claude-code)