### PR TITLE
fix(web): seg-label style lost to leaflet tooltip CSS in prod builds

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -296,8 +296,13 @@ body {
    A permanent Leaflet tooltip rendered as bare text with a theme-aware
    halo (no chip background) so it never hides the waypoints or the
    polyline underneath. The tooltip arrow is removed since the label
-   sits centered on the segment. */
-.ow-seg-label {
+   sits centered on the segment.
+   The selector doubles up with .leaflet-tooltip on purpose: in the
+   production bundle leaflet.css is emitted AFTER this file, so a bare
+   .ow-seg-label loses to Leaflet's white default tooltip at equal
+   specificity (white chips + #222 text in prod, correct style on the
+   Vite dev server). Two classes beat it regardless of bundle order. */
+.leaflet-tooltip.ow-seg-label {
   font-family: var(--ow-font-mono);
   font-size: 10px;
   font-weight: 600;
@@ -314,7 +319,7 @@ body {
     0 0 3px var(--ow-bg-1),
     0 1px 2px var(--ow-bg-1);
 }
-.ow-seg-label::before {
+.leaflet-tooltip.ow-seg-label::before {
   display: none;
 }
 


### PR DESCRIPTION
Retour utilisateur : en prod les labels de distance apparaissent en chips blanches avec un texte flou, alors que le style validé (#167) est du texte nu avec halo.

## Cause
Dans le bundle de production, leaflet.css est émis APRÈS src/index.css. À spécificité égale (une classe), `.leaflet-tooltip` (background #fff, color #222, padding 6px, radius 3px) écrase `.ow-seg-label`. Le « flou » vient de notre text-shadow (halo prévu pour la carte sombre) qui reste appliqué sous le texte sombre sur le fond blanc de Leaflet. Le serveur de dev Vite injecte les styles dans l'ordre des imports, où notre règle gagne : le bug était invisible en HMR et sur les vérifs locales, il n'existait que dans les builds déployés.

## Fix
Sélecteur doublé `.leaflet-tooltip.ow-seg-label` (+ ::before) : deux classes battent la règle Leaflet quel que soit l'ordre d'émission du bundle. Commentaire ajouté dans le CSS pour expliquer pourquoi le doublement est volontaire.

## Vérification
Vérifié cette fois sur le BUILD DE PRODUCTION (vite preview, contexte navigateur vierge, thème sombre) : background transparent, color fg-1, padding 0, halo correct, ordre des règles inchangé dans le bundle mais notre sélecteur gagne. 68 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)