### PR TITLE
fix(web): align hero stats tiles between mobile and desktop, hide when stale

### DIFF
--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1189,13 +1189,13 @@ export function PlanSidebar({
       {/* Total route stats (Distance / Durée / Arrivée + segment bar).
           Desktop only: on mobile the floating overlay (PlanHeroStats) stays
           the single source of truth for these totals, per the b90a5bf
-          decision. Dimmed when the route was edited without recalculating so
-          the numbers read as stale. */}
-      <div className="hidden lg:block px-4 py-3.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
-        <div style={{ opacity: isStale ? 0.45 : 1 }}>
+          decision. Hidden entirely when the route was edited without
+          recalculating, same rule as the mobile overlay. */}
+      {!isStale && (
+        <div className="hidden lg:block px-4 py-3.5" style={{ borderBottom: "1px solid var(--ow-line)" }}>
           <HeroStats passage={passage} />
         </div>
-      </div>
+      )}
 
       {/* Warnings */}
       {hasWarnings && (

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -7,6 +7,7 @@ import { buildForecastCacheSafe, singleWindowMs, sweepWindowMs, etaWindowMs } fr
 import { Header } from "../components/Header";
 import { RebrandBanner } from "../components/RebrandBanner";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
+import { fmtDuration, fr1 } from "../plan/format";
 import {
   loadLastSimulation,
   saveLastSimulation,
@@ -80,20 +81,14 @@ function toTzAware(iso: string): string {
 function fmtTime(iso: string) {
   return new Date(iso).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
-function fmtDuration(h: number) {
-  const hrs = Math.floor(h);
-  const mins = Math.round((h - hrs) * 60);
-  return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
-}
-
 // Hero stats overlay — absolute, bottom of map, mobile only.
-// 3 tiles (ETA / Durée / Dist) — complexity is conveyed by the segment color
-// of the route on the map itself.
+// Same tiles, labels and formats as the desktop HeroStats block in the
+// sidebar (Distance / Durée / Arrivée) so both surfaces read identically.
 function PlanHeroStats({ passage }: { passage: PassageReport }) {
   const stats = [
-    { label: "ETA", value: fmtTime(passage.arrival_time) },
+    { label: "Distance", value: `${fr1(passage.distance_nm)} nm` },
     { label: "Durée", value: fmtDuration(passage.duration_h) },
-    { label: "Dist", value: `${passage.distance_nm.toFixed(1)} nm` },
+    { label: "Arrivée", value: fmtTime(passage.arrival_time) },
   ];
   return (
     <div className="flex gap-1.5">
@@ -838,9 +833,10 @@ export function PlanPage() {
             </div>
           )}
           {/* Hero stats overlay — mobile only, single-mode results.
-              3 tiles (ETA / Durée / Dist). Complexity is read from the
-              colored route on the map itself. */}
-          {passage && planMode === "single" && (
+              Hidden as soon as the route was edited without recalculating:
+              stale totals would contradict the "Recalculer" hint in the
+              drawer. Complexity is read from the colored route itself. */}
+          {passage && planMode === "single" && !isStale && (
             <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
               <PlanHeroStats passage={passage} />
             </div>


### PR DESCRIPTION
Retour utilisateur sur #163 : les tuiles mobiles et le bloc desktop divergeaient (ETA/Dist vs Arrivée/Distance, "3h 16m" vs "12h30", "28.6" vs "28,6"), et les totaux périmés restaient affichés sur mobile alors que le drawer demandait de recalculer.

- PlanHeroStats (mobile) utilise désormais les mêmes libellés, le même ordre (Distance / Durée / Arrivée) et les formatteurs partagés `fmtDuration` + `fr1` de src/plan/format.ts ; le formatteur local "12h 30m" est supprimé.
- Dès que l'itinéraire est modifié sans recalcul, les totaux disparaissent sur les deux surfaces (le grisé 45 % desktop est remplacé par un masquage complet, même règle que mobile).

Vérifié en runtime (émulation mobile 390px + desktop 1440px, vrai backend dev) : tuiles identiques au bloc desktop, disparition immédiate des deux surfaces à l'ajout d'un waypoint avec hint Recalculer visible. Tests et build verts, lint : baseline inchangée (26 préexistantes, 0 nouvelle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)