### PR TITLE
fix(web): make segment-length labels discreet, hide them earlier

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -293,23 +293,26 @@ body {
 }
 
 /* Live segment-length label at each leg midpoint while tracing a route.
-   A permanent Leaflet tooltip styled as a small glass chip; tokens are
-   theme-aware so it stays legible in both light and dark maps. The
-   tooltip arrow is removed since the chip sits centered on the segment. */
+   A permanent Leaflet tooltip rendered as bare text with a theme-aware
+   halo (no chip background) so it never hides the waypoints or the
+   polyline underneath. The tooltip arrow is removed since the label
+   sits centered on the segment. */
 .ow-seg-label {
   font-family: var(--ow-font-mono);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
   line-height: 1;
-  padding: 2px 5px;
-  color: var(--ow-fg-0);
-  background: var(--ow-surface-glass);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  border: 1px solid var(--ow-line-2);
-  border-radius: var(--ow-r-sm);
+  padding: 0;
+  color: var(--ow-fg-1);
+  background: none;
+  border: none;
+  border-radius: 0;
   box-shadow: none;
   white-space: nowrap;
+  text-shadow:
+    0 0 3px var(--ow-bg-1),
+    0 0 3px var(--ow-bg-1),
+    0 1px 2px var(--ow-bg-1);
 }
 .ow-seg-label::before {
   display: none;

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -7,9 +7,9 @@ import { cxLevel, CX_COLORS } from "./types";
 import { haversineNm, fmtNm } from "../utils/geo";
 
 /** Hide a segment label when the leg is shorter than this on screen (px).
-    Below it the chips overlap and clutter the map, so we let them fade out
+    Below it the labels crowd the waypoint markers, so we let them fade out
     as the user zooms out. */
-const SEG_LABEL_MIN_PX = 48;
+const SEG_LABEL_MIN_PX = 90;
 
 export interface PlanMapHandle {
   recenter: (lat: number, lon: number) => void;


### PR DESCRIPTION
Retour utilisateur sur #164 : les chips de distance prenaient trop de place et masquaient les waypoints (capture Marseille-Toulon).

- Label en texte nu avec halo theme-aware (text-shadow sur --ow-bg-1), 10px, couleur secondaire fg-1 : lisible sur les deux thèmes sans recouvrir marqueurs ni polyline.
- Seuil de masquage 48 px -> 90 px : les labels s'effacent plus tôt au dézoom.

Vérifié en runtime (thèmes clair et sombre, 5 waypoints serrés autour de Toulon) : 68 tests verts, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)