### PR TITLE
fix(mcp): advertise server icons + website URL (#128)

### DIFF
--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -37,6 +37,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import Icon
 from openwind_data.adapters.base import MarineDataAdapter
 from openwind_data.adapters.openmeteo import AUTO_MODEL, OpenMeteoAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
@@ -78,6 +79,16 @@ PLAN_UI_MIME = "text/html;profile=mcp-app"
 # the ui/notifications/tool-result listener. Same CDN as the official
 # qr-server / say-server / threejs-server examples.
 PLAN_UI_RESOURCE_DOMAINS = ["https://unpkg.com"]
+
+# Server icons advertised in the MCP `initialize` response (Implementation.icons).
+# Hosts (Claude, Claude Desktop, ChatGPT, …) use these to badge tool calls and
+# the connector picker. The files are served from openwind.fr with CORS open
+# (`access-control-allow-origin: *`), so cross-origin fetch from the host works.
+_OPENWIND_ICONS = [
+    Icon(src="https://openwind.fr/icon-512.png", mimeType="image/png", sizes=["512x512"]),
+    Icon(src="https://openwind.fr/icon-192.png", mimeType="image/png", sizes=["192x192"]),
+    Icon(src="https://openwind.fr/favicon.svg", mimeType="image/svg+xml", sizes=["any"]),
+]
 
 # Body of the MCP Apps UI resource. Uses the official @modelcontextprotocol/
 # ext-apps SDK from unpkg for the handshake (same pattern as qr-server /
@@ -548,6 +559,8 @@ def build_server(
         "openwind",
         stateless_http=True,
         json_response=True,
+        website_url="https://openwind.fr",
+        icons=_OPENWIND_ICONS,
     )
     if adapter is not None:
         fetch_adapter: MarineDataAdapter = adapter

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -70,6 +70,18 @@ class TestBuildServer:
         server = build_server(adapter=StubAdapter())
         assert isinstance(server, FastMCP)
 
+    def test_advertises_icons_and_website(self) -> None:
+        # Hosts (Claude, ChatGPT, …) badge tool calls and the connector
+        # picker with Implementation.icons returned from `initialize`.
+        # Without these the openwind logo never shows up next to a tool
+        # call — see issue #128.
+        server = build_server(adapter=StubAdapter())
+        assert server.website_url == "https://openwind.fr"
+        icons = server.icons
+        assert icons and len(icons) >= 1
+        srcs = {i.src for i in icons}
+        assert any(s.startswith("https://openwind.fr/") for s in srcs)
+
     async def test_lists_five_tools(self) -> None:
         # The V1 surface: 3 functional tools + read_me for methodology Q&A
         # + feedback for LLM-side issue reporting.


### PR DESCRIPTION
Hosts (Claude, Claude Desktop, ChatGPT, …) badge tool calls and the connector picker with the icons advertised in `Implementation.icons` from the MCP `initialize` response. Until now `FastMCP("openwind", …)` shipped without icons, so no logo ever showed up next to an openwind tool call. Point at the existing PNG/SVG assets served from openwind.fr (CORS open) and set `website_url` while we're here.