### PR TITLE
feat(web): /config page for weather model ordering + AROME HD fix

### DIFF
--- a/packages/web/src/api/openmeteo.ts
+++ b/packages/web/src/api/openmeteo.ts
@@ -7,10 +7,10 @@ import {
 
 const MODEL_ENDPOINTS: Record<ModelName, { endpoint: string; extraParams?: string }> = {
   AROME: {
-    endpoint: "https://api.open-meteo.com/v1/meteofrance",
-    extraParams: "&models=arome_france",
-  },
-  AROME_HD: {
+    // arome_france_hd is the 1.5 km high-resolution Météo-France AROME. The
+    // 2.5 km arome_france variant was dropped: same horizon, same cadence,
+    // lower resolution, and 1.5 km better captures coastal sheltering and
+    // thermal effects on complex terrain (Med, Bretagne sud).
     endpoint: "https://api.open-meteo.com/v1/meteofrance",
     extraParams: "&models=arome_france_hd",
   },

--- a/packages/web/src/api/openmeteo.ts
+++ b/packages/web/src/api/openmeteo.ts
@@ -1,15 +1,61 @@
 import type { ModelForecast, HourlyData, GeocodingResult } from "../types";
+import {
+  activeModels,
+  loadModelConfig,
+  type ModelName,
+} from "../config/modelConfig";
 
-const MODELS = [
-  { name: "ECMWF", endpoint: "https://api.open-meteo.com/v1/ecmwf" },
-  { name: "GFS", endpoint: "https://api.open-meteo.com/v1/gfs" },
-  { name: "ICON", endpoint: "https://api.open-meteo.com/v1/dwd-icon" },
-  {
-    name: "AROME",
+const MODEL_ENDPOINTS: Record<ModelName, { endpoint: string; extraParams?: string }> = {
+  AROME: {
     endpoint: "https://api.open-meteo.com/v1/meteofrance",
     extraParams: "&models=arome_france",
   },
-];
+  AROME_HD: {
+    endpoint: "https://api.open-meteo.com/v1/meteofrance",
+    extraParams: "&models=arome_france_hd",
+  },
+  ARPEGE_EU: {
+    endpoint: "https://api.open-meteo.com/v1/meteofrance",
+    extraParams: "&models=arpege_europe",
+  },
+  ARPEGE_W: {
+    endpoint: "https://api.open-meteo.com/v1/meteofrance",
+    extraParams: "&models=arpege_world",
+  },
+  ICON: { endpoint: "https://api.open-meteo.com/v1/dwd-icon" },
+  ICON_GLOBAL: {
+    endpoint: "https://api.open-meteo.com/v1/dwd-icon",
+    extraParams: "&models=icon_global",
+  },
+  ICON_D2: {
+    endpoint: "https://api.open-meteo.com/v1/dwd-icon",
+    extraParams: "&models=icon_d2",
+  },
+  ECMWF: { endpoint: "https://api.open-meteo.com/v1/ecmwf" },
+  ECMWF_AIFS: {
+    endpoint: "https://api.open-meteo.com/v1/ecmwf",
+    extraParams: "&models=ecmwf_aifs025",
+  },
+  GFS: { endpoint: "https://api.open-meteo.com/v1/gfs" },
+  UKMO: {
+    endpoint: "https://api.open-meteo.com/v1/ukmo",
+    extraParams: "&models=ukmo_global_deterministic_10km",
+  },
+  UKMO_UK: {
+    endpoint: "https://api.open-meteo.com/v1/ukmo",
+    extraParams: "&models=ukmo_uk_deterministic_2km",
+  },
+  GEM: { endpoint: "https://api.open-meteo.com/v1/gem" },
+  DMI_HARMONIE: {
+    // DMI has no dedicated /v1/dmi endpoint on Open-Meteo; we route via the
+    // unified /v1/forecast endpoint with an explicit `&models=` filter. A
+    // single-model request still returns unsuffixed `hourly.*` keys, so the
+    // existing payload parser works unchanged.
+    endpoint: "https://api.open-meteo.com/v1/forecast",
+    extraParams: "&models=dmi_harmonie_arome_europe",
+  },
+  METNO_NORDIC: { endpoint: "https://api.open-meteo.com/v1/metno" },
+};
 
 const PARAMS =
   "hourly=wind_speed_10m,wind_direction_10m,wind_gusts_10m,weather_code,is_day&wind_speed_unit=kn&timezone=Europe/Paris&forecast_days=7";
@@ -63,25 +109,32 @@ export async function fetchAllModels(
   lat: number,
   lon: number
 ): Promise<ModelForecast[]> {
-  const key = `${lat.toFixed(4)},${lon.toFixed(4)}`;
-  const cached = cache.get(key);
+  const config = loadModelConfig();
+  const selected = activeModels(config);
+  // Cache key includes the active model list so that reordering or swapping
+  // models in /config doesn't return a stale subset on the next page load.
+  const cacheKey = `${lat.toFixed(4)},${lon.toFixed(4)}|${selected.join(",")}`;
+  const cached = cache.get(cacheKey);
   if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
     return cached.models;
   }
 
   const base = `?latitude=${lat}&longitude=${lon}&${PARAMS}`;
 
-  const results = await Promise.allSettled(
-    MODELS.map((model) =>
-      fetch(`${model.endpoint}${base}${model.extraParams || ""}`)
+  const results = await Promise.allSettled<ModelForecast>(
+    selected.map((name) => {
+      const model = MODEL_ENDPOINTS[name];
+      return fetch(`${model.endpoint}${base}${model.extraParams || ""}`)
         .then((r) => r.json())
-        .then((data) => ({
-          modelName: model.name,
+        .then((data): ModelForecast => ({
+          modelName: name,
           hourly: data.hourly ? sanitizeHourly(data.hourly) : data.hourly,
-        }))
-    )
+        }));
+    })
   );
 
+  // Promise.allSettled preserves input order, so the user's configured order
+  // flows through to the WindTable rendering loop.
   const models = results
     .filter(
       (r): r is PromiseFulfilledResult<ModelForecast> =>
@@ -89,7 +142,7 @@ export async function fetchAllModels(
     )
     .map((r) => r.value);
 
-  cache.set(key, { models, fetchedAt: Date.now() });
+  cache.set(cacheKey, { models, fetchedAt: Date.now() });
   return models;
 }
 

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -4,27 +4,22 @@ import { TimelineHeader } from "./TimelineHeader";
 import { WindCell } from "./WindCell";
 import { useTimezone } from "../hooks/useTimezone";
 import { nowParisHourPrefix } from "../utils/format";
+import { MODEL_META, type ModelName } from "../config/modelConfig";
 
-const MODEL_STEP: Record<string, number> = {
-  AROME: 1,
-  ICON: 3,
-  GFS: 3,
-  ECMWF: 6,
-};
+function modelStep(name: string): number {
+  const meta = MODEL_META[name as ModelName];
+  return meta ? meta.nativeStepHours : 3;
+}
 
-const MODEL_LABELS: Record<string, string> = {
-  AROME: "AROME",
-  ICON: "ICON",
-  GFS: "GFS",
-  ECMWF: "ECMWF",
-};
+function modelLabel(name: string): string {
+  return MODEL_META[name as ModelName]?.label ?? name;
+}
 
-const MODEL_DESCRIPTIONS: Record<string, string> = {
-  AROME: "AROME — Modèle haute résolution (1h) — Météo-France",
-  ICON: "ICON — Modèle global (3h) — DWD Allemagne",
-  GFS: "GFS — Modèle global (3h) — NOAA États-Unis",
-  ECMWF: "ECMWF — Modèle global (6h) — Centre européen",
-};
+function modelDescription(name: string): string {
+  const meta = MODEL_META[name as ModelName];
+  if (!meta) return name;
+  return `${meta.label} (${meta.nativeStepHours}h) . ${meta.provider}`;
+}
 
 // Approximate cell width (must match WindCell min-w-[36px])
 const CELL_W = 36;
@@ -32,7 +27,7 @@ const CELL_W = 36;
 function autoResolution(forecasts: ModelForecast[]): number {
   let finest = 6;
   for (const f of forecasts) {
-    const step = MODEL_STEP[f.modelName] ?? 3;
+    const step = modelStep(f.modelName);
     if (step < finest) finest = step;
   }
   return finest;
@@ -186,9 +181,9 @@ export function WindTable({
                         <span
                           className="text-[11px] lg:text-[12px] font-bold tracking-wide"
                           style={{ color: 'var(--ow-fg-0)' }}
-                          title={MODEL_DESCRIPTIONS[forecast.modelName] ?? forecast.modelName}
+                          title={modelDescription(forecast.modelName)}
                         >
-                          {MODEL_LABELS[forecast.modelName] ?? forecast.modelName}
+                          {modelLabel(forecast.modelName)}
                         </span>
                         <span className="text-[8px] font-medium" style={{ color: 'var(--ow-fg-2)' }}>kn</span>
                       </div>

--- a/packages/web/src/config/modelConfig.ts
+++ b/packages/web/src/config/modelConfig.ts
@@ -13,7 +13,6 @@ export const ACTIVE_LIMIT = 4;
 
 export type ModelName =
   | "AROME"
-  | "AROME_HD"
   | "ARPEGE_EU"
   | "ARPEGE_W"
   | "ICON"
@@ -30,7 +29,6 @@ export type ModelName =
 
 export const ALL_MODELS: readonly ModelName[] = [
   "AROME",
-  "AROME_HD",
   "ARPEGE_EU",
   "ARPEGE_W",
   "ICON",
@@ -53,7 +51,6 @@ export const DEFAULT_ORDER: readonly ModelName[] = [
   "ICON",
   "ECMWF",
   "GFS",
-  "AROME_HD",
   "ARPEGE_EU",
   "ARPEGE_W",
   "ICON_GLOBAL",
@@ -88,21 +85,12 @@ export interface ModelMeta {
 
 export const MODEL_META: Record<ModelName, ModelMeta> = {
   AROME: {
-    label: "AROME",
-    provider: "Météo-France",
-    resolutionKm: 1.3,
-    horizonHours: 51,
-    coverage: "France",
-    description: "Haute résolution, capte les effets thermiques et locaux.",
-    nativeStepHours: 1,
-  },
-  AROME_HD: {
     label: "AROME HD",
     provider: "Météo-France",
-    resolutionKm: 1.3,
+    resolutionKm: 1.5,
     horizonHours: 51,
     coverage: "France",
-    description: "Variante AROME avec champs de surface plus complets.",
+    description: "Haute résolution Météo-France, capte les effets thermiques et l'abri côtier.",
     nativeStepHours: 1,
   },
   ARPEGE_EU: {

--- a/packages/web/src/config/modelConfig.ts
+++ b/packages/web/src/config/modelConfig.ts
@@ -1,0 +1,277 @@
+// Persisted ordering of the wind models the app fetches from Open-Meteo.
+// The top `ACTIVE_LIMIT` models in the order are the ones actually fetched
+// and shown as rows in the forecast table; the rest are kept in the catalog
+// (visible in /config, greyed out) so the user can promote them later
+// without losing their place.
+//
+// Only affects the web client. Server-side `plan_passage` still uses its own
+// `model="auto"` chain.
+
+const STORAGE_KEY = "ow_model_config_v1";
+
+export const ACTIVE_LIMIT = 4;
+
+export type ModelName =
+  | "AROME"
+  | "AROME_HD"
+  | "ARPEGE_EU"
+  | "ARPEGE_W"
+  | "ICON"
+  | "ICON_GLOBAL"
+  | "ICON_D2"
+  | "ECMWF"
+  | "ECMWF_AIFS"
+  | "GFS"
+  | "UKMO"
+  | "UKMO_UK"
+  | "GEM"
+  | "DMI_HARMONIE"
+  | "METNO_NORDIC";
+
+export const ALL_MODELS: readonly ModelName[] = [
+  "AROME",
+  "AROME_HD",
+  "ARPEGE_EU",
+  "ARPEGE_W",
+  "ICON",
+  "ICON_GLOBAL",
+  "ICON_D2",
+  "ECMWF",
+  "ECMWF_AIFS",
+  "GFS",
+  "UKMO",
+  "UKMO_UK",
+  "GEM",
+  "DMI_HARMONIE",
+  "METNO_NORDIC",
+];
+
+// Default ranking — the four historical models stay active out of the box so
+// existing users see no change, the rest appended (greyed) for opt-in promotion.
+export const DEFAULT_ORDER: readonly ModelName[] = [
+  "AROME",
+  "ICON",
+  "ECMWF",
+  "GFS",
+  "AROME_HD",
+  "ARPEGE_EU",
+  "ARPEGE_W",
+  "ICON_GLOBAL",
+  "ICON_D2",
+  "ECMWF_AIFS",
+  "UKMO",
+  "UKMO_UK",
+  "GEM",
+  "DMI_HARMONIE",
+  "METNO_NORDIC",
+];
+
+export interface ModelConfig {
+  order: ModelName[];
+}
+
+interface PersistedConfig {
+  v: 1;
+  order: string[];
+}
+
+export interface ModelMeta {
+  label: string;
+  provider: string;
+  resolutionKm: number;
+  horizonHours: number;
+  coverage: string;
+  description: string;
+  // Native time step used to mask the timeline cells in WindTable.
+  nativeStepHours: number;
+}
+
+export const MODEL_META: Record<ModelName, ModelMeta> = {
+  AROME: {
+    label: "AROME",
+    provider: "Météo-France",
+    resolutionKm: 1.3,
+    horizonHours: 51,
+    coverage: "France",
+    description: "Haute résolution, capte les effets thermiques et locaux.",
+    nativeStepHours: 1,
+  },
+  AROME_HD: {
+    label: "AROME HD",
+    provider: "Météo-France",
+    resolutionKm: 1.3,
+    horizonHours: 51,
+    coverage: "France",
+    description: "Variante AROME avec champs de surface plus complets.",
+    nativeStepHours: 1,
+  },
+  ARPEGE_EU: {
+    label: "ARPEGE EU",
+    provider: "Météo-France",
+    resolutionKm: 10,
+    horizonHours: 96,
+    coverage: "Europe",
+    description: "Modèle français moyenne échéance, prolonge AROME.",
+    nativeStepHours: 1,
+  },
+  ARPEGE_W: {
+    label: "ARPEGE Monde",
+    provider: "Météo-France",
+    resolutionKm: 50,
+    horizonHours: 102,
+    coverage: "Global",
+    description: "Pilote global de Météo-France, basse résolution.",
+    nativeStepHours: 3,
+  },
+  ICON: {
+    label: "ICON-EU",
+    provider: "DWD (Allemagne)",
+    resolutionKm: 7,
+    horizonHours: 120,
+    coverage: "Europe",
+    description: "Modèle régional européen, bon compromis portée / précision.",
+    nativeStepHours: 3,
+  },
+  ICON_GLOBAL: {
+    label: "ICON Global",
+    provider: "DWD (Allemagne)",
+    resolutionKm: 13,
+    horizonHours: 180,
+    coverage: "Global",
+    description: "Version globale d'ICON, portée étendue.",
+    nativeStepHours: 3,
+  },
+  ICON_D2: {
+    label: "ICON D2",
+    provider: "DWD (Allemagne)",
+    resolutionKm: 2,
+    horizonHours: 48,
+    coverage: "Allemagne + frontières",
+    description: "Très haute résolution DWD, marges utiles sur l'est français.",
+    nativeStepHours: 1,
+  },
+  ECMWF: {
+    label: "ECMWF",
+    provider: "Centre européen",
+    resolutionKm: 25,
+    horizonHours: 240,
+    coverage: "Global",
+    description: "Référence à moyenne échéance, résolution plus grossière.",
+    nativeStepHours: 6,
+  },
+  ECMWF_AIFS: {
+    label: "ECMWF AIFS",
+    provider: "Centre européen",
+    resolutionKm: 25,
+    horizonHours: 240,
+    coverage: "Global (IA)",
+    description: "Modèle IA d'ECMWF, performances proches de l'IFS.",
+    nativeStepHours: 6,
+  },
+  GFS: {
+    label: "GFS",
+    provider: "NOAA (États-Unis)",
+    resolutionKm: 25,
+    horizonHours: 384,
+    coverage: "Global",
+    description: "Très longue portée, rafales peu fiables en faible vent.",
+    nativeStepHours: 3,
+  },
+  UKMO: {
+    label: "UKMO Global",
+    provider: "Met Office (UK)",
+    resolutionKm: 10,
+    horizonHours: 168,
+    coverage: "Global",
+    description: "Modèle global du Met Office, bon sur l'Atlantique nord.",
+    nativeStepHours: 1,
+  },
+  UKMO_UK: {
+    label: "UKMO UK",
+    provider: "Met Office (UK)",
+    resolutionKm: 2,
+    horizonHours: 120,
+    coverage: "Îles Britanniques + Manche",
+    description: "Haute résolution UK, utile sur la Manche occidentale.",
+    nativeStepHours: 1,
+  },
+  GEM: {
+    label: "GEM",
+    provider: "Env. Canada",
+    resolutionKm: 15,
+    horizonHours: 240,
+    coverage: "Global",
+    description: "Modèle global canadien, complément utile.",
+    nativeStepHours: 3,
+  },
+  DMI_HARMONIE: {
+    label: "DMI Harmonie",
+    provider: "DMI (Danemark)",
+    resolutionKm: 2,
+    horizonHours: 60,
+    coverage: "Europe du Nord + Manche",
+    description: "Haute résolution scandinave, utile en Manche et Mer du Nord.",
+    nativeStepHours: 1,
+  },
+  METNO_NORDIC: {
+    label: "METNO Nordic",
+    provider: "MET Norway",
+    resolutionKm: 1,
+    horizonHours: 60,
+    coverage: "Scandinavie + Mer du Nord",
+    description: "Modèle norvégien très haute résolution sur la Mer du Nord.",
+    nativeStepHours: 1,
+  },
+};
+
+function isModelName(x: unknown): x is ModelName {
+  return typeof x === "string" && (ALL_MODELS as readonly string[]).includes(x);
+}
+
+function normalize(order: ModelName[]): ModelConfig {
+  // Dedupe while preserving order, then append any missing models so the
+  // config always contains every known model (new models added later show up
+  // at the end, greyed out, until the user promotes them).
+  const seen = new Set<ModelName>();
+  const deduped: ModelName[] = [];
+  for (const m of order) {
+    if (isModelName(m) && !seen.has(m)) {
+      deduped.push(m);
+      seen.add(m);
+    }
+  }
+  for (const m of ALL_MODELS) {
+    if (!seen.has(m)) deduped.push(m);
+  }
+  return { order: deduped };
+}
+
+export function defaultConfig(): ModelConfig {
+  return normalize([...DEFAULT_ORDER]);
+}
+
+export function loadModelConfig(): ModelConfig {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultConfig();
+    const parsed = JSON.parse(raw) as PersistedConfig;
+    if (parsed.v !== 1) return defaultConfig();
+    const order = (parsed.order ?? []).filter(isModelName);
+    return normalize(order);
+  } catch {
+    return defaultConfig();
+  }
+}
+
+export function saveModelConfig(cfg: ModelConfig): void {
+  try {
+    const payload: PersistedConfig = { v: 1, order: cfg.order };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage unavailable / full — fail silently; next load returns default.
+  }
+}
+
+export function activeModels(cfg: ModelConfig): ModelName[] {
+  return cfg.order.slice(0, ACTIVE_LIMIT);
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -4,6 +4,7 @@ import "./index.css";
 import App from "./App";
 import { PlanPage } from "./routes/PlanPage";
 import { MethodologiePage } from "./routes/MethodologiePage";
+import { ConfigPage } from "./routes/ConfigPage";
 import { ThemeProvider } from "./design/theme";
 
 // GitHub Pages 404.html redirect: restore original path stored in sessionStorage
@@ -22,11 +23,20 @@ const rawPath = window.location.pathname;
 const path = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
 const isPlan = path === "/plan";
 const isMethodologie = path === "/methodologie";
+const isConfig = path === "/config";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
-      {isPlan ? <PlanPage /> : isMethodologie ? <MethodologiePage /> : <App />}
+      {isPlan ? (
+        <PlanPage />
+      ) : isMethodologie ? (
+        <MethodologiePage />
+      ) : isConfig ? (
+        <ConfigPage />
+      ) : (
+        <App />
+      )}
     </ThemeProvider>
   </StrictMode>
 );

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -1,0 +1,300 @@
+import { useMemo, useState } from "react";
+import {
+  ACTIVE_LIMIT,
+  MODEL_META,
+  defaultConfig,
+  loadModelConfig,
+  saveModelConfig,
+  type ModelConfig,
+  type ModelName,
+} from "../config/modelConfig";
+
+function formatHorizon(hours: number): string {
+  if (hours < 72) return `${hours} h`;
+  return `${Math.round(hours / 24)} j`;
+}
+
+export function ConfigPage() {
+  const [config, setConfig] = useState<ModelConfig>(() => loadModelConfig());
+  const [savedOnce, setSavedOnce] = useState(false);
+  // Track the dragged item by model identity (not by index) so the visual
+  // index of the dragged row can shift as the preview reorders without us
+  // losing track of which row is being moved.
+  const [dragModel, setDragModel] = useState<ModelName | null>(null);
+  const [overIdx, setOverIdx] = useState<number | null>(null);
+
+  function update(next: ModelConfig) {
+    setConfig(next);
+    saveModelConfig(next);
+    setSavedOnce(true);
+  }
+
+  function reset() {
+    update(defaultConfig());
+  }
+
+  // Order the user currently sees while dragging. When the user hovers a row,
+  // we splice the dragged item to that target slot so the rest of the list
+  // visibly shifts in real time. Drop just commits this preview to state.
+  const previewOrder = useMemo<ModelName[]>(() => {
+    if (dragModel == null || overIdx == null) return config.order;
+    const from = config.order.indexOf(dragModel);
+    if (from < 0) return config.order;
+    if (from === overIdx) return config.order;
+    const next = [...config.order];
+    const [item] = next.splice(from, 1);
+    next.splice(overIdx, 0, item);
+    return next;
+  }, [config.order, dragModel, overIdx]);
+
+  function onDragStart(e: React.DragEvent, model: ModelName, idx: number) {
+    setDragModel(model);
+    setOverIdx(idx);
+    e.dataTransfer.setData("text/plain", model);
+    e.dataTransfer.effectAllowed = "move";
+  }
+
+  function onDragOver(e: React.DragEvent, idx: number) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    if (overIdx !== idx) setOverIdx(idx);
+  }
+
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    if (dragModel != null) {
+      update({ ...config, order: previewOrder });
+    }
+    setDragModel(null);
+    setOverIdx(null);
+  }
+
+  function onDragEnd() {
+    // Fires after drop as well as for cancelled drags (Esc, drop outside any
+    // valid target). Resetting here makes a cancelled drag revert smoothly
+    // because previewOrder falls back to config.order once dragModel is null.
+    setDragModel(null);
+    setOverIdx(null);
+  }
+
+  const totalRows = previewOrder.length;
+  const ignoredRows = totalRows - ACTIVE_LIMIT;
+
+  return (
+    <div className="config-root min-h-screen overflow-y-auto">
+      <header className="config-header sticky top-0 z-10 border-b backdrop-blur">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <a href="/" className="text-sm font-medium opacity-80 hover:opacity-100 transition">
+            ← OpenWind
+          </a>
+          <span className="text-xs opacity-60">Configuration</span>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-10">
+        <h1 className="text-3xl font-bold mb-2">Modèles météo</h1>
+        <p className="text-sm opacity-80 mb-8 leading-relaxed">
+          Les {ACTIVE_LIMIT} premiers modèles sont affichés dans la table de
+          prévision, dans cet ordre. Glisse-dépose pour réordonner. Cette
+          configuration ne touche pas les plans de passage.
+        </p>
+
+        <div className="config-list-with-zones">
+          <ol className="config-list">
+            {previewOrder.map((model, idx) => {
+              const meta = MODEL_META[model];
+              const isActive = idx < ACTIVE_LIMIT;
+              const isDragging = dragModel === model;
+              return (
+                <li
+                  key={model}
+                  draggable
+                  onDragStart={(e) => onDragStart(e, model, idx)}
+                  onDragOver={(e) => onDragOver(e, idx)}
+                  onDrop={onDrop}
+                  onDragEnd={onDragEnd}
+                  className={`config-row flex items-stretch gap-3 rounded-xl border p-3 select-none ${
+                    isActive ? "is-active" : "is-inactive"
+                  } ${isDragging ? "is-dragging" : ""}`}
+                >
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="config-handle" aria-hidden>
+                      ⋮⋮
+                    </span>
+                    <span
+                      className={`config-rank ${
+                        isActive ? "" : "config-rank-off"
+                      }`}
+                    >
+                      {idx + 1}
+                    </span>
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-baseline gap-2 flex-wrap">
+                      <span className="text-base font-semibold">
+                        {meta.label}
+                      </span>
+                      <span className="text-xs opacity-70">
+                        {meta.provider}
+                      </span>
+                    </div>
+                    <p className="text-sm opacity-80 mt-1">{meta.description}</p>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1.5 text-xs opacity-70">
+                      <span>{meta.resolutionKm} km</span>
+                      <span>~{formatHorizon(meta.horizonHours)}</span>
+                      <span>{meta.coverage}</span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+
+          {/* Right-side bracket annotating which rows are used vs ignored.
+              Flex-grow proportional to row counts so the segments line up with
+              the corresponding list rows. */}
+          <div className="config-zones" aria-hidden>
+            <div
+              className="config-zone is-active"
+              style={{ flexGrow: ACTIVE_LIMIT }}
+            >
+              <span className="config-zone-label">Utilisé dans l'app</span>
+            </div>
+            {ignoredRows > 0 && (
+              <div
+                className="config-zone is-ignored"
+                style={{ flexGrow: ignoredRows }}
+              >
+                <span className="config-zone-label">Ignorés</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 flex-wrap mt-6">
+          <button type="button" onClick={reset} className="config-reset">
+            Réinitialiser
+          </button>
+          {savedOnce && (
+            <span className="text-xs opacity-50">· enregistré</span>
+          )}
+        </div>
+      </main>
+
+      <style>{`
+        .config-root {
+          background: var(--ow-bg-0, #0b1220);
+          color: var(--ow-fg-0, #e2e8f0);
+        }
+        .config-header {
+          background: color-mix(in srgb, var(--ow-bg-0, #0b1220) 75%, transparent);
+          border-color: var(--ow-line-2, rgba(255,255,255,0.08));
+        }
+        .config-list-with-zones {
+          display: grid;
+          grid-template-columns: 1fr 140px;
+          gap: 18px;
+          align-items: stretch;
+        }
+        .config-list {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+        .config-row {
+          background: var(--ow-bg-1, rgba(255,255,255,0.04));
+          border-color: var(--ow-line-2, rgba(255,255,255,0.08));
+          cursor: grab;
+          transition: opacity 150ms ease, transform 200ms ease, border-color 120ms ease, background 120ms ease;
+        }
+        .config-row:active {
+          cursor: grabbing;
+        }
+        .config-row.is-inactive {
+          opacity: 0.45;
+        }
+        .config-row.is-dragging {
+          opacity: 0.35;
+          border-style: dashed;
+        }
+        .config-handle {
+          font-size: 14px;
+          opacity: 0.35;
+          letter-spacing: -2px;
+          font-weight: 700;
+          color: var(--ow-fg-1, #cbd5e1);
+        }
+        .config-rank {
+          display: inline-flex;
+          width: 22px;
+          height: 22px;
+          align-items: center;
+          justify-content: center;
+          border-radius: 50%;
+          background: var(--ow-accent, #14b8a6);
+          color: #fff;
+          font-size: 11px;
+          font-weight: 700;
+        }
+        .config-rank-off {
+          background: var(--ow-bg-2, rgba(255,255,255,0.08));
+          color: var(--ow-fg-2, #94a3b8);
+        }
+        .config-reset {
+          font-size: 13px;
+          padding: 8px 14px;
+          border-radius: 8px;
+          color: var(--ow-fg-1, #cbd5e1);
+          background: transparent;
+          border: 1px solid var(--ow-line-2, rgba(255,255,255,0.12));
+          transition: background 120ms ease, color 120ms ease;
+        }
+        .config-reset:hover {
+          background: var(--ow-bg-2, rgba(255,255,255,0.06));
+          color: var(--ow-fg-0, #e2e8f0);
+        }
+        .config-zones {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+        .config-zone {
+          position: relative;
+          display: flex;
+          align-items: center;
+          padding-left: 14px;
+          min-height: 0;
+        }
+        .config-zone::before {
+          content: "";
+          position: absolute;
+          top: 6px;
+          bottom: 6px;
+          left: 0;
+          width: 2px;
+          border-radius: 2px;
+        }
+        .config-zone.is-active::before {
+          background: var(--ow-accent, #14b8a6);
+        }
+        .config-zone.is-ignored::before {
+          background: var(--ow-line-2, rgba(255,255,255,0.20));
+        }
+        .config-zone-label {
+          font-size: 11px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          line-height: 1.2;
+        }
+        .config-zone.is-active .config-zone-label {
+          color: var(--ow-accent, #14b8a6);
+        }
+        .config-zone.is-ignored .config-zone-label {
+          color: var(--ow-fg-2, #94a3b8);
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New `/config` page lets users reorder the weather models shown in the forecast table (drag-and-drop, persisted in localStorage). Top 4 are fetched and rendered as rows; the rest stay greyed out for opt-in promotion.
- **Bug fix surfaced by [a forum report](https://example-forum) on AROME values at Canet-en-Roussillon**: the "AROME" row was wired to Open-Meteo's `arome_france` (0.025°, **~2.5 km**) while `MODEL_META` advertised 1.3 km. A parallel "AROME HD" row pointed to `arome_france_hd` (0.01°, **~1.5 km**). Same horizon (51 h), same cadence (3 h), but on coastal points with complex terrain (Cap Sicié, Calanques, Bretagne sud) the 2.5 km variant misses local sheltering and reports rafales 4-5 kn higher than the 1.5 km one.

Dropped the 2.5 km variant; "AROME" now serves the real 1.5 km HD. Label updated to "AROME HD" to make the resolution explicit. Internal `ModelName` stays `"AROME"` so existing localStorage configs keep working; persisted `"AROME_HD"` values are silently filtered by `isModelName`.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Visit `/config`, drag a model, reload → order persisted
- [ ] Compare AROME values for Canet vs Saint-Cyr-sur-Mer (complex terrain) → expect 1.5 km values lower at sheltered points
- [ ] Existing user with persisted `"AROME_HD"` in localStorage → row silently dropped, no console error
- [ ] Weather icons in TimelineHeader still render (fallback to ICON/ECMWF when `weather_code` is null on AROME HD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)