### PR TITLE
fix: trim HF short_description + restore /methodologie route (hotfix #119)

### DIFF
--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -7,7 +7,7 @@ sdk: docker
 app_port: 7860
 pinned: false
 license: mit
-short_description: French Atlantic and Mediterranean sailing planner for any MCP client.
+short_description: French Atlantic + Mediterranean sailing planner via MCP.
 ---
 
 # OpenWind MCP ⛵

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -13,7 +13,13 @@ if (spaRedirect) {
   window.history.replaceState(null, "", spaRedirect);
 }
 
-const path = window.location.pathname;
+// Normalise trailing slashes: GitHub Pages adds them automatically when a
+// matching directory exists under public/ (e.g. ``public/methodologie/`` for
+// the coverage map asset), which turns ``/methodologie`` into ``/methodologie/``
+// during the 404→SPA redirect dance. Strip the trailing slash so route
+// matches stay simple.
+const rawPath = window.location.pathname;
+const path = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
 const isPlan = path === "/plan";
 const isMethodologie = path === "/methodologie";
 


### PR DESCRIPTION
Two follow-ups to PR #119 caught by the live deploy.

## 1. HF Space sync rejected — ``short_description`` over 60 chars

PR #119 set ``packages/hf-space/README.md``'s ``short_description`` to "French Atlantic and Mediterranean sailing planner for any MCP client." (69 chars). HF Spaces enforces a 60-char limit on that frontmatter field and the pre-receive hook rejected the post-merge sync, blocking the Space rebuild.

Rephrased to **"French Atlantic + Mediterranean sailing planner via MCP."** (56 chars) — keeps the bi-coastal branding and fits the cap.

## 2. ``openwind.fr/methodologie`` no longer accessible

Same PR added ``packages/web/public/methodologie/coverage_map.png`` to embed the new coverage figure in the methodology page. That created a real ``methodologie/`` directory in the published GH Pages bundle, which changed the redirect chain:

1. User hits ``openwind.fr/methodologie``
2. GitHub Pages 301s to ``openwind.fr/methodologie/`` (it now sees a directory)
3. ``/methodologie/`` 404s (no ``index.html`` inside)
4. The SPA 404 helper stores ``"/methodologie/"`` (with trailing slash) and redirects to ``/``
5. ``main.tsx`` restores the path: ``window.location.pathname === "/methodologie/"``
6. The route check ``path === "/methodologie"`` no longer matches → falls through to the default ``<App />``

Fix: strip a lone trailing slash before matching in ``main.tsx``. ``/methodologie`` and ``/methodologie/`` both render the methodology page again.

## Verification

- ``short_description`` length: 56 chars (vs. 60-cap)
- Trailing-slash normalisation lives in ``main.tsx`` before the ``isMethodologie`` check, so both URL forms work
- HF Space sync should re-fire cleanly on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)