### PR TITLE
refacto(web): tabular LegRow summary with leg labels and trimmed expand

### DIFF
--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -236,8 +236,11 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
       ? `${tws} (${Math.round(leg.gust_max_kn)}) kn`
       : `${tws} kn`;
   const fmtFR1 = (n: number) => n.toFixed(1).replace(".", ",");
+  // Compact French form mirrors the KpiBlock used in PlanSidebar: "1,8m (6s)"
+  // rather than "1,8 m (6 s)" — keeps the compass labels short enough to fit
+  // beside the wheel without getting clipped at LABEL_R on narrow viewports.
   const waveLine = leg.hs_avg_m != null
-    ? `${fmtFR1(leg.hs_avg_m)} m${leg.tp_avg_s != null ? ` (${Math.round(leg.tp_avg_s)} s)` : ""}`
+    ? `${fmtFR1(leg.hs_avg_m)}m${leg.tp_avg_s != null ? ` (${Math.round(leg.tp_avg_s)}s)` : ""}`
     : "";
   const hasWaves = leg.hs_avg_m != null;
 
@@ -367,9 +370,10 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
             fill={COLORS.wind}
             style={{ fontFamily: "var(--ow-font-mono)" }}
           >
-            <tspan fontSize="9" fontWeight="500">
-              {leg.gust_max_kn != null && leg.gust_max_kn > tws + 1 ? "Vent (rafales)" : "Vent"}
-            </tspan>
+            {/* Just "Vent": when gusts are present the value already shows
+                them in parentheses (e.g. "21 (27) kn"), no need to double the
+                "(rafales)" cue in the label. */}
+            <tspan fontSize="9" fontWeight="500">Vent</tspan>
             <tspan x={windLx + windLabel.dx} dy="13" fontSize="12" fontWeight="700">
               {windLine}
             </tspan>
@@ -388,9 +392,10 @@ export function LegDetailCard({ leg }: { leg: AggregatedLeg }) {
                 fill={COLORS.waves}
                 style={{ fontFamily: "var(--ow-font-mono)" }}
               >
-                <tspan fontSize="9" fontWeight="500">
-                  {leg.tp_avg_s != null ? "Hauteur vagues (période)" : "Hauteur vagues"}
-                </tspan>
+                {/* "Vagues" only: hauteur + période are visible in the value
+                    line below ("1,8m (6s)"). The long "Hauteur vagues
+                    (période)" label was clipping at the SVG edge. */}
+                <tspan fontSize="9" fontWeight="500">Vagues</tspan>
                 <tspan x={waveLx + waveLabel.dx} dy="13" fontSize="12" fontWeight="700">
                   {waveLine}
                 </tspan>

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTheme } from "../design/theme";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "./types";
-import { aggregateLegs, type AggregatedLeg } from "./aggregateLegs";
+import { aggregateLegs, buildLegSummaryCells, type AggregatedLeg } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
 import { WindowsTable } from "./WindowsTable";
 import { ModeToggle, TimeAnchorToggle, type PlanMode, type TimeAnchor } from "./ModeToggle";
@@ -468,13 +468,65 @@ function ArchetypeSelector({
 }
 
 // ── LegList ──────────────────────────────────────────────────────────────────
-// Click-to-expand list of legs, with the "Comment c'est calculé" build-up
-// rendered inline for the open leg.
+// Click-to-expand list of legs. Collapsed = single natural-language summary
+// line ("Tronçon 1 : 45 mn au près avec mer formée"). Expanded = a 4-block KPI
+// grid (vent / mer / distance / temps) above the existing compass-and-build-up
+// LegDetailCard so the user can scan or drill.
 
-// Shared 4-column template for the leg sub-line — kept as a constant so the
-// sidebar's legend header and every row use the same widths and the values
-// (allure / vent / vagues / distance) line up vertically across rows.
-const SEG_SUBLINE_COLS = "minmax(50px,0.7fr) minmax(40px,0.5fr) minmax(82px,1fr) minmax(44px,0.5fr)";
+function fmtHM(iso: string): string {
+  return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function SummaryCell({ value }: { value: string | null }) {
+  if (!value) return null;
+  return (
+    <span
+      className="text-[10px] whitespace-normal"
+      style={{ color: "var(--ow-fg-1)", lineHeight: 1, display: "inline-block" }}
+    >
+      {value}
+    </span>
+  );
+}
+
+function KpiBlock({
+  value,
+  label,
+  tone,
+}: {
+  value: string;
+  label?: string;
+  tone?: "default" | "warn";
+}) {
+  return (
+    <div
+      className="rounded-md border px-2 py-1"
+      style={{
+        background: tone === "warn"
+          ? "color-mix(in srgb, var(--ow-warn, #fbbf24) 14%, transparent)"
+          : "var(--ow-bg-1)",
+        borderColor: tone === "warn"
+          ? "color-mix(in srgb, var(--ow-warn, #fbbf24) 38%, transparent)"
+          : "var(--ow-line)",
+      }}
+    >
+      <div
+        className="text-[11px] font-semibold tabular-nums leading-tight break-words"
+        style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        {value}
+      </div>
+      {label && (
+        <div
+          className="text-[9px] uppercase tracking-wider leading-tight mt-0.5 break-words"
+          style={{ color: "var(--ow-fg-2)" }}
+        >
+          {label}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function LegRow({
   leg,
@@ -488,62 +540,114 @@ function LegRow({
   onToggle: () => void;
 }) {
   const cx = cxLevel((leg.tws_min + leg.tws_max) / 2);
-  const tws = Math.round(leg.tws_avg_kn);
-  const seaPart = leg.hs_avg_m != null
-    ? `${leg.hs_avg_m.toFixed(1)}m ${leg.sea_direction ?? ""}`.trim()
-    : "—";
-  const fmtHM = (iso: string) =>
-    new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+  const summary = buildLegSummaryCells(leg);
+
+  // KPI values shown on expand. Wind + allure are intentionally absent —
+  // the collapsed row already carries them, no point repeating.
+  // Compact French formatting: "1,8m (6s)" matches sailing-French copy.
+  const fr1 = (n: number) => n.toFixed(1).replace(".", ",");
+
+  const seaValue = leg.hs_avg_m == null
+    ? "—"
+    : leg.tp_avg_s != null
+      ? `${fr1(leg.hs_avg_m)}m (${leg.tp_avg_s.toFixed(0)}s)`
+      : `${fr1(leg.hs_avg_m)}m`;
+  const seaLabel = leg.hs_avg_m == null
+    ? "mer non observée"
+    : leg.sea_direction === "face"
+      ? "de face"
+      : leg.sea_direction === "travers"
+        ? "de travers"
+        : "par l'arrière";
+
+  // Warn tint when sea state notable. Mirrors the same Hs threshold the
+  // summary line uses, so "Mer Formée" badge and warn-coloured KPI agree.
+  const seaWarn = leg.hs_avg_m != null && leg.hs_avg_m > 1.25;
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onToggle();
+    }
+  };
+  const rowBg = expanded ? "var(--ow-bg-2)" : "transparent";
+
+  // Each leg returns three `<tr>`s into the shared `<table>` in LegList:
+  // a title row (badge + name + speed + chevron), a chip row (the four
+  // summary cells), and an optional expand row (KPIs + LegDetailCard).
+  // Because they're all in the same table, the colgroup defined in LegList
+  // forces every leg's chip cells to live in the same column widths —
+  // exactly the cross-row alignment a tableless flex/grid layout couldn't
+  // give us when each LegRow had its own grid container.
   return (
-    <div style={{ borderBottom: "1px solid var(--ow-line)", background: expanded ? "var(--ow-bg-2)" : "transparent" }}>
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full flex items-center gap-2.5 px-4 py-2.5 text-left"
+    <>
+      {/* Single-row leg: badge + 4 info cells + chevron. The speed
+          indicator was dropped and the redundant "Tronçon X" label was
+          dropped earlier — the numbered badge identifies the leg. */}
+      <tr
+        role="button"
+        tabIndex={0}
         aria-expanded={expanded}
+        onClick={onToggle}
+        onKeyDown={handleKey}
+        className="cursor-pointer"
+        style={{ background: rowBg }}
       >
-        <span
-          className="shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-[11px] font-bold tabular-nums"
-          style={{ background: CX_COLORS[cx], color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
-        >
-          {index + 1}
-        </span>
-        <div className="flex-1 min-w-0">
-          <div className="text-xs font-semibold truncate" style={{ color: "var(--ow-fg-0)" }}>
-            Tronçon {index + 1}
-          </div>
-          <div
-            className="grid gap-2 mt-0.5 text-[10px] tabular-nums"
-            style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)", gridTemplateColumns: SEG_SUBLINE_COLS }}
+        <td className="py-2 pl-3 pr-2 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          {/* Leg label is "from→to" using user-waypoint indices (1-based).
+              `index` here is 0-based across legs, so leg N goes from
+              waypoint N to waypoint N+1. */}
+          <span
+            className="inline-flex h-6 px-1.5 rounded-md items-center justify-center text-[10px] font-bold tabular-nums whitespace-nowrap"
+            style={{ background: CX_COLORS[cx], color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
           >
-            <span className="truncate">{leg.point_of_sail}</span>
-            <span>{tws} kn</span>
-            <span className="truncate">{seaPart}</span>
-            <span>{leg.distance_nm.toFixed(1)} nm</span>
-          </div>
-          <div className="text-[10px] mt-0.5 tabular-nums" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
-            {fmtHM(leg.start_time)} → {fmtHM(leg.end_time)}
-          </div>
-        </div>
-        <span className="text-[11px] tabular-nums shrink-0 font-semibold" style={{ color: "var(--ow-fg-0)", fontFamily: "var(--ow-font-mono)" }}>
-          {leg.target_speed_kn.toFixed(1)} kn
-        </span>
-        <span
-          aria-hidden="true"
-          className="inline-flex"
-          style={{
-            color: expanded ? "var(--ow-accent)" : "var(--ow-fg-3)",
-            transform: expanded ? "rotate(180deg)" : "none",
-            transition: "transform 150ms ease, color 150ms ease",
-          }}
-        >
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 6l5 5 5-5" />
-          </svg>
-        </span>
-      </button>
-      {expanded && <LegDetailCard leg={leg} />}
-    </div>
+            {index + 1}→{index + 2}
+          </span>
+        </td>
+        <td className="py-2 px-1 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <SummaryCell value={summary.duration} />
+        </td>
+        <td className="py-2 px-1 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <SummaryCell value={summary.allure} />
+        </td>
+        <td className="py-2 px-1 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <SummaryCell value={summary.wind} />
+        </td>
+        <td className="py-2 px-1 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <SummaryCell value={summary.flag} />
+        </td>
+        <td className="py-2 pl-1 pr-3 text-right align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
+          <span
+            aria-hidden="true"
+            className="inline-flex"
+            style={{
+              color: expanded ? "var(--ow-accent)" : "var(--ow-fg-3)",
+              transform: expanded ? "rotate(180deg)" : "none",
+              transition: "transform 150ms ease, color 150ms ease",
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 6l5 5 5-5" />
+            </svg>
+          </span>
+        </td>
+      </tr>
+      {expanded && (
+        <tr style={{ background: rowBg }}>
+          <td colSpan={6} className="px-4 pb-3">
+            {/* Three KPI cells (time / distance / sea) — wind and allure
+                already appear in the collapsed row above, repeating them
+                in the expand was visual noise. */}
+            <div className="grid grid-cols-3 gap-2 mb-3">
+              <KpiBlock value={`${fmtHM(leg.start_time)} → ${fmtHM(leg.end_time)}`} label="dep → arr" />
+              <KpiBlock value={fr1(leg.distance_nm)} label="miles" />
+              <KpiBlock value={seaValue} label={seaLabel} tone={seaWarn ? "warn" : "default"} />
+            </div>
+            <LegDetailCard leg={leg} />
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 
@@ -567,34 +671,29 @@ function LegList({
           cliquez pour détailler
         </span>
       </div>
-      <div
-        className="flex items-center gap-2.5 px-4 pb-1.5 text-[9px]"
-        style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}
-      >
-        <span className="shrink-0 w-6" />
-        <div
-          className="flex-1 min-w-0 grid gap-2"
-          style={{ gridTemplateColumns: SEG_SUBLINE_COLS }}
-        >
-          <span>allure</span>
-          <span>vent</span>
-          <span>vagues</span>
-          <span>distance</span>
-        </div>
-        <span className="shrink-0">vitesse cible</span>
-        <span className="shrink-0 w-[14px]" />
-      </div>
-      <div style={{ borderTop: "1px solid var(--ow-line)" }}>
-        {legs.map((leg, i) => (
-          <LegRow
-            key={i}
-            leg={leg}
-            index={i}
-            expanded={openIdx === i}
-            onToggle={() => onOpenChange(openIdx === i ? null : i)}
-          />
-        ))}
-      </div>
+      {/* A single table for all legs so the colgroup forces every leg's
+          chip cells into the exact same column widths — alignment for free,
+          no subgrid acrobatics. `table-fixed` makes columns honour the
+          colgroup widths instead of auto-sizing per row. */}
+      {/* `table-auto` (default) lets columns shrink with the viewport: a
+          narrow sidebar tightens the inter-cell spacing automatically.
+          We keep the same column order (badge / duration / allure / wind /
+          flag / chev) but drop the rigid colgroup widths so the browser
+          can rebalance. `min-width: 0` on the flag cell allows the wrap
+          point to slide leftward instead of pushing the chevron offscreen. */}
+      <table className="w-full" style={{ borderCollapse: "collapse" }}>
+        <tbody>
+          {legs.map((leg, i) => (
+            <LegRow
+              key={i}
+              leg={leg}
+              index={i}
+              expanded={openIdx === i}
+              onToggle={() => onOpenChange(openIdx === i ? null : i)}
+            />
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -58,6 +58,71 @@ function twaToPointOfSail(twa: number): string {
   return "Arrière";
 }
 
+export function legDurationLabel(leg: AggregatedLeg): string {
+  const ms = new Date(leg.end_time).getTime() - new Date(leg.start_time).getTime();
+  const totalMin = Math.max(0, Math.round(ms / 60000));
+  if (totalMin < 60) return `${totalMin} mn`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (m === 0) return `${h} h`;
+  // "1h30" form — compact, no zero-pad on minutes since sailors read "1h05" oddly.
+  return `${h}h${m.toString().padStart(2, "0")}`;
+}
+
+// Build the leg summary as a list of standalone "cells" — duration,
+// allure, plus any qualifiers triggered by the current/wave/wind thresholds.
+// Rendered as a flex-wrap row of chips in LegRow so each cell wraps onto a
+// new line when the sidebar is narrow.
+//
+// Sea/wind thresholds match the server-side complexity scorer (Météo-France
+// classification) so the summary stays coherent with the warnings the LLM
+// surfaces in MCP. Wind-against-current requires both an opposing direction
+// AND a material current speed (>= 1.5 kn), mirroring the server cutoff.
+//
+// Clapot detection (short period × Hs) will land in a follow-up PR and feed
+// into this same `qualifiers` array.
+export interface LegSummaryCells {
+  duration: string;
+  allure: string;
+  wind: string;
+  // Single optional flag cell — covers either sea state (Mer Formée / Grosse
+  // Mer) or wind-against-current. When both fire on a leg, current wins
+  // because it's the rarer and more decision-shaping signal. Null = empty
+  // cell, kept in the grid so columns line up vertically across rows.
+  flag: string | null;
+}
+
+// Build the leg summary as a fixed set of named cells so LegRow can render
+// them in a CSS grid with stable column positions (each leg's duration sits
+// under the previous leg's duration, etc.). Returning a positional string[]
+// here used to drift on narrow viewports — the wrapping reordered cells.
+export function buildLegSummaryCells(leg: AggregatedLeg): LegSummaryCells {
+  const tMin = Math.round(leg.tws_min);
+  const tMax = Math.round(leg.tws_max);
+  // NBSP between the number and "kn" so the wind chip stays on one line when
+  // SummaryCell renders with width:min-content. Multi-word labels (Mer Formée,
+  // Vent Contre Courant) still break at their normal spaces.
+  const wind = tMin === tMax ? `${tMin} kn` : `${tMin}–${tMax} kn`;
+
+  let flag: string | null = null;
+  if (leg.current_relative === "contraire" && (leg.current_speed_kn ?? 0) >= 1.5) {
+    flag = "Vent Contre Courant";
+  } else if (leg.hs_avg_m != null) {
+    if (leg.hs_avg_m > 2.5) flag = "Grosse Mer";
+    else if (leg.hs_avg_m > 1.25) flag = "Mer Formée";
+  }
+
+  return {
+    duration: legDurationLabel(leg),
+    // Bare one-word allure ("Près" / "Travers" / "Largue" / "Arrière") to keep
+    // the cell narrow enough for the grid; matches the WindowsTable ALLURE
+    // column copy.
+    allure: leg.point_of_sail,
+    wind,
+    flag,
+  };
+}
+
 // Inclusive-exclusive segment ranges per user-waypoint leg. Shared between
 // the sidebar (drives the click-to-expand list) and the map (drives the
 // highlight overlay when a leg is selected).


### PR DESCRIPTION
## Summary

Refactors the per-leg sidebar row into a real table so the segment KPIs line up vertically across legs without CSS Grid acrobatics.

### Collapsed row

Each leg is now one \`<tr>\` in a shared \`<table>\`:

| Badge | Durée | Allure | Vent | Mer / flag | Chevron |
|---|---|---|---|---|---|
| 1→2 | 7 h | Arrière | 22-27 kn | Mer Formée | ▾ |
| 2→3 | 5h02 | Près | 23 kn | _empty_ | ▾ |

- Numbered badge labels the leg as \`from → to\` using the user-waypoint indices.
- Allure is bare (\`Près\` / \`Travers\` / \`Largue\` / \`Arrière\`) so it lines up with the WindowsTable's ALLURE column.
- Wind is the raw range (\`22-27 kn\`) — more useful at a glance than the qualitative \`Vent Soutenu\` bucket.
- Flag cell carries either Mer Formée / Grosse Mer (Hs thresholds) or Vent Contre Courant (current ≥ 1.5 kn and opposing); empty otherwise.
- Native table-auto column sizing handles cross-row alignment; \`whitespace-normal\` lets the flag wrap (\`Mer / Formée\`) when the sidebar narrows so the chevron never gets pushed offscreen.

### Expand view

- Three KPI tiles: \`dep → arr\` · miles · mer (height + period + relative direction).
- Wind + allure were dropped from the expand since they already appear in the collapsed row.

### LegDetailCard tweaks

- Wind label: \`Vent (rafales)\` → \`Vent\` (parens in the value already signal gusts).
- Wave label: \`Hauteur vagues (période)\` → \`Vagues\` (parens in the value already signal period).
- Wave value: \`1,8 m (6 s)\` → \`1,8m (6s)\` — matches KPI tile, stops clipping at the SVG edge.

### Helpers

- \`legDurationLabel(leg)\` — formats minutes / hours (\`5h02\`, \`37 mn\`, \`7 h\`).
- \`buildLegSummaryCells(leg)\` — returns the four named cells consumed by LegRow. Sea / wind / current thresholds mirror the server-side complexity scorer so summary chips stay coherent with the warnings the LLM surfaces in MCP.

## Not in this PR

- The clapot alert (Hs × short period × boat length) discussed earlier — will feed into this same flag cell in a follow-up.
- Wiring the user's polar config / model order to \`plan_passage\` server-side — separate sprint.

## Test plan

- [ ] \`npm run build\` from \`packages/web/\` succeeds.
- [ ] \`tsc --noEmit\` clean.
- [ ] \`/plan\` route renders a multi-leg passage with the new collapsed rows; columns line up vertically across legs.
- [ ] Narrow the sidebar — Mer Formée wraps inside its cell, no clipping or chevron offscreen.
- [ ] Click a row to expand; KPI tiles show dep→arr · miles · mer; LegDetailCard renders below.
- [ ] LegDetailCard compass labels show \`Vent\` / \`Vagues\` (not the long form), wave value \`1,8m (6s)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)