### PR TITLE
fix(web): add Organization JSON-LD so Google can render the logo

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -31,6 +31,17 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="apple-touch-icon" sizes="192x192" href="/icon-192.png">
+
+    <!-- Structured data: Organization logo for Google search -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "OpenWind",
+        "url": "https://openwind.fr",
+        "logo": "https://openwind.fr/icon-512.png"
+      }
+    </script>
   </head>
   <body class="bg-gray-950 text-white">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Add a `schema.org/Organization` JSON-LD block in [packages/web/index.html](packages/web/index.html) pointing Google at `icon-512.png` as the official OpenWind logo.
- Closes #122 (no logo on Google search).

## Why
Google uses the `Organization.logo` structured-data property to render a brand logo in search results and knowledge panels ([doc](https://developers.google.com/search/docs/appearance/structured-data/logo)). The site shipped without it, so SERPs fall back to a blank/default tile.

`icon-512.png` already satisfies Google's constraints (square, 512×512, crawlable at https://openwind.fr/icon-512.png).

## Test plan
- [ ] After deploy, paste https://openwind.fr/ into [Rich Results Test](https://search.google.com/test/rich-results) — expect a green "Logo" detection
- [ ] Submit a recrawl via Search Console (effect takes days to weeks before SERP updates)
- [ ] Quick visual check: `view-source:https://openwind.fr/` shows the JSON-LD block under the favicon links

🤖 Generated with [Claude Code](https://claude.com/claude-code)