### PR TITLE
fix(shom-c2d): anchor tidal coefficient on Brest, not the local ref port

### DIFF
--- a/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
+++ b/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
@@ -263,20 +263,32 @@ class ShomC2dRegistry:
         return scan_times[idx]
 
     def _coefficient_for_day(self, port: _RefPortMeta, target_t: datetime) -> float:
-        """Approximate tidal coefficient at the reference port for the day.
+        """National tidal coefficient (Brest-anchored) at ``target_t``.
 
-        Predict the tide over a 25 h window centred on target_t and read
-        ``range = max - min``. Coef = 100 x range / 6.1 m, clamped to
-        [20, 120] (SHOM's documented range). The 6.1 m normalisation is
-        Brest's mean-equinox spring range, which is the standard
-        denominator for the French tidal coefficient regardless of port.
+        The French tidal coefficient is defined **at Brest** by convention:
+        100 = mean-equinox spring range = 6.1 m. The same coefficient
+        applies nationwide regardless of where you are — at Port-Navalo
+        a 95-coef day still has the local Port-Navalo range, smaller than
+        Brest's, but the coefficient itself is 95.
+
+        Predicting the range at the local reference port and dividing by
+        Brest's 6.1 m therefore produces a systematic underestimate (the
+        local range is smaller than Brest's), which led to currents being
+        scaled with an effective coef ~50-60 even on vives-eaux days.
+
+        Fix: always use Brest's harmonic constants for this calculation
+        when they're available in the ref-ports table; fall back to the
+        local port only when Brest is absent (defensive — should never
+        happen in practice since Brest is one of the SHOM ref ports).
         """
         if target_t.tzinfo is None:
             target_t = target_t.replace(tzinfo=UTC)
+        brest = self.ref_ports.get("BREST")
+        anchor = brest if brest is not None else port
         # 25 h window with 30-min step covers two semi-diurnal cycles.
         offsets_min = np.linspace(-12.5 * 60, 12.5 * 60, 51)
         scan_times = [target_t + timedelta(minutes=float(m)) for m in offsets_min]
-        heights = harmonic_predict(scan_times, port.constants)
+        heights = harmonic_predict(scan_times, anchor.constants)
         rng = float(heights.max() - heights.min())
         coef = 100.0 * rng / _BREST_MEAN_RANGE_M
         return max(20.0, min(120.0, coef))


### PR DESCRIPTION
## Why

You reported peak currents looking too low even on vives-eaux days: at Port-Navalo on May 16 2026 (new moon, true coef ~95), the web map showed ~2.9 kt at the goulet — but SHOM C2D stores a 5.8 kt VE peak at the same point, and the Tascon hotspot just inside the gulf rendered ~4 kt against a 7.6 kt SHOM peak. A 2× shortfall, consistent across the whole Morbihan.

## Root cause

``_coefficient_for_day`` in ``ShomC2dRegistry`` interpolates between the coef-45 (mortes-eaux) and coef-95 (vives-eaux) timeseries that SHOM stores, weighted by the day's tidal coefficient. The function computed that coefficient as:

```
coef = 100 * range_at_local_ref_port / 6.1 m
```

The denominator 6.1 m is **Brest's mean-equinox spring range**, but the numerator was measured at the local atlas's ref port. At Port-Navalo (atlas 558) the local range at coef 95 is ~3.4 m — much smaller than Brest's ~5.8 m — so the formula yielded coef ~57 on a day that SHOM officially calls coef 95. Currents got scaled to the mortes-eaux side accordingly.

The French tidal coefficient is defined **at Brest** by national convention (100 = mean-equinox vives-eaux at Brest). It applies nationwide; only the local amplitude shrinks with distance from Brest, not the coefficient itself.

## Fix

Always read the day's range from Brest's harmonic constants when present in the ref-ports table (Brest is always there since it's atlas 560's ref port). PM/BM event location continues to use the **local** ref port — only the coefficient is anchored to Brest.

## Verification

Before:

```
Tascon (47.5733, -2.8903) on May 16 2026 noon
  peak: ~4.0 kt   (expected ~7.6 kt at coef 95)
```

After (this PR):

```
Tascon (47.5733, -2.8903) on May 16 2026 24-hour scan
  peak: 7.57 kt   computed coef: 91 (matches new moon May 16)
```

7.57 kt vs SHOM-documented 7.6 kt is within rounding noise.

## Test plan

- [x] ``pytest packages/data-adapters/tests`` — 191 passed
- [x] ``ruff check packages/data-adapters/src`` clean
- [ ] Post-merge + Space rebuild: re-smoke ``/api/v1/marine/marc?lat=47.5733&lon=-2.8903&...`` for a vives-eaux date → expect peak in the 6-8 kt range
- [ ] Web smoke: click in the Morbihan interior (Tascon / Île-aux-Moines area) on a vives-eaux day → expect peak currents reaching the SHOM-documented 6-8 kt range

🤖 Generated with [Claude Code](https://claude.com/claude-code)