### PR TITLE
feat(web): wire /config polar + model priority into plan_passage

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -280,6 +280,8 @@ async def estimate_passage(
     model: str = DEFAULT_MODEL,
     heuristic_speed_kn: float = HEURISTIC_SPEED_KN,
     use_wave_correction: bool = False,
+    polar_override: BoatPolar | None = None,
+    model_chain: tuple[str, ...] | None = None,
 ) -> PassageReport:
     """Estimate a passage's per-segment timing, speed, and warnings.
 
@@ -314,8 +316,9 @@ async def estimate_passage(
         raise ValueError("efficiency must be in (0, 1]")
 
     if model == AUTO_MODEL:
+        chain = model_chain if model_chain else AUTO_FALLBACK_CHAIN
         last_err: ForecastHorizonError | None = None
-        for candidate in AUTO_FALLBACK_CHAIN:
+        for candidate in chain:
             try:
                 return await _estimate_with_model(
                     waypoints,
@@ -327,6 +330,7 @@ async def estimate_passage(
                     model=candidate,
                     heuristic_speed_kn=heuristic_speed_kn,
                     use_wave_correction=use_wave_correction,
+                    polar_override=polar_override,
                 )
             except ForecastHorizonError as exc:
                 last_err = exc
@@ -343,6 +347,7 @@ async def estimate_passage(
         model=model,
         heuristic_speed_kn=heuristic_speed_kn,
         use_wave_correction=use_wave_correction,
+        polar_override=polar_override,
     )
 
 
@@ -357,8 +362,9 @@ async def _estimate_with_model(
     model: str,
     heuristic_speed_kn: float,
     use_wave_correction: bool,
+    polar_override: BoatPolar | None = None,
 ) -> PassageReport:
-    polar = get_polar(boat_archetype)
+    polar = polar_override if polar_override is not None else get_polar(boat_archetype)
     effective_length_nm, capped_route_nm = _resolve_segment_length(waypoints, segment_length_nm)
     segments = segment_route(waypoints, effective_length_nm)
     departure_utc = departure_time.astimezone(UTC)
@@ -494,6 +500,7 @@ async def _estimate_backward_with_model(
     model: str,
     heuristic_speed_kn: float,
     use_wave_correction: bool,
+    polar_override: BoatPolar | None = None,
 ) -> PassageReport:
     """Mirror of `_estimate_with_model` anchored at arrival, solving backward.
 
@@ -505,7 +512,7 @@ async def _estimate_backward_with_model(
     is needed. Mid-time guesses use `heuristic_speed_kn` like the forward path,
     same temporal-correlation argument applies.
     """
-    polar = get_polar(boat_archetype)
+    polar = polar_override if polar_override is not None else get_polar(boat_archetype)
     effective_length_nm, capped_route_nm = _resolve_segment_length(waypoints, segment_length_nm)
     segments = segment_route(waypoints, effective_length_nm)
     target_utc = target_arrival.astimezone(UTC)
@@ -644,6 +651,8 @@ async def estimate_passage_windows(
     adapter: MarineDataAdapter | None = None,
     model: str = AUTO_MODEL,
     use_wave_correction: bool = False,
+    polar_override: BoatPolar | None = None,
+    model_chain: tuple[str, ...] | None = None,
 ) -> list[PassageReport]:
     """Simulate multiple departure windows for a fixed route.
 
@@ -708,6 +717,8 @@ async def estimate_passage_windows(
             adapter=fetch_adapter,
             model=model,
             use_wave_correction=use_wave_correction,
+            polar_override=polar_override,
+            model_chain=model_chain,
         )
         resolved_model = first.model
         reports: list[PassageReport] = [first]
@@ -733,6 +744,7 @@ async def estimate_passage_windows(
         # the user pinned a specific model (model != "auto"), we respect that
         # and skip out-of-horizon windows — explicit choice wins.
         # ValueError / KeyError still bubble (caller-side bugs).
+        effective_chain = model_chain if model_chain else AUTO_FALLBACK_CHAIN
         current = earliest_utc + timedelta(hours=sweep_interval_hours)
         while current <= latest_utc:
             try:
@@ -745,10 +757,11 @@ async def estimate_passage_windows(
                     adapter=fetch_adapter,
                     model=resolved_model,
                     use_wave_correction=use_wave_correction,
+                    polar_override=polar_override,
                 )
                 reports.append(report)
             except ForecastHorizonError:
-                if model == AUTO_MODEL and resolved_model != AUTO_FALLBACK_CHAIN[-1]:
+                if model == AUTO_MODEL and resolved_model != effective_chain[-1]:
                     try:
                         report = await estimate_passage(
                             waypoints,
@@ -759,6 +772,8 @@ async def estimate_passage_windows(
                             adapter=fetch_adapter,
                             model=AUTO_MODEL,
                             use_wave_correction=use_wave_correction,
+                            polar_override=polar_override,
+                            model_chain=model_chain,
                         )
                         reports.append(report)
                     except ForecastHorizonError:
@@ -782,6 +797,8 @@ async def estimate_passage_for_arrival(
     model: str = AUTO_MODEL,
     heuristic_speed_kn: float = HEURISTIC_SPEED_KN,
     use_wave_correction: bool = False,
+    polar_override: BoatPolar | None = None,
+    model_chain: tuple[str, ...] | None = None,
 ) -> EtaPassagePlan:
     """Inverse of `estimate_passage`: solve for a departure given a target arrival.
 
@@ -816,8 +833,9 @@ async def estimate_passage_for_arrival(
     target_utc = target_arrival.astimezone(UTC)
 
     if model == AUTO_MODEL:
+        chain = model_chain if model_chain else AUTO_FALLBACK_CHAIN
         last_err: ForecastHorizonError | None = None
-        for candidate in AUTO_FALLBACK_CHAIN:
+        for candidate in chain:
             try:
                 report = await _estimate_backward_with_model(
                     waypoints,
@@ -829,6 +847,7 @@ async def estimate_passage_for_arrival(
                     model=candidate,
                     heuristic_speed_kn=heuristic_speed_kn,
                     use_wave_correction=use_wave_correction,
+                    polar_override=polar_override,
                 )
                 return EtaPassagePlan(report=report, target_arrival=target_utc)
             except ForecastHorizonError as exc:
@@ -847,5 +866,6 @@ async def estimate_passage_for_arrival(
         model=model,
         heuristic_speed_kn=heuristic_speed_kn,
         use_wave_correction=use_wave_correction,
+        polar_override=polar_override,
     )
     return EtaPassagePlan(report=report, target_arrival=target_utc)

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -1055,3 +1055,158 @@ class TestEstimatePassageForArrival:
             segment_length_nm=10.0,
         )
         assert plan.target_arrival == target_local.astimezone(UTC)
+
+
+class TestPolarOverride:
+    """Custom polar payload overrides the bundled archetype polar."""
+
+    @staticmethod
+    def _doubled_polar(base_name: str) -> "BoatPolar":
+        from openwind_data.routing.archetypes import BoatPolar
+
+        base = get_polar(base_name)
+        doubled = tuple(tuple(v * 2.0 for v in row) for row in base.boat_speed_kn)
+        return BoatPolar(
+            name="custom",
+            length_ft=base.length_ft,
+            type=base.type,
+            category=base.category,
+            examples=base.examples,
+            performance_class=base.performance_class,
+            tws_kn=base.tws_kn,
+            twa_deg=base.twa_deg,
+            boat_speed_kn=doubled,
+        )
+
+    async def test_override_changes_duration(self) -> None:
+        # Doubling polar speeds → ~half the duration (modulo VMG kicker around
+        # close-hauled, identical here because we set up a beam reach).
+        adapter_base = StubAdapter(tws_kn=12.0, twd_deg=0.0)
+        baseline = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter_base,
+            segment_length_nm=10.0,
+        )
+
+        adapter_custom = StubAdapter(tws_kn=12.0, twd_deg=0.0)
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter_custom,
+            segment_length_nm=10.0,
+            polar_override=self._doubled_polar("cruiser_40ft"),
+        )
+        # Halved speed → halved duration; allow 5 % slack for VMG corrections.
+        assert report.duration_h == pytest.approx(baseline.duration_h / 2.0, rel=0.05)
+        # Archetype label preserved (the override is a perf layer, not a relabel).
+        assert report.archetype == "cruiser_40ft"
+
+    async def test_override_used_in_compare_windows(self) -> None:
+        # Sweep mode must thread polar_override through every window.
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=0.0)
+        custom = self._doubled_polar("cruiser_40ft")
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            DEPARTURE + timedelta(hours=3),
+            "cruiser_40ft",
+            sweep_interval_hours=1,
+            adapter=adapter,
+            segment_length_nm=10.0,
+            polar_override=custom,
+        )
+        # 4 windows (hours 0..3), all using the custom polar.
+        assert len(reports) == 4
+        baseline_dur = reports[0].duration_h
+        # Identical wind series + identical polar → identical durations across windows.
+        for r in reports:
+            assert r.duration_h == pytest.approx(baseline_dur, rel=0.01)
+
+    async def test_override_used_in_eta_solver(self) -> None:
+        adapter = StubAdapter(tws_kn=12.0, twd_deg=0.0)
+        target = datetime(2026, 5, 1, 14, 0, tzinfo=UTC)
+        baseline = await estimate_passage_for_arrival(
+            [MARSEILLE, PORQUEROLLES],
+            target,
+            "cruiser_40ft",
+            adapter=StubAdapter(tws_kn=12.0, twd_deg=0.0),
+            segment_length_nm=10.0,
+        )
+        custom = self._doubled_polar("cruiser_40ft")
+        plan = await estimate_passage_for_arrival(
+            [MARSEILLE, PORQUEROLLES],
+            target,
+            "cruiser_40ft",
+            adapter=adapter,
+            segment_length_nm=10.0,
+            polar_override=custom,
+        )
+        assert plan.report.duration_h == pytest.approx(baseline.report.duration_h / 2.0, rel=0.05)
+        assert plan.report.arrival_time == target
+
+
+class TestModelChainOverride:
+    """Caller-supplied model chain overrides the default AROME→ICON→ECMWF→GFS."""
+
+    async def test_chain_walked_in_order(self) -> None:
+        # AROME has no horizon → chain should fall through to ICON-EU.
+        adapter = HorizonLimitedStubAdapter(short_horizon_models=("meteofrance_arome_france",))
+        report = await estimate_passage(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            "cruiser_40ft",
+            adapter=adapter,
+            model="auto",
+            model_chain=("meteofrance_arome_france", "icon_eu"),
+            segment_length_nm=10.0,
+        )
+        assert report.model == "icon_eu"
+
+    async def test_chain_can_skip_default_models(self) -> None:
+        # Only one model in the chain; if it has no horizon, all fail.
+        adapter = HorizonLimitedStubAdapter(short_horizon_models=("icon_eu",))
+        with pytest.raises(ForecastHorizonError) as excinfo:
+            await estimate_passage(
+                [MARSEILLE, PORQUEROLLES],
+                DEPARTURE,
+                "cruiser_40ft",
+                adapter=adapter,
+                model="auto",
+                model_chain=("icon_eu",),
+                segment_length_nm=10.0,
+            )
+        assert excinfo.value.model == "icon_eu"
+
+    async def test_chain_threaded_through_windows(self) -> None:
+        # First-window resolution must respect model_chain, not fall back to
+        # the hard-coded AUTO chain.
+        adapter = HorizonLimitedStubAdapter(short_horizon_models=("meteofrance_arome_france",))
+        reports = await estimate_passage_windows(
+            [MARSEILLE, PORQUEROLLES],
+            DEPARTURE,
+            DEPARTURE + timedelta(hours=2),
+            "cruiser_40ft",
+            sweep_interval_hours=1,
+            adapter=adapter,
+            model="auto",
+            model_chain=("meteofrance_arome_france", "icon_eu"),
+            segment_length_nm=10.0,
+        )
+        assert all(r.model == "icon_eu" for r in reports)
+
+    async def test_chain_threaded_through_eta_solver(self) -> None:
+        adapter = HorizonLimitedStubAdapter(short_horizon_models=("meteofrance_arome_france",))
+        target = datetime(2026, 5, 1, 14, 0, tzinfo=UTC)
+        plan = await estimate_passage_for_arrival(
+            [MARSEILLE, PORQUEROLLES],
+            target,
+            "cruiser_40ft",
+            adapter=adapter,
+            model="auto",
+            model_chain=("meteofrance_arome_france", "icon_eu"),
+            segment_length_nm=10.0,
+        )
+        assert plan.report.model == "icon_eu"

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -31,7 +31,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from openwind_data.adapters.base import ForecastHorizonError
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
-from openwind_data.routing.archetypes import list_archetypes_metadata
+from openwind_data.routing.archetypes import BoatPolar, list_archetypes_metadata
 from openwind_data.routing.complexity import score_complexity
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import (
@@ -292,6 +292,94 @@ def _to_json(obj: Any) -> Any:
     return obj
 
 
+# Maps the web client's user-facing model names (see packages/web/src/config/
+# modelConfig.ts) to the Open-Meteo unified-API slugs that the data-adapter
+# already exercises in AUTO_FALLBACK_CHAIN. V1 scope: only the four chain
+# members translate. Other web models (ARPEGE_*, ICON_GLOBAL/_D2, UKMO_*, GEM,
+# DMI, METNO, ECMWF_AIFS) stay in the web table for forecast display but are
+# silently dropped here because their slugs haven't been validated end-to-end
+# against passage timing. Always append gfs_seamless as ultimate fallback so
+# an exotic top-of-chain pick never leaves the chain empty at far horizons.
+_MODEL_NAME_MAP: dict[str, str] = {
+    "AROME": "meteofrance_arome_france",
+    "ICON": "icon_eu",
+    "ECMWF": "ecmwf_ifs025",
+    "GFS": "gfs_seamless",
+}
+
+
+def _translate_models(raw: Any) -> tuple[str, ...] | None:
+    """Translate web model names to Open-Meteo slugs. Returns None when the
+    caller didn't send a `models` field or the list is empty after filtering.
+    Always appends gfs_seamless as last-resort fallback unless already present.
+    """
+    if not isinstance(raw, list):
+        return None
+    translated: list[str] = []
+    for name in raw:
+        if not isinstance(name, str):
+            continue
+        slug = _MODEL_NAME_MAP.get(name)
+        if slug and slug not in translated:
+            translated.append(slug)
+    if not translated:
+        return None
+    if "gfs_seamless" not in translated:
+        translated.append("gfs_seamless")
+    return tuple(translated)
+
+
+def _parse_polar(raw: Any) -> BoatPolar | None:
+    """Build a BoatPolar from the web client's `polar` payload. Returns None
+    when no payload is provided. Raises ValueError on shape mismatch / invalid
+    values so the caller can surface a 422 with the original message.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("polar must be an object")
+    try:
+        tws = [float(v) for v in raw["tws_kn"]]
+        twa = [float(v) for v in raw["twa_deg"]]
+        matrix = [[float(v) for v in row] for row in raw["boat_speed_kn"]]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"polar fields missing or non-numeric: {exc}") from exc
+    if len(tws) < 2 or len(twa) < 2:
+        raise ValueError("polar must have >= 2 TWS and >= 2 TWA entries")
+    from itertools import pairwise
+    if any(a >= b for a, b in pairwise(tws)):
+        raise ValueError("polar tws_kn must be strictly ascending")
+    if any(a >= b for a, b in pairwise(twa)):
+        raise ValueError("polar twa_deg must be strictly ascending")
+    if twa[0] < 0 or twa[-1] > 180:
+        raise ValueError("polar twa_deg must lie in [0, 180]")
+    if len(matrix) != len(tws):
+        raise ValueError(
+            f"polar boat_speed_kn has {len(matrix)} rows, expected {len(tws)} (one per TWS)"
+        )
+    for i, row in enumerate(matrix):
+        if len(row) != len(twa):
+            raise ValueError(
+                f"polar boat_speed_kn row {i} has {len(row)} cols, expected {len(twa)}"
+            )
+        for j, v in enumerate(row):
+            if v < 0 or v > 30:
+                raise ValueError(
+                    f"polar boat_speed_kn[{i}][{j}]={v} out of range [0, 30]"
+                )
+    return BoatPolar(
+        name=str(raw.get("name", "custom")),
+        length_ft=int(raw.get("length_ft", 0) or 0),
+        type=str(raw.get("type", "monohull")),
+        category=str(raw.get("category", "custom")),
+        examples=tuple(str(e) for e in raw.get("examples", ())),
+        performance_class=str(raw.get("performance_class", "custom")),
+        tws_kn=tuple(tws),
+        twa_deg=tuple(twa),
+        boat_speed_kn=tuple(tuple(row) for row in matrix),
+    )
+
+
 async def _index(_request) -> HTMLResponse:
     return HTMLResponse(LANDING_HTML)
 
@@ -350,6 +438,12 @@ async def _api_passage(request: Request) -> JSONResponse:
     except (TypeError, ValueError) as exc:
         return JSONResponse({"error": f"invalid efficiency: {exc}"}, status_code=422)
 
+    try:
+        polar_override = _parse_polar(body.get("polar"))
+    except ValueError as exc:
+        return JSONResponse({"error": f"invalid polar: {exc}"}, status_code=422)
+    model_chain = _translate_models(body.get("models"))
+
     # Sweep mode — triggered when ``latest_departure`` is provided.
     latest_raw = body.get("latest_departure")
     if latest_raw is not None:
@@ -374,6 +468,7 @@ async def _api_passage(request: Request) -> JSONResponse:
             reports = await estimate_passage_windows(
                 waypoints, departure, latest_departure, body["archetype"],
                 sweep_interval_hours=sweep_interval, efficiency=efficiency, model="auto",
+                polar_override=polar_override, model_chain=model_chain,
             )
         except KeyError as exc:
             return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
@@ -454,10 +549,11 @@ async def _api_passage(request: Request) -> JSONResponse:
             "forecast_updated_at": datetime.now(UTC).isoformat(),
         })
 
-    # Single mode — unchanged.
+    # Single mode.
     try:
         passage = await estimate_passage(
-            waypoints, departure, body["archetype"], efficiency=efficiency, model="auto"
+            waypoints, departure, body["archetype"], efficiency=efficiency, model="auto",
+            polar_override=polar_override, model_chain=model_chain,
         )
     except KeyError as exc:
         return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
@@ -518,12 +614,20 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
         return JSONResponse({"error": f"invalid efficiency: {exc}"}, status_code=422)
 
     try:
+        polar_override = _parse_polar(body.get("polar"))
+    except ValueError as exc:
+        return JSONResponse({"error": f"invalid polar: {exc}"}, status_code=422)
+    model_chain = _translate_models(body.get("models"))
+
+    try:
         plan = await estimate_passage_for_arrival(
             waypoints,
             target_arrival,
             body["archetype"],
             efficiency=efficiency,
             model="auto",
+            polar_override=polar_override,
+            model_chain=model_chain,
         )
     except KeyError as exc:
         return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -1,4 +1,15 @@
 import type { PassageResponse, PassageByEtaResponse, MultiWindowResponse, Archetype } from "../plan/types";
+import type { ModelName } from "../config/modelConfig";
+import type { PolarData } from "../config/polarConfig";
+
+// Plan-time overrides driven by the user's /config preferences. Both are
+// optional — when omitted, the server falls back to its bundled archetype
+// polar and the hard-coded AUTO model chain. The shape mirrors what the
+// HF Space's `_parse_polar` and `_translate_models` helpers expect.
+export interface PlanOverrides {
+  models?: ModelName[];
+  polar?: PolarData;
+}
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https://qdonnars-openwind-mcp.hf.space";
 
@@ -42,16 +53,20 @@ export async function fetchPassage(params: {
   departure: string;
   archetype: string;
   efficiency?: number;
+  overrides?: PlanOverrides;
 }): Promise<PassageResponse> {
+  const body: Record<string, unknown> = {
+    waypoints: params.waypoints,
+    departure: params.departure,
+    archetype: params.archetype,
+    efficiency: params.efficiency ?? 0.75,
+  };
+  if (params.overrides?.models?.length) body["models"] = params.overrides.models;
+  if (params.overrides?.polar) body["polar"] = params.overrides.polar;
   const res = await fetch(`${API_BASE}/api/v1/passage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      waypoints: params.waypoints,
-      departure: params.departure,
-      archetype: params.archetype,
-      efficiency: params.efficiency ?? 0.75,
-    }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({})) as Record<string, string>;
@@ -68,6 +83,7 @@ export async function fetchPassageWindows(params: {
   intervalHours: number;
   targetEta?: string;
   efficiency?: number;
+  overrides?: PlanOverrides;
 }): Promise<MultiWindowResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -78,6 +94,8 @@ export async function fetchPassageWindows(params: {
     sweep_interval_hours: params.intervalHours,
   };
   if (params.targetEta) body["target_eta"] = params.targetEta;
+  if (params.overrides?.models?.length) body["models"] = params.overrides.models;
+  if (params.overrides?.polar) body["polar"] = params.overrides.polar;
 
   const res = await fetch(`${API_BASE}/api/v1/passage`, {
     method: "POST",
@@ -96,6 +114,7 @@ export async function fetchPassageByEta(params: {
   targetArrival: string;
   archetype: string;
   efficiency?: number;
+  overrides?: PlanOverrides;
 }): Promise<PassageByEtaResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -103,6 +122,8 @@ export async function fetchPassageByEta(params: {
     archetype: params.archetype,
     efficiency: params.efficiency ?? 0.75,
   };
+  if (params.overrides?.models?.length) body["models"] = params.overrides.models;
+  if (params.overrides?.polar) body["polar"] = params.overrides.polar;
 
   const res = await fetch(`${API_BASE}/api/v1/passage-by-eta`, {
     method: "POST",

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -2,6 +2,7 @@ import type { Spot } from "../types";
 import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";
 import { InfoButton } from "./InfoButton";
+import { rememberReturnPath } from "../config/returnPath";
 
 
 interface HeaderProps {
@@ -33,6 +34,7 @@ function SettingsButton() {
   return (
     <a
       href="/config"
+      onClick={rememberReturnPath}
       aria-label="Paramètres"
       title="Paramètres"
       className="shrink-0 min-w-[36px] min-h-[36px] flex items-center justify-center rounded-lg transition-colors"

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -228,3 +228,27 @@ export function effectivePolar(cfg: PolarConfig): PolarData {
 export function hasOverrides(cfg: PolarConfig): boolean {
   return Object.keys(cfg.overrides).length > 0;
 }
+
+// True when the polar deviates from the default for `archetype` — i.e. the
+// editor's base differs, the scale is non-neutral, a spi mode is selected, or
+// any cell has been hand-tuned. Used to decide whether to push the custom
+// matrix to the planner; when false, the server's bundled polar suffices.
+export function isPolarCustomized(cfg: PolarConfig, archetype: string): boolean {
+  return (
+    cfg.base !== archetype ||
+    cfg.scale !== SCALE_DEFAULT ||
+    cfg.spi !== "off" ||
+    hasOverrides(cfg)
+  );
+}
+
+// Compact key capturing every input that affects effectivePolar(). Used to
+// invalidate the lastSimulation cache so a /config tweak doesn't leave stale
+// results on /plan.
+export function polarFingerprint(cfg: PolarConfig): string {
+  const overrideKey = Object.keys(cfg.overrides)
+    .sort()
+    .map((k) => `${k}=${cfg.overrides[k]}`)
+    .join(",");
+  return `${cfg.base}|${cfg.scale}|${cfg.spi}|${overrideKey}`;
+}

--- a/packages/web/src/config/returnPath.ts
+++ b/packages/web/src/config/returnPath.ts
@@ -1,0 +1,29 @@
+// Remember which page the user was on before opening /config so the back
+// link can land them where they came from instead of always bouncing to "/".
+// Stored in sessionStorage (not local) because the value is only meaningful
+// within the current tab session — a fresh tab opened on /config has no
+// meaningful "previous page".
+
+const KEY = "ow_config_return_to";
+
+export function rememberReturnPath(): void {
+  try {
+    const here = window.location.pathname + window.location.search;
+    // Never recurse into /config itself.
+    if (here.startsWith("/config")) return;
+    sessionStorage.setItem(KEY, here);
+  } catch {
+    // sessionStorage unavailable (Safari private mode etc.) — back link
+    // gracefully falls back to "/".
+  }
+}
+
+export function consumeReturnPath(): string {
+  try {
+    const v = sessionStorage.getItem(KEY);
+    sessionStorage.removeItem(KEY);
+    return v ?? "/";
+  } catch {
+    return "/";
+  }
+}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -8,6 +8,14 @@ import { ModeToggle, TimeAnchorToggle, type PlanMode, type TimeAnchor } from "./
 import { LegDetailCard } from "./LegDetailCard";
 import { EmptyState, ModePicker, Warn, RecapButton } from "./PlanStates";
 import { useHasChosenMode } from "./useChosenMode";
+import {
+  ARCHETYPE_LABELS,
+  defaultPolarConfig,
+  isPolarCustomized,
+  loadPolarConfig,
+  savePolarConfig,
+} from "../config/polarConfig";
+import { rememberReturnPath } from "../config/returnPath";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -412,24 +420,50 @@ function ArchetypeSelector({
   currentSlug,
   archetypes,
   onChange,
+  onCustomCleared,
 }: {
   currentSlug: string;
   archetypes: Archetype[];
   onChange: (slug: string) => void;
+  // Notify the parent that the custom polar was reset so it can re-fetch
+  // (the new fingerprint won't match the cached one, and resolveOverrides
+  // will stop sending the custom matrix).
+  onCustomCleared?: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  // Re-read the polar config every render. Cheap (localStorage parse + a few
+  // boolean checks) and ensures the "Custom" pill appears immediately after
+  // the user edits /config in another tab and comes back here.
+  const polarCfg = loadPolarConfig();
+  const isCustom = isPolarCustomized(polarCfg, currentSlug);
+  const baseLabel = ARCHETYPE_LABELS[polarCfg.base] ?? polarCfg.base;
   const current = archetypes.find((a) => a.slug === currentSlug);
-  const label = current?.name ?? currentSlug;
+  const archetypeLabel = current?.name ?? currentSlug;
+  const label = isCustom ? "Custom" : archetypeLabel;
+
+  function resetCustom() {
+    savePolarConfig(defaultPolarConfig());
+    setOpen(false);
+    onCustomCleared?.();
+  }
 
   return (
     <div className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
         className="flex items-center gap-1.5 text-sm transition-colors"
-        style={{ color: "var(--ow-fg-1)" }}
-        title="Changer le type de bateau"
+        style={{ color: isCustom ? "var(--ow-accent)" : "var(--ow-fg-1)" }}
+        title={isCustom ? `Polaire personnalisée active (base : ${baseLabel})` : "Changer le type de bateau"}
       >
         {label}
+        {isCustom && (
+          <span
+            className="text-[9px] font-semibold uppercase tracking-wider px-1 py-0.5 rounded"
+            style={{ background: "var(--ow-accent-soft)", color: "var(--ow-accent)" }}
+          >
+            perso
+          </span>
+        )}
         <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" style={{ opacity: 0.5 }}>
           <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round"/>
         </svg>
@@ -440,17 +474,49 @@ function ArchetypeSelector({
           {/* backdrop */}
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
           <div
-            className="absolute left-0 top-7 z-20 min-w-[220px] rounded-xl shadow-xl border overflow-hidden"
+            className="absolute left-0 top-7 z-20 min-w-[240px] rounded-xl shadow-xl border overflow-hidden"
             style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line-2)", boxShadow: "var(--ow-shadow-pop)" }}
           >
+            {isCustom && (
+              <div
+                className="px-4 py-3 text-xs"
+                style={{
+                  background: "var(--ow-accent-soft)",
+                  color: "var(--ow-accent)",
+                  borderBottom: "1px solid var(--ow-line)",
+                }}
+              >
+                <div className="font-semibold mb-1">Polaire personnalisée active</div>
+                <div className="opacity-80 mb-2">Base : {baseLabel}</div>
+                <div className="flex gap-2">
+                  <a
+                    href="/config"
+                    onClick={rememberReturnPath}
+                    className="underline"
+                    style={{ color: "var(--ow-accent)" }}
+                  >
+                    éditer
+                  </a>
+                  <span style={{ opacity: 0.4 }}>·</span>
+                  <button
+                    type="button"
+                    onClick={resetCustom}
+                    className="underline"
+                    style={{ color: "var(--ow-accent)" }}
+                  >
+                    réinitialiser
+                  </button>
+                </div>
+              </div>
+            )}
             {archetypes.map((a) => (
               <button
                 key={a.slug}
                 onClick={() => { onChange(a.slug); setOpen(false); }}
                 className="w-full text-left px-4 py-3 text-sm transition-colors"
                 style={{
-                  background: a.slug === currentSlug ? "var(--ow-accent-soft)" : "transparent",
-                  color: a.slug === currentSlug ? "var(--ow-accent)" : "var(--ow-fg-0)",
+                  background: !isCustom && a.slug === currentSlug ? "var(--ow-accent-soft)" : "transparent",
+                  color: !isCustom && a.slug === currentSlug ? "var(--ow-accent)" : "var(--ow-fg-0)",
                   borderBottom: "1px solid var(--ow-line)",
                 }}
               >
@@ -481,8 +547,8 @@ function SummaryCell({ value }: { value: string | null }) {
   if (!value) return null;
   return (
     <span
-      className="text-[10px] whitespace-normal"
-      style={{ color: "var(--ow-fg-1)", lineHeight: 1, display: "inline-block" }}
+      className="text-xs whitespace-normal"
+      style={{ color: "var(--ow-fg-1)", lineHeight: 1.15, display: "inline-block" }}
     >
       {value}
     </span>
@@ -662,26 +728,20 @@ function LegList({
 }) {
   return (
     <div>
-      <div
-        className="flex items-center justify-between px-4 pt-3 pb-1 text-[10px] uppercase tracking-widest font-bold"
-        style={{ color: "var(--ow-fg-2)" }}
-      >
-        Segments
-        <span className="text-[9px] font-medium normal-case tracking-normal" style={{ color: "var(--ow-fg-3)", fontFamily: "var(--ow-font-mono)" }}>
-          cliquez pour détailler
-        </span>
-      </div>
-      {/* A single table for all legs so the colgroup forces every leg's
-          chip cells into the exact same column widths — alignment for free,
-          no subgrid acrobatics. `table-fixed` makes columns honour the
-          colgroup widths instead of auto-sizing per row. */}
-      {/* `table-auto` (default) lets columns shrink with the viewport: a
-          narrow sidebar tightens the inter-cell spacing automatically.
-          We keep the same column order (badge / duration / allure / wind /
-          flag / chev) but drop the rigid colgroup widths so the browser
-          can rebalance. `min-width: 0` on the flag cell allows the wrap
-          point to slide leftward instead of pushing the chevron offscreen. */}
       <table className="w-full" style={{ borderCollapse: "collapse" }}>
+        <thead>
+          <tr
+            className="text-[9px] uppercase tracking-widest"
+            style={{ color: "var(--ow-fg-3)" }}
+          >
+            <th className="py-1 pl-3 pr-2 pt-3 text-left font-semibold">Tronçon</th>
+            <th className="py-1 px-1 pt-3 text-left font-semibold">Durée</th>
+            <th className="py-1 px-1 pt-3 text-left font-semibold">Allure</th>
+            <th className="py-1 px-1 pt-3 text-left font-semibold">Vent (kn)</th>
+            <th className="py-1 px-1 pt-3 text-left font-semibold">Mer</th>
+            <th className="py-1 pl-1 pr-3 pt-3" />
+          </tr>
+        </thead>
         <tbody>
           {legs.map((leg, i) => (
             <LegRow
@@ -953,6 +1013,7 @@ export function PlanSidebar({
               currentSlug={currentArchetypeSlug}
               archetypes={archetypes}
               onChange={onArchetypeChange}
+              onCustomCleared={onRefetch}
             />
           </div>
         )}
@@ -1005,6 +1066,7 @@ export function PlanSidebar({
           currentSlug={currentArchetypeSlug}
           archetypes={archetypes}
           onChange={onArchetypeChange}
+          onCustomCleared={onRefetch}
         />
 
         <button
@@ -1079,6 +1141,7 @@ export function PlanSidebar({
             currentSlug={currentArchetypeSlug}
             archetypes={archetypes}
             onChange={onArchetypeChange}
+            onCustomCleared={onRefetch}
           />
         </div>
       )}

--- a/packages/web/src/plan/WindowsTable.tsx
+++ b/packages/web/src/plan/WindowsTable.tsx
@@ -126,8 +126,8 @@ export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
         <SortHeader k="complexity" label="⚡" align="center" />
       </div>
 
-      <div className="divide-y" style={{ borderColor: "var(--ow-line)" }}>
-        {sorted.map((w) => {
+      <div>
+        {sorted.map((w, idx) => {
           // Defensive reads — backend version skew (e.g. older HF Space) may
           // omit nested fields that newer types declare. Default to empty
           // shapes so display falls back to "—" instead of crashing.
@@ -145,6 +145,7 @@ export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
                 gridTemplateColumns: "1.4fr 0.7fr 0.7fr 0.9fr 0.9fr 0.9fr 0.55fr",
                 fontFamily: "var(--ow-font-mono)",
                 color: "var(--ow-fg-1)",
+                borderTop: idx === 0 ? "none" : "1px solid var(--ow-line)",
               }}
               title="Voir le détail de cette fenêtre"
             >

--- a/packages/web/src/plan/lastSimulation.ts
+++ b/packages/web/src/plan/lastSimulation.ts
@@ -14,6 +14,11 @@ const STORAGE_KEY = "ow_last_simulation_v1";
 export interface LastSimulation {
   waypoints: [number, number][];
   archetype: string;
+  // Fingerprint of the /config preferences in effect when the simulation ran
+  // (model order + polar customization). Compared on rehydration so a user
+  // tweaking /config and returning to /plan never sees stale results
+  // computed against the previous preferences.
+  configFingerprint?: string;
   // Last active mode at save time. Drives which tab the user lands on when
   // we rehydrate after a navigation away from /plan (e.g. round-trip via /).
   mode: "single" | "compare";

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -8,6 +8,7 @@ import {
   type ModelConfig,
   type ModelName,
 } from "../config/modelConfig";
+import { consumeReturnPath } from "../config/returnPath";
 import { PolarEditor } from "../components/PolarEditor";
 
 type Tab = "models" | "polar";
@@ -21,6 +22,10 @@ export function ConfigPage() {
   const [tab, setTab] = useState<Tab>("models");
   const [config, setConfig] = useState<ModelConfig>(() => loadModelConfig());
   const [savedOnce, setSavedOnce] = useState(false);
+  // Resolved at mount so the back link is stable across re-renders. Consuming
+  // here also clears the stash, so a hard reload of /config (no remembered
+  // path) falls back to "/" on the next click, which is the right default.
+  const [returnPath] = useState<string>(() => consumeReturnPath());
   // Track the dragged item by model identity (not by index) so the visual
   // index of the dragged row can shift as the preview reorders without us
   // losing track of which row is being moved.
@@ -88,7 +93,7 @@ export function ConfigPage() {
     <div className="config-root min-h-screen">
       <header className="config-header sticky top-0 z-10 border-b backdrop-blur">
         <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
-          <a href="/" className="text-sm font-medium opacity-80 hover:opacity-100 transition">
+          <a href={returnPath} className="text-sm font-medium opacity-80 hover:opacity-100 transition">
             ← OpenWind
           </a>
           <span className="text-xs opacity-60">Configuration</span>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from "re
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
-import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError } from "../api/passage";
+import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError, type PlanOverrides } from "../api/passage";
 import { Header } from "../components/Header";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import {
@@ -14,6 +14,32 @@ import {
 } from "../plan/lastSimulation";
 import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
+import { activeModels, loadModelConfig } from "../config/modelConfig";
+import { effectivePolar, isPolarCustomized, loadPolarConfig, polarFingerprint } from "../config/polarConfig";
+
+// Build the plan-time overrides payload from current /config preferences.
+// Read at request time (not at mount) so a /config tweak takes effect on the
+// next refetch without a page reload. Polar matrix is only attached when the
+// editor deviates from the default for the active archetype — otherwise the
+// server's bundled polar wins, saving ~kB per request.
+function resolveOverrides(archetype: string): PlanOverrides {
+  const overrides: PlanOverrides = {};
+  const modelCfg = loadModelConfig();
+  const models = activeModels(modelCfg);
+  if (models.length > 0) overrides.models = models;
+  const polarCfg = loadPolarConfig();
+  if (isPolarCustomized(polarCfg, archetype)) {
+    overrides.polar = effectivePolar(polarCfg);
+  }
+  return overrides;
+}
+
+// Joint fingerprint of model + polar config. Same shape across single &
+// compare so the cache check is one-liner. Read at the same moment as the
+// fetch so the persisted simulation is paired with the config that produced it.
+function currentConfigFingerprint(): string {
+  return `${activeModels(loadModelConfig()).join(",")}|${polarFingerprint(loadPolarConfig())}`;
+}
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
@@ -336,9 +362,10 @@ export function PlanPage() {
   function doFetch(wpts: [number, number][], arch: string, dep: string, anchor: TimeAnchor = "departure") {
     setIsLoading(true);
     setApiError(null);
+    const overrides = resolveOverrides(arch);
     const promise = anchor === "arrival"
-      ? fetchPassageByEta({ waypoints: wpts, targetArrival: toTzAware(dep), archetype: arch })
-      : fetchPassage({ waypoints: wpts, departure: toTzAware(dep), archetype: arch });
+      ? fetchPassageByEta({ waypoints: wpts, targetArrival: toTzAware(dep), archetype: arch, overrides })
+      : fetchPassage({ waypoints: wpts, departure: toTzAware(dep), archetype: arch, overrides });
     promise
       .then((res) => {
         setPassage(res.passage);
@@ -362,6 +389,7 @@ export function PlanPage() {
         saveLastSimulation({
           waypoints: wpts,
           archetype: arch,
+          configFingerprint: currentConfigFingerprint(),
           mode: "single",
           single: {
             departure: resolvedDep,
@@ -385,7 +413,11 @@ export function PlanPage() {
       const cacheMatches =
         cached &&
         waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
-        cached.archetype === initialParsed.archetype;
+        cached.archetype === initialParsed.archetype &&
+        // Reject the cache if the user tweaked /config since the simulation
+        // ran — the persisted result is stale relative to the active
+        // preferences. Treat missing fingerprint as "pre-config-era" cache.
+        cached.configFingerprint === currentConfigFingerprint();
       if (cacheMatches) {
         if (cached.single && cached.single.departure === departure) {
           setPassage(cached.single.passage);
@@ -411,6 +443,15 @@ export function PlanPage() {
     // useState initializers above. Hydrate the simulation results, sync the
     // URL so reload/share works, and skip any network call.
     if (useCachedRoute && cachedAtMount) {
+      const url = buildPlanUrl(cachedAtMount.waypoints, departure, cachedAtMount.archetype);
+      window.history.replaceState(null, "", url);
+      // /config changed since the cache was written — discard the persisted
+      // results and refetch so the plan reflects the user's current
+      // preferences. Route + archetype + departure remain seeded.
+      if (cachedAtMount.configFingerprint !== currentConfigFingerprint()) {
+        doFetch(cachedAtMount.waypoints, cachedAtMount.archetype, departure);
+        return;
+      }
       if (cachedAtMount.single) {
         setPassage(cachedAtMount.single.passage);
         setComplexity(cachedAtMount.single.complexity);
@@ -423,8 +464,6 @@ export function PlanPage() {
           setForecastUpdatedAt(cachedAtMount.compare.forecastUpdatedAt);
         }
       }
-      const url = buildPlanUrl(cachedAtMount.waypoints, departure, cachedAtMount.archetype);
-      window.history.replaceState(null, "", url);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -482,6 +521,7 @@ export function PlanPage() {
       latest: toTzAware(sweepLatest),
       archetype,
       intervalHours: sweepInterval,
+      overrides: resolveOverrides(archetype),
     })
       .then((res) => {
         setWindows(res.windows);
@@ -497,6 +537,7 @@ export function PlanPage() {
         saveLastSimulation({
           waypoints,
           archetype,
+          configFingerprint: currentConfigFingerprint(),
           mode: "compare",
           single: sameRoute ? prev?.single : undefined,
           compare: {
@@ -590,6 +631,9 @@ export function PlanPage() {
       saveLastSimulation({
         waypoints,
         archetype,
+        // Inherit the fingerprint from the compare-mode cache that produced
+        // this window — drill-down is metadata reshuffling, not a new run.
+        configFingerprint: prev?.configFingerprint ?? currentConfigFingerprint(),
         mode: "single",
         single: {
           departure: naiveDep,


### PR DESCRIPTION
The /config page already let users reorder weather models and edit a custom polar, but those preferences only influenced the forecast table on /. The plan_passage route ignored them: it always used the AROME auto-chain and the bundled archetype polar.

Server side, estimate_passage / estimate_passage_windows / estimate_passage_for_arrival now accept polar_override and model_chain kwargs. The HF Space route parses optional `polar` and `models` body fields, validates the polar shape, translates web model names to Open-Meteo slugs (AROME → meteofrance_arome_france, ICON → icon_eu, ECMWF → ecmwf_ifs025, GFS → gfs_seamless), and always appends gfs_seamless as ultimate fallback so an exotic top-of-chain pick never leaves the chain empty at far horizons.

Web side, PlanPage reads loadModelConfig + loadPolarConfig at each fetch (not at mount) so /config edits take effect on the next refetch. A config fingerprint is stamped on lastSimulation; mismatches invalidate the cache. PlanSidebar's archetype dropdown shows "Custom" + a perso badge when the polar deviates from the default, with edit / reset shortcuts. ArchetypeSelector calls back onCustomCleared so reset triggers a refetch.

Also bundles the return-path UX (sessionStorage stash on settings gear
+ "éditer" link, consumed by ConfigPage back link) and a small WindowsTable visual fix (drop divide-y in favor of a manual top border to skip the first row's separator).

MCP tool plan_passage left unchanged — those clients don't have /config.