### PR TITLE
chore: gitignore /tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ dist-ssr
 # Internal scoping/decision docs (not part of the public repo)
 /plan/
 
+# Local scratch / browser exports / non-tracked working files
+/tmp/
+
 # Test artifacts
 test-results/
 eval_screenshots.ts


### PR DESCRIPTION
Untracks the `/tmp/` scratch directory used for local browser HTML exports and other throwaway working files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)