### PR TITLE
feat(web): add settings gear in header + flatten info button

### DIFF
--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -20,6 +20,29 @@ function WindIcon() {
   );
 }
 
+function SettingsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+function SettingsButton() {
+  return (
+    <a
+      href="/config"
+      aria-label="Paramètres"
+      title="Paramètres"
+      className="shrink-0 min-w-[36px] min-h-[36px] flex items-center justify-center rounded-lg transition-colors"
+      style={{ color: 'var(--ow-fg-1)', background: 'transparent' }}
+    >
+      <SettingsIcon />
+    </a>
+  );
+}
+
 export function Header({ onSelectSpot, canSave = false, onSave }: HeaderProps) {
   return (
     <header
@@ -46,6 +69,7 @@ export function Header({ onSelectSpot, canSave = false, onSave }: HeaderProps) {
           </button>
         )}
         <InfoButton />
+        <SettingsButton />
         <ThemeToggle />
       </div>
     </header>

--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -72,12 +72,8 @@ export function InfoButton() {
         onClick={() => setOpen(true)}
         aria-label="À propos d'OpenWind"
         title="À propos"
-        className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 active:scale-95"
-        style={{
-          background: "var(--ow-accent-soft)",
-          color: "var(--ow-accent)",
-          border: "1px solid var(--ow-accent-line)",
-        }}
+        className="shrink-0 min-w-[36px] min-h-[36px] flex items-center justify-center rounded-lg transition-colors"
+        style={{ color: "var(--ow-fg-1)", background: "transparent" }}
       >
         <InfoIcon />
       </button>

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -276,6 +276,12 @@ export function ConfigPage() {
           gap: 18px;
           align-items: stretch;
         }
+        @media (max-width: 640px) {
+          .config-list-with-zones {
+            grid-template-columns: 1fr 28px;
+            gap: 10px;
+          }
+        }
         .config-list {
           display: flex;
           flex-direction: column;
@@ -372,6 +378,41 @@ export function ConfigPage() {
         }
         .config-zone.is-ignored .config-zone-label {
           color: var(--ow-fg-2, #94a3b8);
+        }
+        @media (max-width: 640px) {
+          .config-row {
+            padding: 8px 10px;
+            gap: 8px;
+            border-radius: 10px;
+          }
+          .config-row .text-base {
+            font-size: 14px;
+          }
+          .config-row p {
+            font-size: 12px;
+            margin-top: 2px;
+            line-height: 1.35;
+          }
+          .config-row .text-xs {
+            font-size: 11px;
+          }
+          .config-handle {
+            display: none;
+          }
+          .config-zone {
+            padding-left: 10px;
+            justify-content: center;
+          }
+          .config-zone::before {
+            top: 4px;
+            bottom: 4px;
+          }
+          .config-zone-label {
+            writing-mode: vertical-rl;
+            transform: rotate(180deg);
+            font-size: 10px;
+            letter-spacing: 0.08em;
+          }
         }
       `}</style>
     </div>


### PR DESCRIPTION
Drop the accent-coloured ring around the info "i" so it matches the theme toggle, and add a gear icon next to it that links to /config. Also tighten ConfigPage rows on mobile (smaller padding/typography, hide drag handles, rotate zone labels vertically).