### PR TITLE
feat(web): show segment lengths on the map while tracing

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -292,6 +292,29 @@ body {
   }
 }
 
+/* Live segment-length label at each leg midpoint while tracing a route.
+   A permanent Leaflet tooltip styled as a small glass chip; tokens are
+   theme-aware so it stays legible in both light and dark maps. The
+   tooltip arrow is removed since the chip sits centered on the segment. */
+.ow-seg-label {
+  font-family: var(--ow-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 2px 5px;
+  color: var(--ow-fg-0);
+  background: var(--ow-surface-glass);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--ow-line-2);
+  border-radius: var(--ow-r-sm);
+  box-shadow: none;
+  white-space: nowrap;
+}
+.ow-seg-label::before {
+  display: none;
+}
+
 /* Datetime-local input — polishes the native picker to match the
    sidebar's design tokens: accent focus ring, hover lift, and a calendar
    icon that picks up the accent on hover instead of staying browser-grey. */

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -4,6 +4,12 @@ import "leaflet/dist/leaflet.css";
 import { useTheme } from "../design/theme";
 import type { SegmentReport } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
+import { haversineNm, fmtNm } from "../utils/geo";
+
+/** Hide a segment label when the leg is shorter than this on screen (px).
+    Below it the chips overlap and clutter the map, so we let them fade out
+    as the user zooms out. */
+const SEG_LABEL_MIN_PX = 48;
 
 export interface PlanMapHandle {
   recenter: (lat: number, lon: number) => void;
@@ -51,6 +57,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const highlightLineRef = useRef<L.Polyline | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const dragLineRef = useRef<L.Polyline | null>(null);
+  const segLabelsRef = useRef<L.Tooltip[]>([]);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const isDraggingRef = useRef(false);
   const onWptAddRef = useRef(onWptAdd);
@@ -83,6 +90,34 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   useEffect(() => {
     livePositionsRef.current = waypoints;
   }, [waypoints]);
+
+  // Draw the live per-segment length labels: one permanent tooltip at each
+  // leg midpoint, showing the great-circle distance in nm. Auto-hides legs
+  // that render shorter than SEG_LABEL_MIN_PX on screen so the chips don't
+  // pile up at low zoom. Idempotent — clears the previous batch each call.
+  function drawSegLabels(map: L.Map, positions: [number, number][]) {
+    for (const t of segLabelsRef.current) t.remove();
+    segLabelsRef.current = [];
+    if (positions.length < 2) return;
+    for (let i = 0; i < positions.length - 1; i++) {
+      const [aLat, aLon] = positions[i];
+      const [bLat, bLon] = positions[i + 1];
+      const pa = map.latLngToContainerPoint([aLat, aLon]);
+      const pb = map.latLngToContainerPoint([bLat, bLon]);
+      if (pa.distanceTo(pb) < SEG_LABEL_MIN_PX) continue;
+      const mid = L.latLng((aLat + bLat) / 2, (aLon + bLon) / 2);
+      const tip = L.tooltip({
+        permanent: true,
+        direction: "center",
+        className: "ow-seg-label",
+        opacity: 1,
+      })
+        .setLatLng(mid)
+        .setContent(fmtNm(haversineNm(aLat, aLon, bLat, bLon)))
+        .addTo(map);
+      segLabelsRef.current.push(tip);
+    }
+  }
 
   // Switch tiles on theme change
   useEffect(() => {
@@ -131,12 +166,19 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       onMapClickRef.current(e.latlng.lat, e.latlng.lng);
     });
 
+    // Re-evaluate the segment labels on zoom: the screen-length auto-hide
+    // threshold means legs appear/disappear as the scale changes.
+    const onZoomEnd = () => drawSegLabels(map, livePositionsRef.current);
+    map.on("zoomend", onZoomEnd);
+
     const ro = new ResizeObserver(() => map.invalidateSize());
     ro.observe(containerRef.current!);
     setTimeout(() => map.invalidateSize(), 100);
 
     return () => {
       ro.disconnect();
+      map.off("zoomend", onZoomEnd);
+      segLabelsRef.current = [];
       map.remove();
       mapRef.current = null;
     };
@@ -224,6 +266,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         } else {
           dragLineRef.current.setLatLngs(lls);
         }
+        drawSegLabels(map, positions);
       });
 
       marker.on("dragend", () => {
@@ -254,7 +297,10 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     for (const p of polylinesRef.current) p.remove();
     polylinesRef.current = [];
 
-    if (waypoints.length < 2) return;
+    if (waypoints.length < 2) {
+      drawSegLabels(map, waypoints);
+      return;
+    }
 
     if (!segments || isStale) {
       // Dashed + faded only when the line is provisional (loading or stale).
@@ -283,8 +329,14 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         onWptAddRef.current(bestIdx, click.lat, click.lng);
       });
       polylinesRef.current = [line];
+      // Live leg lengths while the route is being traced / not yet computed.
+      drawSegLabels(map, waypoints);
       return;
     }
+
+    // Route is computed: per-leg distance now lives in the sidebar, so drop
+    // the on-map tracing labels to keep the colored segments uncluttered.
+    drawSegLabels(map, []);
 
     segments.forEach((seg, i) => {
       const color = CX_COLORS[cxLevel(seg.tws_kn)];

--- a/packages/web/src/utils/geo.test.ts
+++ b/packages/web/src/utils/geo.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { haversineNm, fmtNm } from "./geo";
+
+describe("haversineNm", () => {
+  it("treats one degree of latitude as ~60 nm", () => {
+    // A degree of latitude is ~60 nm anywhere on the globe by definition.
+    const d = haversineNm(43.0, 5.0, 44.0, 5.0);
+    expect(d).toBeCloseTo(60, 0);
+  });
+
+  it("is symmetric", () => {
+    const ab = haversineNm(43.29, 5.37, 43.0, 6.2);
+    const ba = haversineNm(43.0, 6.2, 43.29, 5.37);
+    expect(ab).toBeCloseTo(ba, 10);
+  });
+
+  it("returns zero for identical points", () => {
+    expect(haversineNm(43.29, 5.37, 43.29, 5.37)).toBe(0);
+  });
+
+  it("gives ~40 nm from Marseille to Porquerolles", () => {
+    // Marseille (43.29, 5.37) -> Porquerolles (43.00, 6.20). The great-circle
+    // distance is ~40 nm; charted passage plans quote ~38 nm along a coastal
+    // rhumb line, so a 36-42 nm band brackets the expected order of magnitude.
+    const d = haversineNm(43.29, 5.37, 43.0, 6.2);
+    expect(d).toBeGreaterThan(36);
+    expect(d).toBeLessThan(42);
+  });
+});
+
+describe("fmtNm", () => {
+  it("keeps one decimal below 10 nm with a French comma", () => {
+    expect(fmtNm(9.83)).toBe("9,8 nm");
+    expect(fmtNm(0)).toBe("0,0 nm");
+    expect(fmtNm(4.25)).toBe("4,3 nm");
+  });
+
+  it("rounds to an integer at or above 10 nm", () => {
+    expect(fmtNm(12.4)).toBe("12 nm");
+    expect(fmtNm(10)).toBe("10 nm");
+    expect(fmtNm(37.6)).toBe("38 nm");
+  });
+});

--- a/packages/web/src/utils/geo.ts
+++ b/packages/web/src/utils/geo.ts
@@ -1,0 +1,35 @@
+// Pure geo helpers for the plan map. Deliberately leaflet-free: leaflet
+// touches the DOM and crashes the node vitest env, and keeping these
+// functions dependency-free makes them unit-testable in isolation.
+
+/** Mean Earth radius in nautical miles (1 nm = 1852 m, R⊕ ≈ 6371 km). */
+const EARTH_RADIUS_NM = 3440.065;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+/**
+ * Great-circle distance between two lat/lon points, in nautical miles.
+ * Uses the haversine formula — accurate enough for the short coastal
+ * legs traced in the planner and stable near the poles.
+ */
+export function haversineNm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_NM * c;
+}
+
+/**
+ * Format a distance in nautical miles for the map labels, French style:
+ * comma decimal separator, one decimal below 10 nm, rounded to an integer
+ * at or above 10 nm. e.g. 9.83 -> "9,8 nm", 12.4 -> "12 nm".
+ */
+export function fmtNm(nm: number): string {
+  if (nm < 10) {
+    return `${nm.toFixed(1).replace(".", ",")} nm`;
+  }
+  return `${Math.round(nm)} nm`;
+}


### PR DESCRIPTION
## Contexte
Feedback Hisse-et-Oh de roc : afficher la longueur des segments des routes qu'on trace. La distance par tronçon existait déjà dans le panneau résultats après calcul ; il manquait les longueurs en direct sur la carte pendant le tracé.

## Changements
- Nouveau `src/utils/geo.ts` : `haversineNm` (R=3440.065 nm) + `fmtNm` (virgule française, 1 décimale sous 10 nm, entier au-dessus), sans dépendance Leaflet, testé (6 tests).
- `PlanMap.tsx` : tooltips permanents `.ow-seg-label` au milieu de chaque segment de la polyline de tracé, mise à jour au drag d'un waypoint, masquage automatique quand le segment fait moins de 48 px à l'écran, réévaluation sur `zoomend`.
- Style `.ow-seg-label` dans index.css (mono, surface glass, tokens thème clair/sombre, sans flèche de tooltip).

## Vérification
- vitest 60/60, build OK ; lint : uniquement les 26 erreurs préexistantes de dev.
- Runtime : tracé de 3 waypoints avec labels corrects ("270 nm"/"277 nm"), disparition après 2 dézooms et réapparition au zoom, clic au centre d'une étiquette insère bien un waypoint (chips en pointer-events none), stress 6 cycles de zoom sans erreur console.
- Note : une erreur `_leaflet_pos` observée une seule fois en tout début de session, non reproduite malgré replay complet et stress zoom ; à surveiller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)