### PR TITLE
feat(meteo): client-side corridor forecast cache for passage planning

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
+++ b/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
@@ -1,0 +1,307 @@
+"""Adapter backed by a client-supplied forecast cache.
+
+Instead of calling Open-Meteo, this adapter reads wind (multi-model) and sea
+state from an in-memory cache the web client posted alongside a passage
+request. The client samples the route corridor in the browser (one Open-Meteo
+call per user IP rather than per HF Space IP), so this distributes the
+upstream load that the single-IP server path would otherwise concentrate.
+
+The server keeps full authority over segmentation and timing: it calls
+``fetch(lat, lon, start, end, models=[slug])`` per segment exactly as it does
+with :class:`~openwind_data.adapters.openmeteo.OpenMeteoAdapter`. Spatial
+lookup is nearest-neighbour over the corridor points; temporal lookup clips a
+shared hourly axis to ``[start, end]``.
+
+All values arrive already in domain units (knots, meteorological "from" wind
+direction, oceanographic "to" current direction) — the client does every
+conversion — so this adapter is a pure passthrough and performs no arithmetic
+on the values. It satisfies the :class:`MarineDataAdapter` Protocol
+structurally (no inheritance) and is used only on the HTTP
+``/api/v1/passage`` path when the body carries ``forecast_cache``; the MCP
+path keeps the live :class:`OpenMeteoAdapter`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from openwind_data.adapters.base import (
+    ForecastBundle,
+    SeaPoint,
+    SeaSeries,
+    WindPoint,
+    WindSeries,
+)
+from openwind_data.routing.geometry import Point, haversine_distance
+
+# Bump when the payload shape changes incompatibly; ``from_payload`` rejects
+# anything it does not recognise so an old web bundle never silently
+# mis-parses against a newer server.
+SUPPORTED_VERSION = 1
+
+# Sea field names carried per corridor point, index-aligned to the shared time
+# axis. Mirrors ``SeaPoint`` minus ``time``/``current_source`` (handled
+# separately) and the openmeteo ``_parse_sea`` output.
+_SEA_FIELDS = (
+    "wave_height_m",
+    "wave_period_s",
+    "wave_direction_deg",
+    "wind_wave_height_m",
+    "swell_wave_height_m",
+    "current_speed_kn",
+    "current_direction_to_deg",
+    "tide_height_m",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _CachePoint:
+    lat: float
+    lon: float
+    # slug -> (speed_kn[], direction_deg[], gust_kn[]), each aligned to the
+    # shared time axis. A slug absent here means "this model has no data at
+    # this point" — fetch() returns an empty WindSeries so the server's
+    # per-segment fallback chain advances, exactly like OpenMeteo off-coverage.
+    wind_by_model: dict[str, tuple[list[float | None], ...]]
+    # field name -> values[], aligned to the shared time axis.
+    sea: dict[str, list[float | None]]
+    # Provenance applied to every covered hour of this point (overlay coverage
+    # is per-location, not per-hour): "openmeteo_smoc" | "marc_<atlas>_<res>m"
+    # | "shom_c2d_*" | None.
+    current_source: str | None
+
+
+def _require(cond: bool, msg: str) -> None:
+    if not cond:
+        raise ValueError(msg)
+
+
+def _as_float_list(raw: Any, n: int, field: str) -> list[float | None]:
+    _require(isinstance(raw, list), f"{field} must be a list")
+    _require(len(raw) == n, f"{field} length {len(raw)} != time axis length {n}")
+    out: list[float | None] = []
+    for v in raw:
+        if v is None:
+            out.append(None)
+        else:
+            try:
+                out.append(float(v))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{field} has non-numeric value {v!r}") from exc
+    return out
+
+
+class CacheBackedAdapter:
+    """Reads wind + sea from a client-supplied corridor cache. See module docstring."""
+
+    def __init__(
+        self,
+        models: tuple[str, ...],
+        times: tuple[datetime, ...],
+        points: tuple[_CachePoint, ...],
+    ) -> None:
+        self._models = models
+        self._times = times
+        self._points = points
+
+    @property
+    def models(self) -> tuple[str, ...]:
+        """Backend model slugs present in the cache, in priority order.
+
+        The HTTP endpoint uses this as the ``model_chain`` so the server's AUTO
+        fallback only walks models the client actually sampled.
+        """
+        return self._models
+
+    # ------------------------------------------------------------------ build
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> CacheBackedAdapter:
+        """Build an adapter from the parsed ``forecast_cache`` JSON object.
+
+        Raises ``ValueError`` on any shape mismatch so the HTTP layer can
+        return 422 (mirrors ``_parse_polar`` in app.py) rather than 500.
+        """
+        _require(isinstance(payload, dict), "forecast_cache must be an object")
+        version = payload.get("version")
+        _require(version == SUPPORTED_VERSION, f"unsupported version {version!r}")
+
+        models_raw = payload.get("models")
+        _require(
+            isinstance(models_raw, list) and len(models_raw) > 0,
+            "models must be a non-empty list",
+        )
+        _require(all(isinstance(m, str) for m in models_raw), "models must be strings")
+        models = tuple(models_raw)
+
+        times_raw = payload.get("times_ms")
+        _require(
+            isinstance(times_raw, list) and len(times_raw) > 0,
+            "times_ms must be a non-empty list",
+        )
+        times: list[datetime] = []
+        for ms in times_raw:
+            _require(isinstance(ms, (int, float)), "times_ms entries must be numbers")
+            times.append(datetime.fromtimestamp(ms / 1000.0, tz=UTC))
+        n = len(times)
+
+        points_raw = payload.get("points")
+        _require(isinstance(points_raw, list), "points must be a list")
+        points: list[_CachePoint] = []
+        for i, pt in enumerate(points_raw):
+            _require(isinstance(pt, dict), f"points[{i}] must be an object")
+            try:
+                lat = float(pt["lat"])
+                lon = float(pt["lon"])
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(f"points[{i}] missing valid lat/lon") from exc
+
+            wbm_raw = pt.get("wind_by_model") or {}
+            _require(isinstance(wbm_raw, dict), f"points[{i}].wind_by_model must be an object")
+            wind_by_model: dict[str, tuple[list[float | None], ...]] = {}
+            for slug, series in wbm_raw.items():
+                _require(
+                    isinstance(series, dict),
+                    f"points[{i}].wind_by_model[{slug}] must be an object",
+                )
+                speed = _as_float_list(series.get("speed_kn"), n, f"points[{i}].{slug}.speed_kn")
+                direction = _as_float_list(
+                    series.get("direction_deg"), n, f"points[{i}].{slug}.direction_deg"
+                )
+                gust = _as_float_list(series.get("gust_kn"), n, f"points[{i}].{slug}.gust_kn")
+                wind_by_model[slug] = (speed, direction, gust)
+
+            sea_raw = pt.get("sea") or {}
+            _require(isinstance(sea_raw, dict), f"points[{i}].sea must be an object")
+            sea: dict[str, list[float | None]] = {}
+            for field in _SEA_FIELDS:
+                raw = sea_raw.get(field)
+                # Optional fields default to all-null (e.g. a coastal spot with
+                # no wave coverage), matching the openmeteo padding behaviour.
+                if raw is None:
+                    sea[field] = [None] * n
+                else:
+                    sea[field] = _as_float_list(raw, n, f"points[{i}].sea.{field}")
+            current_source = sea_raw.get("current_source")
+            _require(
+                current_source is None or isinstance(current_source, str),
+                f"points[{i}].sea.current_source must be a string or null",
+            )
+
+            points.append(
+                _CachePoint(
+                    lat=lat,
+                    lon=lon,
+                    wind_by_model=wind_by_model,
+                    sea=sea,
+                    current_source=current_source,
+                )
+            )
+
+        return cls(models=models, times=tuple(times), points=tuple(points))
+
+    # ------------------------------------------------------------------ fetch
+
+    async def fetch(
+        self,
+        lat: float,
+        lon: float,
+        start: datetime,
+        end: datetime,
+        models: list[str] | None = None,
+    ) -> ForecastBundle:
+        if start.tzinfo is None or end.tzinfo is None:
+            raise ValueError("start and end must be timezone-aware datetimes")
+        start_utc = start.astimezone(UTC)
+        end_utc = end.astimezone(UTC)
+        if end_utc <= start_utc:
+            raise ValueError("end must be strictly after start")
+
+        requested = list(models) if models else list(self._models)
+
+        point = self._nearest(lat, lon)
+        if point is None:
+            # Empty cache: behave like a total off-coverage miss so the caller
+            # surfaces a clean "no model covered" rather than a crash.
+            return ForecastBundle(
+                lat=lat,
+                lon=lon,
+                start=start_utc,
+                end=end_utc,
+                wind_by_model={m: WindSeries(model=m, points=()) for m in requested},
+                sea=SeaSeries(points=()),
+                requested_at=datetime.now(UTC),
+            )
+
+        # Indices of the shared time axis that fall inside the requested window.
+        idx = [i for i, t in enumerate(self._times) if start_utc <= t <= end_utc]
+
+        wind_by_model = {slug: self._wind_series(point, slug, idx) for slug in requested}
+        sea = self._sea_series(point, idx)
+        return ForecastBundle(
+            lat=lat,
+            lon=lon,
+            start=start_utc,
+            end=end_utc,
+            wind_by_model=wind_by_model,
+            sea=sea,
+            requested_at=datetime.now(UTC),
+        )
+
+    # ---------------------------------------------------------------- helpers
+
+    def _nearest(self, lat: float, lon: float) -> _CachePoint | None:
+        if not self._points:
+            return None
+        target = Point(lat=lat, lon=lon)
+        return min(
+            self._points,
+            key=lambda p: haversine_distance(target, Point(lat=p.lat, lon=p.lon)),
+        )
+
+    def _wind_series(self, point: _CachePoint, slug: str, idx: list[int]) -> WindSeries:
+        series = point.wind_by_model.get(slug)
+        if series is None:
+            # Slug absent at this point -> empty series triggers the server's
+            # per-segment model fallback (identical to OpenMeteo off-coverage).
+            return WindSeries(model=slug, points=())
+        speed, direction, gust = series
+        points: list[WindPoint] = []
+        for i in idx:
+            s = speed[i]
+            d = direction[i]
+            # Drop null wind exactly like openmeteo._parse_wind so that
+            # _segment_has_wind sees the same "usable point" semantics.
+            if s is None or d is None:
+                continue
+            points.append(
+                WindPoint(time=self._times[i], speed_kn=s, direction_deg=d, gust_kn=gust[i])
+            )
+        return WindSeries(model=slug, points=tuple(points))
+
+    def _sea_series(self, point: _CachePoint, idx: list[int]) -> SeaSeries:
+        sea = point.sea
+        points: list[SeaPoint] = []
+        for i in idx:
+            cur = sea["current_speed_kn"][i]
+            tide = sea["tide_height_m"][i]
+            # Mirror openmeteo._parse_sea: only tag provenance on hours that
+            # actually carry current/tide data.
+            source = point.current_source if (cur is not None or tide is not None) else None
+            points.append(
+                SeaPoint(
+                    time=self._times[i],
+                    wave_height_m=sea["wave_height_m"][i],
+                    wave_period_s=sea["wave_period_s"][i],
+                    wave_direction_deg=sea["wave_direction_deg"][i],
+                    wind_wave_height_m=sea["wind_wave_height_m"][i],
+                    swell_wave_height_m=sea["swell_wave_height_m"][i],
+                    current_speed_kn=cur,
+                    current_direction_to_deg=sea["current_direction_to_deg"][i],
+                    tide_height_m=tide,
+                    current_source=source,
+                )
+            )
+        return SeaSeries(points=tuple(points))

--- a/packages/data-adapters/tests/test_cache_backed.py
+++ b/packages/data-adapters/tests/test_cache_backed.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from openwind_data.adapters.cache_backed import SUPPORTED_VERSION, CacheBackedAdapter
+from openwind_data.adapters.openmeteo import AUTO_MODEL
+from openwind_data.routing.geometry import Point
+from openwind_data.routing.passage import estimate_passage
+
+# A fixed hourly axis: 2026-05-01 00:00..05:00 UTC (6 points).
+_T0 = datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+_TIMES_MS = [int((_T0 + timedelta(hours=h)).timestamp() * 1000) for h in range(6)]
+
+
+def _wind(speed, direction, gust=None):
+    n = len(_TIMES_MS)
+    return {
+        "speed_kn": list(speed),
+        "direction_deg": list(direction),
+        "gust_kn": list(gust) if gust is not None else [None] * n,
+    }
+
+
+def _sea(**overrides):
+    n = len(_TIMES_MS)
+    base = {
+        "wave_height_m": [0.5] * n,
+        "wave_period_s": [4.0] * n,
+        "wave_direction_deg": [200.0] * n,
+        "current_speed_kn": [0.2] * n,
+        "current_direction_to_deg": [90.0] * n,
+        "tide_height_m": [1.0] * n,
+        "current_source": "openmeteo_smoc",
+    }
+    base.update(overrides)
+    return base
+
+
+def _payload(points, models=("meteofrance_arome_france", "icon_eu")):
+    return {
+        "version": SUPPORTED_VERSION,
+        "models": list(models),
+        "times_ms": list(_TIMES_MS),
+        "points": points,
+    }
+
+
+def _point(lat, lon, wind_by_model, sea=None):
+    return {
+        "lat": lat,
+        "lon": lon,
+        "wind_by_model": wind_by_model,
+        "sea": sea if sea is not None else _sea(),
+    }
+
+
+# --------------------------------------------------------------- from_payload
+
+
+def test_from_payload_valid() -> None:
+    n = len(_TIMES_MS)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})])
+    )
+    assert isinstance(adapter, CacheBackedAdapter)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda p: p.update(version=999),
+        lambda p: p.update(models=[]),
+        lambda p: p.update(times_ms=[]),
+        lambda p: p.update(points="nope"),
+        lambda p: p["points"][0].update(lat="abc"),
+        # wind array length mismatch with the time axis
+        lambda p: p["points"][0]["wind_by_model"]["meteofrance_arome_france"].update(
+            speed_kn=[1.0, 2.0]
+        ),
+        lambda p: p["points"][0]["sea"].update(current_source=123),
+    ],
+)
+def test_from_payload_rejects_bad_shape(mutate) -> None:
+    n = len(_TIMES_MS)
+    payload = _payload(
+        [_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})]
+    )
+    mutate(payload)
+    with pytest.raises(ValueError):
+        CacheBackedAdapter.from_payload(payload)
+
+
+def test_non_dict_payload_rejected() -> None:
+    with pytest.raises(ValueError):
+        CacheBackedAdapter.from_payload([1, 2, 3])
+
+
+# ---------------------------------------------------------------------- fetch
+
+
+@pytest.mark.asyncio
+async def test_fetch_nearest_neighbour_picks_closest_point() -> None:
+    n = len(_TIMES_MS)
+    payload = _payload(
+        [
+            _point(43.0, 5.0, {"meteofrance_arome_france": _wind([5.0] * n, [10.0] * n)}),
+            _point(43.5, 5.5, {"meteofrance_arome_france": _wind([20.0] * n, [200.0] * n)}),
+        ]
+    )
+    adapter = CacheBackedAdapter.from_payload(payload)
+    bundle = await adapter.fetch(
+        43.49, 5.49, _T0, _T0 + timedelta(hours=5), models=["meteofrance_arome_france"]
+    )
+    pts = bundle.wind_by_model["meteofrance_arome_france"].points
+    assert pts and all(p.speed_kn == 20.0 for p in pts)
+
+
+@pytest.mark.asyncio
+async def test_fetch_clips_to_window() -> None:
+    n = len(_TIMES_MS)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})])
+    )
+    bundle = await adapter.fetch(
+        43.3,
+        5.35,
+        _T0 + timedelta(hours=1),
+        _T0 + timedelta(hours=3),
+        models=["meteofrance_arome_france"],
+    )
+    pts = bundle.wind_by_model["meteofrance_arome_france"].points
+    assert [p.time for p in pts] == [
+        _T0 + timedelta(hours=1),
+        _T0 + timedelta(hours=2),
+        _T0 + timedelta(hours=3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_drops_null_wind_hours() -> None:
+    speed = [10.0, None, 10.0, 10.0, None, 10.0]
+    direction = [180.0, 180.0, None, 180.0, 180.0, 180.0]
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind(speed, direction)})])
+    )
+    bundle = await adapter.fetch(
+        43.3, 5.35, _T0, _T0 + timedelta(hours=5), models=["meteofrance_arome_france"]
+    )
+    pts = bundle.wind_by_model["meteofrance_arome_france"].points
+    # Indices 1 (null speed), 2 (null dir), 4 (null speed) dropped -> 3 left.
+    assert [p.time.hour for p in pts] == [0, 3, 5]
+
+
+@pytest.mark.asyncio
+async def test_fetch_absent_slug_returns_empty_series() -> None:
+    n = len(_TIMES_MS)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})])
+    )
+    # ICON not present at this point -> empty series (drives server fallback).
+    bundle = await adapter.fetch(43.3, 5.35, _T0, _T0 + timedelta(hours=5), models=["icon_eu"])
+    assert bundle.wind_by_model["icon_eu"].points == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_window_outside_axis_returns_empty() -> None:
+    n = len(_TIMES_MS)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})])
+    )
+    far = _T0 + timedelta(days=30)
+    bundle = await adapter.fetch(
+        43.3, 5.35, far, far + timedelta(hours=2), models=["meteofrance_arome_france"]
+    )
+    assert bundle.wind_by_model["meteofrance_arome_france"].points == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_current_source_propagates() -> None:
+    n = len(_TIMES_MS)
+    sea = _sea(current_source="marc_finis_250m")
+    adapter = CacheBackedAdapter.from_payload(
+        _payload(
+            [
+                _point(
+                    43.3,
+                    5.35,
+                    {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)},
+                    sea=sea,
+                )
+            ]
+        )
+    )
+    bundle = await adapter.fetch(
+        43.3, 5.35, _T0, _T0 + timedelta(hours=5), models=["meteofrance_arome_france"]
+    )
+    assert all(p.current_source == "marc_finis_250m" for p in bundle.sea.points)
+
+
+@pytest.mark.asyncio
+async def test_fetch_current_source_none_when_no_current_or_tide() -> None:
+    n = len(_TIMES_MS)
+    sea = _sea(current_speed_kn=[None] * n, tide_height_m=[None] * n)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload(
+            [
+                _point(
+                    43.3,
+                    5.35,
+                    {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)},
+                    sea=sea,
+                )
+            ]
+        )
+    )
+    bundle = await adapter.fetch(
+        43.3, 5.35, _T0, _T0 + timedelta(hours=5), models=["meteofrance_arome_france"]
+    )
+    assert all(p.current_source is None for p in bundle.sea.points)
+
+
+@pytest.mark.asyncio
+async def test_fetch_requires_tz_aware() -> None:
+    n = len(_TIMES_MS)
+    adapter = CacheBackedAdapter.from_payload(
+        _payload([_point(43.3, 5.35, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})])
+    )
+    with pytest.raises(ValueError):
+        await adapter.fetch(43.3, 5.35, datetime(2026, 5, 1, 0, 0), _T0 + timedelta(hours=2))
+
+
+# ----------------------------------------------- integration with estimate_passage
+
+_DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+_MARSEILLE = Point(43.30, 5.35)
+_PORQUEROLLES = Point(43.00, 6.20)
+
+
+def _corridor_cache(*, with_arome: bool = True) -> CacheBackedAdapter:
+    """Two-endpoint corridor cache, constant 10 kn northerly, axis 04:00..18:00.
+
+    Constant wind everywhere means nearest-neighbour is immaterial: every
+    segment midpoint snaps to one endpoint and reads the same series. The axis
+    spans the whole passage plus the per-segment +/-90 min fetch windows.
+    """
+    t0 = datetime(2026, 5, 1, 4, 0, tzinfo=UTC)
+    times_ms = [int((t0 + timedelta(hours=h)).timestamp() * 1000) for h in range(15)]
+    n = len(times_ms)
+
+    def wind_block() -> dict:
+        block = {"icon_eu": _const_wind(n)}
+        if with_arome:
+            block["meteofrance_arome_france"] = _const_wind(n)
+        return block
+
+    def sea_block() -> dict:
+        return {
+            "wave_height_m": [0.4] * n,
+            "wave_period_s": [4.0] * n,
+            "wave_direction_deg": [0.0] * n,
+            "current_speed_kn": [0.1] * n,
+            "current_direction_to_deg": [90.0] * n,
+            "tide_height_m": [0.0] * n,
+            "current_source": "openmeteo_smoc",
+        }
+
+    points = [
+        {"lat": p.lat, "lon": p.lon, "wind_by_model": wind_block(), "sea": sea_block()}
+        for p in (_MARSEILLE, _PORQUEROLLES)
+    ]
+    return CacheBackedAdapter.from_payload(
+        {
+            "version": SUPPORTED_VERSION,
+            "models": ["meteofrance_arome_france", "icon_eu"],
+            "times_ms": times_ms,
+            "points": points,
+        }
+    )
+
+
+def _const_wind(n: int) -> dict:
+    return {"speed_kn": [10.0] * n, "direction_deg": [0.0] * n, "gust_kn": [None] * n}
+
+
+@pytest.mark.asyncio
+async def test_estimate_passage_reads_cache() -> None:
+    report = await estimate_passage(
+        [_MARSEILLE, _PORQUEROLLES],
+        _DEPARTURE,
+        "cruiser_40ft",
+        adapter=_corridor_cache(),
+        segment_length_nm=5.0,
+        model=AUTO_MODEL,
+        model_chain=("meteofrance_arome_france", "icon_eu"),
+    )
+    assert 40.0 < report.distance_nm < 43.0
+    assert 6.0 < report.duration_h < 11.0
+    assert all(seg.tws_kn == 10.0 for seg in report.segments)
+    assert all(seg.model_used == "meteofrance_arome_france" for seg in report.segments)
+
+
+@pytest.mark.asyncio
+async def test_estimate_passage_falls_back_when_primary_absent() -> None:
+    # AROME absent from every corridor point -> per-segment fallback to icon_eu.
+    report = await estimate_passage(
+        [_MARSEILLE, _PORQUEROLLES],
+        _DEPARTURE,
+        "cruiser_40ft",
+        adapter=_corridor_cache(with_arome=False),
+        segment_length_nm=5.0,
+        model=AUTO_MODEL,
+        model_chain=("meteofrance_arome_france", "icon_eu"),
+    )
+    assert all(seg.model_used == "icon_eu" for seg in report.segments)

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -30,6 +30,7 @@ import httpx
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
 from openwind_data.adapters.base import ForecastHorizonError
+from openwind_data.adapters.cache_backed import CacheBackedAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 from openwind_data.routing.archetypes import BoatPolar, list_archetypes_metadata
@@ -331,6 +332,23 @@ def _translate_models(raw: Any) -> tuple[str, ...] | None:
     return tuple(translated)
 
 
+def _build_cache_adapter(raw: Any) -> CacheBackedAdapter | None:
+    """Build a CacheBackedAdapter from the request's ``forecast_cache``, or None.
+
+    When the web client has sampled the route corridor in the browser it posts
+    a ``forecast_cache`` object; we read weather from it instead of calling
+    Open-Meteo (distributes the upstream load off the single Space IP). When
+    absent (every MCP client, and web clients that fell back), returns None so
+    the planner uses the default live OpenMeteoAdapter — the MCP path in
+    ``mcp-core`` never reaches this and is unaffected.
+
+    Raises ``ValueError`` on a malformed payload so the caller returns 422.
+    """
+    if raw is None:
+        return None
+    return CacheBackedAdapter.from_payload(raw)
+
+
 def _parse_polar(raw: Any) -> BoatPolar | None:
     """Build a BoatPolar from the web client's `polar` payload. Returns None
     when no payload is provided. Raises ValueError on shape mismatch / invalid
@@ -474,6 +492,15 @@ async def _api_passage(request: Request) -> JSONResponse:
         return JSONResponse({"error": f"invalid polar: {exc}"}, status_code=422)
     model_chain = _translate_models(body.get("models"))
 
+    try:
+        cache_adapter = _build_cache_adapter(body.get("forecast_cache"))
+    except ValueError as exc:
+        return JSONResponse({"error": f"invalid forecast_cache: {exc}"}, status_code=422)
+    if cache_adapter is not None:
+        # The cache's models are already backend slugs in priority order; use
+        # them as the chain so AUTO only walks models actually sampled client-side.
+        model_chain = cache_adapter.models
+
     # Sweep mode — triggered when ``latest_departure`` is provided.
     latest_raw = body.get("latest_departure")
     if latest_raw is not None:
@@ -499,6 +526,7 @@ async def _api_passage(request: Request) -> JSONResponse:
                 waypoints, departure, latest_departure, body["archetype"],
                 sweep_interval_hours=sweep_interval, efficiency=efficiency, model="auto",
                 polar_override=polar_override, model_chain=model_chain,
+                adapter=cache_adapter,
             )
         except KeyError as exc:
             return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
@@ -586,6 +614,7 @@ async def _api_passage(request: Request) -> JSONResponse:
         passage = await estimate_passage(
             waypoints, departure, body["archetype"], efficiency=efficiency, model="auto",
             polar_override=polar_override, model_chain=model_chain,
+            adapter=cache_adapter,
         )
     except KeyError as exc:
         return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)
@@ -654,6 +683,13 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     model_chain = _translate_models(body.get("models"))
 
     try:
+        cache_adapter = _build_cache_adapter(body.get("forecast_cache"))
+    except ValueError as exc:
+        return JSONResponse({"error": f"invalid forecast_cache: {exc}"}, status_code=422)
+    if cache_adapter is not None:
+        model_chain = cache_adapter.models
+
+    try:
         plan = await estimate_passage_for_arrival(
             waypoints,
             target_arrival,
@@ -662,6 +698,7 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
             model="auto",
             polar_override=polar_override,
             model_chain=model_chain,
+            adapter=cache_adapter,
         )
     except KeyError as exc:
         return JSONResponse({"error": f"unknown archetype: {exc}"}, status_code=422)

--- a/packages/hf-space/tests/test_api_passage_cache.py
+++ b/packages/hf-space/tests/test_api_passage_cache.py
@@ -1,0 +1,180 @@
+"""Endpoint tests for the client-supplied forecast_cache wiring in app.py.
+
+hf-space has no pyproject (it ships via Docker), so we load app.py by path and
+drive the handlers with a minimal fake Request. Run from the mcp-core worktree
+venv, which resolves the worktree's editable openwind_data (with cache_backed):
+
+    cd packages/mcp-core && uv run --no-active python -m pytest \
+        ../hf-space/tests/test_api_passage_cache.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+_APP_PATH = (pathlib.Path(__file__).parents[1] / "app.py").resolve()
+_spec = importlib.util.spec_from_file_location("hf_app", _APP_PATH)
+app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(app)
+
+from openwind_data.adapters.cache_backed import CacheBackedAdapter  # noqa: E402
+
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+MARSEILLE = (43.30, 5.35)
+PORQUEROLLES = (43.00, 6.20)
+
+
+class _FakeRequest:
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _resp_json(resp) -> dict:
+    return json.loads(bytes(resp.body))
+
+
+def _corridor_cache(*, with_arome: bool = True) -> dict:
+    """Constant 10 kn northerly along Marseille->Porquerolles, axis 04:00..18:00."""
+    t0 = datetime(2026, 5, 1, 4, 0, tzinfo=UTC)
+    times_ms = [int((t0 + timedelta(hours=h)).timestamp() * 1000) for h in range(15)]
+    n = len(times_ms)
+
+    def wind() -> dict:
+        block = {"icon_eu": {"speed_kn": [10.0] * n, "direction_deg": [0.0] * n, "gust_kn": [None] * n}}
+        if with_arome:
+            block["meteofrance_arome_france"] = {
+                "speed_kn": [10.0] * n,
+                "direction_deg": [0.0] * n,
+                "gust_kn": [None] * n,
+            }
+        return block
+
+    def sea() -> dict:
+        return {
+            "wave_height_m": [0.4] * n,
+            "wave_period_s": [4.0] * n,
+            "wave_direction_deg": [0.0] * n,
+            "current_speed_kn": [0.1] * n,
+            "current_direction_to_deg": [90.0] * n,
+            "tide_height_m": [0.0] * n,
+            "current_source": "openmeteo_smoc",
+        }
+
+    return {
+        "version": 1,
+        "models": ["meteofrance_arome_france", "icon_eu"],
+        "times_ms": times_ms,
+        "points": [
+            {"lat": lat, "lon": lon, "wind_by_model": wind(), "sea": sea()}
+            for (lat, lon) in (MARSEILLE, PORQUEROLLES)
+        ],
+    }
+
+
+def _single_body(**extra) -> dict:
+    body = {
+        "waypoints": [list(MARSEILLE), list(PORQUEROLLES)],
+        "departure": DEPARTURE.isoformat(),
+        "archetype": "cruiser_40ft",
+    }
+    body.update(extra)
+    return body
+
+
+# --------------------------------------------------------------- full path
+
+
+@pytest.mark.asyncio
+async def test_single_with_cache_returns_200_from_cache(monkeypatch) -> None:
+    # Guard: if the handler ever instantiates the live adapter, fail loudly.
+    import httpx
+
+    def _boom(*a, **k):  # noqa: ANN002, ANN003
+        raise AssertionError("forecast_cache path must not hit Open-Meteo")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _boom)
+
+    resp = await app._api_passage(_FakeRequest(_single_body(forecast_cache=_corridor_cache())))
+    assert resp.status_code == 200
+    payload = _resp_json(resp)
+    segments = payload["passage"]["segments"]
+    assert segments and all(seg["tws_kn"] == 10.0 for seg in segments)
+
+
+@pytest.mark.asyncio
+async def test_malformed_cache_returns_422(monkeypatch) -> None:
+    resp = await app._api_passage(
+        _FakeRequest(_single_body(forecast_cache={"version": 999, "models": [], "times_ms": [], "points": []}))
+    )
+    assert resp.status_code == 422
+    assert "forecast_cache" in _resp_json(resp)["error"]
+
+
+# --------------------------------------------------------------- wiring capture
+
+
+@pytest.mark.asyncio
+async def test_single_passes_cache_adapter(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured["adapter"] = kwargs.get("adapter")
+        captured["model_chain"] = kwargs.get("model_chain")
+        raise app.NoModelCoveredError("stop here")  # short-circuit after capture
+
+    monkeypatch.setattr(app, "estimate_passage", _stub)
+
+    # With cache -> CacheBackedAdapter + chain from cache models.
+    await app._api_passage(_FakeRequest(_single_body(forecast_cache=_corridor_cache())))
+    assert isinstance(captured["adapter"], CacheBackedAdapter)
+    assert captured["model_chain"] == ("meteofrance_arome_france", "icon_eu")
+
+    # Without cache -> adapter None (MCP/live path unchanged).
+    captured.clear()
+    await app._api_passage(_FakeRequest(_single_body()))
+    assert captured["adapter"] is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_passes_cache_adapter(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured["adapter"] = kwargs.get("adapter")
+        return []
+
+    monkeypatch.setattr(app, "estimate_passage_windows", _stub)
+    body = _single_body(
+        forecast_cache=_corridor_cache(),
+        latest_departure=(DEPARTURE + timedelta(hours=6)).isoformat(),
+        sweep_interval_hours=3,
+    )
+    await app._api_passage(_FakeRequest(body))
+    assert isinstance(captured["adapter"], CacheBackedAdapter)
+
+
+@pytest.mark.asyncio
+async def test_by_eta_passes_cache_adapter(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured["adapter"] = kwargs.get("adapter")
+        raise app.NoModelCoveredError("stop here")
+
+    monkeypatch.setattr(app, "estimate_passage_for_arrival", _stub)
+    body = {
+        "waypoints": [list(MARSEILLE), list(PORQUEROLLES)],
+        "target_arrival": (DEPARTURE + timedelta(hours=8)).isoformat(),
+        "archetype": "cruiser_40ft",
+        "forecast_cache": _corridor_cache(),
+    }
+    await app._api_passage_by_eta(_FakeRequest(body))
+    assert isinstance(captured["adapter"], CacheBackedAdapter)

--- a/packages/web/src/api/forecastCache.test.ts
+++ b/packages/web/src/api/forecastCache.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  assembleForecastCache,
+  interpolateCorridor,
+  CACHE_MODEL_SLUGS,
+  type SampledPoint,
+} from "./forecastCache";
+import { parisIsoToUtcMs } from "./marine";
+import type { ModelForecast, MarineHourly } from "../types";
+
+const MARSEILLE: [number, number] = [43.3, 5.35];
+const PORQUEROLLES: [number, number] = [43.0, 6.2];
+
+const TIMES = ["2026-05-01T00:00", "2026-05-01T01:00", "2026-05-01T02:00"];
+
+function model(name: string, speeds: (number | null)[], gusts?: (number | null)[]): ModelForecast {
+  return {
+    modelName: name,
+    hourly: {
+      time: TIMES,
+      wind_speed_10m: speeds,
+      wind_direction_10m: speeds.map(() => 180),
+      wind_gusts_10m: gusts ?? speeds.map(() => null),
+      weather_code: speeds.map(() => 1),
+    },
+  };
+}
+
+function marine(source: string | null): MarineHourly {
+  return {
+    time: TIMES,
+    wave_height_m: [0.4, 0.5, 0.6],
+    wave_period_s: [4, 4, 4],
+    wave_direction_deg: [200, 200, 200],
+    current_speed_kn: [0.2, 0.25, 0.3],
+    current_direction_to_deg: [90, 90, 90],
+    tide_height_m: [1.0, 1.1, 1.2],
+    current_source: source ?? undefined,
+  };
+}
+
+describe("interpolateCorridor", () => {
+  it("matches segment_route spacing and hits the waypoints", () => {
+    const pts = interpolateCorridor([MARSEILLE, PORQUEROLLES], 10);
+    // ~41 nm / 10 -> n = ceil(4.1) = 5 -> 6 points.
+    expect(pts.length).toBe(6);
+    expect(pts[0].lat).toBeCloseTo(MARSEILLE[0], 4);
+    expect(pts[0].lon).toBeCloseTo(MARSEILLE[1], 4);
+    expect(pts[5].lat).toBeCloseTo(PORQUEROLLES[0], 4);
+    expect(pts[5].lon).toBeCloseTo(PORQUEROLLES[1], 4);
+  });
+
+  it("does not duplicate the shared waypoint between legs", () => {
+    const mid: [number, number] = [43.15, 5.78];
+    const oneLeg = interpolateCorridor([MARSEILLE, mid], 10).length;
+    const twoLegs = interpolateCorridor([MARSEILLE, mid, PORQUEROLLES], 10).length;
+    const secondLegOnly = interpolateCorridor([mid, PORQUEROLLES], 10).length;
+    // Second leg contributes its points minus the shared start.
+    expect(twoLegs).toBe(oneLeg + (secondLegOnly - 1));
+  });
+
+  it("throws on fewer than 2 waypoints", () => {
+    expect(() => interpolateCorridor([MARSEILLE], 10)).toThrow();
+  });
+});
+
+describe("assembleForecastCache", () => {
+  const samples = (): SampledPoint[] => [
+    {
+      lat: MARSEILLE[0],
+      lon: MARSEILLE[1],
+      models: [
+        model("AROME", [10.04, 11.06, 12.0], [14.05, null, 15.0]),
+        model("ICON", [9, 9, 9]),
+        model("ARPEGE_EU", [8, 8, 8]), // unmappable -> excluded
+      ],
+      marine: marine("marc_finis_250m"),
+    },
+    {
+      lat: PORQUEROLLES[0],
+      lon: PORQUEROLLES[1],
+      models: [model("AROME", [20, 20, 20])],
+      marine: marine("openmeteo_smoc"),
+    },
+  ];
+
+  it("builds an ascending UTC ms axis from Paris-naive timestamps", () => {
+    const cache = assembleForecastCache(samples());
+    expect(cache.times_ms).toEqual(TIMES.map(parisIsoToUtcMs));
+    expect([...cache.times_ms].sort((a, b) => a - b)).toEqual(cache.times_ms);
+  });
+
+  it("maps web model names to backend slugs and drops unmappable models", () => {
+    const cache = assembleForecastCache(samples());
+    const wbm = cache.points[0].wind_by_model;
+    expect(Object.keys(wbm).sort()).toEqual(["icon_eu", "meteofrance_arome_france"]);
+    expect(CACHE_MODEL_SLUGS.AROME).toBe("meteofrance_arome_france");
+    // chain: priority by first appearance + gfs_seamless last resort.
+    expect(cache.models).toEqual(["meteofrance_arome_france", "icon_eu", "gfs_seamless"]);
+  });
+
+  it("passes wind through in knots with rounding and preserves null gusts", () => {
+    const cache = assembleForecastCache(samples());
+    const arome = cache.points[0].wind_by_model["meteofrance_arome_france"];
+    expect(arome.speed_kn).toEqual([10.0, 11.1, 12.0]);
+    expect(arome.direction_deg).toEqual([180, 180, 180]);
+    expect(arome.gust_kn).toEqual([14.1, null, 15.0]);
+  });
+
+  it("carries current_source through per point", () => {
+    const cache = assembleForecastCache(samples());
+    expect(cache.points[0].sea.current_source).toBe("marc_finis_250m");
+    expect(cache.points[1].sea.current_source).toBe("openmeteo_smoc");
+    expect(cache.points[0].sea.current_speed_kn).toEqual([0.2, 0.25, 0.3]);
+  });
+
+  it("clamps the time axis to the window", () => {
+    const startMs = parisIsoToUtcMs(TIMES[1]);
+    const cache = assembleForecastCache(samples(), { startMs });
+    expect(cache.times_ms).toEqual([parisIsoToUtcMs(TIMES[1]), parisIsoToUtcMs(TIMES[2])]);
+    expect(cache.points[0].wind_by_model["meteofrance_arome_france"].speed_kn).toEqual([11.1, 12.0]);
+  });
+
+  it("throws when no sample carries a backend-mappable model", () => {
+    const onlyUnmappable: SampledPoint[] = [
+      { lat: MARSEILLE[0], lon: MARSEILLE[1], models: [model("ARPEGE_EU", [8, 8, 8])], marine: null },
+    ];
+    expect(() => assembleForecastCache(onlyUnmappable)).toThrow();
+  });
+});

--- a/packages/web/src/api/forecastCache.ts
+++ b/packages/web/src/api/forecastCache.ts
@@ -1,0 +1,296 @@
+// Builds the `forecast_cache` payload posted to the backend so passage planning
+// reads weather the BROWSER fetched (one Open-Meteo call per user IP) instead of
+// the HF Space's single IP. The server keeps full authority over segmentation;
+// it reads this cache through a nearest-neighbour adapter (see
+// packages/data-adapters/.../adapters/cache_backed.py). The cache is optional:
+// when absent or the build fails, the server falls back to its live fetch, and
+// MCP clients (no browser) always use the live path.
+
+import type { ModelForecast, MarineHourly } from "../types";
+import type { ModelName } from "../config/modelConfig";
+import { fetchAllModels } from "./openmeteo";
+import { fetchMarine, parisIsoToUtcMs } from "./marine";
+import { haversineNm, interpolateGreatCircle, type GeoPoint } from "../plan/geo";
+
+export const CACHE_VERSION = 1;
+
+// Web model name -> Open-Meteo backend slug. MUST mirror hf-space app.py
+// `_MODEL_NAME_MAP` (a server test and the web test both assert this set). Only
+// these four are validated end-to-end for passage timing; other active web
+// models are display-only and excluded from the cache (matching the server's
+// `_translate_models` silent-drop).
+export const CACHE_MODEL_SLUGS: Partial<Record<ModelName, string>> = {
+  AROME: "meteofrance_arome_france",
+  ICON: "icon_eu",
+  ECMWF: "ecmwf_ifs025",
+  GFS: "gfs_seamless",
+};
+const GFS_SLUG = "gfs_seamless";
+
+// Generous cap on corridor sample points. The browser has its own Open-Meteo
+// quota (~600/min per IP), so we sample far denser than the server's ~10-segment
+// budget; this only guards pathologically long routes from issuing hundreds of
+// requests. Beyond it, spacing stretches.
+const MAX_CORRIDOR_POINTS = 60;
+const DEFAULT_SPACING_NM = 5;
+
+export interface CacheWindSeries {
+  speed_kn: (number | null)[];
+  direction_deg: (number | null)[];
+  gust_kn: (number | null)[];
+}
+
+export interface CacheSea {
+  wave_height_m: (number | null)[];
+  wave_period_s: (number | null)[];
+  wave_direction_deg: (number | null)[];
+  current_speed_kn: (number | null)[];
+  current_direction_to_deg: (number | null)[];
+  tide_height_m: (number | null)[];
+  current_source: string | null;
+}
+
+export interface ForecastCachePoint {
+  lat: number;
+  lon: number;
+  wind_by_model: Record<string, CacheWindSeries>;
+  sea: CacheSea;
+}
+
+export interface ForecastCache {
+  version: number;
+  models: string[];
+  times_ms: number[];
+  points: ForecastCachePoint[];
+}
+
+// A corridor point with its already-fetched per-model wind + marine series.
+export interface SampledPoint {
+  lat: number;
+  lon: number;
+  models: ModelForecast[];
+  marine: MarineHourly | null;
+}
+
+// Optional UTC-ms clamp on the cache time axis (keeps the payload small: a
+// single-day plan needs ~1-2 days of hours, not the full 7-day fetch).
+export interface CacheWindow {
+  startMs?: number;
+  endMs?: number;
+}
+
+function roundOrNull(v: number | null | undefined, dp: number): number | null {
+  if (v == null) return null;
+  return Number(v.toFixed(dp));
+}
+
+// Interpolate sample points along the waypoint polyline at ~spacingNm, denser
+// than the server's segmentation so every server segment midpoint has a near
+// corridor sample. Mirrors segment_route: n = max(1, ceil(d/spacing)) per leg,
+// endpoints hit the waypoints, shared waypoints between legs are not duplicated.
+export function interpolateCorridor(
+  waypoints: [number, number][],
+  spacingNm: number = DEFAULT_SPACING_NM,
+): GeoPoint[] {
+  if (waypoints.length < 2) throw new Error("need at least 2 waypoints");
+  const out: GeoPoint[] = [];
+  for (let leg = 0; leg < waypoints.length - 1; leg++) {
+    const a: GeoPoint = { lat: waypoints[leg][0], lon: waypoints[leg][1] };
+    const b: GeoPoint = { lat: waypoints[leg + 1][0], lon: waypoints[leg + 1][1] };
+    const d = haversineNm(a, b);
+    const n = Math.max(1, Math.ceil(d / spacingNm));
+    for (let i = 0; i <= n; i++) {
+      // Skip every leg's start except the first — it duplicates the previous
+      // leg's end (the shared waypoint).
+      if (i === 0 && leg > 0) continue;
+      out.push(interpolateGreatCircle(a, b, i / n));
+    }
+  }
+  return out;
+}
+
+export function routeLengthNm(waypoints: [number, number][]): number {
+  let total = 0;
+  for (let i = 0; i < waypoints.length - 1; i++) {
+    total += haversineNm(
+      { lat: waypoints[i][0], lon: waypoints[i][1] },
+      { lat: waypoints[i + 1][0], lon: waypoints[i + 1][1] },
+    );
+  }
+  return total;
+}
+
+// Coverage contract (mirrors the server): each segment fetch asks for
+// [mid-90min, mid+90min]; the slowest plausible passage is bounded by a 2 kn
+// floor (PREWARM_MIN_SPEED_KN). The window must therefore span the departure
+// range plus that worst-case duration plus the +/-90 min fetch margin so every
+// segment midtime the server computes falls inside the cached axis.
+const MIN_SPEED_KN = 2.0;
+const MARGIN_MS = 90 * 60 * 1000;
+
+function worstCaseDurationMs(waypoints: [number, number][]): number {
+  return (routeLengthNm(waypoints) / MIN_SPEED_KN) * 3600_000;
+}
+
+export function singleWindowMs(waypoints: [number, number][], departureMs: number): CacheWindow {
+  return {
+    startMs: departureMs - MARGIN_MS,
+    endMs: departureMs + worstCaseDurationMs(waypoints) + MARGIN_MS,
+  };
+}
+
+export function sweepWindowMs(
+  waypoints: [number, number][],
+  earliestMs: number,
+  latestMs: number,
+): CacheWindow {
+  return {
+    startMs: earliestMs - MARGIN_MS,
+    endMs: latestMs + worstCaseDurationMs(waypoints) + MARGIN_MS,
+  };
+}
+
+export function etaWindowMs(waypoints: [number, number][], arrivalMs: number): CacheWindow {
+  return {
+    startMs: arrivalMs - worstCaseDurationMs(waypoints) - MARGIN_MS,
+    endMs: arrivalMs + MARGIN_MS,
+  };
+}
+
+// Assemble a ForecastCache from already-fetched corridor samples. Pure (no
+// network): converts every Open-Meteo Paris-naive timestamp to UTC epoch-ms via
+// parisIsoToUtcMs, builds one shared ascending time axis (optionally clamped to
+// `window`), and index-aligns each per-model wind + sea series onto it. Throws
+// when no sample carries a backend-mappable model, so the caller falls back to
+// the live server path rather than posting an empty chain.
+export function assembleForecastCache(
+  samples: SampledPoint[],
+  window: CacheWindow = {},
+): ForecastCache {
+  // 1. Shared time axis: union of every series' timestamps, clamped to window.
+  const msSet = new Set<number>();
+  const inWindow = (ms: number): boolean =>
+    (window.startMs == null || ms >= window.startMs) &&
+    (window.endMs == null || ms <= window.endMs);
+  for (const s of samples) {
+    for (const mf of s.models) {
+      for (const t of mf.hourly.time) {
+        const ms = parisIsoToUtcMs(t);
+        if (inWindow(ms)) msSet.add(ms);
+      }
+    }
+    if (s.marine) {
+      for (const t of s.marine.time) {
+        const ms = parisIsoToUtcMs(t);
+        if (inWindow(ms)) msSet.add(ms);
+      }
+    }
+  }
+  const timesMs = Array.from(msSet).sort((a, b) => a - b);
+  const n = timesMs.length;
+  const idxByMs = new Map<number, number>();
+  for (let i = 0; i < n; i++) idxByMs.set(timesMs[i], i);
+
+  // 2. Per-point series, tracking slug priority by first appearance.
+  const slugOrder: string[] = [];
+  const seenSlug = new Set<string>();
+  const points: ForecastCachePoint[] = samples.map((s) => {
+    const windByModel: Record<string, CacheWindSeries> = {};
+    for (const mf of s.models) {
+      const slug = CACHE_MODEL_SLUGS[mf.modelName as ModelName];
+      if (!slug || slug in windByModel) continue;
+      const speed: (number | null)[] = new Array(n).fill(null);
+      const direction: (number | null)[] = new Array(n).fill(null);
+      const gust: (number | null)[] = new Array(n).fill(null);
+      const h = mf.hourly;
+      for (let i = 0; i < h.time.length; i++) {
+        const j = idxByMs.get(parisIsoToUtcMs(h.time[i]));
+        if (j == null) continue;
+        speed[j] = roundOrNull(h.wind_speed_10m[i], 1);
+        direction[j] = roundOrNull(h.wind_direction_10m[i], 0);
+        gust[j] = roundOrNull(h.wind_gusts_10m[i], 1);
+      }
+      windByModel[slug] = { speed_kn: speed, direction_deg: direction, gust_kn: gust };
+      if (!seenSlug.has(slug)) {
+        seenSlug.add(slug);
+        slugOrder.push(slug);
+      }
+    }
+    return { lat: s.lat, lon: s.lon, wind_by_model: windByModel, sea: buildSea(s.marine, idxByMs, n) };
+  });
+
+  // 3. Model chain: priority by first appearance, gfs_seamless as last resort
+  //    (mirrors the server's _translate_models append).
+  const models = [...slugOrder];
+  if (!models.includes(GFS_SLUG)) models.push(GFS_SLUG);
+  if (slugOrder.length === 0) {
+    throw new Error("no backend-mappable model in forecast — fall back to live fetch");
+  }
+
+  return { version: CACHE_VERSION, models, times_ms: timesMs, points };
+}
+
+function buildSea(
+  marine: MarineHourly | null,
+  idxByMs: Map<number, number>,
+  n: number,
+): CacheSea {
+  const sea: CacheSea = {
+    wave_height_m: new Array(n).fill(null),
+    wave_period_s: new Array(n).fill(null),
+    wave_direction_deg: new Array(n).fill(null),
+    current_speed_kn: new Array(n).fill(null),
+    current_direction_to_deg: new Array(n).fill(null),
+    tide_height_m: new Array(n).fill(null),
+    current_source: marine?.current_source ?? null,
+  };
+  if (!marine) return sea;
+  for (let i = 0; i < marine.time.length; i++) {
+    const j = idxByMs.get(parisIsoToUtcMs(marine.time[i]));
+    if (j == null) continue;
+    sea.wave_height_m[j] = roundOrNull(marine.wave_height_m[i], 2);
+    sea.wave_period_s[j] = roundOrNull(marine.wave_period_s[i], 1);
+    sea.wave_direction_deg[j] = roundOrNull(marine.wave_direction_deg[i], 0);
+    sea.current_speed_kn[j] = roundOrNull(marine.current_speed_kn[i], 2);
+    sea.current_direction_to_deg[j] = roundOrNull(marine.current_direction_to_deg[i], 0);
+    sea.tide_height_m[j] = roundOrNull(marine.tide_height_m[i], 2);
+  }
+  return sea;
+}
+
+// Sample the route corridor in the browser and assemble the cache. Reuses
+// fetchAllModels (multi-model wind, kn, 30-min cache, fallback chain) and
+// fetchMarine (waves + SMOC currents + MARC overlay) — both already per-point
+// cached and deduped. Throws on no mappable model so the caller can fall back.
+export async function buildForecastCache(
+  waypoints: [number, number][],
+  opts: { spacingNm?: number; window?: CacheWindow } = {},
+): Promise<ForecastCache> {
+  const totalNm = routeLengthNm(waypoints);
+  const spacing = Math.max(opts.spacingNm ?? DEFAULT_SPACING_NM, totalNm / MAX_CORRIDOR_POINTS);
+  const corridor = interpolateCorridor(waypoints, spacing);
+  const samples: SampledPoint[] = await Promise.all(
+    corridor.map(async (p) => {
+      const [models, marine] = await Promise.all([
+        fetchAllModels(p.lat, p.lon),
+        fetchMarine(p.lat, p.lon),
+      ]);
+      return { lat: p.lat, lon: p.lon, models, marine };
+    }),
+  );
+  return assembleForecastCache(samples, opts.window);
+}
+
+// Graceful wrapper: returns undefined instead of throwing so the caller can
+// fall back to the live server fetch (browser offline / rate-limited / no
+// mappable model / too few waypoints). The server then fetches as before.
+export async function buildForecastCacheSafe(
+  waypoints: [number, number][],
+  opts: { spacingNm?: number; window?: CacheWindow } = {},
+): Promise<ForecastCache | undefined> {
+  try {
+    return await buildForecastCache(waypoints, opts);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -2,6 +2,7 @@ import type { PassageResponse, PassageByEtaResponse, MultiWindowResponse, Archet
 import type { ModelName } from "../config/modelConfig";
 import type { PolarData } from "../config/polarConfig";
 import { API_BASE } from "./config";
+import type { ForecastCache } from "./forecastCache";
 
 // Plan-time overrides driven by the user's /config preferences. Both are
 // optional — when omitted, the server falls back to its bundled archetype
@@ -55,6 +56,7 @@ export async function fetchPassage(params: {
   archetype: string;
   efficiency?: number;
   overrides?: PlanOverrides;
+  forecastCache?: ForecastCache;
 }): Promise<PassageResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -64,6 +66,7 @@ export async function fetchPassage(params: {
   };
   if (params.overrides?.models?.length) body["models"] = params.overrides.models;
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
+  if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
   const res = await fetch(`${API_BASE}/api/v1/passage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -85,6 +88,7 @@ export async function fetchPassageWindows(params: {
   targetEta?: string;
   efficiency?: number;
   overrides?: PlanOverrides;
+  forecastCache?: ForecastCache;
 }): Promise<MultiWindowResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -97,6 +101,7 @@ export async function fetchPassageWindows(params: {
   if (params.targetEta) body["target_eta"] = params.targetEta;
   if (params.overrides?.models?.length) body["models"] = params.overrides.models;
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
+  if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
 
   const res = await fetch(`${API_BASE}/api/v1/passage`, {
     method: "POST",
@@ -116,6 +121,7 @@ export async function fetchPassageByEta(params: {
   archetype: string;
   efficiency?: number;
   overrides?: PlanOverrides;
+  forecastCache?: ForecastCache;
 }): Promise<PassageByEtaResponse> {
   const body: Record<string, unknown> = {
     waypoints: params.waypoints,
@@ -125,6 +131,7 @@ export async function fetchPassageByEta(params: {
   };
   if (params.overrides?.models?.length) body["models"] = params.overrides.models;
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
+  if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
 
   const res = await fetch(`${API_BASE}/api/v1/passage-by-eta`, {
     method: "POST",

--- a/packages/web/src/plan/geo.ts
+++ b/packages/web/src/plan/geo.ts
@@ -1,0 +1,59 @@
+// Spherical geometry helpers — distances in nautical miles, angles in degrees.
+// TypeScript mirror of packages/data-adapters/.../routing/geometry.py. Kept in
+// sync so the client can sample the same route polyline the server segments.
+// Earth radius 3440.065 NM (mean radius 6371.0088 km / 1.852).
+
+export interface GeoPoint {
+  lat: number;
+  lon: number;
+}
+
+const EARTH_RADIUS_NM = 3440.065;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+const toDeg = (rad: number): number => (rad * 180) / Math.PI;
+
+function angularDistanceRad(a: GeoPoint, b: GeoPoint): number {
+  const lat1 = toRad(a.lat);
+  const lon1 = toRad(a.lon);
+  const lat2 = toRad(b.lat);
+  const lon2 = toRad(b.lon);
+  const dlat = lat2 - lat1;
+  const dlon = lon2 - lon1;
+  const h =
+    Math.sin(dlat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dlon / 2) ** 2;
+  return 2 * Math.asin(Math.min(1.0, Math.sqrt(h)));
+}
+
+export function haversineNm(a: GeoPoint, b: GeoPoint): number {
+  return EARTH_RADIUS_NM * angularDistanceRad(a, b);
+}
+
+// Spherical linear interpolation along the great circle from a to b.
+// fraction=0 returns a, fraction=1 returns b.
+export function interpolateGreatCircle(
+  a: GeoPoint,
+  b: GeoPoint,
+  fraction: number,
+): GeoPoint {
+  const delta = angularDistanceRad(a, b);
+  if (delta < 1e-12) return { lat: a.lat, lon: a.lon };
+  const lat1 = toRad(a.lat);
+  const lon1 = toRad(a.lon);
+  const lat2 = toRad(b.lat);
+  const lon2 = toRad(b.lon);
+  const sinDelta = Math.sin(delta);
+  const aCoef = Math.sin((1.0 - fraction) * delta) / sinDelta;
+  const bCoef = Math.sin(fraction * delta) / sinDelta;
+  const x =
+    aCoef * Math.cos(lat1) * Math.cos(lon1) +
+    bCoef * Math.cos(lat2) * Math.cos(lon2);
+  const y =
+    aCoef * Math.cos(lat1) * Math.sin(lon1) +
+    bCoef * Math.cos(lat2) * Math.sin(lon2);
+  const z = aCoef * Math.sin(lat1) + bCoef * Math.sin(lat2);
+  const lat = Math.atan2(z, Math.sqrt(x * x + y * y));
+  const lon = Math.atan2(y, x);
+  return { lat: toDeg(lat), lon: toDeg(lon) };
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -3,6 +3,7 @@ import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError, type PlanOverrides } from "../api/passage";
+import { buildForecastCacheSafe, singleWindowMs, sweepWindowMs, etaWindowMs } from "../api/forecastCache";
 import { Header } from "../components/Header";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import {
@@ -401,9 +402,20 @@ export function PlanPage() {
     setIsLoading(true);
     setApiError(null);
     const overrides = resolveOverrides(arch);
-    const promise = anchor === "arrival"
-      ? fetchPassageByEta({ waypoints: wpts, targetArrival: toTzAware(dep), archetype: arch, overrides })
-      : fetchPassage({ waypoints: wpts, departure: toTzAware(dep), archetype: arch, overrides });
+    const depIso = toTzAware(dep);
+    const anchorMs = Date.parse(depIso);
+    // Sample the route corridor in the browser and attach it so the server
+    // reads weather from this payload instead of calling Open-Meteo itself
+    // (distributes the upstream load off the Space's single IP). On any
+    // failure the cache is undefined and the server fetches live.
+    const cacheWindow = anchor === "arrival"
+      ? etaWindowMs(wpts, anchorMs)
+      : singleWindowMs(wpts, anchorMs);
+    const promise = buildForecastCacheSafe(wpts, { window: cacheWindow }).then((forecastCache) =>
+      anchor === "arrival"
+        ? fetchPassageByEta({ waypoints: wpts, targetArrival: depIso, archetype: arch, overrides, forecastCache })
+        : fetchPassage({ waypoints: wpts, departure: depIso, archetype: arch, overrides, forecastCache })
+    );
     promise
       .then((res) => {
         setPassage(res.passage);
@@ -553,14 +565,21 @@ export function PlanPage() {
   function doFetchWindows() {
     setIsLoading(true);
     setApiError(null);
-    fetchPassageWindows({
-      waypoints,
-      earliest: toTzAware(sweepEarliest),
-      latest: toTzAware(sweepLatest),
-      archetype,
-      intervalHours: sweepInterval,
-      overrides: resolveOverrides(archetype),
-    })
+    const earliestIso = toTzAware(sweepEarliest);
+    const latestIso = toTzAware(sweepLatest);
+    const cacheWindow = sweepWindowMs(waypoints, Date.parse(earliestIso), Date.parse(latestIso));
+    buildForecastCacheSafe(waypoints, { window: cacheWindow })
+      .then((forecastCache) =>
+        fetchPassageWindows({
+          waypoints,
+          earliest: earliestIso,
+          latest: latestIso,
+          archetype,
+          intervalHours: sweepInterval,
+          overrides: resolveOverrides(archetype),
+          forecastCache,
+        }),
+      )
       .then((res) => {
         setWindows(res.windows);
         setMetaWarnings(res.meta_warnings);


### PR DESCRIPTION
## But

Déporter le fetch météo marine du serveur vers le **navigateur** pour répartir les appels Open-Meteo sur autant d'IP que d'utilisateurs, au lieu de saturer l'IP unique (rate-limitée) du HF Space. Le client échantillonne le corridor de la route et envoie un `forecast_cache` ; le serveur le lit via un nouvel adapter au lieu d'appeler Open-Meteo.

Le cache est **optionnel** : le serveur garde toute l'autorité sur la segmentation/timing, et quand le cache est absent (tous les clients MCP, plus les clients web qui retombent en fallback) il refetch comme avant. **Le serveur MCP n'est pas touché.**

## Architecture

« Cache corridor + adapter serveur » : zéro duplication de géométrie, 1 aller-retour, plus-proche-voisin (espace) + plus-proche-heure (temps). Périmètre : toute la météo marine (vent + vagues + courants/marées, overlay MARC/SHOM déjà mergé côté client).

## Changements

**Backend**
- `data-adapters` : `CacheBackedAdapter` (Protocol `MarineDataAdapter`) — plus-proche-voisin spatial + clip temporel, passthrough d'unités, drop des heures null (miroir de `_parse_wind`), slug absent → série vide (déclenche le fallback serveur).
- `hf-space` : parse `forecast_cache` dans les 3 handlers passage, construit l'adapter, dérive le `model_chain` du cache. 422 si payload malformé.

**Frontend**
- `plan/geo.ts` : miroir TS de `routing/geometry.py` (haversine + SLERP grand-cercle).
- `api/forecastCache.ts` : interpolation corridor, assemblage cache (axe temps Paris→UTC, mapping modèles web→slugs backend, clamp fenêtre, fallback gracieux).
- `passage.ts` + `PlanPage` : param `forecastCache` optionnel câblé sur les 3 modes (single / sweep / ETA).

## Tests / vérifs

- `data-adapters` : 231 ✓ (dont 19 unitaires cache + 2 intégration `estimate_passage`).
- `mcp-core` : 26 ✓ (chemin MCP intact).
- `hf-space` endpoint : 5 ✓ (wiring + 422 malformé).
- web vitest : 51 ✓ (dont 9 `forecastCache`) ; build TS ✓.
- Smoke HTTP local (stack Starlette) : cache POST → 200 **sans appel Open-Meteo** ; no-cache POST → 200 live ; malformé → 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)