### PR TITLE
feat(web): rename OpenWind to OhMyWind in the web app

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,30 +3,30 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenWind</title>
+    <title>OhMyWind</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#030712" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="OpenWind" />
+    <meta name="apple-mobile-web-app-title" content="OhMyWind" />
 
-    <meta name="description" content="OpenWind — sailing planner for the French Atlantic and Mediterranean coasts. Wind forecasts, passage estimates, complexity scores and high-precision tidal currents (SHOM Atlas C2D + MARC PREVIMER), powered by AROME 1.3 km models.">
+    <meta name="description" content="OhMyWind, sailing planner for the French Atlantic and Mediterranean coasts. Wind forecasts, passage estimates, complexity scores and high-precision tidal currents (SHOM Atlas C2D + MARC PREVIMER), powered by AROME 1.3 km models.">
 
     <!-- Open Graph -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://openwind.fr/">
-    <meta property="og:title" content="OpenWind — French Atlantic and Mediterranean sailing planner">
+    <meta property="og:url" content="https://ohmywind.fr/">
+    <meta property="og:title" content="OhMyWind, French Atlantic and Mediterranean sailing planner">
     <meta property="og:description" content="Wind forecasts, passage estimates, complexity scores and high-precision tidal currents for the French Atlantic and Mediterranean coasts. Powered by AROME 1.3 km, SHOM Atlas C2D and MARC PREVIMER.">
-    <meta property="og:image" content="https://openwind.fr/icon-512.png">
+    <meta property="og:image" content="https://ohmywind.fr/icon-512.png">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="OpenWind — French Atlantic and Mediterranean sailing planner">
+    <meta name="twitter:title" content="OhMyWind, French Atlantic and Mediterranean sailing planner">
     <meta name="twitter:description" content="Wind forecasts, passage estimates, complexity scores and SHOM-grade tidal currents for the French Atlantic and Mediterranean coasts.">
-    <meta name="twitter:image" content="https://openwind.fr/icon-512.png">
+    <meta name="twitter:image" content="https://ohmywind.fr/icon-512.png">
 
     <!-- Canonical -->
-    <link rel="canonical" href="https://openwind.fr/">
+    <link rel="canonical" href="https://ohmywind.fr/">
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -37,9 +37,9 @@
       {
         "@context": "https://schema.org",
         "@type": "Organization",
-        "name": "OpenWind",
-        "url": "https://openwind.fr",
-        "logo": "https://openwind.fr/icon-512.png"
+        "name": "OhMyWind",
+        "url": "https://ohmywind.fr",
+        "logo": "https://ohmywind.fr/icon-512.png"
       }
     </script>
   </head>

--- a/packages/web/public/CNAME
+++ b/packages/web/public/CNAME
@@ -1,1 +1,0 @@
-openwind.fr

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "OpenWind",
-  "short_name": "OpenWind",
+  "name": "OhMyWind",
+  "short_name": "OhMyWind",
   "description": "French Atlantic and Mediterranean sailing planner. Wind forecasts, passage estimates and SHOM-grade tidal currents.",
   "start_url": "/",
   "display": "standalone",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "./api/marine";
 import { useCustomSpots } from "./hooks/useCustomSpots";
 import { Header } from "./components/Header";
+import { RebrandBanner } from "./components/RebrandBanner";
 import { WindTable } from "./components/WindTable";
 import { MarineTable } from "./components/MarineTable";
 import { MetricPills } from "./components/MetricPills";
@@ -135,6 +136,7 @@ function App() {
       style={{ background: 'var(--ow-bg-0)', color: 'var(--ow-fg-0)' }}
     >
       <Header onSelectSpot={setSpot} />
+      <RebrandBanner />
 
       {/* Map fills the entire space; pills + table are an overlay floating
           above its bottom edge so the map keeps showing through the gaps

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -53,7 +53,7 @@ export function Header({ onSelectSpot }: HeaderProps) {
         <div className="flex items-center gap-2 shrink-0">
           <WindIcon />
           <h1 className="hidden sm:block text-xl font-extrabold tracking-tight">
-            <span style={{ color: 'var(--ow-fg-0)' }}>Open</span>
+            <span style={{ color: 'var(--ow-fg-0)' }}>OhMy</span>
             <span style={{ color: 'var(--ow-accent)' }}>Wind</span>
           </h1>
         </div>

--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -35,7 +35,7 @@ function InfoModal({ onClose }: { onClose: () => void }) {
       style={{ background: "rgba(0,0,0,0.6)" }}
       role="dialog"
       aria-modal="true"
-      aria-label="À propos d'OpenWind"
+      aria-label="À propos d'OhMyWind"
     >
       <div
         className="relative w-full lg:max-w-2xl max-h-[92vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl shadow-2xl"
@@ -70,7 +70,7 @@ export function InfoButton() {
     <>
       <button
         onClick={() => setOpen(true)}
-        aria-label="À propos d'OpenWind"
+        aria-label="À propos d'OhMyWind"
         title="À propos"
         className="shrink-0 min-w-[36px] min-h-[36px] flex items-center justify-center rounded-lg transition-colors"
         style={{ color: "var(--ow-fg-1)", background: "transparent" }}

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -8,7 +8,7 @@ export function InfoPanel() {
         className="text-lg lg:text-xl font-bold tracking-tight mb-4"
         style={{ color: "var(--ow-fg-0)" }}
       >
-        À propos d'OpenWind
+        À propos d'OhMyWind
       </h2>
 
       <section className="mb-5">
@@ -19,7 +19,7 @@ export function InfoPanel() {
           Le projet
         </h3>
         <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>
-          OpenWind rend accessible une météo marine de qualité aux voileux. Les
+          OhMyWind rend accessible une météo marine de qualité aux voileux. Les
           modèles AROME, ICON, GFS, ECMWF et les données de vagues, courants et
           marées sont publics et gratuits. Cette app les rassemble dans une vue
           lisible, sans compte ni installation.

--- a/packages/web/src/components/RebrandBanner.tsx
+++ b/packages/web/src/components/RebrandBanner.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+const DISMISS_KEY = "ohmywind_rebrand_banner_dismissed";
+
+function InfoGlyph() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="shrink-0"
+      style={{ color: "var(--ow-accent)" }}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="11" x2="12" y2="17" />
+      <line x1="12" y1="7" x2="12.01" y2="7" />
+    </svg>
+  );
+}
+
+export function RebrandBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) return null;
+
+  function close() {
+    try {
+      localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // localStorage unavailable (private mode): dismiss for this session only.
+    }
+    setDismissed(true);
+  }
+
+  return (
+    <div
+      className="w-full px-3 py-1.5 lg:px-6 text-xs lg:text-sm"
+      style={{
+        background: "var(--ow-accent-soft)",
+        borderBottom: "1px solid var(--ow-accent-line)",
+        color: "var(--ow-fg-0)",
+      }}
+    >
+      <div className="flex items-center gap-2.5 max-w-screen-2xl mx-auto">
+        <InfoGlyph />
+        <p className="flex-1 leading-snug" style={{ color: "var(--ow-fg-1)" }}>
+          <strong style={{ color: "var(--ow-fg-0)" }}>
+            OpenWind devient OhMyWind.
+          </strong>{" "}
+          Le projet reste open source et gratuit : seul le nom change, OpenWind
+          était trop proche d'autres applications. openwind.fr redirige
+          automatiquement, vos plans restent accessibles.
+        </p>
+        <button
+          onClick={close}
+          aria-label="Fermer l'annonce"
+          className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-base leading-none transition-colors hover:opacity-80"
+          style={{ color: "var(--ow-fg-1)", background: "transparent" }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/content/methodologie.md
+++ b/packages/web/src/content/methodologie.md
@@ -1,6 +1,6 @@
 # Méthodologie
 
-OpenWind est un planificateur de navigation à la voile open source pour les côtes françaises. Cette page explique d'où viennent les données, comment on estime un passage, et ce que l'outil ne sait volontairement pas faire.
+OhMyWind est un planificateur de navigation à la voile open source pour les côtes françaises. Cette page explique d'où viennent les données, comment on estime un passage, et ce que l'outil ne sait volontairement pas faire.
 
 ## Sommaire
 
@@ -19,7 +19,7 @@ OpenWind est un planificateur de navigation à la voile open source pour les cô
 - [Comment on déduit le courant en un point MARC](#comment-on-déduit-le-courant-en-un-point-marc)
 - [Comment on note la complexité](#comment-on-note-la-complexité)
 - [Les conventions du domaine](#les-conventions-du-domaine)
-- [Ce qu'OpenWind ne fait pas](#ce-quopenwind-ne-fait-pas)
+- [Ce qu'OhMyWind ne fait pas](#ce-quohmywind-ne-fait-pas)
 - [Sources et licences](#sources-et-licences)
 - [Hébergement](#hébergement)
 - [Code et contributions](#code-et-contributions)
@@ -60,7 +60,7 @@ Limite assumée : 8 km est suffisant au large mais reste trop grossier pour les 
 
 ### Courants côtiers haute précision : SHOM Atlas C2D et MARC PREVIMER
 
-Pour les passes critiques de la façade Atlantique, OpenWind ne se contente pas du SMOC à 8 km. La cascade de courants empile trois sources, du plus fin au plus large :
+Pour les passes critiques de la façade Atlantique, OhMyWind ne se contente pas du SMOC à 8 km. La cascade de courants empile trois sources, du plus fin au plus large :
 
 **1. SHOM Atlas C2D — la référence du SHOM (Service Hydrographique et Océanographique de la Marine).** Les atlas C2D rassemblent les courants de marée des côtes de France (Manche et Atlantique) sous forme de points scattered placés à la main par les hydrographes sur les axes de flux des passes navigationnelles. Édition 2005, 9 atlas (557 Pas de Calais, 558 Bretagne sud, 559 Vendée-Gironde, 560 Iroise / Brest, 561 Baie de Seine, 562 Golfe Normand-Breton, 563 Bretagne nord, 564 Manche, 565 Gascogne), environ 13 000 points au total. La couverture n'est pas continue : ce sont des cartouches centrés sur les zones d'intérêt nautique (Goulet de Brest, Rade de Brest, Raz de Sein, Goulet du Morbihan, Quiberon, Saint-Malo, Hague, etc.). Distribué par data.gouv.fr sous Licence Ouverte v2.0 Etalab. À chaque point, deux séries horaires de 13 valeurs U/V (composantes est-ouest et nord-sud) sont stockées, l'une pour les vives-eaux (coefficient 95), l'autre pour les mortes-eaux (coefficient 45), heures de -6 h à +6 h relatives à la pleine mer (ou basse mer) du port de référence de la zone (Port-Navalo, Brest, Saint-Malo…).
 
@@ -68,7 +68,7 @@ Pour les passes critiques de la façade Atlantique, OpenWind ne se contente pas 
 
 **3. Open-Meteo SMOC — fallback global** (déjà décrit ci-dessus, 8 km).
 
-À chaque point de route, OpenWind applique la cascade :
+À chaque point de route, OhMyWind applique la cascade :
 
 ```
 si point ∈ emprise SHOM C2D (≤ 5 km du point le plus proche)  →  SHOM (référence française)
@@ -84,15 +84,15 @@ Le champ `current_source` exposé sur chaque tronçon de route indique la source
 
 ## Comment on estime un passage
 
-Quand on demande "combien de temps pour aller de Marseille à Porquerolles avec un croiseur de 40 pieds", OpenWind procède en six temps.
+Quand on demande "combien de temps pour aller de Marseille à Porquerolles avec un croiseur de 40 pieds", OhMyWind procède en six temps.
 
 ### 1. Choix du voilier-type
 
-On commence par associer le bateau à un **archétype** standard. Chaque archétype porte un polaire **ORC** (Offshore Racing Congress, l'organisme international de jauge) théorique, c'est-à-dire la vitesse du bateau pour chaque combinaison de **TWS** (True Wind Speed, vitesse réelle du vent) et **TWA** (True Wind Angle, angle entre le vent réel et le cap du bateau). OpenWind n'associe pas un modèle commercial à un archétype côté serveur : la correspondance se fait à partir des descriptions textuelles publiées pour chaque archétype.
+On commence par associer le bateau à un **archétype** standard. Chaque archétype porte un polaire **ORC** (Offshore Racing Congress, l'organisme international de jauge) théorique, c'est-à-dire la vitesse du bateau pour chaque combinaison de **TWS** (True Wind Speed, vitesse réelle du vent) et **TWA** (True Wind Angle, angle entre le vent réel et le cap du bateau). OhMyWind n'associe pas un modèle commercial à un archétype côté serveur : la correspondance se fait à partir des descriptions textuelles publiées pour chaque archétype.
 
 Les polaires utilisées sont consultables ci-dessous (cliquez pour ouvrir). Chaque diagramme est tracé en demi-cercle (côté droit) : la vitesse du bateau est la distance au centre (en nœuds), l'angle au vent TWA est lu autour de la circonférence (0° = vent debout en haut, 90° = travers à droite, 180° = vent arrière en bas). Une courbe par valeur de TWS, du bleu clair (vent faible) au magenta (vent fort).
 
-> **Note de lecture.** Les polaires ne descendent pas jusqu'à TWA = 0°. Par convention, les tableaux ORC ne définissent la vitesse qu'à partir de l'angle minimal de remontée du bateau (typiquement 40° à 45°). Dans la zone "interdite" plus serrée que cet angle, OpenWind ne lit pas un zéro dans la polaire (qui annulerait la vitesse de planification) : on bascule sur le calcul de louvoyage par projection VMG décrit à l'[étape 4 ci-dessous](#4-polaire-angle-au-vent-et-tactique-au-près). C'est pour cette raison que les courbes apparaissent ouvertes en haut.
+> **Note de lecture.** Les polaires ne descendent pas jusqu'à TWA = 0°. Par convention, les tableaux ORC ne définissent la vitesse qu'à partir de l'angle minimal de remontée du bateau (typiquement 40° à 45°). Dans la zone "interdite" plus serrée que cet angle, OhMyWind ne lit pas un zéro dans la polaire (qui annulerait la vitesse de planification) : on bascule sur le calcul de louvoyage par projection VMG décrit à l'[étape 4 ci-dessous](#4-polaire-angle-au-vent-et-tactique-au-près). C'est pour cette raison que les courbes apparaissent ouvertes en haut.
 
 <details>
 <summary>Polaire — croiseur 20 pieds (Beneteau First 210, Catalina 22, Jeanneau Tonic 23, Jeanneau Sun 2000)</summary>
@@ -133,7 +133,7 @@ Les fichiers source (JSON) sont dans le dépôt sous [`packages/data-adapters/sr
 
 ### 2. Découpage de la route
 
-La route est une polyligne de points de route (point de départ, escales, arrivée). Pour chaque **tronçon** (paire de points de route consécutifs) de longueur $d$, OpenWind calcule un nombre de sous-segments :
+La route est une polyligne de points de route (point de départ, escales, arrivée). Pour chaque **tronçon** (paire de points de route consécutifs) de longueur $d$, OhMyWind calcule un nombre de sous-segments :
 
 $$
 n = \max\bigl(1,\ \lceil d / L \rceil\bigr)
@@ -163,7 +163,7 @@ soit la valeur absolue de l'écart angulaire ramenée dans $[0,\ 180]$. Les pola
 
 On lit ensuite la vitesse polaire $v_{\text{polaire}} = \text{polar}(\text{TWS},\ \text{TWA})$ par interpolation bilinéaire dans le tableau JSON de l'archétype.
 
-**Cas du près serré.** Si l'angle au vent demandé est plus serré que l'angle optimal de remontée du polaire (typiquement $\text{TWA} < 40\degree$ à $45\degree$), le bateau ne peut pas tenir directement le cap : il faut tirer des bords. OpenWind balaye TWA dans $[30\degree,\ 90\degree]$ pour trouver l'angle qui maximise le **VMG** (Velocity Made Good, projection de la vitesse polaire sur l'axe du vent : $v \cdot \cos(\text{TWA})$), puis projette la vitesse polaire à cet angle optimal sur le cap réel :
+**Cas du près serré.** Si l'angle au vent demandé est plus serré que l'angle optimal de remontée du polaire (typiquement $\text{TWA} < 40\degree$ à $45\degree$), le bateau ne peut pas tenir directement le cap : il faut tirer des bords. OhMyWind balaye TWA dans $[30\degree,\ 90\degree]$ pour trouver l'angle qui maximise le **VMG** (Velocity Made Good, projection de la vitesse polaire sur l'axe du vent : $v \cdot \cos(\text{TWA})$), puis projette la vitesse polaire à cet angle optimal sur le cap réel :
 
 $$
 v_{\text{eff}} = v_{\text{polaire}}(\text{TWA}_{\text{opt}}) \cdot \cos(\text{TWA}_{\text{opt}} - \text{TWA})
@@ -181,9 +181,9 @@ $$
 
 avec :
 
-- **`η` (efficacité)** : facteur multiplicatif qui ramène le polaire ORC théorique à la voile réelle. **OpenWind utilise actuellement la valeur 0.75 par défaut, et cette valeur n'est pas modifiable depuis l'interface web.** Le paramètre existe côté serveur (un client expert peut le surcharger) mais aucun champ utilisateur ne l'expose pour l'instant. Valeurs de référence si on devait l'ajuster :
+- **`η` (efficacité)** : facteur multiplicatif qui ramène le polaire ORC théorique à la voile réelle. **OhMyWind utilise actuellement la valeur 0.75 par défaut, et cette valeur n'est pas modifiable depuis l'interface web.** Le paramètre existe côté serveur (un client expert peut le surcharger) mais aucun champ utilisateur ne l'expose pour l'instant. Valeurs de référence si on devait l'ajuster :
   - `0.85` régate (carène propre, voiles fraîches, équipage attentif)
-  - `0.75` croisière (réglages standards, marges de confort, défaut OpenWind)
+  - `0.75` croisière (réglages standards, marges de confort, défaut OhMyWind)
   - `0.65` croisière chargée en famille (eau, gasoil, équipement, carène salie)
   - `0.55` mer formée, carène négligée, équipage réduit
 
@@ -210,7 +210,7 @@ Les deux champs doivent être remplis ensemble pour que la bascule s'active ; si
 
 Côté affichage, l'allure du leg (Près / Travers / Largue / Arrière) est remplacée par **Moteur** dès que plus de la moitié de la distance du leg a été parcourue moteur en route. Sous ce seuil, l'allure voile prévaut même si quelques sous-segments ont basculé.
 
-Cette modélisation est volontairement simple : pas de gestion de carburant, pas de seuil par angle au vent, pas de modulation du moteur par la mer. L'objectif est de rendre les estimations réalistes en zone de vent faible (typiquement Méditerranée d'été) sans transformer OpenWind en gestionnaire de bord.
+Cette modélisation est volontairement simple : pas de gestion de carburant, pas de seuil par angle au vent, pas de modulation du moteur par la mer. L'objectif est de rendre les estimations réalistes en zone de vent faible (typiquement Méditerranée d'été) sans transformer OhMyWind en gestionnaire de bord.
 
 ### 6. Vitesse au sol (SOG), courant et durée
 
@@ -232,7 +232,7 @@ et la durée totale du passage est la somme des durées des sous-segments.
 
 ## Comment on déduit le courant en un point MARC
 
-À l'intérieur d'une emprise MARC, les amplitudes et phases harmoniques des composantes **U** (est-ouest) et **V** (nord-sud) du courant sont stockées par cellule (250 m à 2 km selon l'atlas), une valeur par constituant astronomique. Pour évaluer le courant à un instant $t$ et une position donnée, OpenWind exécute le prédicteur Schureman/Cartwright séparément sur U et V :
+À l'intérieur d'une emprise MARC, les amplitudes et phases harmoniques des composantes **U** (est-ouest) et **V** (nord-sud) du courant sont stockées par cellule (250 m à 2 km selon l'atlas), une valeur par constituant astronomique. Pour évaluer le courant à un instant $t$ et une position donnée, OhMyWind exécute le prédicteur Schureman/Cartwright séparément sur U et V :
 
 $$
 U(t) = U_0 + \sum_{i=1}^{N} H_i^U \cdot f_i(t) \cdot \cos\bigl(\sigma_i \cdot (t - t_0) + V_{0,i}(t_0) + u_i(t) - G_i^U\bigr)
@@ -246,7 +246,7 @@ et symétriquement pour $V(t)$, avec :
 - $f_i(t),\ u_i(t)$ : corrections nodales (variation lente sur 18,6 ans liées aux mouvements de la lune) ;
 - $U_0,\ V_0$ : résiduel moyen non-tidal 2008-2009 inclus dans l'atlas (capture la circulation moyenne, mais pas la variabilité météo court-terme).
 
-OpenWind reconstruit ainsi $U$ et $V$ pour chaque sondage, puis en déduit la **vitesse** et la **direction** du courant total :
+OhMyWind reconstruit ainsi $U$ et $V$ pour chaque sondage, puis en déduit la **vitesse** et la **direction** du courant total :
 
 $$
 V_{\text{courant}} = \sqrt{U^2 + V^2}, \qquad \theta_{\text{courant}} = \operatorname{atan2}(U,\ V)
@@ -296,11 +296,11 @@ Côté niveaux de mer :
 - En Méditerranée et au large, l'affichage reste en MSL.
 - En zone MARC (Atlantique), on calcule un **zéro hydrographique** local (minimum de prédiction sur 19 ans par cellule) pour s'aligner sur la convention française.
 
-## Ce qu'OpenWind ne fait pas
+## Ce qu'OhMyWind ne fait pas
 
 Par choix de conception :
 
-- **Pas de routeur d'optimisation**. OpenWind ne cherche pas la "meilleure route" ni la "meilleure fenêtre". Il restitue les données brutes ; l'interprétation revient au marin.
+- **Pas de routeur d'optimisation**. OhMyWind ne cherche pas la "meilleure route" ni la "meilleure fenêtre". Il restitue les données brutes ; l'interprétation revient au marin.
 - **Pas un substitut à un atlas SHOM ou à une carte papier** dans une passe étroite. C'est un outil de planification, pas de pilotage.
 
 Limites assumées des données :
@@ -322,13 +322,13 @@ Référence académique pour MARC : Pineau-Guillou Lucia (2013). PREVIMER, Valid
 
 ## Hébergement
 
-OpenWind tourne intégralement sur des plateformes ouvertes et gratuites.
+OhMyWind tourne intégralement sur des plateformes ouvertes et gratuites.
 
-- L'application web statique [openwind.fr](https://openwind.fr) est servie par **GitHub Pages**, qui héberge gratuitement les pages publiques de tout dépôt open source, avec HTTPS et domaine personnalisé inclus.
+- L'application web statique [ohmywind.fr](https://ohmywind.fr) est servie par **Cloudflare Pages**, qui héberge gratuitement les pages publiques d'un dépôt open source, avec HTTPS et domaine personnalisé inclus.
 - Le serveur MCP tourne sur **Hugging Face Spaces** en Docker SDK, qui fournit gratuitement un conteneur public Linux, le HTTPS, et un service de Dataset privé pour héberger les atlas harmoniques MARC pré-calculés (5 GB, tirés au moment du build de l'image).
 
-Faire vivre un planificateur météo-marine open source et sans publicité serait significativement plus coûteux sans ces deux infrastructures. Merci à GitHub et à Hugging Face de les rendre accessibles à tous.
+Faire vivre un planificateur météo-marine open source et sans publicité serait significativement plus coûteux sans ces deux infrastructures. Merci à Cloudflare et à Hugging Face de les rendre accessibles à tous.
 
 ## Code et contributions
 
-OpenWind est intégralement open source. Le code, les polaires, le prédicteur harmonique et la cascade de routage sont sur le dépôt GitHub. Les contributions sont bienvenues, en particulier sur les polaires de nouveaux archétypes et sur l'extension de la couverture MARC.
+OhMyWind est intégralement open source. Le code, les polaires, le prédicteur harmonique et la cascade de routage sont sur le dépôt GitHub. Les contributions sont bienvenues, en particulier sur les polaires de nouveaux archétypes et sur l'extension de la couverture MARC.

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -144,7 +144,7 @@ export function ModePicker({
         icon="route"
         accent="var(--ow-accent)"
         title="Simuler ma route"
-        body="Vous savez quand partir. OpenWind calcule le temps du trajet, l'ETA et les conditions sur chaque segment."
+        body="Vous savez quand partir. OhMyWind calcule le temps du trajet, l'ETA et les conditions sur chaque segment."
         example="Ex. : « Si je pars samedi 17:00, j'arrive quand ? »"
         onClick={() => onPick("single")}
       />
@@ -152,7 +152,7 @@ export function ModePicker({
         icon="clock"
         accent="#F4C25C"
         title="Comparer les fenêtres"
-        body="Vous savez où aller. OpenWind teste plusieurs heures de départ et classe les créneaux par confort."
+        body="Vous savez où aller. OhMyWind teste plusieurs heures de départ et classe les créneaux par confort."
         example="Ex. : « Quel est le meilleur départ entre samedi et lundi ? »"
         onClick={() => onPick("compare")}
       />

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -94,7 +94,7 @@ export function ConfigPage() {
       <header className="config-header sticky top-0 z-10 border-b backdrop-blur">
         <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
           <a href={returnPath} className="text-sm font-medium opacity-80 hover:opacity-100 transition">
-            ← OpenWind
+            ← OhMyWind
           </a>
           <span className="text-xs opacity-60">Configuration</span>
         </div>
@@ -228,7 +228,7 @@ export function ConfigPage() {
         )}
 
         <footer className="config-storage-note mt-10">
-          OpenWind ne propose volontairement pas de comptes utilisateurs :
+          OhMyWind ne propose volontairement pas de comptes utilisateurs :
           aucune donnée n'est envoyée sur un serveur pour identifier qui tu es.
           Tes préférences (modèles, polaire perso) sont stockées localement
           dans ton navigateur. Si tu changes d'appareil, de navigateur ou si

--- a/packages/web/src/routes/MethodologiePage.tsx
+++ b/packages/web/src/routes/MethodologiePage.tsx
@@ -20,7 +20,7 @@ export function MethodologiePage() {
       <header className="methodo-header sticky top-0 z-10 border-b backdrop-blur">
         <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
           <a href="/" className="text-sm font-medium opacity-80 hover:opacity-100 transition">
-            ← OpenWind
+            ← OhMyWind
           </a>
           <span className="text-xs opacity-60">Méthodologie</span>
         </div>

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -5,6 +5,7 @@ import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError, type PlanOverrides } from "../api/passage";
 import { buildForecastCacheSafe, singleWindowMs, sweepWindowMs, etaWindowMs } from "../api/forecastCache";
 import { Header } from "../components/Header";
+import { RebrandBanner } from "../components/RebrandBanner";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import {
   loadLastSimulation,
@@ -787,6 +788,7 @@ export function PlanPage() {
       <Header
         onSelectSpot={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
       />
+      <RebrandBanner />
 
       {/* Body */}
       <div className="flex-1 min-h-0 flex flex-col lg:flex-row">


### PR DESCRIPTION
## Contexte
Début de la migration de marque : OpenWind devient OhMyWind (le nom était trop proche d'autres applications). Le projet reste open source et gratuit, et la communication doit le rappeler. Domaine canonique : https://ohmywind.fr (openwind.fr passera en 301, checklist Cloudflare hors repo).

## Changements
- Rename visible web uniquement : title, meta, OG/Twitter, schema.org, manifest, wordmark header (OhMy + Wind), InfoPanel/InfoButton, ModePicker, ConfigPage, MethodologiePage, methodologie.md (+ correction hébergement GitHub Pages -> Cloudflare Pages).
- URLs canonical/OG/schema basculées vers https://ohmywind.fr en un commit atomique.
- Nouvelle bannière d'annonce dismissible sous le header (home + /plan) : "OpenWind devient OhMyWind. Le projet reste open source et gratuit : seul le nom change..." (localStorage `ohmywind_rebrand_banner_dismissed`).
- Suppression de `public/CNAME` (reliquat GitHub Pages).

## Volontairement non renommé (phase 2 du rebrand)
- Clés localStorage `openwind_custom_spots` / `openwind:onboarding-v1` (perte de données utilisateur sinon), URLs backend hf.space, ko-fi.com/openwind, package.json, mcp-core/hf-space/README, `public/_headers` (infra Cloudflare actuelle).

## Vérification
- vitest 54/54, build OK (dist : 6 OhMyWind, 6 ohmywind.fr, plus de CNAME) ; lint : uniquement les erreurs préexistantes.
- Runtime : titre onglet, wordmark deux tons, bannière avec la copy validée, fermeture persistante après reload, canonical/og:url sur ohmywind.fr, /methodologie sans aucun "OpenWind" restant, aria-labels renommés. Aucun tiret cadratin dans la copy ajoutée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)