### PR TITLE
feat(hf-space): variabilize dev Space README + polish marketing copy

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -52,6 +52,26 @@ jobs:
           ls -la "$BUILD_DIR"
           ls -la "$BUILD_DIR/vendor"
 
+      - name: Variabilize README for the dev Space
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          set -euo pipefail
+          # The committed README carries the prod Space's metadata. On the dev
+          # Space, rewrite the HF card frontmatter and the advertised endpoint so
+          # the two Spaces are visually distinct on the dashboard and demos hit dev.
+          README=/tmp/hf-build/README.md
+          sed -i \
+            -e 's/^title: OpenWind MCP$/title: OpenWind MCP (dev)/' \
+            -e 's/^colorFrom: blue$/colorFrom: gray/' \
+            -e 's/^colorTo: indigo$/colorTo: yellow/' \
+            -e 's/^short_description: /short_description: (dev) /' \
+            -e 's/^# OpenWind MCP ⛵$/# OpenWind MCP (dev) ⛵/' \
+            -e 's#qdonnars-openwind-mcp\.hf\.space#qdonnars-openwind-mcp-dev.hf.space#g' \
+            -e 's/on `main`/on `dev`/g' \
+            "$README"
+          echo "Patched dev README frontmatter:"
+          sed -n '1,13p' "$README"
+
       - name: Push to HF Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > **Talk to your LLM. Cast off with confidence.**
 >
-> OpenWind turns any MCP-capable assistant Claude, Le Chat, Cursor, Goose,
-> Zed, Continue into a sailing planner for the French Atlantic and
+> OpenWind turns any MCP-capable assistant (Claude, Le Chat, Cursor, Goose,
+> Zed, Continue) into a sailing planner for the French Atlantic and
 > Mediterranean coasts. Ask in plain language. Get a per-leg ETA, a 1‑5
 > complexity score, high-precision tidal currents on the Atlantic
 > (SHOM Atlas C2D and MARC PREVIMER), and a deep-link to the full plan.
 > Free, keyless, open source.
 
-[**openwind.fr**](https://openwind.fr) · [`mcp.openwind.fr`](https://qdonnars-openwind-mcp.hf.space/) · MIT
+[**openwind.fr**](https://openwind.fr) · [MCP endpoint](https://qdonnars-openwind-mcp.hf.space/mcp) · MIT
 
 ![OpenWind passage plan rendered in the web app](docs/screenshots/plan.png)
 
@@ -31,9 +31,9 @@ https://qdonnars-openwind-mcp.hf.space/mcp
 **3.** Your assistant calls the OpenWind tools and answers in plain language.
 On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix)
 (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam) you
-also get a live, interactive widget the [openwind.fr](https://openwind.fr)
+also get a live, interactive widget: the [openwind.fr](https://openwind.fr)
 plan view rendered inline. On hosts that don't (Cursor, Le Chat, terminal),
-the assistant hands you the same plan as a [openwind.fr](https://openwind.fr)
+the assistant hands you the same plan as an [openwind.fr](https://openwind.fr)
 deep-link. No account. No API key. No credit card.
 
 > **First time with MCP?** It takes 2 minutes. Pick your client on
@@ -41,19 +41,21 @@ deep-link. No account. No API key. No credit card.
 > then follow the
 > [remote-server quickstart](https://modelcontextprotocol.io/docs/develop/connect-remote-servers).
 > Claude Desktop users can start with the
-> [user quickstart](https://modelcontextprotocol.io/quickstart/user).
+> [user quickstart](https://modelcontextprotocol.io/quickstart/user). In Le Chat,
+> add it under **Connectors → Add connector → Custom MCP connector** and paste
+> the endpoint above.
 
 ## Why OpenWind
 
 |                              |                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------|
 | 🆓 **Free, keyless**         | Wind & sea via [Open-Meteo](https://open-meteo.com) (CC BY 4.0). No account, no API key.     |
-| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
+| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km, catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
 | ⛵ **Boat-aware**             | Seven archetypes from 20 ft trailer-cruisers to bluewater 50-footers, real polars, an `efficiency` parameter for trim and crew level. |
-| 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot no math by hand. |
+| 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot, no math by hand. |
 | 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
 | 🖼️ **Rich on supporting hosts** | On Claude / ChatGPT / VS Code Copilot / Goose, an interactive widget renders inline via [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix). Other hosts fall back to a clean text summary + deep-link. |
-| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, your VPS `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
+| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, or your own VPS: `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. |
 
 ## What the LLM sees
 
@@ -63,13 +65,13 @@ Four MCP tools, all async, all keyless:
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Seven descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out the LLM picks the calmest slot. |
-| `read_me`                 | Returns OpenWind's calculation methodology call when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out, and the LLM picks the calmest slot. |
+| `read_me`                 | Returns OpenWind's calculation methodology. Call it when the user asks how things are computed. |
 
 `plan_passage` declares an MCP Apps UI resource (`ui://openwind/plan-passage`)
 on its `_meta`. Hosts that support [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix)
-render the live `openwind.fr/plan?…` view in a sandboxed iframe automatically
-  no host-specific CSS, no vendor lock-in. Hosts without MCP Apps support
+render the live `openwind.fr/plan?…` view in a sandboxed iframe automatically,
+with no host-specific CSS and no vendor lock-in. Hosts without MCP Apps support
 silently get the structured payload + the `openwind_url` deep-link.
 
 ## Architecture
@@ -109,7 +111,7 @@ npm run build          # outputs packages/web/dist
 ## V1 scope
 
 Wind, sea (`Hs` max), per-leg ETA, 1–5 complexity. Tides and currents ignored
-on the Med (negligible). No automatic routing optimisation the LLM and the
+on the Med (negligible). No automatic routing optimisation: the LLM and the
 human stay in the loop. Roadmap and scope decisions live in
 [`plan/`](plan/) (local).
 
@@ -126,14 +128,14 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 
 ### Boat speed adjustments
 
-- **Efficiency factor (default 0.75)** ORC polars are theoretical maxima. Real cruising loses ~25% (sail trim, comfort margins, helmsman, untracked currents). Override per call: `0.85` racing, `0.75` cruising, `0.65` loaded family cruising, `0.55` heavy seas / fouled hull.
-- **VMG / tacking correction** when the route's TWA is below the boat's optimal upwind angle (typically ~42-48°), the simulator assumes the sailor tacks. Effective speed toward destination is `polar(optimal_TWA) × cos(optimal_TWA − route_TWA)`. At dead upwind this reduces to `polar(opt) × cos(opt) ≈ polar / √2`; at TWA=20° with opt=45° the reduction is only `cos(25°) ≈ 0.91`.
-- **Wave derate (opt-in)** `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Disabled by default sea state feeds the warning bar rather than slowing the boat.
-- **Minimum boat speed** 0.5 kn floor, prevents division blow-up in extreme stalls.
+- **Efficiency factor (default 0.75).** ORC polars are theoretical maxima. Real cruising loses ~25% (sail trim, comfort margins, helmsman, untracked currents). Override per call: `0.85` racing, `0.75` cruising, `0.65` loaded family cruising, `0.55` heavy seas / fouled hull.
+- **VMG / tacking correction.** When the route's TWA is below the boat's optimal upwind angle (typically ~42-48°), the simulator assumes the sailor tacks. Effective speed toward destination is `polar(optimal_TWA) × cos(optimal_TWA − route_TWA)`. At dead upwind this reduces to `polar(opt) × cos(opt) ≈ polar / √2`; at TWA=20° with opt=45° the reduction is only `cos(25°) ≈ 0.91`.
+- **Wave derate (opt-in).** `max(0.5, 1 − 0.05 × Hs^1.75 × cos²(TWA/2))`. Disabled by default; sea state feeds the warning bar rather than slowing the boat.
+- **Minimum boat speed.** 0.5 kn floor, prevents division blow-up in extreme stalls.
 
 ### Timing
 
-- **Single-pass approximation** a 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
+- **Single-pass approximation.** A 6 kn heuristic estimates segment mid-times, then real polar speeds are computed at each mid-time's actual wind. No convergence iteration. Bias is bounded by the Mediterranean's multi-hour wind correlation length.
 - Routes are split into ~10 nm sub-segments by default for per-segment weather sampling. Drop to 5 nm for tight coastal work; raise to 20 nm for long offshore legs.
 
 ### Compare-windows mode
@@ -142,15 +144,15 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 
 ### Mediterranean defaults
 
-- **Tides ignored** < 40 cm in the Med, negligible vs. forecast uncertainty.
-- **Currents ignored** Liguro-Provençal current too weak / variable for V1.
-- **Wind model** AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → ECMWF IFS 0.25° (≤10 d) → GFS (≤16 d) when the passage extends past AROME.
-- **Wave model** Open-Meteo Marine (significant Hs, period, direction).
+- **Tides ignored.** < 40 cm in the Med, negligible vs. forecast uncertainty.
+- **Currents ignored.** Liguro-Provençal current too weak / variable for V1.
+- **Wind model.** AROME 1.3 km (≤48 h horizon, captures thermals and local winds). Auto-falls back to ICON-EU (≤5 d) → ECMWF IFS 0.25° (≤10 d) → GFS (≤16 d) when the passage extends past AROME.
+- **Wave model.** Open-Meteo Marine (significant Hs, period, direction).
 
 ### What's not modelled (V1)
 
-- No automatic routing optimisation the LLM and human stay in the loop on departure choice.
-- No coastal acceleration zones (capes, peninsulas) caller adds intermediate waypoints.
+- No automatic routing optimisation: the LLM and human stay in the loop on departure choice.
+- No coastal acceleration zones (capes, peninsulas): the caller adds intermediate waypoints.
 - No port/starboard polar asymmetry, no spinnaker-specific curves, no hull condition modelling beyond the `efficiency` knob.
 
 ## Credits

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -47,16 +47,17 @@ card.
 > then follow the
 > [remote-server quickstart](https://modelcontextprotocol.io/docs/develop/connect-remote-servers).
 > Works with Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, and any
-> other MCP-compatible host.
+> other MCP-compatible host. In Le Chat, add it under **Connectors → Add
+> connector → Custom MCP connector** and paste the endpoint above.
 
 ## Why OpenWind
 
-- **Free & keyless** wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
-- **Mediterranean-tuned** AROME 1.3 km by default, catches thermals & mistral. ICON-EU → ECMWF → GFS for longer reach.
-- **Boat-aware** 7 archetypes from 20 to 50 ft, real polars, `efficiency` parameter for trim and crew level.
-- **Window-aware** one call sweeps up to 14 days of hourly departures so the LLM can pick the calmest slot.
-- **Client-agnostic** one HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
-- **Open source, MIT** self-host on Fly, Modal, your VPS in minutes.
+- **Free and keyless.** Wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
+- **Mediterranean-tuned.** AROME 1.3 km by default, catches thermals and mistral. ICON-EU → ECMWF → GFS for longer reach.
+- **Boat-aware.** 7 archetypes from 20 to 50 ft, real polars, an `efficiency` parameter for trim and crew level.
+- **Window-aware.** One call sweeps up to 14 days of hourly departures so the LLM can pick the calmest slot.
+- **Client-agnostic.** One HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
+- **Open source, MIT.** Self-host on Fly, Modal, or your own VPS in minutes.
 
 ## Four tools
 
@@ -64,8 +65,8 @@ card.
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Seven descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft`. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource supporting hosts auto-render the live plan in a sandboxed iframe. |
-| `read_me`                 | Returns OpenWind's calculation methodology call when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
+| `read_me`                 | Returns OpenWind's calculation methodology. Call it when the user asks how things are computed. |
 
 ## About this Space
 
@@ -76,11 +77,11 @@ card.
 
 **Source of truth:** <https://github.com/qdonnars/openwind>. This Space is
 auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Don't
-commit directly to the Space repo your changes will be overwritten at the
+commit directly to the Space repo; your changes will be overwritten at the
 next push.
 
 The Space wrapper is intentionally minimal (~20 lines in `app.py`). All logic
-lives in `openwind-mcp-core` and `openwind-data` upstream re-deployable on
+lives in `openwind-mcp-core` and `openwind-data` upstream, re-deployable on
 Fly, Modal, or a VPS by writing a different wrapper.
 
 ## Cold-start

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -639,7 +639,7 @@ def build_server(
 
     @server.tool()
     def list_boat_archetypes() -> list[dict[str, Any]]:
-        """List the 5 boat archetypes with descriptive metadata.
+        """List the 7 boat archetypes with descriptive metadata.
 
         The LLM (or user) maps a commercial model (e.g. "Sun Odyssey 32") to one
         of these archetypes from the metadata — there is no server-side mapping.


### PR DESCRIPTION
## What

Marketing/README pass across the GitHub repo and the Hugging Face Spaces, plus per-environment HF card metadata.

### 1. Variabilize the HF Space card per environment (sync-hf-space.yml)
A new step rewrites the committed (prod) README for the dev Space when deploying a non-main branch, so the two Spaces are distinct on the HF dashboard and dev demos hit the dev endpoint:
- title -> "OpenWind MCP (dev)", colorFrom/To -> gray/yellow, short_description prefixed "(dev)", H1 suffixed "(dev)"
- endpoint qdonnars-openwind-mcp.hf.space -> qdonnars-openwind-mcp-dev.hf.space
- source note "on main" -> "on dev"

Single README source (prod values); the dev variant is derived in CI.

### 2. Marketing copy polish (README.md + packages/hf-space/README.md)
- Repair punctuation lost in the earlier em-dash strip pass (colons/periods after bold leads, run-on sentences).
- Fix the misleading mcp.openwind.fr link text (custom domain not live yet; keep the hf.space URL).
- Add Le Chat custom-connector instructions (Connectors -> Add connector -> Custom MCP connector), reflecting Mistral's current connector flow.

### 3. Server description nit
- list_boat_archetypes docstring: "5 boat archetypes" -> "7".

## Notes
- No em-dashes added. Dev README rewrite simulated locally. server.py compiles.
- No functional MCP behaviour change (docstring text only). Dev Space requires qdonnars/openwind-mcp-dev to exist (or set repo variable HF_SPACE_ID_DEV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)