### PR TITLE
feat(web): mobile UX polish, leg distance in Tronçon column, Clapot suiveur copy

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/complexity.py
+++ b/packages/data-adapters/src/openwind_data/routing/complexity.py
@@ -238,9 +238,7 @@ def score_complexity(
     # sea and don't compound. Without this, a passage with WAC on the first half
     # and chop on the second half would jump +2 levels for what is essentially
     # the same physical signal restated.
-    bumped_level = (
-        min(5, level + 1) if (wind_against_current or chop_contributes_bump) else level
-    )
+    bumped_level = min(5, level + 1) if (wind_against_current or chop_contributes_bump) else level
 
     if wind_against_current:
         affected_wac = tuple(wac_indices)
@@ -266,19 +264,20 @@ def score_complexity(
         tp_range = _compact_range(chop_tp, 0)
         if chop_following_only:
             chop_label = "Clapot suiveur"
-            chop_suffix = "barre attentive, risque de départ au lof"
+            chop_suffix: str | None = None
             chop_warning_level = level  # no bump credited to this warning
         else:
             chop_label = "Clapot court"
             chop_suffix = "mer désagréable"
             chop_warning_level = bumped_level
+        suffix_part = f", {chop_suffix}" if chop_suffix else ""
         warnings.append(
             ComplexityWarning(
                 kind="chop",
                 level=chop_warning_level,
                 message=(
                     f"{chop_label} : Hs {hs_range} m à Tp {tp_range} s sur "
-                    f"{affected_chop_nm:.0f} nm, {chop_suffix}"
+                    f"{affected_chop_nm:.0f} nm{suffix_part}"
                 ),
                 affected_segments=affected_chop,
             )

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -211,7 +211,21 @@ body {
   background: #e84118;
 }
 @media (hover: none) {
-  .ow-wpt-x { opacity: 1; }
+  .ow-wpt-x {
+    opacity: 1;
+    width: 22px;
+    height: 22px;
+    top: -10px;
+    right: -10px;
+    font-size: 15px;
+  }
+  /* Extends the tap zone beyond the visible button without making the icon
+     bigger. Effective hit area ≈ 38×38px, comfortable for thumbs. */
+  .ow-wpt-x::before {
+    content: "";
+    position: absolute;
+    inset: -8px;
+  }
 }
 
 /* Departure slider */

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -168,8 +168,11 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       const xBtn = el?.querySelector<HTMLButtonElement>(".ow-wpt-x");
       if (xBtn) {
         L.DomEvent.disableClickPropagation(xBtn);
+        // Only stop propagation — calling preventDefault on touchstart would
+        // suppress the synthesized click event on touch devices, leaving the
+        // button visibly pressed but unresponsive on release.
         L.DomEvent.on(xBtn, "mousedown touchstart pointerdown", (ev) => {
-          L.DomEvent.stop(ev as Event);
+          L.DomEvent.stopPropagation(ev as Event);
         });
         L.DomEvent.on(xBtn, "click", (ev) => {
           L.DomEvent.stop(ev as Event);

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -662,13 +662,22 @@ function LegRow({
         <td className="py-2 pl-3 pr-2 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
           {/* Leg label is "from→to" using user-waypoint indices (1-based).
               `index` here is 0-based across legs, so leg N goes from
-              waypoint N to waypoint N+1. */}
-          <span
-            className="inline-flex h-6 px-1.5 rounded-md items-center justify-center text-[10px] font-bold tabular-nums whitespace-nowrap"
-            style={{ background: CX_COLORS[cx], color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
-          >
-            {index + 1}→{index + 2}
-          </span>
+              waypoint N to waypoint N+1. Distance sits under the badge so
+              the user can scan leg length without expanding. */}
+          <div className="flex flex-col items-start gap-0.5">
+            <span
+              className="inline-flex h-6 px-1.5 rounded-md items-center justify-center text-[10px] font-bold tabular-nums whitespace-nowrap"
+              style={{ background: CX_COLORS[cx], color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
+            >
+              {index + 1}→{index + 2}
+            </span>
+            <span
+              className="text-[10px] tabular-nums whitespace-nowrap"
+              style={{ color: "var(--ow-fg-2)", fontFamily: "var(--ow-font-mono)" }}
+            >
+              {fr1(leg.distance_nm)} nm
+            </span>
+          </div>
         </td>
         <td className="py-2 px-1 align-middle" style={{ borderTop: "1px solid var(--ow-line)" }}>
           <SummaryCell value={summary.duration} />
@@ -701,12 +710,11 @@ function LegRow({
       {expanded && (
         <tr style={{ background: rowBg }}>
           <td colSpan={6} className="px-4 pb-3">
-            {/* Three KPI cells (time / distance / sea) — wind and allure
-                already appear in the collapsed row above, repeating them
-                in the expand was visual noise. */}
-            <div className="grid grid-cols-3 gap-2 mb-3">
+            {/* Two KPI cells (time / sea). Wind, allure and distance all
+                appear in the collapsed row above; repeating them in the
+                expand was visual noise. */}
+            <div className="grid grid-cols-2 gap-2 mb-3">
               <KpiBlock value={`${fmtHM(leg.start_time)} → ${fmtHM(leg.end_time)}`} label="dep → arr" />
-              <KpiBlock value={fr1(leg.distance_nm)} label="miles" />
               <KpiBlock value={seaValue} label={seaLabel} tone={seaWarn ? "warn" : "default"} />
             </div>
             <LegDetailCard leg={leg} />

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   ACTIVE_LIMIT,
   MODEL_META,
@@ -31,6 +32,9 @@ export function ConfigPage() {
   // losing track of which row is being moved.
   const [dragModel, setDragModel] = useState<ModelName | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
+  // Tap-to-swap fallback for touch devices where HTML5 drag-and-drop doesn't
+  // work. Tracks the index of the row whose position the user wants to swap.
+  const [swapFromIdx, setSwapFromIdx] = useState<number | null>(null);
 
   function update(next: ModelConfig) {
     setConfig(next);
@@ -86,6 +90,31 @@ export function ConfigPage() {
     setOverIdx(null);
   }
 
+  function commitSwap(targetIdx: number) {
+    if (swapFromIdx == null || swapFromIdx === targetIdx) {
+      setSwapFromIdx(null);
+      return;
+    }
+    const next = [...config.order];
+    [next[swapFromIdx], next[targetIdx]] = [next[targetIdx], next[swapFromIdx]];
+    update({ ...config, order: next });
+    setSwapFromIdx(null);
+  }
+
+  useEffect(() => {
+    if (swapFromIdx == null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSwapFromIdx(null);
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [swapFromIdx]);
+
   const totalRows = previewOrder.length;
   const ignoredRows = totalRows - ACTIVE_LIMIT;
 
@@ -127,8 +156,9 @@ export function ConfigPage() {
         <h1 className="text-3xl font-bold mb-2">Modèles météo</h1>
         <p className="text-sm opacity-80 mb-8 leading-relaxed">
           Les {ACTIVE_LIMIT} premiers modèles sont affichés dans la table de
-          prévision, dans cet ordre. Glisse-dépose pour réordonner. Cette
-          configuration ne touche pas les plans de passage.
+          prévision, dans cet ordre. Glisse-dépose pour réordonner, ou tape
+          une ligne pour l'échanger avec une autre. Cette configuration ne
+          touche pas les plans de passage.
         </p>
 
         <div className="config-list-with-zones">
@@ -145,6 +175,7 @@ export function ConfigPage() {
                   onDragOver={(e) => onDragOver(e, idx)}
                   onDrop={onDrop}
                   onDragEnd={onDragEnd}
+                  onClick={() => setSwapFromIdx(idx)}
                   className={`config-row flex items-stretch gap-3 rounded-xl border p-3 select-none ${
                     isActive ? "is-active" : "is-inactive"
                   } ${isDragging ? "is-dragging" : ""}`}
@@ -226,6 +257,85 @@ export function ConfigPage() {
             <PolarEditor />
           </>
         )}
+
+        {swapFromIdx !== null &&
+          createPortal(
+            <div
+              className="fixed inset-0 z-[1000] flex items-end lg:items-center justify-center animate-fade-in"
+              style={{ background: "rgba(0,0,0,0.6)" }}
+              onClick={() => setSwapFromIdx(null)}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Échanger un modèle"
+            >
+              <div
+                className="config-swap-sheet relative w-full lg:max-w-md max-h-[88vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  onClick={() => setSwapFromIdx(null)}
+                  aria-label="Fermer"
+                  className="config-swap-close"
+                >
+                  ✕
+                </button>
+                <div className="p-5 pr-12">
+                  <p className="text-xs opacity-60 mb-1">Échanger</p>
+                  <h2 className="text-lg font-semibold mb-3">
+                    {MODEL_META[previewOrder[swapFromIdx]].label}
+                    <span className="ml-2 text-sm opacity-60">
+                      (position {swapFromIdx + 1})
+                    </span>
+                  </h2>
+                  <p className="text-sm opacity-80 mb-4">
+                    Sélectionne le modèle avec lequel échanger sa position.
+                  </p>
+
+                  <div className="config-swap-tip">
+                    On recommande de garder GFS parmi les {ACTIVE_LIMIT}{" "}
+                    modèles actifs. C'est le seul à couvrir les prévisions à
+                    plus d'une semaine, jusqu'à 16 jours.
+                  </div>
+
+                  <ul className="flex flex-col gap-2 mt-4">
+                    {previewOrder.map((m, i) => {
+                      if (i === swapFromIdx) return null;
+                      const meta = MODEL_META[m];
+                      const isActive = i < ACTIVE_LIMIT;
+                      return (
+                        <li key={m}>
+                          <button
+                            type="button"
+                            onClick={() => commitSwap(i)}
+                            className={`config-swap-option ${
+                              isActive ? "" : "is-inactive"
+                            }`}
+                          >
+                            <span
+                              className={`config-rank ${
+                                isActive ? "" : "config-rank-off"
+                              }`}
+                            >
+                              {i + 1}
+                            </span>
+                            <span className="config-swap-option-body">
+                              <span className="config-swap-option-label">
+                                {meta.label}
+                              </span>
+                              <span className="config-swap-option-meta">
+                                {meta.provider} · ~{formatHorizon(meta.horizonHours)}
+                              </span>
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )}
 
         <footer className="config-storage-note mt-10">
           OpenWind ne propose volontairement pas de comptes utilisateurs :
@@ -418,6 +528,72 @@ export function ConfigPage() {
             font-size: 10px;
             letter-spacing: 0.08em;
           }
+        }
+        .config-swap-sheet {
+          background: var(--ow-bg-0, #0b1220);
+          border: 1px solid var(--ow-line-2, rgba(255,255,255,0.10));
+          color: var(--ow-fg-0, #e2e8f0);
+        }
+        .config-swap-close {
+          position: absolute;
+          top: 12px;
+          right: 12px;
+          width: 32px;
+          height: 32px;
+          border-radius: 9999px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 14px;
+          font-weight: 600;
+          background: var(--ow-bg-1, rgba(255,255,255,0.04));
+          color: var(--ow-fg-1, #cbd5e1);
+          border: 1px solid var(--ow-line-2, rgba(255,255,255,0.10));
+        }
+        .config-swap-tip {
+          font-size: 12.5px;
+          line-height: 1.5;
+          color: var(--ow-fg-1, #cbd5e1);
+          padding: 10px 12px;
+          border-radius: 8px;
+          background: var(--ow-accent-soft, rgba(20, 184, 166, 0.08));
+          border: 1px solid var(--ow-accent-line, rgba(20, 184, 166, 0.25));
+          border-left-width: 3px;
+          border-left-color: var(--ow-accent, #14b8a6);
+        }
+        .config-swap-option {
+          width: 100%;
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 12px 14px;
+          border-radius: 10px;
+          background: var(--ow-bg-1, rgba(255,255,255,0.04));
+          border: 1px solid var(--ow-line-2, rgba(255,255,255,0.08));
+          color: var(--ow-fg-0, #e2e8f0);
+          text-align: left;
+          transition: background 120ms ease, border-color 120ms ease;
+        }
+        .config-swap-option:hover {
+          background: var(--ow-bg-2, rgba(255,255,255,0.08));
+          border-color: var(--ow-accent-line, rgba(20, 184, 166, 0.35));
+        }
+        .config-swap-option.is-inactive {
+          opacity: 0.6;
+        }
+        .config-swap-option-body {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          min-width: 0;
+        }
+        .config-swap-option-label {
+          font-size: 14px;
+          font-weight: 600;
+        }
+        .config-swap-option-meta {
+          font-size: 11.5px;
+          opacity: 0.65;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary

Small UX polish bundle, 3 independent commits:

- **Mobile UX — waypoint delete + model reorder** (`e03b1fc`)
  - On touch devices the waypoint X button grows from 16→22 px visible, and gets an invisible `::before` hit-area extension (~38×38 px effective).
  - Fixes the silent "press but nothing on release" bug on touch: the old `mousedown/touchstart` handler called `L.DomEvent.stop` which `preventDefault`'d `touchstart`, suppressing the synthesized `click`. Now only `stopPropagation` is called.
  - On `/config`, tapping a model row opens a bottom-sheet "Échanger {modèle} (position N)" listing the other models. Selecting one swaps the two positions. Drag-and-drop is preserved on pointer devices, both UX cohabit. Sheet shows a tip recommending GFS stay among the 4 active models (only model covering forecasts > 1 week).

- **Leg distance in the Tronçon column** (`26e93d8`)
  - Distance was only visible after expanding a leg. Now sits as a small mono line under the leg badge (`52,8 nm` under `1→2`).
  - The duplicated `KpiBlock` for distance was dropped from the expand to follow the existing principle ("repeating them in the expand was visual noise").

- **Drop helm-advice suffix from "Clapot suiveur" warning** (`4cf4090`)
  - `Clapot suiveur : Hs 0,8 m à Tp 4 s sur 18 nm, barre attentive, risque de départ au lof`
  - → `Clapot suiveur : Hs 0,8 m à Tp 4 s sur 18 nm`
  - The helm-reaction prescription belonged in documentation, not in a state warning. The rationale stays in `methodologie.md` and `mcp-core/server.py` LLM docs. "Clapot court : … mer désagréable" unchanged.

## Test plan

- [x] `tsc --noEmit` on web — clean
- [x] `pytest tests/test_complexity.py` — 33/33 pass
- [x] Live MCP smoke (Marseille → Porquerolles, 2026-05-18 09:00, cruiser_30ft) — 5 segments returned, warnings format cleanly with no stray commas / `None` leaks
- [x] Visual check on `/plan` simulation table — distance renders aligned under each leg badge, expanded view no longer duplicates it
- [x] Visual check on `/config` — swap sheet opens on tap, recommendation banner readable, swap commits correctly to localStorage
- [ ] Test on a real touch device that the waypoint X now reacts on release (was unreachable via Leaflet's synthetic touch in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)