### PR TITLE
chore(seo): noindex pages.dev URLs from main deploy

### DIFF
--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -1,0 +1,8 @@
+https://dev.openwind.fr/*
+  X-Robots-Tag: noindex, nofollow
+
+https://openwind.pages.dev/*
+  X-Robots-Tag: noindex, nofollow
+
+https://*.openwind.pages.dev/*
+  X-Robots-Tag: noindex, nofollow


### PR DESCRIPTION
## Why

After this morning's migration from GitHub Pages to Cloudflare Pages, the production deployment serves the site at **two URLs**:

- `https://openwind.fr/` (canonical custom domain)
- `https://openwind.pages.dev/` (auto-assigned Cloudflare Pages URL)

Both URLs return identical content. Without an SEO directive, Google could index both and treat openwind.pages.dev as duplicate content — penalising the ranking of the canonical openwind.fr.

## Fix

Adds `packages/web/public/_headers` to ship a `X-Robots-Tag: noindex, nofollow` header for:

- `https://openwind.pages.dev/*` — the prod's `.pages.dev` mirror
- `https://*.openwind.pages.dev/*` — all preview branch deployments
- `https://dev.openwind.fr/*` — the dev branch's custom domain (already covered by the dev branch's own `_headers`, but kept here so future feature branches inherit consistent behaviour)

openwind.fr itself is **not** covered by any of these patterns, so it stays indexable.

## Verified locally before opening

```
curl -sI https://openwind.fr/         → no X-Robots-Tag  (indexable, correct)
curl -sI https://openwind.pages.dev/  → no X-Robots-Tag  (BUG — to be fixed by this PR)
curl -sI https://dev.openwind.fr/     → X-Robots-Tag: noindex, nofollow  (correct, served by dev branch's _headers)
```

## Test plan

After merge, the Cloudflare Pages production deploy will pick up the new `_headers`. To verify:

```
curl -sI https://openwind.fr/         → no X-Robots-Tag
curl -sI https://openwind.pages.dev/  → X-Robots-Tag: noindex, nofollow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)