### PR TITLE
feat(complexity): détecter le clapot court et le clapot suiveur

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/base.py
+++ b/packages/data-adapters/src/openwind_data/adapters/base.py
@@ -32,6 +32,19 @@ TIDE_RANGE_RELEVANCE_THRESHOLD_M = 0.5
 WIND_AGAINST_CURRENT_WARNING_THRESHOLD_KN = 1.5
 WIND_AGAINST_CURRENT_OPPOSITION_DEG = 120.0
 
+# Chop detection: short-period steep wind sea ("clapot"). Index = Hs / Tp^2
+# (proxy for wave steepness). > 0.05 flags genuinely uncomfortable chop —
+# Hs 1.2 m at Tp 5 s, Hs 0.8 m at Tp 4 s. CHOP_HS_FLOOR_M guards against
+# absurd flags on ripples (Hs 0.3 m at Tp 2 s mathematically scores 0.075).
+CHOP_INDEX_THRESHOLD = 0.05
+CHOP_HS_FLOOR_M = 0.8
+# |TWA| >= 120° = sea coming from behind the boat (running / broad reach).
+# Chop on this angle is uncomfortable but not equivalent to taking it on the
+# bow: the boat moves with the wave, slamming is rare, and surfing is often
+# a gain. We still emit a warning (broaching / accidental gybe risks remain)
+# but skip the complexity bump when *all* chop segments are on this angle.
+CHOP_FOLLOWING_TWA_DEG = 120.0
+
 
 class ForecastHorizonError(RuntimeError):
     """Raised when a forecast model's horizon does not cover the requested time.

--- a/packages/data-adapters/src/openwind_data/routing/complexity.py
+++ b/packages/data-adapters/src/openwind_data/routing/complexity.py
@@ -18,6 +18,9 @@ from dataclasses import dataclass
 from typing import Literal
 
 from openwind_data.adapters.base import (
+    CHOP_FOLLOWING_TWA_DEG,
+    CHOP_HS_FLOOR_M,
+    CHOP_INDEX_THRESHOLD,
     WIND_AGAINST_CURRENT_OPPOSITION_DEG,
     WIND_AGAINST_CURRENT_WARNING_THRESHOLD_KN,
 )
@@ -82,7 +85,7 @@ def _compact_range(values: list[float], decimals: int) -> str:
 
 @dataclass(frozen=True, slots=True)
 class ComplexityWarning:
-    kind: Literal["wind", "sea", "current"]
+    kind: Literal["wind", "sea", "current", "chop"]
     level: int  # 1..5 — same scale as the axis that triggered it
     message: str
     affected_segments: tuple[int, ...]  # indices into PassageReport.segments
@@ -101,6 +104,7 @@ class ComplexityScore:
     rationale: str
     warnings: tuple[ComplexityWarning, ...] = ()
     wind_against_current: bool = False  # True when at least one segment triggered the bump
+    chop_present: bool = False  # True when short-period steep wind sea is flagged
 
 
 def score_complexity(
@@ -183,7 +187,8 @@ def score_complexity(
     # legs almost never qualify; Atlantic tidal passes (Goulet de Brest, Raz de
     # Sein) routinely do. Triggers a +1 bump on the overall level (cap 5) plus
     # an explicit warning so the LLM/UI can flag the chop, mirroring nautical
-    # practice.
+    # practice. The bump is shared with the chop detector below — both flag
+    # broken/uncomfortable sea and only contribute +1 in total.
     wac_indices: list[int] = []
     wac_currents: list[float] = []
     for i, s in enumerate(passage.segments):
@@ -198,8 +203,46 @@ def score_complexity(
             wac_currents.append(s.current_speed_kn)
 
     wind_against_current = bool(wac_indices)
+
+    # Chop detection: short-period steep wind sea ("clapot"). Index = Hs/Tp²
+    # is a steepness proxy. We exclude segments already flagged by WAC since
+    # the WAC warning ("mer hachée probable") already covers chop on those
+    # legs — no need to fire two warnings for the same phenomenon.
+    chop_indices: list[int] = []
+    chop_hs: list[float] = []
+    chop_tp: list[float] = []
+    wac_index_set = set(wac_indices)
+    for i, s in enumerate(passage.segments):
+        if i in wac_index_set:
+            continue
+        if s.hs_m is None or s.wave_period_s is None:
+            continue
+        if s.hs_m < CHOP_HS_FLOOR_M or s.wave_period_s <= 0:
+            continue
+        if s.hs_m / (s.wave_period_s**2) > CHOP_INDEX_THRESHOLD:
+            chop_indices.append(i)
+            chop_hs.append(s.hs_m)
+            chop_tp.append(s.wave_period_s)
+
+    chop_present = bool(chop_indices)
+    # Following chop (sea from behind) is much less penalising — emit the
+    # warning so the sailor sees it but skip the bump when *every* chop
+    # segment is on a running angle. A single bow-on or beam segment in the
+    # set still bumps, because that's where slamming happens.
+    chop_following_only = chop_present and all(
+        abs(passage.segments[i].twa_deg) >= CHOP_FOLLOWING_TWA_DEG for i in chop_indices
+    )
+    chop_contributes_bump = chop_present and not chop_following_only
+
+    # Single +1 bump shared by WAC and chop — both describe broken/uncomfortable
+    # sea and don't compound. Without this, a passage with WAC on the first half
+    # and chop on the second half would jump +2 levels for what is essentially
+    # the same physical signal restated.
+    bumped_level = (
+        min(5, level + 1) if (wind_against_current or chop_contributes_bump) else level
+    )
+
     if wind_against_current:
-        bumped_level = min(5, level + 1)
         affected_wac = tuple(wac_indices)
         affected_wac_nm = sum(passage.segments[i].distance_nm for i in affected_wac)
         cur_range = _compact_range(wac_currents, 1)
@@ -215,7 +258,34 @@ def score_complexity(
             )
         )
         rationale = f"{rationale}, vent contre courant"
-        level = bumped_level
+
+    if chop_present:
+        affected_chop = tuple(chop_indices)
+        affected_chop_nm = sum(passage.segments[i].distance_nm for i in affected_chop)
+        hs_range = _compact_range(chop_hs, 1)
+        tp_range = _compact_range(chop_tp, 0)
+        if chop_following_only:
+            chop_label = "Clapot suiveur"
+            chop_suffix = "barre attentive, risque de départ au lof"
+            chop_warning_level = level  # no bump credited to this warning
+        else:
+            chop_label = "Clapot court"
+            chop_suffix = "mer désagréable"
+            chop_warning_level = bumped_level
+        warnings.append(
+            ComplexityWarning(
+                kind="chop",
+                level=chop_warning_level,
+                message=(
+                    f"{chop_label} : Hs {hs_range} m à Tp {tp_range} s sur "
+                    f"{affected_chop_nm:.0f} nm, {chop_suffix}"
+                ),
+                affected_segments=affected_chop,
+            )
+        )
+        rationale = f"{rationale}, {chop_label.lower()}"
+
+    level = bumped_level
 
     return ComplexityScore(
         level=level,
@@ -229,4 +299,5 @@ def score_complexity(
         rationale=rationale,
         warnings=tuple(warnings),
         wind_against_current=wind_against_current,
+        chop_present=chop_present,
     )

--- a/packages/data-adapters/tests/test_complexity.py
+++ b/packages/data-adapters/tests/test_complexity.py
@@ -17,8 +17,10 @@ def _make_segment(
     hs_m: float | None = None,
     *,
     twd_deg: float = 0.0,
+    twa_deg: float = 90.0,
     current_speed_kn: float | None = None,
     current_direction_to_deg: float | None = None,
+    wave_period_s: float | None = None,
 ) -> SegmentReport:
     return SegmentReport(
         start=Point(43.0, 5.0),
@@ -29,13 +31,14 @@ def _make_segment(
         end_time=DEPARTURE + timedelta(hours=1),
         tws_kn=tws_kn,
         twd_deg=twd_deg,
-        twa_deg=90.0,
+        twa_deg=twa_deg,
         polar_speed_kn=6.0,
         boat_speed_kn=5.0,
         duration_h=1.0,
         hs_m=hs_m,
         current_speed_kn=current_speed_kn,
         current_direction_to_deg=current_direction_to_deg,
+        wave_period_s=wave_period_s,
     )
 
 
@@ -290,6 +293,147 @@ class TestWindAgainstCurrent:
         s = score_complexity(p)
         assert s.wind_against_current is True
         assert s.level == 5  # no overflow
+
+
+class TestChop:
+    """Chop ("clapot") detection: short-period steep wind sea flagged via the
+    Hs/Tp² steepness proxy. Bump is shared with wind-against-current — they
+    describe the same broken-sea phenomenon and don't compound.
+    """
+
+    def test_short_period_steep_chop_triggers_warning_and_bump(self) -> None:
+        # Hs 1.2 m at Tp 4.5 s → index = 1.2 / 20.25 ≈ 0.059, over 0.05.
+        seg = _make_segment(tws_kn=12.0, hs_m=1.2, wave_period_s=4.5)
+        p = _make_passage([12.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.chop_present is True
+        assert s.wind_level == 2  # 12 kn → "modéré"
+        assert s.sea_level == 3  # Hs 1.2 m → "agitée"
+        assert s.level == 4  # sea_level 3 + chop bump
+        chop_warnings = [w for w in s.warnings if w.kind == "chop"]
+        assert len(chop_warnings) == 1
+        w = chop_warnings[0]
+        assert w.level == 4
+        assert "clapot" in w.message.lower()
+        assert "1.2" in w.message
+        assert "clapot court" in s.rationale.lower()
+
+    def test_long_period_swell_no_trigger_even_when_hs_high(self) -> None:
+        # Hs 1.8 m at Tp 11 s → index = 1.8 / 121 ≈ 0.0149, below 0.05.
+        # Comfortable long swell — no chop warning, no bump on top of sea_level.
+        seg = _make_segment(tws_kn=12.0, hs_m=1.8, wave_period_s=11.0)
+        p = _make_passage([12.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.chop_present is False
+        assert s.sea_level == 3  # Hs 1.8 m sits in "agitée"
+        assert s.level == 3  # no bump
+        assert not any(w.kind == "chop" for w in s.warnings)
+
+    def test_tiny_hs_no_trigger_even_when_period_very_short(self) -> None:
+        # Hs 0.4 m at Tp 2 s → index = 0.4 / 4 = 0.1, well over 0.05, but Hs
+        # is below the 0.8 m floor so we don't flag (harmless ripples).
+        seg = _make_segment(tws_kn=10.0, hs_m=0.4, wave_period_s=2.0)
+        p = _make_passage([10.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.chop_present is False
+        assert s.level == s.wind_level
+
+    def test_missing_tp_no_trigger(self) -> None:
+        # Hs present but Tp missing (e.g., older adapter response) → no chop
+        # flag possible. Fail closed, not open.
+        seg = _make_segment(tws_kn=15.0, hs_m=1.5, wave_period_s=None)
+        p = _make_passage([15.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.chop_present is False
+        assert not any(w.kind == "chop" for w in s.warnings)
+
+    def test_chop_and_wind_against_current_share_a_single_bump(self) -> None:
+        # Two segments: one WAC, one chop. Both fire warnings but the +1 bump
+        # only applies once (shared) — broken sea is broken sea, the two
+        # mechanisms describe the same phenomenon.
+        wac_seg = _make_segment(
+            tws_kn=15.0,
+            hs_m=0.6,
+            twd_deg=270.0,
+            current_speed_kn=2.5,
+            current_direction_to_deg=270.0,
+        )
+        chop_seg = _make_segment(tws_kn=15.0, hs_m=1.2, wave_period_s=4.5)
+        p = _make_passage([15.0, 15.0])
+        p = dataclasses.replace(p, segments=(wac_seg, chop_seg))
+        s = score_complexity(p)
+
+        assert s.wind_against_current is True
+        assert s.chop_present is True
+        # wind level 2, sea level 3 → max = 3 → +1 (shared) → 4
+        assert s.level == 4
+        kinds = {w.kind for w in s.warnings}
+        assert "current" in kinds
+        assert "chop" in kinds
+
+    def test_following_chop_emits_warning_but_skips_bump(self) -> None:
+        # Same chop conditions as the bump test, but at TWA 150° (running) —
+        # sea comes from behind. We emit the warning (broaching risk) but
+        # complexity stays at sea_level, no +1.
+        seg = _make_segment(tws_kn=12.0, hs_m=1.2, wave_period_s=4.5, twa_deg=150.0)
+        p = _make_passage([12.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.chop_present is True
+        assert s.sea_level == 3
+        assert s.level == 3  # no bump (was 4 with twa=90 in the earlier test)
+        chop_warnings = [w for w in s.warnings if w.kind == "chop"]
+        assert len(chop_warnings) == 1
+        w = chop_warnings[0]
+        assert w.level == 3
+        assert "clapot suiveur" in w.message.lower()
+        assert "clapot suiveur" in s.rationale.lower()
+
+    def test_mixed_following_and_beam_chop_still_bumps(self) -> None:
+        # Two chop segments: one beam (twa 90°), one running (twa 150°). The
+        # presence of even one non-running chop segment is enough to bump —
+        # the boat will slam on that beam segment.
+        beam = _make_segment(tws_kn=12.0, hs_m=1.2, wave_period_s=4.5, twa_deg=90.0)
+        run = _make_segment(tws_kn=12.0, hs_m=1.2, wave_period_s=4.5, twa_deg=150.0)
+        p = _make_passage([12.0, 12.0])
+        p = dataclasses.replace(p, segments=(beam, run))
+        s = score_complexity(p)
+
+        assert s.chop_present is True
+        assert s.level == 4  # bumped
+        chop_warnings = [w for w in s.warnings if w.kind == "chop"]
+        assert len(chop_warnings) == 1
+        assert "clapot court" in chop_warnings[0].message.lower()
+
+    def test_wac_segment_excluded_from_chop_detection(self) -> None:
+        # A WAC segment that would also qualify for chop on its own should
+        # not trigger the chop warning separately — WAC already says "mer
+        # hachée probable" and we don't restate it.
+        seg = _make_segment(
+            tws_kn=15.0,
+            hs_m=1.2,
+            twd_deg=270.0,
+            current_speed_kn=2.5,
+            current_direction_to_deg=270.0,
+            wave_period_s=4.5,
+        )
+        p = _make_passage([15.0])
+        p = dataclasses.replace(p, segments=(seg,))
+        s = score_complexity(p)
+
+        assert s.wind_against_current is True
+        assert s.chop_present is False
+        assert any(w.kind == "current" for w in s.warnings)
+        assert not any(w.kind == "chop" for w in s.warnings)
 
 
 def test_empty_passage_rejected() -> None:

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -462,6 +462,22 @@ hachee probable") and the overall complexity level is bumped by +1
 (capped at 5). Mirrors nautical practice: chop builds when wind blows
 into a contrary tide.
 
+## Short-period chop ("clapot")
+
+Independently of currents, a steep wind sea is flagged when the
+steepness proxy Hs / Tp^2 exceeds 0.05 on a segment with Hs >= 0.8 m
+(e.g. Hs 1.0 m at Tp 4.5 s). This catches short fetch-built chop in
+fresh breeze even without contrary current — typical of a Mistral or
+Tramontane lee shore. Bump and warning mirror the wind-against-current
+case; the +1 bump is shared, so a passage with both signals does not
+jump +2.
+
+When *every* triggering segment is on a running angle (|TWA| >= 120°,
+sea coming from behind), the warning becomes "Clapot suiveur" and the
++1 bump is skipped. The boat surfs with the wave rather than slamming
+into it; broaching and accidental gybe risks remain, hence the warning,
+but the underlying complexity is unchanged.
+
 ## What is NOT modelled (V1)
 
 - No automatic routing optimisation (LLM + human choose).

--- a/packages/web/src/content/methodologie.md
+++ b/packages/web/src/content/methodologie.md
@@ -262,7 +262,14 @@ Le niveau du passage est `max(niveau_vent, niveau_mer)`. Pas de moyenne magique,
 | 4      | exigeant   |
 | 5      | dangereux  |
 
-Les avertissements (vent fort, mer forte, vent contre courant) sont rattachés à la portion de route concernée et restitués tels quels.
+Deux signaux distincts viennent ensuite **incrémenter le niveau de +1** (plafonné à 5) quand la mer est cassée :
+
+- **Vent contre courant** : courant ≥ 1.5 kt opposé au vent par ≥ 120° (typique des passes tidales atlantiques — Goulet de Brest, Raz de Sein, Raz Blanchard).
+- **Clapot court** : cambrure $H_s / T_p^2 > 0{,}05$ avec $H_s \geq 0{,}8$ m. Détecte une mer du vent levée à courte période — Hs 1,2 m à Tp 4,5 s par exemple. Une longue houle au même Hs (Hs 1,8 m à Tp 11 s, cambrure ≈ 0,015) **ne déclenche pas** ce bump et garde son label "mer formée" : grosse, mais confortable. Quand **tous** les segments concernés sont au vent arrière ($|TWA| \geq 120°$), on parle de "clapot suiveur" : le warning reste émis (risque de départ au lof, d'empannage involontaire) mais on **n'applique pas** le +1 — le bateau marche avec la lame plutôt que dedans.
+
+Les deux signaux peuvent coexister sur un même passage, mais **partagent un seul bump** (+1 total) — ils décrivent le même phénomène physique de mer cassée et ne se cumulent pas.
+
+Les avertissements (vent fort, mer forte, vent contre courant, clapot court) sont rattachés à la portion de route concernée et restitués tels quels.
 
 ## Les conventions du domaine
 

--- a/packages/web/src/plan/aggregateLegs.test.ts
+++ b/packages/web/src/plan/aggregateLegs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aggregateLegs } from "./aggregateLegs";
+import { aggregateLegs, buildLegSummaryCells, type AggregatedLeg } from "./aggregateLegs";
 import type { SegmentReport } from "./types";
 
 function seg(overrides: Partial<SegmentReport> = {}): SegmentReport {
@@ -77,5 +77,86 @@ describe("aggregateLegs", () => {
 
   it("returns empty array when there are no segments", () => {
     expect(aggregateLegs([], [[43, 5], [43.1, 5.1]])).toEqual([]);
+  });
+});
+
+function makeLeg(overrides: Partial<AggregatedLeg> = {}): AggregatedLeg {
+  return {
+    distance_nm: 5,
+    start_time: "2026-05-08T10:00:00+02:00",
+    end_time: "2026-05-08T11:00:00+02:00",
+    tws_min: 12,
+    tws_max: 14,
+    tws_avg_kn: 13,
+    twa_avg_deg: 90,
+    twd_avg_deg: 270,
+    bearing_avg_deg: 0,
+    gust_max_kn: null,
+    point_of_sail: "Travers",
+    polar_after_eff_kn: 4.5,
+    wave_delta_kn: 0,
+    current_delta_kn: null,
+    boat_speed_kn: 4.5,
+    target_speed_kn: 4.5,
+    efficiency: 0.75,
+    hs_avg_m: null,
+    hs_max_m: null,
+    tp_avg_s: null,
+    sea_direction: null,
+    current_speed_kn: null,
+    current_direction_to_deg: null,
+    current_relative: null,
+    ...overrides,
+  };
+}
+
+describe("buildLegSummaryCells.flag", () => {
+  it("flags Clapot when Hs/Tp² > 0.05 and Hs >= 0.8 m", () => {
+    // Hs 1.2 m at Tp 4.5 s → index ≈ 0.059, in "Mer Formée" Hs range but
+    // labelled Clapot because the period is short and steep.
+    const flag = buildLegSummaryCells(makeLeg({ hs_avg_m: 1.2, tp_avg_s: 4.5 })).flag;
+    expect(flag).toBe("Clapot");
+  });
+
+  it("keeps Mer Formée label for long-period swell at the same Hs", () => {
+    // Hs 1.8 m at Tp 11 s → index ≈ 0.0149, comfortable long swell.
+    const flag = buildLegSummaryCells(makeLeg({ hs_avg_m: 1.8, tp_avg_s: 11 })).flag;
+    expect(flag).toBe("Mer Formée");
+  });
+
+  it("does not flag Clapot when Hs is below the 0.8 m floor", () => {
+    // Hs 0.4 m at Tp 2 s → mathematically index 0.1 but harmless ripples.
+    const flag = buildLegSummaryCells(makeLeg({ hs_avg_m: 0.4, tp_avg_s: 2 })).flag;
+    expect(flag).toBeNull();
+  });
+
+  it("Grosse Mer overrides Clapot when Hs > 2.5 m", () => {
+    // Hs 2.8 m at Tp 5 s → both Clapot (steep) and Grosse Mer apply; the
+    // bigger-picture label wins.
+    const flag = buildLegSummaryCells(makeLeg({ hs_avg_m: 2.8, tp_avg_s: 5 })).flag;
+    expect(flag).toBe("Grosse Mer");
+  });
+
+  it("labels Clapot Suiveur when sea_direction is arrière", () => {
+    // Same chop conditions, but running with the sea — broaching / gybe
+    // risks remain, but no slamming, hence the distinct label.
+    const flag = buildLegSummaryCells(
+      makeLeg({ hs_avg_m: 1.2, tp_avg_s: 4.5, sea_direction: "arrière" }),
+    ).flag;
+    expect(flag).toBe("Clapot Suiveur");
+  });
+
+  it("Vent Contre Courant overrides Clapot", () => {
+    // WAC already implies mer hachée — it wins as the more decision-shaping
+    // signal.
+    const flag = buildLegSummaryCells(
+      makeLeg({
+        hs_avg_m: 1.2,
+        tp_avg_s: 4.5,
+        current_relative: "contraire",
+        current_speed_kn: 2.0,
+      }),
+    ).flag;
+    expect(flag).toBe("Vent Contre Courant");
   });
 });

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -79,16 +79,20 @@ export function legDurationLabel(leg: AggregatedLeg): string {
 // surfaces in MCP. Wind-against-current requires both an opposing direction
 // AND a material current speed (>= 1.5 kn), mirroring the server cutoff.
 //
-// Clapot detection (short period × Hs) will land in a follow-up PR and feed
-// into this same `qualifiers` array.
+// Clapot ("steepness" Hs/Tp² > 0.05 with Hs >= 0.8 m) takes precedence over
+// the generic "Mer Formée" label because it carries a sharper meaning for the
+// sailor — short steep wind sea, not just heavy seas. Long-period swell at
+// the same Hs (e.g. Hs 1.8 m at Tp 11 s) keeps the "Mer Formée" label since
+// it isn't clapot. Thresholds match the server-side ComplexityWarning kind=
+// "chop".
 export interface LegSummaryCells {
   duration: string;
   allure: string;
   wind: string;
   // Single optional flag cell — covers either sea state (Mer Formée / Grosse
-  // Mer) or wind-against-current. When both fire on a leg, current wins
-  // because it's the rarer and more decision-shaping signal. Null = empty
-  // cell, kept in the grid so columns line up vertically across rows.
+  // Mer / Clapot) or wind-against-current. When both fire on a leg, current
+  // wins because it's the rarer and more decision-shaping signal. Null =
+  // empty cell, kept in the grid so columns line up vertically across rows.
   flag: string | null;
 }
 
@@ -104,11 +108,22 @@ export function buildLegSummaryCells(leg: AggregatedLeg): LegSummaryCells {
   // Vent Contre Courant) still break at their normal spaces.
   const wind = tMin === tMax ? `${tMin} kn` : `${tMin}–${tMax} kn`;
 
+  const chopIndex =
+    leg.hs_avg_m != null && leg.tp_avg_s != null && leg.tp_avg_s > 0
+      ? leg.hs_avg_m / (leg.tp_avg_s * leg.tp_avg_s)
+      : null;
+
   let flag: string | null = null;
   if (leg.current_relative === "contraire" && (leg.current_speed_kn ?? 0) >= 1.5) {
     flag = "Vent Contre Courant";
   } else if (leg.hs_avg_m != null) {
     if (leg.hs_avg_m > 2.5) flag = "Grosse Mer";
+    else if (chopIndex != null && chopIndex > 0.05 && leg.hs_avg_m >= 0.8) {
+      // Following sea (TWA >= 120°): the chop is uncomfortable but doesn't
+      // bump complexity server-side either. We rename the chip rather than
+      // hide it because broaching / accidental gybe risks remain.
+      flag = leg.sea_direction === "arrière" ? "Clapot Suiveur" : "Clapot";
+    }
     else if (leg.hs_avg_m > 1.25) flag = "Mer Formée";
   }
 


### PR DESCRIPTION
Ajoute un signal de cambrure de mer (Hs / Tp² > 0.05 avec Hs ≥ 0.8 m) au scoreur de complexité — indépendant du vent-contre-courant déjà en place. Une longue houle au même Hs (Tp ≥ ~10 s) ne déclenche pas le bump, ce qui règle le faux positif "grosse mer" sur les passages confortables au large.

Quand tous les segments concernés sont au vent arrière (|TWA| ≥ 120°), le warning devient "Clapot suiveur" et le bump est sauté : le bateau marche avec la lame, slamming rare, mais on garde le warning pour le risque de départ au lof / empannage involontaire.

Le chip "Clapot" / "Clapot Suiveur" apparaît dans le résumé par leg côté web, en remplaçant "Mer Formée" quand la cambrure est élevée.