### PR TITLE
feat(mcp): add feedback tool with HF Dataset sink

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -18,8 +18,11 @@ website, not via the HF catalog. Re-evaluate if traffic plateaus.
 from __future__ import annotations
 
 import dataclasses
+import json
+import logging
 import os
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -44,6 +47,8 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
+
+_logger = logging.getLogger(__name__)
 
 PORT = 7860
 
@@ -523,6 +528,92 @@ _MARC_REGISTRY = MarcAtlasRegistry.from_directory(
 _SHOM_REGISTRY = ShomC2dRegistry.from_directory(os.environ.get("SHOM_C2D_DIR", ""))
 
 
+# ---------------------------------------------------------------------------
+# Feedback sink — pushes the `feedback` MCP tool's entries to a private HF
+# Dataset repo via CommitScheduler (background thread, batched every 10 min).
+# ---------------------------------------------------------------------------
+#
+# Required env on the Space:
+#   OPENWIND_FEEDBACK_DATASET_REPO  e.g. "Qdonnars/openwind-feedback"
+#   HF_TOKEN_FEEDBACK               write-scoped on the feedback dataset
+#                                   (separate Space secret so the read-scoped
+#                                   HF_TOKEN used at build time to pull the
+#                                   tidal atlas stays minimum-privilege).
+#                                   Falls back to HF_TOKEN if unset (handy
+#                                   for local dev with a single write token
+#                                   in .env).
+#
+# When the dataset repo or both tokens are missing, the sink degrades to a
+# stderr log — the tool still returns ack="thanks" so the LLM keeps a
+# uniform contract regardless of deployment.
+_FEEDBACK_FOLDER = Path(os.environ.get("OPENWIND_FEEDBACK_DIR", "/tmp/openwind-feedback"))
+_FEEDBACK_FILE = _FEEDBACK_FOLDER / "feedback.jsonl"
+_FEEDBACK_REPO = os.environ.get("OPENWIND_FEEDBACK_DATASET_REPO")
+_FEEDBACK_EVERY_MIN = int(os.environ.get("OPENWIND_FEEDBACK_EVERY_MIN", "10"))
+_feedback_scheduler: Any | None = None
+
+
+def _build_feedback_scheduler() -> Any | None:
+    """Lazy construct a CommitScheduler if the env is wired, else None.
+
+    Imported inside the function so module import doesn't fail when
+    huggingface_hub is missing in unrelated environments (tests, etc.).
+    """
+    if not _FEEDBACK_REPO:
+        _logger.info(
+            "openwind.feedback: OPENWIND_FEEDBACK_DATASET_REPO unset, "
+            "feedback will only log to stderr"
+        )
+        return None
+    token = os.environ.get("HF_TOKEN_FEEDBACK") or os.environ.get("HF_TOKEN")
+    if not token:
+        _logger.warning(
+            "openwind.feedback: HF_TOKEN_FEEDBACK / HF_TOKEN unset, "
+            "cannot push to %s — feedback will only log to stderr",
+            _FEEDBACK_REPO,
+        )
+        return None
+    try:
+        from huggingface_hub import CommitScheduler
+
+        _FEEDBACK_FOLDER.mkdir(parents=True, exist_ok=True)
+        scheduler = CommitScheduler(
+            repo_id=_FEEDBACK_REPO,
+            repo_type="dataset",
+            folder_path=str(_FEEDBACK_FOLDER),
+            path_in_repo="data",
+            every=_FEEDBACK_EVERY_MIN,
+            private=True,
+            token=token,
+        )
+        _logger.info(
+            "openwind.feedback: CommitScheduler attached to %s (every=%d min)",
+            _FEEDBACK_REPO,
+            _FEEDBACK_EVERY_MIN,
+        )
+        return scheduler
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("openwind.feedback: scheduler init failed: %s", exc)
+        return None
+
+
+def _hf_feedback_sink(entry: dict[str, Any]) -> None:
+    """Append one JSONL row inside the scheduler's lock.
+
+    The scheduler watches ``_FEEDBACK_FOLDER`` and pushes the file to the
+    dataset repo every ``every`` minutes. ``CommitScheduler.lock`` is a
+    threading lock — combine with the file's ``"a"`` mode for the
+    append-only contract that CommitScheduler requires.
+    """
+    if _feedback_scheduler is None:
+        _logger.info("openwind.feedback (no sink): %s", entry)
+        return
+    with _feedback_scheduler.lock:
+        with _FEEDBACK_FILE.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False))
+            f.write("\n")
+
+
 async def _api_marc_overlay(request: Request) -> JSONResponse:
     """Return MARC PREVIMER currents and tide-height predictions for a point.
 
@@ -658,7 +749,9 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
 
 
 def main() -> None:
-    server = build_server()
+    global _feedback_scheduler
+    _feedback_scheduler = _build_feedback_scheduler()
+    server = build_server(feedback_sink=_hf_feedback_sink)
     server.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=ALLOWED_HOSTS,

--- a/packages/mcp-core/src/openwind_mcp_core/feedback.py
+++ b/packages/mcp-core/src/openwind_mcp_core/feedback.py
@@ -1,0 +1,97 @@
+"""Feedback tool: lets a calling LLM log a structured note about a tool
+interaction (an unclear parameter, missing data, a wrong-feeling result,
+a feature request).
+
+Cloud-agnostic by construction. The persistence target is injected as a
+``FeedbackSink`` callable; ``mcp-core`` never imports ``huggingface_hub``.
+The HF Spaces wrapper plugs in a ``CommitScheduler``-backed sink that
+appends to a private dataset repo (see ``packages/hf-space/app.py``).
+
+Local dev with no sink wired falls back to ``_stderr_sink``, which logs
+the entry via the standard ``logging`` module — handy for inspecting
+the payload shape during development without setting up a dataset.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+FeedbackCategory = Literal[
+    "unclear_param",
+    "missing_data",
+    "wrong_result",
+    "feature_request",
+    "other",
+]
+FeedbackToolName = Literal[
+    "plan_passage",
+    "get_marine_forecast",
+    "list_boat_archetypes",
+    "read_me",
+    "feedback",
+    "general",
+]
+FeedbackSeverity = Literal["low", "medium", "high"]
+
+_MAX_MESSAGE_CHARS = 2000
+_MAX_CONTEXT_CHARS = 4000
+
+
+class FeedbackSink(Protocol):
+    """Persists a feedback entry. MUST NOT raise — wrap your I/O.
+
+    Implementations are expected to be cheap and non-blocking; the HF
+    sink uses a ``CommitScheduler`` background thread so the tool call
+    returns immediately even when the dataset push is in flight.
+    """
+
+    def __call__(self, entry: dict[str, Any]) -> None: ...
+
+
+def stderr_sink(entry: dict[str, Any]) -> None:
+    """Default sink: log to stderr at INFO level."""
+    logger.info("openwind.feedback %s", entry)
+
+
+def build_feedback_entry(
+    *,
+    category: str,
+    tool_name: str,
+    severity: str,
+    message: str,
+    context_json: dict[str, Any] | None = None,
+    client_hint: str | None = None,
+) -> dict[str, Any]:
+    """Normalize a feedback payload into the JSONL row shape.
+
+    Truncates ``message`` and a JSON-serialised ``context_json`` so a
+    runaway LLM cannot blow up the dataset row size.
+    """
+    if len(message) > _MAX_MESSAGE_CHARS:
+        message = message[:_MAX_MESSAGE_CHARS] + " ...[truncated]"
+    ctx = context_json
+    if ctx is not None:
+        import json as _json
+
+        try:
+            serialised = _json.dumps(ctx, ensure_ascii=False, default=str)
+        except Exception:
+            serialised = str(ctx)
+        if len(serialised) > _MAX_CONTEXT_CHARS:
+            ctx = {"_truncated": True, "preview": serialised[:_MAX_CONTEXT_CHARS]}
+    return {
+        "feedback_id": uuid.uuid4().hex,
+        "received_at": datetime.now(UTC).isoformat(),
+        "category": category,
+        "tool_name": tool_name,
+        "severity": severity,
+        "message": message,
+        "context_json": ctx,
+        "client_hint": client_hint,
+    }

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -57,6 +57,14 @@ from openwind_data.routing import (
     score_complexity as _score_complexity,
 )
 
+from .feedback import (
+    FeedbackCategory,
+    FeedbackSeverity,
+    FeedbackSink,
+    FeedbackToolName,
+    build_feedback_entry,
+    stderr_sink,
+)
 from .render import build_openwind_url
 
 # MCP Apps UI resource URI for plan_passage. The host fetches this resource
@@ -496,7 +504,11 @@ def _build_window_dict(
     }
 
 
-def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
+def build_server(
+    *,
+    adapter: MarineDataAdapter | None = None,
+    feedback_sink: FeedbackSink | None = None,
+) -> FastMCP:
     """Build a FastMCP server with all OpenWind tools registered.
 
     Args:
@@ -508,7 +520,13 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
             ``MARC_ATLAS_DIR``. Either or both can be absent; the cascade
             degrades gracefully (SHOM > MARC > SMOC). Override the whole
             adapter in tests.
+        feedback_sink: optional callable invoked by the ``feedback`` tool
+            with the normalized entry dict. ``mcp-core`` stays cloud-agnostic
+            (no ``huggingface_hub`` import); the HF Spaces wrapper plugs in
+            a ``CommitScheduler``-backed sink that pushes to a private
+            dataset. Defaults to ``stderr_sink`` for local dev.
     """
+    sink: FeedbackSink = feedback_sink or stderr_sink
     server: FastMCP = FastMCP("openwind")
     if adapter is not None:
         fetch_adapter: MarineDataAdapter = adapter
@@ -851,6 +869,90 @@ def build_server(*, adapter: MarineDataAdapter | None = None) -> FastMCP:
             "passage": _passage_to_dict(report),
             "complexity": asdict(score),
             "openwind_url": build_openwind_url(waypoints, departure, archetype),
+        }
+
+    @server.tool()
+    def feedback(
+        category: FeedbackCategory,
+        tool_name: FeedbackToolName,
+        severity: FeedbackSeverity,
+        message: str,
+        context_json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Log a structured note about an OpenWind tool interaction.
+
+        ## Call this ONLY when one of the following is true
+
+        - A previous tool call returned an error you couldn't recover from,
+          or a result that contradicts what the user asked
+          (``category="wrong_result"``).
+        - A parameter description was unclear and you had to guess
+          (``category="unclear_param"``).
+        - You needed data that no current tool exposes
+          (``category="missing_data"`` — for example, official BMS
+          bulletins, port closures, fuel stops).
+        - The user explicitly asked for a feature that doesn't exist yet
+          (``category="feature_request"``).
+        - The user expresses dissatisfaction in chat ("c'est faux",
+          "ce n'est pas ce que je voulais") about an OpenWind result.
+
+        ## Do NOT call this tool
+
+        - On routine successful calls. Silence is the right answer when
+          things work.
+        - As a chat acknowledgement. The user does not see your call.
+        - Multiple times for the same incident. One feedback per turn,
+          per distinct issue.
+        - For errors that are clearly the user's input fault (typo in a
+          city name, impossible date) — only call when the issue is on
+          OpenWind's side or in the tool surface.
+
+        ## Args
+
+            category: nature of the feedback (see triggers above).
+            tool_name: which OpenWind tool the feedback is about. Use
+                ``"general"`` for cross-cutting feedback, ``"feedback"``
+                for meta-feedback about this tool itself.
+            severity: ``"low"`` (nice-to-have, doesn't block the user),
+                ``"medium"`` (degrades the experience), ``"high"`` (broke
+                the user's workflow or returned a misleading result).
+            message: short free-text description, max ~2000 chars. Be
+                concrete: name the symptom, not the fix. Good: "passage
+                from Marseille to Calvi returned distance_nm=0 even
+                though waypoints are >100nm apart". Bad: "should fix
+                the distance bug".
+            context_json: optional dict with reproducer hints — the
+                input args you passed, the offending excerpt of the
+                response, the user's original phrasing. Capped at ~4000
+                chars after JSON serialisation.
+
+        ## Returns
+
+        ``{"feedback_id": <uuid hex>, "received_at": <iso8601>,
+        "ack": "thanks"}`` — never raises. If persistence fails on the
+        server side it is logged and ``ack`` reflects ``"buffered"``.
+        Do not surface the ack to the user; just continue the
+        conversation.
+        """
+        entry = build_feedback_entry(
+            category=category,
+            tool_name=tool_name,
+            severity=severity,
+            message=message,
+            context_json=context_json,
+        )
+        ack = "thanks"
+        try:
+            sink(entry)
+        except Exception as exc:
+            import logging as _logging
+
+            _logging.getLogger(__name__).warning("openwind.feedback sink failed: %s", exc)
+            ack = "buffered"
+        return {
+            "feedback_id": entry["feedback_id"],
+            "received_at": entry["received_at"],
+            "ack": ack,
         }
 
     return server

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -70,8 +70,9 @@ class TestBuildServer:
         server = build_server(adapter=StubAdapter())
         assert isinstance(server, FastMCP)
 
-    async def test_lists_four_tools(self) -> None:
-        # The V1 surface: 3 functional tools + read_me for methodology Q&A.
+    async def test_lists_five_tools(self) -> None:
+        # The V1 surface: 3 functional tools + read_me for methodology Q&A
+        # + feedback for LLM-side issue reporting.
         server = build_server(adapter=StubAdapter())
         tools = await server.list_tools()
         names = {t.name for t in tools}
@@ -80,6 +81,7 @@ class TestBuildServer:
             "list_boat_archetypes",
             "get_marine_forecast",
             "plan_passage",
+            "feedback",
         }
 
 
@@ -291,6 +293,94 @@ class TestPlanPassageSweep:
             assert False, "expected an exception for oversized sweep"
         except Exception as exc:
             assert "336" in str(exc) or "cap" in str(exc).lower() or "windows" in str(exc).lower()
+
+
+class TestFeedback:
+    """The feedback tool is the LLM-side issue reporting channel.
+
+    Contract: the sink receives a normalised entry with stable keys; the
+    tool never raises (a failing sink degrades to ``ack="buffered"``);
+    the LLM-facing payload only exposes ``feedback_id``, ``received_at``,
+    and ``ack``."""
+
+    @staticmethod
+    def _args(**overrides: object) -> dict:
+        base = {
+            "category": "wrong_result",
+            "tool_name": "plan_passage",
+            "severity": "medium",
+            "message": "distance_nm=0 for Marseille -> Calvi",
+        }
+        base.update(overrides)
+        return base
+
+    async def test_feedback_listed(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert "feedback" in names
+
+    async def test_default_sink_does_not_raise(self) -> None:
+        # No sink provided → stderr_sink default. Tool returns ack="thanks".
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "feedback", self._args())
+        assert out["ack"] == "thanks"
+        assert isinstance(out["feedback_id"], str) and len(out["feedback_id"]) > 0
+        assert isinstance(out["received_at"], str)
+
+    async def test_custom_sink_receives_normalised_entry(self) -> None:
+        captured: list[dict] = []
+
+        def sink(entry: dict) -> None:
+            captured.append(entry)
+
+        server = build_server(adapter=StubAdapter(), feedback_sink=sink)
+        await _call(
+            server,
+            "feedback",
+            self._args(context_json={"waypoints": [[43.3, 5.35], [42.5, 8.7]]}),
+        )
+        assert len(captured) == 1
+        e = captured[0]
+        assert {
+            "feedback_id",
+            "received_at",
+            "category",
+            "tool_name",
+            "severity",
+            "message",
+            "context_json",
+            "client_hint",
+        } <= e.keys()
+        assert e["category"] == "wrong_result"
+        assert e["tool_name"] == "plan_passage"
+        assert e["severity"] == "medium"
+        assert e["context_json"] == {"waypoints": [[43.3, 5.35], [42.5, 8.7]]}
+        assert e["client_hint"] is None
+
+    async def test_failing_sink_degrades_to_buffered(self) -> None:
+        def sink(_entry: dict) -> None:
+            raise RuntimeError("HF push failed")
+
+        server = build_server(adapter=StubAdapter(), feedback_sink=sink)
+        out = await _call(server, "feedback", self._args())
+        assert out["ack"] == "buffered"
+        # ID and timestamp still returned, so the LLM never sees a tool error.
+        assert isinstance(out["feedback_id"], str) and len(out["feedback_id"]) > 0
+
+    async def test_long_message_is_truncated(self) -> None:
+        captured: list[dict] = []
+        server = build_server(adapter=StubAdapter(), feedback_sink=captured.append)
+        await _call(server, "feedback", self._args(message="x" * 5000))
+        assert "[truncated]" in captured[0]["message"]
+        assert len(captured[0]["message"]) < 5000
+
+    async def test_response_does_not_leak_message(self) -> None:
+        # The tool response should be a thin ack — not echo back the
+        # user's full message (no point round-tripping it to the LLM).
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "feedback", self._args(message="some private note"))
+        assert "some private note" not in str(out)
 
 
 class TestGetMarineForecast:


### PR DESCRIPTION
## Summary

- New MCP tool `feedback` that LLMs call when they hit unclear params, missing data, wrong-feeling results, or feature requests. Strict `Literal` schema (5 categories, 6 tool names, 3 severities), `message` truncated to 2000 chars, optional `context_json` capped at 4000 chars after serialisation.
- Entries are forwarded to an injected `FeedbackSink`. On the HF Space the sink is a `huggingface_hub.CommitScheduler` that pushes JSONL rows to a private dataset (`Qdonnars/openwind-feedback`) in 10-min batches, keyed off `HF_TOKEN_FEEDBACK` (write-scoped, separate from the read-scoped `HF_TOKEN` used at build time for the tidal atlas).
- `mcp-core` stays cloud-agnostic: zero `huggingface_hub` imports outside `packages/hf-space/`. Local dev without sink env wired falls back to a stderr logger, the tool still returns `ack="thanks"` to the LLM regardless.
- Tool description steers the LLM hard: 5 explicit triggers (when to call) + 4 anti-triggers (when NOT to call — routine success, chat acks, duplicate incidents, user-fault input errors).

## Test plan

- [x] 26 mcp-core tests pass (6 new `TestFeedback` cases: tool listed, default sink works, custom sink receives normalised entry, failing sink degrades to `ack="buffered"`, long message truncated, response doesn't leak message back to LLM)
- [x] 191 data-adapters tests still pass (sanity)
- [x] `hf-space/app.py` syntax check OK
- [x] Dataset `Qdonnars/openwind-feedback` created (private) with README
- [x] Variable `OPENWIND_FEEDBACK_DATASET_REPO=Qdonnars/openwind-feedback` set on the Space
- [x] Secret `HF_TOKEN_FEEDBACK` set on the Space (write-scoped on the feedback dataset only)
- [ ] Post-merge: redeploy HF Space, call the feedback tool from a Claude conversation, confirm a JSONL row lands in the dataset after the first 10-min commit window

🤖 Generated with [Claude Code](https://claude.com/claude-code)