### PR TITLE
feat(dev): variante Android dev + parcours de tests QA

### DIFF
--- a/docs/qa/user-journeys.md
+++ b/docs/qa/user-journeys.md
@@ -1,0 +1,64 @@
+# Parcours de tests utilisateur (QA manuelle ou sous-agent)
+
+Checklist à dérouler avant toute promotion `dev` → `main`. Chaque parcours est autonome: précondition, étapes, résultat attendu. Un sous-agent peut exécuter un ou plusieurs parcours et rendre un verdict OK/KO par parcours, avec description précise de tout écart.
+
+## Environnements
+
+| Cible | URL / app | Quand |
+|---|---|---|
+| Web dev | https://dev.ohmywind.fr | avant chaque promotion |
+| Web prod | https://ohmywind.fr | après promotion (smoke) |
+| Android dev | app `fr.ohmywind.app.dev` (TWA sur dev.ohmywind.fr) | changements UI mobile ou wrapper |
+| Android prod | app `fr.ohmywind.app` (TWA sur ohmywind.fr) | avant upload Play Store |
+
+Outils: navigateur piloté (Chrome DevTools MCP) pour le web, émulateur Android + adb pour les apps (SDK dans `~/.bubblewrap/`, AVD `ohmywind`, cf. `packages/android/README.md`).
+
+## Parcours
+
+### J1. Premier lancement et géolocalisation
+- Précondition: stockage vierge (navigation privée, ou `pm clear` du navigateur sur émulateur; ne jamais `pm clear` en session partagée).
+- Étapes: ouvrir l'app. Accepter la demande de position.
+- Attendu: hint « Appui long pour placer votre premier spot » visible; après acceptation, la carte se centre sur la position (ou reste sur la France si position hors zone).
+
+### J2. Création de spot
+- Étapes: appui long (>1 s) sur une zone de mer.
+- Attendu: dialogue « New spot » avec coordonnées; « Create » crée le spot, la carte affiche le marqueur et la vue prévisions s'ouvre.
+
+### J3. Prévisions multi-modèles
+- Précondition: un spot existe (J2).
+- Étapes: observer le tableau horaire; swiper horizontalement; basculer les toggles Wind / Waves / Currents.
+- Attendu: AROME HD listé en premier; vitesses en nœuds (jamais km/h); flèches de direction cohérentes; le tableau scrolle; chaque toggle change les données affichées. En Méditerranée, l'absence de données marées/courants est normale (seuils: courant >= 0.3 kt, marnage >= 0.5 m).
+
+### J4. Recherche de lieu
+- Étapes: taper « Porquerolles » dans le champ Search, choisir un résultat.
+- Attendu: suggestions pertinentes; la carte se centre sur le lieu choisi.
+
+### J5. Planification d'itinéraire
+- Précondition: un spot existe (J2).
+- Étapes: entrer en mode planification (bouton compas). Tracer une route d'au moins 2 segments par appuis sur la carte. Observer le bandeau/tiroir de plan (récapitulatif distance, durée, complexité). Taper dessus, puis essayer un swipe vertical dessus.
+- Attendu: chaque waypoint s'ajoute avec segments visibles et longueurs; le bandeau de plan réagit au toucher (expansion/détail). ATTENTION, bug rapporté le 2026-07-11 sur mobile: bandeau non cliquable dans cette vue. Vérifier explicitement au toucher (pas à la souris).
+
+### J6. Dark mode
+- Étapes: basculer l'icône lune, recharger la page, rebasculer.
+- Attendu: bascule immédiate de toute l'UI (carte comprise), préférence persistée au rechargement.
+
+### J7. Bandeau rebrand OpenWind → OhMyWind
+- Étapes: premier affichage: lire le bandeau; cliquer la croix; recharger.
+- Attendu: texte mentionne la redirection openwind.fr et l'open source; la croix ferme le bandeau; il ne réapparaît pas après rechargement.
+
+### J8. Android: plein écran TWA et permissions
+- Précondition: app installée (adb), assetlinks à jour sur l'hôte visé.
+- Étapes: lancer l'app. Observer la barre du haut. Vérifier la demande de position.
+- Attendu: AUCUNE barre Chrome (pas d'URL visible), app bord à bord; la demande de position apparaît et fonctionne. Si barre Chrome: vérifier `https://<host>/.well-known/assetlinks.json` (200, bon package, bonne empreinte) puis purger les données Chrome et relancer.
+
+### J9. PWA (web)
+- Étapes: sur Chrome desktop, vérifier l'invite d'installation (icône dans l'omnibox); installer; lancer.
+- Attendu: fenêtre standalone, icône OhMyWind, thème sombre du manifest.
+
+## Lancer un sous-agent sur ces parcours
+
+Prompt type: « Exécute les parcours J2, J3, J5 de docs/qa/user-journeys.md contre https://dev.ohmywind.fr (ou l'app Android dev sur l'émulateur). Rends un verdict OK/KO par parcours avec repro exacte des écarts, texte seul. » Fournir au sous-agent: chemin adb et nom d'AVD pour l'Android, pièges connus de l'émulateur (popup Google Translate, panneau stylet Gboard, snackbar « Running in Chrome »).
+
+## Historique des bugs trouvés via ces parcours
+
+- 2026-07-11, J5: bandeau de plan non cliquable au toucher sur mobile (rapporté manuellement, en cours d'investigation).

--- a/packages/android-dev/.gitignore
+++ b/packages/android-dev/.gitignore
@@ -1,0 +1,4 @@
+# Whitelist: only the TWA config is versioned (see ../android/README.md).
+*
+!.gitignore
+!twa-manifest.json

--- a/packages/android-dev/twa-manifest.json
+++ b/packages/android-dev/twa-manifest.json
@@ -13,8 +13,8 @@
   "backgroundColor": "#030712",
   "enableNotifications": false,
   "startUrl": "/",
-  "iconUrl": "https://dev.ohmywind.fr/icon-512.png",
-  "maskableIconUrl": "https://dev.ohmywind.fr/icon-512.png",
+  "iconUrl": "https://ohmywind.fr/icon-512.png",
+  "maskableIconUrl": "https://ohmywind.fr/icon-512.png",
   "splashScreenFadeOutDuration": 300,
   "signingKey": {
     "path": "../android/android.keystore",

--- a/packages/android-dev/twa-manifest.json
+++ b/packages/android-dev/twa-manifest.json
@@ -1,0 +1,51 @@
+{
+  "packageId": "fr.ohmywind.app.dev",
+  "host": "dev.ohmywind.fr",
+  "name": "OhMyWind Dev",
+  "launcherName": "OhMyWind Dev",
+  "display": "standalone",
+  "themeColor": "#030712",
+  "themeColorDark": "#030712",
+  "navigationColor": "#030712",
+  "navigationColorDark": "#030712",
+  "navigationDividerColor": "#030712",
+  "navigationDividerColorDark": "#030712",
+  "backgroundColor": "#030712",
+  "enableNotifications": false,
+  "startUrl": "/",
+  "iconUrl": "https://dev.ohmywind.fr/icon-512.png",
+  "maskableIconUrl": "https://dev.ohmywind.fr/icon-512.png",
+  "splashScreenFadeOutDuration": 300,
+  "signingKey": {
+    "path": "../android/android.keystore",
+    "alias": "android"
+  },
+  "appVersionCode": 1,
+  "shortcuts": [],
+  "generatorApp": "bubblewrap-cli",
+  "webManifestUrl": "https://dev.ohmywind.fr/manifest.json",
+  "fallbackType": "customtabs",
+  "features": {
+    "locationDelegation": {
+      "enabled": true
+    }
+  },
+  "alphaDependencies": {
+    "enabled": false
+  },
+  "enableSiteSettingsShortcut": true,
+  "isChromeOSOnly": false,
+  "isMetaQuest": false,
+  "fullScopeUrl": "https://dev.ohmywind.fr/",
+  "minSdkVersion": 21,
+  "orientation": "default",
+  "fingerprints": [
+    {
+      "value": "91:53:D9:7A:BA:E2:F2:E0:6F:CD:A7:75:92:A5:D0:8D:F3:7B:8C:80:3C:05:9C:4E:02:78:D0:F8:60:E2:A6:19"
+    }
+  ],
+  "additionalTrustedOrigins": [],
+  "retainedBundles": [],
+  "displayOverride": [],
+  "appVersion": "1.0.0"
+}

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -32,6 +32,10 @@ Le contenu web, lui, se met à jour tout seul (c'est le site). Un rebuild n'est 
 
 `packages/web/public/.well-known/assetlinks.json` doit contenir l'empreinte SHA256 du certificat de signature, sinon l'app s'ouvre avec la barre Chrome au lieu du plein écran. Il est servi sur https://ohmywind.fr/.well-known/assetlinks.json. Si le keystore change (jamais, en principe), régénérer via `bubblewrap fingerprint` et redéployer le site.
 
+## Variante dev
+
+`packages/android-dev/` contient la même app pointée sur https://dev.ohmywind.fr, package `fr.ohmywind.app.dev`, installable à côté de la prod. Même keystore (chemin relatif `../android/android.keystore`), même procédure de build depuis `packages/android-dev/`. Elle ne se publie jamais sur le Play Store: usage interne pour tester la branche `dev` dans la coquille TWA. Son empreinte est déclarée dans le même `assetlinks.json`.
+
 ## Test sur device
 
 ```bash

--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -1,8 +1,18 @@
-[{
-      "relation": ["delegate_permission/common.handle_all_urls"],
-      "target": {
-        "namespace": "android_app",
-        "package_name": "fr.ohmywind.app",
-        "sha256_cert_fingerprints": ["91:53:D9:7A:BA:E2:F2:E0:6F:CD:A7:75:92:A5:D0:8D:F3:7B:8C:80:3C:05:9C:4E:02:78:D0:F8:60:E2:A6:19"]
-      }
-    }]
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "fr.ohmywind.app",
+      "sha256_cert_fingerprints": ["91:53:D9:7A:BA:E2:F2:E0:6F:CD:A7:75:92:A5:D0:8D:F3:7B:8C:80:3C:05:9C:4E:02:78:D0:F8:60:E2:A6:19"]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "fr.ohmywind.app.dev",
+      "sha256_cert_fingerprints": ["91:53:D9:7A:BA:E2:F2:E0:6F:CD:A7:75:92:A5:D0:8D:F3:7B:8C:80:3C:05:9C:4E:02:78:D0:F8:60:E2:A6:19"]
+    }
+  }
+]


### PR DESCRIPTION
## Quoi

- `packages/android-dev/`: TWA `fr.ohmywind.app.dev` pointée sur https://dev.ohmywind.fr, signée avec le même keystore, installable à côté de l'app prod. Usage interne uniquement, jamais publiée sur le Play Store.
- `assetlinks.json`: deuxième entrée pour le package dev (même empreinte de certificat). Nécessaire au plein écran TWA de l'app dev; sans effet sur la prod.
- `docs/qa/user-journeys.md`: parcours de tests utilisateur J1-J9 (spot, prévisions, itinéraire, dark mode, TWA plein écran...), pensés pour être exécutés par un sous-agent avant chaque promotion. Inclut le bug bandeau J5 rapporté ce jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)