### PR TITLE
feat(web): restore total route stats in desktop sidebar

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -6,7 +6,7 @@ import { cxLevel, CX_COLORS } from "./types";
 import { WindowsTable } from "./WindowsTable";
 import { ModeToggle, TimeAnchorToggle, type PlanMode, type TimeAnchor } from "./ModeToggle";
 import { LegDetailCard } from "./LegDetailCard";
-import { EmptyState, ModePicker, Warn, RecapButton } from "./PlanStates";
+import { EmptyState, ModePicker, Warn, RecapButton, HeroStats } from "./PlanStates";
 import {
   ARCHETYPE_LABELS,
   defaultPolarConfig,
@@ -1185,6 +1185,17 @@ export function PlanSidebar({
           />
         </div>
       )}
+
+      {/* Total route stats (Distance / Durée / Arrivée + segment bar).
+          Desktop only: on mobile the floating overlay (PlanHeroStats) stays
+          the single source of truth for these totals, per the b90a5bf
+          decision. Dimmed when the route was edited without recalculating so
+          the numbers read as stale. */}
+      <div className="hidden lg:block px-4 py-3.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
+        <div style={{ opacity: isStale ? 0.45 : 1 }}>
+          <HeroStats passage={passage} />
+        </div>
+      </div>
 
       {/* Warnings */}
       {hasWarnings && (

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -3,6 +3,7 @@
 
 import type { PassageReport, SegmentReport } from "./types";
 import { CX_COLORS, cxLevel } from "./types";
+import { fmtDuration, fr1 } from "./format";
 
 // ── EmptyState ────────────────────────────────────────────────────────────────
 // Shown when fewer than 2 waypoints are placed: invites the user to draw a
@@ -164,14 +165,6 @@ export function ModePicker({
 // 4-cell stats row with a segmented complexity bar underneath; matches the
 // design's "Sim filled" header block.
 
-function fmtDuration(h: number): string {
-  const hrs = Math.floor(h);
-  const mins = Math.round((h - hrs) * 60);
-  if (hrs === 0) return `${mins}m`;
-  if (mins === 0) return `${hrs}h`;
-  return `${hrs}h${String(mins).padStart(2, "0")}`;
-}
-
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
@@ -241,7 +234,7 @@ export function HeroStats({
   return (
     <div>
       <div className="grid grid-cols-3 gap-3 mb-3">
-        <HeroCell label="Distance" value={passage.distance_nm.toFixed(1)} unit="nm" />
+        <HeroCell label="Distance" value={fr1(passage.distance_nm)} unit="nm" />
         <HeroCell label="Durée" value={fmtDuration(passage.duration_h)} />
         <HeroCell label="Arrivée" value={fmtTime(passage.arrival_time)} />
       </div>

--- a/packages/web/src/plan/WindowsTable.tsx
+++ b/packages/web/src/plan/WindowsTable.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { PassageWindow } from "./types";
 import { CX_COLORS } from "./types";
+import { fmtDurationSafe } from "./format";
 
 type SortKey = "departure" | "duration" | "complexity";
 
@@ -16,12 +17,6 @@ function fmtDeparture(iso: string): string {
   const day = d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
   const hh = d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
   return `${day} · ${hh}`;
-}
-
-function fmtDuration(h: number): string {
-  const hrs = Math.floor(h);
-  const mins = Math.round((h - hrs) * 60);
-  return mins > 0 ? `${hrs}h${String(mins).padStart(2, "0")}` : `${hrs}h`;
 }
 
 function fmtTime(iso: string): string {
@@ -43,11 +38,6 @@ function fmtRange(min: number | null | undefined, max: number | null | undefined
 function fmtHsRange(min: number | null | undefined, max: number | null | undefined): string {
   if (min == null && max == null) return "—";
   return fmtRange(min, max, "m", 1);
-}
-
-function fmtDurationSafe(h: number | null | undefined): string {
-  if (h == null || !Number.isFinite(h)) return "—";
-  return fmtDuration(h);
 }
 
 function fmtTimeSafe(iso: string | null | undefined): string {

--- a/packages/web/src/plan/format.test.ts
+++ b/packages/web/src/plan/format.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { fmtDuration, fmtDurationSafe, fr1 } from "./format";
+
+describe("fmtDuration", () => {
+  it("formats whole hours without minutes", () => {
+    expect(fmtDuration(3)).toBe("3h");
+  });
+
+  it("formats sub-hour durations as minutes only", () => {
+    expect(fmtDuration(0.5)).toBe("30m");
+  });
+
+  it("zero-pads minutes in the 12h30 convention", () => {
+    expect(fmtDuration(12.5)).toBe("12h30");
+    expect(fmtDuration(1 + 5 / 60)).toBe("1h05");
+  });
+
+  it("rounds minutes to the nearest whole", () => {
+    // 2h 29.5m rounds up to 2h30
+    expect(fmtDuration(2 + 29.5 / 60)).toBe("2h30");
+  });
+});
+
+describe("fmtDurationSafe", () => {
+  it("delegates to fmtDuration for finite numbers", () => {
+    expect(fmtDurationSafe(12.5)).toBe("12h30");
+  });
+
+  it("returns a dash for null, undefined and non-finite input", () => {
+    expect(fmtDurationSafe(null)).toBe("—");
+    expect(fmtDurationSafe(undefined)).toBe("—");
+    expect(fmtDurationSafe(Number.NaN)).toBe("—");
+    expect(fmtDurationSafe(Infinity)).toBe("—");
+  });
+});
+
+describe("fr1", () => {
+  it("formats one decimal with a comma separator", () => {
+    expect(fr1(38.2)).toBe("38,2");
+  });
+
+  it("keeps a trailing zero", () => {
+    expect(fr1(40)).toBe("40,0");
+  });
+});

--- a/packages/web/src/plan/format.ts
+++ b/packages/web/src/plan/format.ts
@@ -1,0 +1,32 @@
+// Shared number/duration formatters for the /plan panel. Consolidates helpers
+// that had drifted into separate copies across PlanStates.tsx and
+// WindowsTable.tsx so the "12h30" convention and French decimals stay in one
+// tested place.
+
+/**
+ * Duration in decimal hours to the compact "12h30" convention.
+ * - whole hours drop the minutes: 3 → "3h"
+ * - sub-hour durations show only minutes: 0.5 → "30m"
+ * - otherwise minutes are zero-padded: 12.5 → "12h30"
+ */
+export function fmtDuration(h: number): string {
+  const hrs = Math.floor(h);
+  const mins = Math.round((h - hrs) * 60);
+  if (hrs === 0) return `${mins}m`;
+  if (mins === 0) return `${hrs}h`;
+  return `${hrs}h${String(mins).padStart(2, "0")}`;
+}
+
+/**
+ * Defensive wrapper: a HF Space deployment lag may serve a response missing a
+ * duration field. Prefer a graceful "—" over rendering "NaNh".
+ */
+export function fmtDurationSafe(h: number | null | undefined): string {
+  if (h == null || !Number.isFinite(h)) return "—";
+  return fmtDuration(h);
+}
+
+/** One-decimal French number: 38.2 → "38,2". Matches sailing-French copy. */
+export function fr1(n: number): string {
+  return n.toFixed(1).replace(".", ",");
+}


### PR DESCRIPTION
## Contexte
Feedback Hisse-et-Oh de Gunter_H : chaque tronçon affiche sa durée mais la durée totale de la route n'apparaît pas sur PC. Les 3 tuiles (ETA/Durée/Dist) existaient sur mobile (overlay flottant) mais rien en desktop depuis b90a5bf.

## Changements
- Remonte le composant HeroStats existant (Distance / Durée / Arrivée + SegmentBar) dans le sidebar desktop, entre le recap et les warnings, en `hidden lg:block` : le mobile garde l'overlay comme source unique, pas de duplication.
- Etat périmé : bloc à 45% d'opacité quand la route est modifiée sans recalcul.
- Consolidation des formatteurs de durée dupliqués dans `src/plan/format.ts` (convention "12h30") + tests ; tuile distance au format français ("38,2").
- PlanPage garde son formatteur local "12h 30m" pour ne pas changer l'overlay mobile.

## Vérification
- vitest 62/62, build tsc+vite OK ; lint : 26 erreurs préexistantes sur dev, zéro nouvelle (vérifié par comparaison stash).
- Vérifié en runtime contre le backend dev (passage réel calculé) : bloc visible à ≥1024px avec totaux corrects (42,6 nm / 17h26 / 15:25), masqué à 390px au profit de l'overlay, opacité 0.45 après modification de la route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)