### PR TITLE
feat(web): persist last plan across forecast↔plan navigation

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -638,6 +638,55 @@ interface PlanSidebarProps {
   /** Mobile-only: pop the bottom drawer up to a readable height when the
    *  user picks a mode (no-op on desktop). */
   onExpandDrawer?: () => void;
+  /** Discard the current plan: clears waypoints, results, cache, URL. */
+  onReset?: () => void;
+}
+
+// Header row: ModeToggle + an optional trash button to discard the plan.
+// The trash sits flush with the toggle and only renders when a route exists
+// (no waypoints → nothing to reset). Tooltip: "Réinitialiser".
+function PlanHeaderRow({
+  mode,
+  onModeChange,
+  locked,
+  onReset,
+}: {
+  mode: PlanMode;
+  onModeChange: (m: PlanMode) => void;
+  locked?: boolean;
+  onReset?: () => void;
+}) {
+  return (
+    <div className="flex items-stretch gap-2">
+      <div className="flex-1 min-w-0">
+        <ModeToggle value={mode} onChange={onModeChange} locked={locked} />
+      </div>
+      {onReset && (
+        <button
+          type="button"
+          onClick={onReset}
+          title="Nouveau plan"
+          aria-label="Nouveau plan"
+          className="shrink-0 flex items-center justify-center rounded-lg transition-colors hover:opacity-100"
+          style={{
+            width: 38,
+            background: "var(--ow-bg-2)",
+            border: "1px solid var(--ow-line)",
+            color: "var(--ow-fg-2)",
+            opacity: 0.85,
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M2.5 4h11" />
+            <path d="M6 4V2.5h4V4" />
+            <path d="M3.5 4l.9 9.2a1 1 0 0 0 1 .8h5.2a1 1 0 0 0 1-.8L12.5 4" />
+            <path d="M6.5 6.5v5" />
+            <path d="M9.5 6.5v5" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
 }
 
 export function PlanSidebar({
@@ -672,7 +721,11 @@ export function PlanSidebar({
   selectedLegIdx,
   onSelectedLegChange,
   onExpandDrawer,
+  onReset,
 }: PlanSidebarProps) {
+  // Show the trash button only when the user has placed enough to have
+  // something to clear — nothing to reset on a fully-empty form.
+  const resetHandler = onReset && waypointCount >= 2 ? onReset : undefined;
   const { resolvedTheme } = useTheme();
   const sweepValid = mode === "compare"
     ? validateSweep(sweepEarliest, sweepLatest, sweepIntervalHours)
@@ -711,7 +764,7 @@ export function PlanSidebar({
   if (error) {
     return (
       <div className="p-4">
-        <ModeToggle value={mode} onChange={handleModeChange} locked={waypointCount < 2} />
+        <PlanHeaderRow mode={mode} onModeChange={handleModeChange} locked={waypointCount < 2} onReset={resetHandler} />
         <div className="mt-4 rounded-xl p-4 text-sm" style={{ background: "var(--ow-err-soft)", color: "var(--ow-err)", border: "1px solid var(--ow-err-line)" }}>
           <p className="font-semibold mb-1">Erreur</p>
           <p className="leading-relaxed">{error}</p>
@@ -724,7 +777,7 @@ export function PlanSidebar({
   if (waypointCount < 2) {
     return (
       <div className="p-4 animate-fade-in">
-        <ModeToggle value={mode} onChange={handleModeChange} locked />
+        <PlanHeaderRow mode={mode} onModeChange={handleModeChange} locked />
         <EmptyState />
       </div>
     );
@@ -734,7 +787,7 @@ export function PlanSidebar({
   if (showModePicker) {
     return (
       <div className="p-4 space-y-4 animate-fade-in">
-        <ModeToggle value={mode} onChange={handleModeChange} locked />
+        <PlanHeaderRow mode={mode} onModeChange={handleModeChange} locked onReset={resetHandler} />
         <ModePicker
           onPick={(m) => {
             handleModeChange(m);
@@ -760,7 +813,7 @@ export function PlanSidebar({
     return (
       <div className="animate-fade-in">
         <div className="px-4 pt-4 pb-3" style={{ borderBottom: "1px solid var(--ow-line)" }}>
-          <ModeToggle value={mode} onChange={handleModeChange} />
+          <PlanHeaderRow mode={mode} onModeChange={handleModeChange} onReset={resetHandler} />
         </div>
 
         <div className="px-4 py-2.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
@@ -826,7 +879,7 @@ export function PlanSidebar({
     const ctaInk = mode === "compare" ? "#3a2a08" : "#fff";
     return (
       <div className="p-4 space-y-4 animate-fade-in">
-        <ModeToggle value={mode} onChange={handleModeChange} />
+        <PlanHeaderRow mode={mode} onModeChange={handleModeChange} onReset={resetHandler} />
 
         {mode === "single" ? (
           <div className="space-y-2">
@@ -886,7 +939,7 @@ export function PlanSidebar({
     <div className="animate-fade-in">
       {/* Mode tabs */}
       <div className="px-4 pt-4 pb-3" style={{ borderBottom: "1px solid var(--ow-line)" }}>
-        <ModeToggle value={mode} onChange={handleModeChange} />
+        <PlanHeaderRow mode={mode} onModeChange={handleModeChange} onReset={resetHandler} />
       </div>
 
       {/* Recalculer bar */}

--- a/packages/web/src/plan/lastSimulation.ts
+++ b/packages/web/src/plan/lastSimulation.ts
@@ -14,6 +14,9 @@ const STORAGE_KEY = "ow_last_simulation_v1";
 export interface LastSimulation {
   waypoints: [number, number][];
   archetype: string;
+  // Last active mode at save time. Drives which tab the user lands on when
+  // we rehydrate after a navigation away from /plan (e.g. round-trip via /).
+  mode: "single" | "compare";
   // Single-mode (may be null if the user only ran a sweep)
   single?: {
     departure: string; // naive local "YYYY-MM-DDTHH:MM"
@@ -47,7 +50,15 @@ export function loadLastSimulation(): LastSimulation | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw) as LastSimulation;
+    const parsed = JSON.parse(raw) as LastSimulation;
+    // Caches written before `mode` existed default to single — that's the
+    // mode the user was last looking at if their cache only has `single`,
+    // and a safe fallback if it has `compare` (the table reappears as soon
+    // as they toggle, no data lost).
+    if (parsed.mode !== "single" && parsed.mode !== "compare") {
+      parsed.mode = parsed.compare && !parsed.single ? "compare" : "single";
+    }
+    return parsed;
   } catch {
     return null;
   }

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -8,6 +8,7 @@ import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from ".
 import {
   loadLastSimulation,
   saveLastSimulation,
+  clearLastSimulation,
   waypointsEqual,
   type LastSimulation,
 } from "../plan/lastSimulation";
@@ -265,16 +266,33 @@ export function PlanPage() {
   const drawerRef = useRef<DrawerHandle>(null);
   const initialParsed = parsePlanUrl(window.location.search);
 
-  const [waypoints, setWaypoints] = useState<[number, number][]>(
-    isParsedOk(initialParsed) ? initialParsed.waypoints : []
-  );
-  const [archetype, setArchetype] = useState(
-    isParsedOk(initialParsed) && initialParsed.archetype ? initialParsed.archetype : "cruiser_30ft"
-  );
+  // If the URL is empty (typical after a /plan FAB click from the home page),
+  // fall back to the cached last simulation so the user lands back on their
+  // route + archetype + departure instead of an empty plan. Captured once at
+  // mount so all useState initializers see the same snapshot.
+  const urlHasWaypoints = isParsedOk(initialParsed) && initialParsed.waypoints.length >= 2;
+  const cachedAtMount = !urlHasWaypoints ? loadLastSimulation() : null;
+  const useCachedRoute = !!(cachedAtMount && cachedAtMount.waypoints.length >= 2);
+
+  const [waypoints, setWaypoints] = useState<[number, number][]>(() => {
+    if (urlHasWaypoints) return (initialParsed as { waypoints: [number, number][] }).waypoints;
+    if (useCachedRoute) return cachedAtMount!.waypoints;
+    return [];
+  });
+  const [archetype, setArchetype] = useState(() => {
+    if (isParsedOk(initialParsed) && initialParsed.archetype) return initialParsed.archetype;
+    if (useCachedRoute) return cachedAtMount!.archetype;
+    return "cruiser_30ft";
+  });
   const [departure, setDeparture] = useState(() => {
     const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";
-    if (!raw || new Date(raw) < new Date()) return tomorrowRoundedLocal();
-    return raw;
+    if (raw && new Date(raw) >= new Date()) return raw;
+    // Try cache: prefer the single-mode departure, then fall back to the
+    // sweep's earliest timestamp so compare-only caches still seed the slider.
+    const cachedDep =
+      cachedAtMount?.single?.departure ?? cachedAtMount?.compare?.sweepEarliest;
+    if (cachedDep && new Date(cachedDep) >= new Date()) return cachedDep;
+    return tomorrowRoundedLocal();
   });
   const [timeAnchor, setTimeAnchor] = useState<TimeAnchor>("departure");
 
@@ -287,15 +305,22 @@ export function PlanPage() {
   const [isStale, setIsStale] = useState(false);
 
   // Compare-windows mode (lifted from PlanSidebar in step 2)
-  const [planMode, setPlanMode] = useState<"single" | "compare">("single");
-  const [sweepEarliest, setSweepEarliest] = useState(() => departure);
+  const [planMode, setPlanMode] = useState<"single" | "compare">(
+    () => cachedAtMount?.mode ?? "single",
+  );
+  const [sweepEarliest, setSweepEarliest] = useState(
+    () => cachedAtMount?.compare?.sweepEarliest ?? departure,
+  );
   const [sweepLatest, setSweepLatest] = useState(() => {
+    if (cachedAtMount?.compare?.sweepLatest) return cachedAtMount.compare.sweepLatest;
     const d = new Date(departure);
     d.setDate(d.getDate() + 2);
     const pad = (n: number) => String(n).padStart(2, "0");
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   });
-  const [sweepInterval, setSweepInterval] = useState<number>(3);
+  const [sweepInterval, setSweepInterval] = useState<number>(
+    () => cachedAtMount?.compare?.sweepIntervalHours ?? 3,
+  );
   // Selected leg for the sidebar's expanded "Comment c'est calculé" — also
   // drives the highlight overlay on the map. Cleared whenever the route or
   // its segments change so we never highlight stale ranges.
@@ -337,6 +362,7 @@ export function PlanPage() {
         saveLastSimulation({
           waypoints: wpts,
           archetype: arch,
+          mode: "single",
           single: {
             departure: resolvedDep,
             passage: res.passage,
@@ -352,38 +378,54 @@ export function PlanPage() {
   }
 
   useEffect(() => {
-    if (!isParsedOk(initialParsed) || initialParsed.waypoints.length < 2) return;
-    // Try the localStorage cache first: if we have a saved simulation for the
-    // same route + archetype, hydrate state directly and skip the network call.
-    // The user sees their last plan instantly on reload.
-    const cached: LastSimulation | null = loadLastSimulation();
-    const cacheMatches =
-      cached &&
-      waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
-      cached.archetype === initialParsed.archetype;
-    if (cacheMatches) {
-      // Restore single-mode result if its departure matches the URL departure.
-      if (cached.single && cached.single.departure === departure) {
-        setPassage(cached.single.passage);
-        setComplexity(cached.single.complexity);
-        setForecastUpdatedAt(cached.single.forecastUpdatedAt);
+    // Path A — URL has waypoints: respect the URL, restore from cache if it
+    // matches the same route + archetype, otherwise fetch fresh.
+    if (urlHasWaypoints) {
+      const cached: LastSimulation | null = loadLastSimulation();
+      const cacheMatches =
+        cached &&
+        waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
+        cached.archetype === initialParsed.archetype;
+      if (cacheMatches) {
+        if (cached.single && cached.single.departure === departure) {
+          setPassage(cached.single.passage);
+          setComplexity(cached.single.complexity);
+          setForecastUpdatedAt(cached.single.forecastUpdatedAt);
+        }
+        // Always restore compare-mode windows + sweep params if present —
+        // sweep range isn't encoded in the URL, so we trust the cache.
+        if (cached.compare) {
+          setWindows(cached.compare.windows);
+          setMetaWarnings(cached.compare.metaWarnings);
+          if (!cached.single || cached.single.departure !== departure) {
+            setForecastUpdatedAt(cached.compare.forecastUpdatedAt);
+          }
+        }
+        if (cached.single || cached.compare) return;
       }
-      // Always restore compare-mode windows + sweep params if present —
-      // sweep range isn't encoded in the URL, so we trust the cache.
-      if (cached.compare) {
-        setWindows(cached.compare.windows);
-        setMetaWarnings(cached.compare.metaWarnings);
-        setSweepEarliest(cached.compare.sweepEarliest);
-        setSweepLatest(cached.compare.sweepLatest);
-        setSweepInterval(cached.compare.sweepIntervalHours);
-        if (!cached.single || cached.single.departure !== departure) {
-          setForecastUpdatedAt(cached.compare.forecastUpdatedAt);
+      doFetch(initialParsed.waypoints, initialParsed.archetype, departure);
+      return;
+    }
+
+    // Path B — URL is empty: state was already seeded from cache by the
+    // useState initializers above. Hydrate the simulation results, sync the
+    // URL so reload/share works, and skip any network call.
+    if (useCachedRoute && cachedAtMount) {
+      if (cachedAtMount.single) {
+        setPassage(cachedAtMount.single.passage);
+        setComplexity(cachedAtMount.single.complexity);
+        setForecastUpdatedAt(cachedAtMount.single.forecastUpdatedAt);
+      }
+      if (cachedAtMount.compare) {
+        setWindows(cachedAtMount.compare.windows);
+        setMetaWarnings(cachedAtMount.compare.metaWarnings);
+        if (!cachedAtMount.single) {
+          setForecastUpdatedAt(cachedAtMount.compare.forecastUpdatedAt);
         }
       }
-      // If we restored anything, skip the auto-fetch.
-      if (cached.single || cached.compare) return;
+      const url = buildPlanUrl(cachedAtMount.waypoints, departure, cachedAtMount.archetype);
+      window.history.replaceState(null, "", url);
     }
-    doFetch(initialParsed.waypoints, initialParsed.archetype, departure);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -455,6 +497,7 @@ export function PlanPage() {
         saveLastSimulation({
           waypoints,
           archetype,
+          mode: "compare",
           single: sameRoute ? prev?.single : undefined,
           compare: {
             sweepEarliest,
@@ -469,6 +512,34 @@ export function PlanPage() {
       })
       .catch((e: Error) => setApiError(friendlyError(e.message)))
       .finally(() => setIsLoading(false));
+  }
+
+  function handleReset() {
+    clearLastSimulation();
+    // Also expire the dormant ow_last_trip cookie so a future read (if we ever
+    // wire it up) doesn't resurrect a stale plan.
+    document.cookie = "ow_last_trip=;max-age=0;path=/;SameSite=Lax";
+    setWaypoints([]);
+    setPassage(null);
+    setComplexity(null);
+    setWindows(null);
+    setMetaWarnings([]);
+    setApiError(null);
+    setIsStale(false);
+    setSelectedLegIdx(null);
+    setForecastUpdatedAt(null);
+    setPlanMode("single");
+    setTimeAnchor("departure");
+    setArchetype("cruiser_30ft");
+    const dep = tomorrowRoundedLocal();
+    setDeparture(dep);
+    setSweepEarliest(dep);
+    const d = new Date(dep);
+    d.setDate(d.getDate() + 2);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    setSweepLatest(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`);
+    setSweepInterval(3);
+    window.history.replaceState(null, "", "/plan");
   }
 
   function handleModeChange(next: "single" | "compare") {
@@ -511,6 +582,24 @@ export function PlanPage() {
       // see the table again without re-fetching the sweep.
       // setWindows(null) intentionally NOT called — user toggling back to
       // compare should see their table immediately.
+      // Persist: same route → keep compare data, overwrite single with the
+      // freshly-picked window, flip mode back to single.
+      const prev = loadLastSimulation();
+      const sameRoute =
+        prev && waypointsEqual(prev.waypoints, waypoints) && prev.archetype === archetype;
+      saveLastSimulation({
+        waypoints,
+        archetype,
+        mode: "single",
+        single: {
+          departure: naiveDep,
+          passage: w.passage,
+          complexity: w.complexity_full,
+          forecastUpdatedAt: forecastUpdatedAt ?? "",
+        },
+        compare: sameRoute ? prev?.compare : undefined,
+        cachedAt: Date.now(),
+      });
     } else {
       // Backwards-compatible fallback: re-fetch.
       setWindows(null);
@@ -632,6 +721,7 @@ export function PlanPage() {
             selectedLegIdx={selectedLegIdx}
             onSelectedLegChange={setSelectedLegIdx}
             onExpandDrawer={() => drawerRef.current?.expand()}
+            onReset={handleReset}
           />
         </ResizableDesktopSidebar>
       </div>


### PR DESCRIPTION
## Summary
- Le FAB boussole de la home naviguait vers `/plan` sans query string, ce qui ramenait l'utilisateur sur un formulaire vide alors que sa dernière simulation était encore en cache.
- `PlanPage` rehydrate maintenant depuis `localStorage` quand l'URL est vide (waypoints + archétype + départ + sweep params reconstruits, URL `replaceState`'d pour cohérence + reload).
- Le mode actif (`single`/`compare`) est désormais persisté dans `LastSimulation`, donc on retombe sur le bon onglet après aller-retour.
- Ajoute un bouton corbeille "Nouveau plan" (tooltip + aria-label) à côté du toggle de mode pour vider le cache et repartir à zéro.

## Test plan
- [ ] Placer une route, simuler en single → naviguer `/` puis cliquer la boussole → la route et le passage reviennent
- [ ] Idem en mode compare → on retombe sur l'onglet compare avec le tableau des fenêtres
- [ ] Sélectionner une fenêtre depuis compare → naviguer / puis revenir → on est en single sur la fenêtre choisie, table compare conservée si on toggle
- [ ] Cliquer "Nouveau plan" → waypoints/résultats/cache vidés, URL revient à `/plan` nu
- [ ] Reload navigateur sur une URL `/plan?wpts=...` non modifiée → comportement inchangé (la rehydratation existante prime sur celle du cache vide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)