### PR TITLE
feat(deploy): dev HF Space pipeline + per-env web backend URL

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -2,7 +2,7 @@ name: Sync HF Space
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "packages/hf-space/**"
       - "packages/mcp-core/**"
@@ -10,17 +10,31 @@ on:
       - ".github/workflows/sync-hf-space.yml"
   workflow_dispatch:
 
-# Single source of truth = this repo. The HF Space repo is treated as a mirror;
+# Single source of truth = this repo. The HF Space repos are treated as mirrors;
 # any direct commit there will be overwritten on the next sync.
+# main -> prod Space, dev -> dev Space (resolved per-branch below). The HF_TOKEN
+# secret must have write access to BOTH Spaces (a single qdonnars user token does).
 jobs:
   sync:
     runs-on: ubuntu-latest
     env:
-      # Override via repo Variables → Actions if you renamed the Space.
-      HF_SPACE_ID: ${{ vars.HF_SPACE_ID || 'qdonnars/openwind-mcp' }}
+      # Override via repo Variables → Actions if you renamed a Space.
+      HF_SPACE_ID_PROD: ${{ vars.HF_SPACE_ID || 'qdonnars/openwind-mcp' }}
+      HF_SPACE_ID_DEV: ${{ vars.HF_SPACE_ID_DEV || 'qdonnars/openwind-mcp-dev' }}
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4
+
+      - name: Resolve target Space
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TARGET="${HF_SPACE_ID_PROD}"
+          else
+            TARGET="${HF_SPACE_ID_DEV}"
+          fi
+          echo "HF_SPACE_ID=${TARGET}" >> "$GITHUB_ENV"
+          echo "Branch ${GITHUB_REF_NAME} -> Space ${TARGET}"
 
       - name: Assemble Space build context
         run: |

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,10 @@
+# URL du backend MCP / HF Space.
+# Laisser vide pour taper la prod par defaut (fallback code = Space prod).
+#
+# Cloudflare Pages pose cette variable par environnement au build :
+#   Production -> https://qdonnars-openwind-mcp.hf.space
+#   Preview    -> https://qdonnars-openwind-mcp-dev.hf.space
+#
+# Dev local contre le Space dev :
+#   VITE_API_BASE=https://qdonnars-openwind-mcp-dev.hf.space
+VITE_API_BASE=

--- a/packages/web/src/api/config.ts
+++ b/packages/web/src/api/config.ts
@@ -1,0 +1,7 @@
+// Base du backend MCP / HF Space. Surchargée par environnement via VITE_API_BASE
+// (Cloudflare Pages : Production -> Space prod, Preview -> Space dev). Sans
+// override, on retombe sur la prod. Vite expose toute var d'env préfixée
+// VITE_ présente au build, donc les env vars Cloudflare sont bien injectées.
+export const API_BASE =
+  (import.meta.env.VITE_API_BASE as string | undefined) ??
+  "https://qdonnars-openwind-mcp.hf.space";

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -5,6 +5,7 @@ import {
   CURRENT_RELEVANCE_THRESHOLD_KN,
   TIDE_RANGE_RELEVANCE_THRESHOLD_M,
 } from "../types";
+import { API_BASE } from "./config";
 
 const MARINE_URL = "https://marine-api.open-meteo.com/v1/marine";
 
@@ -23,8 +24,7 @@ const KMH_TO_KN = 1 / 1.852;
 // of the 7 published atlases (ATLNE, MANGA, FINIS, MANW, MANE, SUDBZH, AQUI).
 // Outside coverage the response carries ``covered: false`` and we keep the
 // Open-Meteo SMOC values.
-const MARC_URL =
-  "https://qdonnars-openwind-mcp.hf.space/api/v1/marine/marc";
+const MARC_URL = `${API_BASE}/api/v1/marine/marc`;
 
 const cache = new Map<string, { data: MarineHourly; fetchedAt: number }>();
 const CACHE_TTL = 30 * 60 * 1000;

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -1,6 +1,7 @@
 import type { PassageResponse, PassageByEtaResponse, MultiWindowResponse, Archetype } from "../plan/types";
 import type { ModelName } from "../config/modelConfig";
 import type { PolarData } from "../config/polarConfig";
+import { API_BASE } from "./config";
 
 // Plan-time overrides driven by the user's /config preferences. Both are
 // optional — when omitted, the server falls back to its bundled archetype
@@ -10,8 +11,6 @@ export interface PlanOverrides {
   models?: ModelName[];
   polar?: PolarData;
 }
-
-const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "https://qdonnars-openwind-mcp.hf.space";
 
 // Translate known backend error messages to actionable French. Returns the
 // original string if no rule matches, so unknown errors stay debuggable.


### PR DESCRIPTION
## Contexte

Met en place un **environnement de dev isolé** : pousser sur `dev` publie un déploiement *preview* Cloudflare qui tape un **HF Space dev** dédié (`qdonnars/openwind-mcp-dev`), sans jamais toucher la prod.

## Changements

**Web (variabilisation par environnement)**
- `src/api/config.ts` (nouveau) : source unique pour la base backend (`VITE_API_BASE`, fallback prod).
- `passage.ts` / `marine.ts` : dérivent de `config.ts` ; suppression de l'URL MARC en dur dans `marine.ts`.
- `.env.example` : doc `VITE_API_BASE` pour le dev local.

**CI**
- `sync-hf-space.yml` : déclenché sur `main` **et** `dev` ; résout le Space cible par branche (`main → openwind-mcp`, `dev → openwind-mcp-dev`), overridable via vars repo `HF_SPACE_ID` / `HF_SPACE_ID_DEV`. Un push `dev` ne touche jamais la prod.

## Setup dashboard hors-repo (non inclus dans cette PR)
- HF : dupliquer le Space prod → `openwind-mcp-dev` ; poser `OPENWIND_ALLOWED_HOSTS=qdonnars-openwind-mcp-dev.hf.space` + `HF_TOKEN` (atlas partagé lecture seule) ; feedback désactivé.
- Cloudflare Pages : `VITE_API_BASE` par environnement (Production → Space prod, Preview → Space dev).

## Vérification
- `npm run test` : 42/42 ✓
- `npm run build` (tsc + vite) : ✓
- Les 3 fichiers touchés passent le lint (les 26 erreurs `react-hooks` de `npm run lint` pré-existent sur `main`, fichiers non touchés ici).

🤖 Generated with [Claude Code](https://claude.com/claude-code)