### PR TITLE
perf(meteo): batch server-side Open-Meteo fetch via multi-coordinate prewarm

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -261,6 +261,162 @@ class OpenMeteoAdapter:
             return SeaSeries(points=())
         return _parse_sea(resp.json(), start, end)
 
+    # ---- batched multi-coordinate prewarm --------------------------------
+    # A passage samples one (lat, lon) per segment; the per-segment ``fetch``
+    # path therefore issues ~2*N HTTP calls (wind + sea per point), paced by
+    # the single-IP throttle. Open-Meteo accepts comma-separated coordinates
+    # and returns an array aligned to the inputs, so ``prewarm_batch`` fetches
+    # ALL points in ``len(models)+1`` calls and writes the per-point bundles
+    # into the same cache the per-segment ``fetch`` reads — turning those N
+    # fetches into cache hits. Pure optimization: it never changes results, and
+    # on any upstream error it simply caches nothing so the per-point path runs
+    # unchanged. Matters most on the MCP/server path (the one IP Open-Meteo
+    # rate-limits); the web path already fetches client-side.
+
+    def _fresh_cached(
+        self, key: _CacheKey, start_utc: datetime, end_utc: datetime, now: datetime
+    ) -> bool:
+        cached = self._cache.get(key)
+        return (
+            cached is not None
+            and (now - cached.fetched_at) < CACHE_TTL
+            and cached.bundle.start <= start_utc
+            and cached.bundle.end >= end_utc
+        )
+
+    def _cache_put(self, key: _CacheKey, now: datetime, bundle: ForecastBundle) -> None:
+        if len(self._cache) >= CACHE_MAX_ENTRIES and key not in self._cache:
+            self._cache.pop(next(iter(self._cache)))  # FIFO eviction, mirrors fetch()
+        self._cache[key] = _CacheEntry(fetched_at=now, bundle=bundle)
+
+    async def prewarm_batch(
+        self,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+        models: list[str] | None = None,
+    ) -> None:
+        """Warm the cache for many ``(lat, lon)`` points in as few HTTP calls as
+        possible (Open-Meteo multi-coordinate), so subsequent per-point
+        ``fetch`` calls for ``[start, end]`` are served without HTTP.
+
+        Best-effort and cache-aware: points already covered are skipped, and any
+        horizon/HTTP error aborts silently (the per-point path then runs as
+        before). Caches wind + sea together per point, exactly like ``fetch``.
+        """
+        if not points:
+            return
+        if start.tzinfo is None or end.tzinfo is None:
+            raise ValueError("start and end must be timezone-aware datetimes")
+        start_utc = start.astimezone(UTC)
+        end_utc = end.astimezone(UTC)
+        if end_utc <= start_utc:
+            raise ValueError("end must be strictly after start")
+        models = models or [DEFAULT_MODEL]
+        now = datetime.now(UTC)
+        api_max_end = now + timedelta(days=API_MAX_FUTURE_DAYS)
+        if start_utc > api_max_end:
+            return  # out of horizon — let per-point fetch raise the proper error
+
+        # Only fetch points missing a covering entry for at least one model.
+        def _key(pt: tuple[float, float], model: str) -> _CacheKey:
+            return _CacheKey(round(pt[0], GRID_DECIMALS), round(pt[1], GRID_DECIMALS), (model,))
+
+        todo = [
+            pt
+            for pt in points
+            if any(not self._fresh_cached(_key(pt, m), start_utc, end_utc, now) for m in models)
+        ]
+        if not todo:
+            return
+
+        # Widen like fetch() so later calls with shifted windows still hit.
+        fetch_start = start_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        fetch_end = min(max(end_utc, start_utc + timedelta(days=FETCH_HORIZON_DAYS)), api_max_end)
+
+        owns_client = self._client is None
+        client = self._client or httpx.AsyncClient(timeout=self._timeout)
+        try:
+            wind_per_model = await asyncio.gather(
+                *[self._fetch_wind_batch(client, todo, fetch_start, fetch_end, m) for m in models]
+            )
+            sea_per_point = await self._fetch_sea_batch(client, todo, fetch_start, fetch_end)
+        except (ForecastHorizonError, httpx.HTTPError):
+            return  # abort the optimization; per-point fetch path stays correct
+        finally:
+            if owns_client:
+                await client.aclose()
+
+        # Defensive: only cache when array shapes line up with the request.
+        if len(sea_per_point) != len(todo) or any(len(w) != len(todo) for w in wind_per_model):
+            return
+        for mi, model in enumerate(models):
+            winds = wind_per_model[mi]
+            for pi, pt in enumerate(todo):
+                bundle = ForecastBundle(
+                    lat=pt[0],
+                    lon=pt[1],
+                    start=fetch_start,
+                    end=fetch_end,
+                    wind_by_model={model: winds[pi]},
+                    sea=sea_per_point[pi],
+                    requested_at=now,
+                )
+                self._cache_put(_key(pt, model), now, bundle)
+
+    async def _fetch_wind_batch(
+        self,
+        client: httpx.AsyncClient,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+        model: str,
+    ) -> list[WindSeries]:
+        params = {
+            "latitude": ",".join(str(p[0]) for p in points),
+            "longitude": ",".join(str(p[1]) for p in points),
+            "hourly": _WIND_VARS,
+            "wind_speed_unit": "kn",
+            "models": model,
+            "timezone": "UTC",
+            "start_date": start.date().isoformat(),
+            "end_date": end.date().isoformat(),
+        }
+        await self._pace_http()
+        resp = await client.get(FORECAST_URL, params=params)
+        try:
+            _raise_for_status_with_horizon(resp, model, start)
+        except _OffCoverageError:
+            # Whole batch off-coverage: empty series per point → per-segment
+            # fallback chain advances, same as the single-point path.
+            return [WindSeries(model=model, points=()) for _ in points]
+        elems = _as_coord_list(resp.json(), len(points))
+        return [_parse_wind(el, model, start, end) for el in elems]
+
+    async def _fetch_sea_batch(
+        self,
+        client: httpx.AsyncClient,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+    ) -> list[SeaSeries]:
+        params = {
+            "latitude": ",".join(str(p[0]) for p in points),
+            "longitude": ",".join(str(p[1]) for p in points),
+            "hourly": _MARINE_VARS,
+            "timezone": "UTC",
+            "start_date": start.date().isoformat(),
+            "end_date": end.date().isoformat(),
+        }
+        await self._pace_http()
+        resp = await client.get(MARINE_URL, params=params)
+        try:
+            _raise_for_status_with_horizon(resp, "open-meteo-marine", start)
+        except _OffCoverageError:
+            return [SeaSeries(points=()) for _ in points]
+        elems = _as_coord_list(resp.json(), len(points))
+        return [_parse_sea(el, start, end) for el in elems]
+
 
 def _raise_for_status_with_horizon(
     resp: httpx.Response, model: str, requested_time: datetime
@@ -329,6 +485,20 @@ def _slice_bundle(bundle: ForecastBundle, start: datetime, end: datetime) -> For
         sea=sliced_sea,
         requested_at=bundle.requested_at,
     )
+
+
+def _as_coord_list(data: Any, n: int) -> list[dict[str, Any]]:
+    """Normalize an Open-Meteo response to a list of ``n`` per-coordinate objects.
+
+    Multi-coordinate requests return a JSON array (one object per input
+    coordinate, order preserved); a single coordinate may come back as a bare
+    object. Short arrays are padded with empty dicts so callers can index by
+    position without bounds checks (a missing element parses to an empty series).
+    """
+    elems = data if isinstance(data, list) else [data]
+    if len(elems) < n:
+        elems = list(elems) + [{}] * (n - len(elems))
+    return elems[:n]
 
 
 def _parse_wind(data: dict[str, Any], model: str, start: datetime, end: datetime) -> WindSeries:

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -526,6 +526,17 @@ async def _estimate_with_model(
     own_adapter = adapter is None
     fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
     try:
+        # Warm the cache for every segment point in one batched multi-coordinate
+        # call (adapters that support it), so the per-segment gather below is
+        # served from cache instead of one HTTP call per point. Pure speedup;
+        # adapters without prewarm_batch (cache-backed, stubs) skip it.
+        if hasattr(fetch_adapter, "prewarm_batch"):
+            await fetch_adapter.prewarm_batch(
+                [(pt.lat, pt.lon) for pt in seg_mid_points],
+                min(seg_mid_times) - WIND_FETCH_WINDOW / 2,
+                max(seg_mid_times) + WIND_FETCH_WINDOW / 2,
+                [model],
+            )
         # First pass: batch-fetch all segments with the primary model. Same
         # request shape as before — routes 100% covered by the primary see
         # exactly one batched gather (preserves cache prewarm behaviour).
@@ -753,6 +764,15 @@ async def _estimate_backward_with_model(
     own_adapter = adapter is None
     fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
     try:
+        # Batched multi-coordinate prewarm so the per-segment gather is cache-
+        # served (one HTTP call for all points instead of one per point).
+        if hasattr(fetch_adapter, "prewarm_batch"):
+            await fetch_adapter.prewarm_batch(
+                [(pt.lat, pt.lon) for pt in seg_mid_points],
+                min(seg_mid_times) - WIND_FETCH_WINDOW / 2,
+                max(seg_mid_times) + WIND_FETCH_WINDOW / 2,
+                [model],
+            )
         bundles = await asyncio.gather(
             *[
                 fetch_adapter.fetch(
@@ -994,18 +1014,28 @@ async def estimate_passage_windows(
         resolved_model = first.model
         reports: list[PassageReport] = [first]
 
-        # Prewarm cache for the entire sweep horizon so all remaining calls are hits.
+        # Prewarm cache for the entire sweep horizon so all remaining calls are
+        # hits. One batched multi-coordinate call when the adapter supports it
+        # (all points in ~2 HTTP requests), else the per-point gather.
         prewarm_end = (
             latest_utc + timedelta(hours=route_nm / PREWARM_MIN_SPEED_KN) + WIND_FETCH_WINDOW
         )
-        await asyncio.gather(
-            *[
-                fetch_adapter.fetch(
-                    pt.lat, pt.lon, earliest_utc, prewarm_end, models=[resolved_model]
-                )
-                for pt in seg_mid_points
-            ]
-        )
+        if hasattr(fetch_adapter, "prewarm_batch"):
+            await fetch_adapter.prewarm_batch(
+                [(pt.lat, pt.lon) for pt in seg_mid_points],
+                earliest_utc,
+                prewarm_end,
+                [resolved_model],
+            )
+        else:
+            await asyncio.gather(
+                *[
+                    fetch_adapter.fetch(
+                        pt.lat, pt.lon, earliest_utc, prewarm_end, models=[resolved_model]
+                    )
+                    for pt in seg_mid_points
+                ]
+            )
 
         # Sweep remaining departure windows sequentially. The first window's
         # resolved model is the cache-warmed default; later windows that fall

--- a/packages/data-adapters/tests/test_openmeteo_batch.py
+++ b/packages/data-adapters/tests/test_openmeteo_batch.py
@@ -1,0 +1,126 @@
+"""Tests for OpenMeteoAdapter.prewarm_batch (multi-coordinate batching).
+
+The win: a passage samples one point per segment, so the per-segment fetch path
+issues ~2*N HTTP calls. prewarm_batch fetches all points in 1 wind + 1 marine
+call and fills the cache, so those per-segment fetches become hits — making the
+call count independent of the number of segments.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import respx
+
+from openwind_data.adapters.openmeteo import (
+    DEFAULT_MODEL,
+    FORECAST_URL,
+    MARINE_URL,
+    OpenMeteoAdapter,
+)
+from openwind_data.routing.geometry import Point
+from openwind_data.routing.passage import estimate_passage
+
+POINTS = [(43.30, 5.35), (43.15, 5.78), (43.00, 6.20)]
+
+
+def _start_end():
+    return datetime(2026, 4, 26, 0, 0, tzinfo=UTC), datetime(2026, 4, 26, 23, 0, tzinfo=UTC)
+
+
+@respx.mock
+async def test_prewarm_batch_one_call_per_endpoint_then_cache_hits(
+    forecast_marseille_arome, marine_porquerolles
+):
+    fc = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=[forecast_marseille_arome] * len(POINTS))
+    )
+    mr = respx.get(MARINE_URL).mock(
+        return_value=httpx.Response(200, json=[marine_porquerolles] * len(POINTS))
+    )
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    start, end = _start_end()
+
+    await adapter.prewarm_batch(POINTS, start, end, [DEFAULT_MODEL])
+    # One request total per endpoint, regardless of point count.
+    assert fc.call_count == 1
+    assert mr.call_count == 1
+
+    # Every point now resolves from cache — no new HTTP.
+    for lat, lon in POINTS:
+        bundle = await adapter.fetch(lat, lon, start, end, models=[DEFAULT_MODEL])
+        assert bundle.wind_by_model[DEFAULT_MODEL].points
+        assert bundle.sea.points
+    assert fc.call_count == 1
+    assert mr.call_count == 1
+
+
+@respx.mock
+async def test_prewarm_batch_is_cache_aware_idempotent(
+    forecast_marseille_arome, marine_porquerolles
+):
+    fc = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=[forecast_marseille_arome] * len(POINTS))
+    )
+    respx.get(MARINE_URL).mock(
+        return_value=httpx.Response(200, json=[marine_porquerolles] * len(POINTS))
+    )
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    start, end = _start_end()
+
+    await adapter.prewarm_batch(POINTS, start, end, [DEFAULT_MODEL])
+    await adapter.prewarm_batch(POINTS, start, end, [DEFAULT_MODEL])
+    # Second call finds everything covered → no extra request.
+    assert fc.call_count == 1
+
+
+@respx.mock
+async def test_prewarmed_fetch_matches_single_point_fetch(
+    forecast_marseille_arome, marine_porquerolles
+):
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=[forecast_marseille_arome]))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=[marine_porquerolles]))
+    start, end = _start_end()
+
+    batched = OpenMeteoAdapter(http_min_interval_s=0)
+    await batched.prewarm_batch([POINTS[0]], start, end, [DEFAULT_MODEL])
+    via_cache = await batched.fetch(*POINTS[0], start, end, models=[DEFAULT_MODEL])
+
+    # Same payload via the single-point endpoint (object, not array).
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+    direct = OpenMeteoAdapter(http_min_interval_s=0)
+    via_http = await direct.fetch(*POINTS[0], start, end, models=[DEFAULT_MODEL])
+
+    assert (
+        via_cache.wind_by_model[DEFAULT_MODEL].points
+        == via_http.wind_by_model[DEFAULT_MODEL].points
+    )
+    assert via_cache.sea.points == via_http.sea.points
+
+
+@respx.mock
+async def test_estimate_passage_call_count_independent_of_segments(
+    forecast_marseille_arome, marine_porquerolles
+):
+    fc = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(200, json=[forecast_marseille_arome] * 12)
+    )
+    mr = respx.get(MARINE_URL).mock(
+        return_value=httpx.Response(200, json=[marine_porquerolles] * 12)
+    )
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    # ~41 nm at 5 nm segments → ~9 segments; without batching that is ~9 wind +
+    # ~9 marine calls. With prewarm_batch it is 1 + 1.
+    report = await estimate_passage(
+        [Point(43.30, 5.35), Point(43.00, 6.20)],
+        datetime(2026, 4, 26, 6, 0, tzinfo=UTC),
+        "cruiser_40ft",
+        adapter=adapter,
+        segment_length_nm=5.0,
+        model=DEFAULT_MODEL,
+    )
+    assert report.segments
+    assert fc.call_count == 1
+    assert mr.call_count == 1


### PR DESCRIPTION
## But : réduire les appels Open-Meteo depuis le serveur (chemin MCP)

Le chemin serveur/MCP (`plan_passage` sans navigateur) fetchait la météo **par segment** : ~2×N appels HTTP (vent + mer par point), cadencés par le throttle 0.1s qui protège l'IP unique du rate-limit Open-Meteo. Open-Meteo accepte les **coordonnées multiples** (réponse en tableau), donc `OpenMeteoAdapter.prewarm_batch` fetche tous les points en `modèles+1` appels (1 vent + 1 marine) et remplit le **même cache** que lit le fetch par segment → ces fetchs deviennent des cache hits.

## Garanties

- **Pur speedup, résultats identiques** : cache-aware (points déjà couverts ignorés) + best-effort (toute erreur horizon/HTTP annule le prewarm → le chemin par point tourne inchangé).
- **Guardé par `hasattr`** : les adapters `CacheBackedAdapter` (chemin web) et les stubs de test ne sont pas affectés.
- N'aide que le chemin serveur/MCP (l'IP unique rate-limitée) ; le web fetch déjà côté client.

## Mesure (smoke live, vrai Open-Meteo)

Marseille→Porquerolles, 9 segments : **2 requêtes** (1 vent 9-coords + 1 marine 9-coords) au lieu de ~18. Plan identique (11.1h, AROME).

## Changements

- `openmeteo.py` : `prewarm_batch(points, start, end, models)` + `_fetch_wind_batch` / `_fetch_sea_batch` (multi-coord) + helper `_as_coord_list`.
- `passage.py` : appel `prewarm_batch` guardé dans `_estimate_with_model`, `estimate_passage_for_arrival`, et le prewarm du sweep.
- Tests : `test_openmeteo_batch.py` (comptage 1+1, idempotence cache-aware, équivalence prewarm vs single-point, `estimate_passage` indépendant du nb de segments). data-adapters 235 ✓, mcp-core 26 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)