### PR TITLE
feat(web): bouton "centrer sur moi" sur les cartes Explore et /plan

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { nowParisHourPrefix } from "./utils/format";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "./types";
 import { fetchAllModels } from "./api/openmeteo";
@@ -17,6 +17,8 @@ import { MetricPills } from "./components/MetricPills";
 import { TideChart } from "./components/TideChart";
 import { SpotMap } from "./components/SpotMap";
 import { Onboarding } from "./components/Onboarding";
+import { LocateButton } from "./components/LocateButton";
+import { useGeolocation } from "./hooks/useGeolocation";
 
 const DEFAULT_MAP_CENTER: { lat: number; lon: number } = { lat: 43.3, lon: 5.35 };
 
@@ -53,7 +55,17 @@ function App() {
   // to drop their first one. Returning users with saved spots resume on
   // their first favorite.
   const [spot, setSpot] = useState<Spot | null>(() => customSpots[0] ?? null);
-  const [geolocCenter, setGeolocCenter] = useState<{ lat: number; lon: number } | null>(null);
+  const { position: userPosition, status: geolocStatus, locate } = useGeolocation();
+  // Which fix the map is allowed to fly to. Set only on an explicit request
+  // (first visit, or a tap on the locate button) so an incoming fix never
+  // steals the viewport on its own.
+  const [flyToStamp, setFlyToStamp] = useState<number | null>(null);
+  // Read inside the mount-time geolocation callback, which must not re-run
+  // when the spot changes.
+  const spotRef = useRef<Spot | null>(spot);
+  useEffect(() => {
+    spotRef.current = spot;
+  }, [spot]);
   const [forecasts, setForecasts] = useState<ModelForecast[]>([]);
   const [marine, setMarine] = useState<MarineHourly | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -101,21 +113,25 @@ function App() {
   // spot. That way the canvas frames their region but stays empty (no
   // arrows, no forecasts) until they actively drop their first spot.
   // Denied / error → silent, the SpotMap falls back to its default center.
+  // High accuracy is off here: framing a region needs a city-level fix, and
+  // waking the GPS unprompted on a first visit is a poor trade.
   useEffect(() => {
     if (customSpots.length > 0) return;
-    if (!navigator.geolocation) return;
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        setGeolocCenter({ lat: pos.coords.latitude, lon: pos.coords.longitude });
-      },
-      () => {
-        /* permission denied or unavailable — keep SpotMap default center */
-      },
-      { timeout: 8000, maximumAge: 5 * 60 * 1000 },
-    );
+    locate({ enableHighAccuracy: false, maximumAge: 5 * 60 * 1000 }).then((fix) => {
+      // A spot picked while the fix was in flight means the user already
+      // chose their focus — leave the viewport alone.
+      if (fix && !spotRef.current) setFlyToStamp(fix.stamp);
+    });
   // Run once on mount; the customSpots check covers the returning-user case.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Explicit "centre sur moi": always honor it, spot selected or not.
+  const handleLocate = useCallback(() => {
+    locate().then((fix) => {
+      if (fix) setFlyToStamp(fix.stamp);
+    });
+  }, [locate]);
 
   // If the active view's data becomes irrelevant for the new spot (e.g. moving
   // from Atlantic to Med drops Tides/Currents below threshold), fall back to Wind.
@@ -145,7 +161,8 @@ function App() {
         <SpotMap
           current={spot}
           customSpots={customSpots}
-          geolocCenter={geolocCenter}
+          userPosition={userPosition}
+          flyToStamp={flyToStamp}
           defaultCenter={DEFAULT_MAP_CENTER}
           onSelectSpot={setSpot}
           onAddSpot={(s) => { addSpot(s); setSpot(s); }}
@@ -169,6 +186,10 @@ function App() {
         >
           <img src="/compass.png" alt="" width="88" height="88" className="select-none" draggable={false} />
         </a>
+
+        {/* Locate FAB — top right, opposite the compass, clear of the
+            bottom data overlay. */}
+        <LocateButton status={geolocStatus} onClick={handleLocate} className="top-3 right-3" />
 
         {/* Bottom overlay: pills (fixed at top of overlay) + scrollable table
             below. Pills sit in a ``shrink-0`` band so vertical scroll inside

--- a/packages/web/src/components/LocateButton.tsx
+++ b/packages/web/src/components/LocateButton.tsx
@@ -1,0 +1,70 @@
+import type { GeolocStatus } from "../hooks/useGeolocation";
+import { geolocMessage } from "../hooks/useGeolocation";
+
+interface LocateButtonProps {
+  status: GeolocStatus;
+  onClick: () => void;
+  /** Positioning is left to the host map so each page can dodge its own
+      overlays (drawer, hero stats, zoom control). */
+  className?: string;
+}
+
+/**
+ * "Centrer sur ma position" control, shared by the explore map and the
+ * planner map. Failures surface as a bubble next to the button rather than
+ * a blocking dialog: a refused permission should not interrupt someone who
+ * is mid-route. The bubble is a pure function of the status, so it clears
+ * itself as soon as the user retries rather than on a timer the user
+ * cannot see.
+ */
+export function LocateButton({ status, onClick, className = "" }: LocateButtonProps) {
+  const message = geolocMessage(status);
+  const locating = status === "locating";
+
+  return (
+    <div className={`absolute z-[400] flex flex-col items-end gap-2 ${className}`}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={locating}
+        aria-label="Centrer sur ma position"
+        title="Centrer sur ma position"
+        className="w-12 h-12 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95 disabled:cursor-progress"
+        style={{
+          background: "var(--ow-surface-glass)",
+          backdropFilter: "blur(8px)",
+          border: "1px solid var(--ow-line-2)",
+          color: status === "ready" ? "var(--ow-accent)" : "var(--ow-fg-1)",
+        }}
+      >
+        {locating ? (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="animate-spin">
+            <path d="M12 3a9 9 0 1 0 9 9" />
+          </svg>
+        ) : (
+          // Crosshair: the near-universal "locate me" glyph on maps.
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <circle cx="12" cy="12" r="7" />
+            <circle cx="12" cy="12" r="2.5" fill="currentColor" stroke="none" />
+            <path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3" />
+          </svg>
+        )}
+      </button>
+
+      {message && (
+        <p
+          role="status"
+          className="max-w-[15rem] px-3 py-2 rounded-xl text-xs animate-fade-in"
+          style={{
+            background: "var(--ow-surface-glass)",
+            backdropFilter: "blur(8px)",
+            border: "1px solid var(--ow-line-2)",
+            color: "var(--ow-fg-1)",
+          }}
+        >
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -4,6 +4,8 @@ import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "../types";
 import { QUICK_SPOTS } from "../spots";
 import { useTheme } from "../design/theme";
+import type { UserPosition } from "../hooks/useGeolocation";
+import { syncUserPositionLayer } from "../utils/userPositionLayer";
 
 // Spot-map arrows are drawn into a single 300×300 SVG anchored at the spot
 // (centre = 150,150). For ``wind``, each forecast contributes one arrow + label.
@@ -146,10 +148,15 @@ interface SpotMapProps {
   // viewport where it is rather than yanking back to a default center.
   current: Spot | null;
   customSpots: Spot[];
-  // First-visit hint: user position once the browser grants geolocation.
-  // The map recenters to it without auto-creating a spot, so new users
-  // see their region without arrows until they drop their first pin.
-  geolocCenter?: { lat: number; lon: number } | null;
+  // User position once the browser grants geolocation. Drawn as a dot with
+  // an accuracy halo, and used as the initial center when it is already
+  // known at mount. Never auto-creates a spot: new users see their region
+  // without arrows until they drop their first pin.
+  userPosition?: UserPosition | null;
+  // Bumped by the page when it wants the camera moved onto the user. Kept
+  // separate from `userPosition` so the map draws the dot without deciding
+  // when the viewport may be taken over: that policy lives in the page.
+  flyToStamp?: number | null;
   defaultCenter?: { lat: number; lon: number };
   onSelectSpot: (spot: Spot) => void;
   onAddSpot: (spot: Spot) => void;
@@ -168,7 +175,8 @@ function spotKey(s: Spot) {
 export function SpotMap({
   current,
   customSpots,
-  geolocCenter,
+  userPosition,
+  flyToStamp,
   defaultCenter,
   onSelectSpot,
   onAddSpot,
@@ -183,6 +191,7 @@ export function SpotMap({
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<Map<string, L.CircleMarker>>(new Map());
   const arrowLayerRef = useRef<L.Marker | null>(null);
+  const userLayerRef = useRef<L.LayerGroup | null>(null);
   const onSelectRef = useRef(onSelectSpot);
   onSelectRef.current = onSelectSpot;
   const onAddRef = useRef(onAddSpot);
@@ -225,16 +234,25 @@ export function SpotMap({
     }
   }, [resolvedTheme]);
 
-  // Geolocation arrives async after init. When it lands AND the user has no
-  // active spot yet (typical first-visit case), smoothly fly to it so the map
-  // frames their region. If a spot is selected, the user has already chosen
-  // their focus — don't yank the viewport away.
+  // Draw the "you are here" dot whenever a fix is known.
   useEffect(() => {
     if (!mapRef.current) return;
-    if (!geolocCenter) return;
-    if (current) return;
-    mapRef.current.flyTo([geolocCenter.lat, geolocCenter.lon], 10, { duration: 1.2 });
-  }, [geolocCenter, current]);
+    syncUserPositionLayer(mapRef.current, userLayerRef, userPosition ?? null);
+  }, [userPosition]);
+
+  // Fly to the user only when the page asks for it (first visit with no
+  // saved spot, or an explicit tap on the locate button). Keying on the
+  // stamp rather than the coordinates means a second tap still recenters
+  // after the user has panned away, even though the fix is unchanged.
+  useEffect(() => {
+    if (!mapRef.current) return;
+    if (!flyToStamp || !userPosition) return;
+    mapRef.current.flyTo([userPosition.lat, userPosition.lon], 10, { duration: 1.2 });
+    // userPosition is intentionally not a dependency: the stamp is what
+    // expresses "a move was requested", and a fresh fix alone must not
+    // steal the viewport.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flyToStamp]);
 
   // Init map once
   useEffect(() => {
@@ -242,8 +260,8 @@ export function SpotMap({
 
     const initialCenter: [number, number] = current
       ? [current.latitude, current.longitude]
-      : geolocCenter
-        ? [geolocCenter.lat, geolocCenter.lon]
+      : userPosition
+        ? [userPosition.lat, userPosition.lon]
         : defaultCenter
           ? [defaultCenter.lat, defaultCenter.lon]
           : [43.3, 5.35];
@@ -251,7 +269,7 @@ export function SpotMap({
     // (typical first-visit + denied case), open wide enough to show OpenWind's
     // full scope — Atlantic + Mediterranean French coast — so the user
     // understands the geographic reach before zooming into their region.
-    const initialZoom = current || geolocCenter ? 10 : 6;
+    const initialZoom = current || userPosition ? 10 : 6;
     const map = L.map(containerRef.current, {
       zoomControl: false,
       attributionControl: false,

--- a/packages/web/src/hooks/useGeolocation.test.ts
+++ b/packages/web/src/hooks/useGeolocation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { statusFromErrorCode, geolocMessage } from "./useGeolocation";
+
+describe("statusFromErrorCode", () => {
+  it("maps PERMISSION_DENIED to denied", () => {
+    expect(statusFromErrorCode(1)).toBe("denied");
+  });
+
+  it("maps TIMEOUT to timeout", () => {
+    expect(statusFromErrorCode(3)).toBe("timeout");
+  });
+
+  it("maps POSITION_UNAVAILABLE to unavailable", () => {
+    expect(statusFromErrorCode(2)).toBe("unavailable");
+  });
+
+  it("falls back to unavailable for codes outside the spec", () => {
+    // Some WebViews report codes the spec does not define; a wrong-but-safe
+    // "unavailable" beats crashing on an unmapped value.
+    expect(statusFromErrorCode(0)).toBe("unavailable");
+    expect(statusFromErrorCode(42)).toBe("unavailable");
+  });
+});
+
+describe("geolocMessage", () => {
+  it("stays silent while nothing has gone wrong", () => {
+    expect(geolocMessage("idle")).toBeNull();
+    expect(geolocMessage("locating")).toBeNull();
+    expect(geolocMessage("ready")).toBeNull();
+  });
+
+  it("explains every failure state", () => {
+    for (const status of ["denied", "unavailable", "timeout"] as const) {
+      expect(geolocMessage(status)).toBeTruthy();
+    }
+  });
+
+  it("keeps user-facing copy free of em-dashes", () => {
+    for (const status of ["denied", "unavailable", "timeout"] as const) {
+      expect(geolocMessage(status)).not.toContain("—");
+    }
+  });
+});

--- a/packages/web/src/hooks/useGeolocation.ts
+++ b/packages/web/src/hooks/useGeolocation.ts
@@ -1,0 +1,119 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface UserPosition {
+  lat: number;
+  lon: number;
+  /** Horizontal accuracy radius in metres, as reported by the browser. */
+  accuracyM: number;
+  /** Monotonic id bumped on every fix. Consumers key their "fly to me"
+      effects on it so a second tap on the locate button still recenters,
+      even when the coordinates came back byte-identical to the previous
+      fix (stationary user, cached position). */
+  stamp: number;
+}
+
+export type GeolocStatus =
+  | "idle"
+  | "locating"
+  | "ready"
+  | "denied"
+  | "unavailable"
+  | "timeout";
+
+/** Browser error code → status. Codes are the GeolocationPositionError
+    constants (1 PERMISSION_DENIED, 2 POSITION_UNAVAILABLE, 3 TIMEOUT);
+    they are read numerically because the constants are unavailable in a
+    non-DOM test environment. */
+export function statusFromErrorCode(code: number): GeolocStatus {
+  switch (code) {
+    case 1:
+      return "denied";
+    case 3:
+      return "timeout";
+    default:
+      return "unavailable";
+  }
+}
+
+/** User-facing French copy for the failure states. Returns null when there
+    is nothing to say (idle, locating, ready). */
+export function geolocMessage(status: GeolocStatus): string | null {
+  switch (status) {
+    case "denied":
+      return "Position refusée. Autorisez la localisation dans les réglages de votre navigateur.";
+    case "unavailable":
+      return "Position indisponible. Vérifiez que la localisation est activée sur votre appareil.";
+    case "timeout":
+      return "La position met trop de temps à arriver. Réessayez.";
+    default:
+      return null;
+  }
+}
+
+/** A locate() request that never rejects: failures resolve to null and are
+    reflected in `status`. Geolocation denial is an ordinary outcome here,
+    not an exception to handle at every call site. */
+const DEFAULT_OPTIONS: PositionOptions = {
+  enableHighAccuracy: true,
+  timeout: 10_000,
+  // A minute-old fix is fine for framing a map. Anything older and we would
+  // risk centering on the harbour the user left this morning.
+  maximumAge: 60_000,
+};
+
+/**
+ * Browser geolocation as a mechanism, with no policy of its own.
+ *
+ * Callers decide *when* to ask and *what* to do with a fix. `locate()`
+ * resolves with the position so a page can act on that specific fix
+ * (recenter, bias a search) without racing an effect on shared state.
+ */
+export function useGeolocation() {
+  const [position, setPosition] = useState<UserPosition | null>(null);
+  const [status, setStatus] = useState<GeolocStatus>("idle");
+  const stampRef = useRef(0);
+  const inFlightRef = useRef<Promise<UserPosition | null> | null>(null);
+
+  const locate = useCallback(
+    (options?: PositionOptions): Promise<UserPosition | null> => {
+      if (typeof navigator === "undefined" || !navigator.geolocation) {
+        setStatus("unavailable");
+        return Promise.resolve(null);
+      }
+      // Rapid double-taps share one browser prompt rather than queueing a
+      // second permission dialog behind the first.
+      if (inFlightRef.current) return inFlightRef.current;
+
+      setStatus("locating");
+      const request = new Promise<UserPosition | null>((resolve) => {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            stampRef.current += 1;
+            const next: UserPosition = {
+              lat: pos.coords.latitude,
+              lon: pos.coords.longitude,
+              accuracyM: pos.coords.accuracy,
+              stamp: stampRef.current,
+            };
+            setPosition(next);
+            setStatus("ready");
+            resolve(next);
+          },
+          (err) => {
+            setStatus(statusFromErrorCode(err.code));
+            resolve(null);
+          },
+          { ...DEFAULT_OPTIONS, ...options },
+        );
+      }).finally(() => {
+        inFlightRef.current = null;
+      });
+
+      inFlightRef.current = request;
+      return request;
+    },
+    [],
+  );
+
+  return { position, status, locate };
+}

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -5,6 +5,8 @@ import { useTheme } from "../design/theme";
 import type { SegmentReport } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
 import { haversineNm, fmtNm } from "../utils/geo";
+import type { UserPosition } from "../hooks/useGeolocation";
+import { syncUserPositionLayer } from "../utils/userPositionLayer";
 
 /** Hide a segment label when the leg is shorter than this on screen (px).
     Below it the labels crowd the waypoint markers, so we let them fade out
@@ -32,6 +34,9 @@ interface PlanMapProps {
   /** Optional hint for the initial view when there are no waypoints yet
       (typically propagated from the home spot via `?center=lat,lon`). */
   initialCenter?: [number, number] | null;
+  /** Drawn as a dot with an accuracy halo. Recentering stays the page's
+      call, through the `recenter` imperative handle. */
+  userPosition?: UserPosition | null;
 }
 
 function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon {
@@ -47,7 +52,7 @@ function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon 
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick, highlightedSegmentRange, initialCenter }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick, highlightedSegmentRange, initialCenter, userPosition }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -58,6 +63,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const markersRef = useRef<L.Marker[]>([]);
   const dragLineRef = useRef<L.Polyline | null>(null);
   const segLabelsRef = useRef<L.Tooltip[]>([]);
+  const userLayerRef = useRef<L.LayerGroup | null>(null);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const isDraggingRef = useRef(false);
   const onWptAddRef = useRef(onWptAdd);
@@ -90,6 +96,11 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   useEffect(() => {
     livePositionsRef.current = waypoints;
   }, [waypoints]);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    syncUserPositionLayer(mapRef.current, userLayerRef, userPosition ?? null);
+  }, [userPosition]);
 
   // Draw the live per-segment length labels: one permanent tooltip at each
   // leg midpoint, showing the great-circle distance in nm. Auto-hides legs

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from "react";
+import { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
@@ -20,6 +20,8 @@ import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
 import { effectivePolar, isPolarCustomized, loadPolarConfig, polarFingerprint } from "../config/polarConfig";
+import { LocateButton } from "../components/LocateButton";
+import { useGeolocation } from "../hooks/useGeolocation";
 
 // Build the plan-time overrides payload from current /config preferences.
 // Read at request time (not at mount) so a /config tweak takes effect on the
@@ -304,6 +306,15 @@ function ResizableDesktopSidebar({
 
 export function PlanPage() {
   const mapRef = useRef<PlanMapHandle>(null);
+
+  const { position: userPosition, status: geolocStatus, locate } = useGeolocation();
+  // On /plan the user is building a route, so a locate request is always
+  // explicit: no first-visit auto-centering here.
+  const handleLocate = useCallback(() => {
+    locate().then((fix) => {
+      if (fix) mapRef.current?.recenter(fix.lat, fix.lon);
+    });
+  }, [locate]);
   const drawerRef = useRef<DrawerHandle>(null);
   const initialParsed = parsePlanUrl(window.location.search);
 
@@ -799,6 +810,7 @@ export function PlanPage() {
             onWptDelete={handleWptDelete}
             onMapClick={handleMapClick}
             initialCenter={isParsedOk(initialParsed) ? initialParsed.center : null}
+            userPosition={userPosition}
             highlightedSegmentRange={
               selectedLegIdx != null && passage
                 ? computeLegSegmentRanges(passage.segments as { start: { lat: number; lon: number } }[], waypoints)[selectedLegIdx] ?? null
@@ -814,6 +826,9 @@ export function PlanPage() {
           >
             <img src="/wind-icon.png" alt="" width="88" height="88" className="select-none" draggable={false} />
           </a>
+          {/* Locate FAB — top right, clear of the bottom-right zoom control
+              and of the mobile hero stats overlay. */}
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="top-3 right-3" />
           {/* Hint overlay while building the route */}
           {waypoints.length < 2 && (
             <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">

--- a/packages/web/src/utils/accuracy.test.ts
+++ b/packages/web/src/utils/accuracy.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { shouldDrawAccuracy } from "./accuracy";
+
+describe("shouldDrawAccuracy", () => {
+  it("draws the halo for a typical GPS fix", () => {
+    expect(shouldDrawAccuracy(30)).toBe(true);
+    expect(shouldDrawAccuracy(1200)).toBe(true);
+  });
+
+  it("skips a halo smaller than the dot itself", () => {
+    expect(shouldDrawAccuracy(5)).toBe(false);
+  });
+
+  it("skips the halo for a coarse desktop fix", () => {
+    // Wi-Fi and IP-derived fixes routinely report tens of kilometres. A disc
+    // that size hides the coastline the user is reading.
+    expect(shouldDrawAccuracy(50_000)).toBe(false);
+  });
+
+  it("rejects non-finite accuracies", () => {
+    expect(shouldDrawAccuracy(Number.NaN)).toBe(false);
+    expect(shouldDrawAccuracy(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});

--- a/packages/web/src/utils/accuracy.ts
+++ b/packages/web/src/utils/accuracy.ts
@@ -1,0 +1,21 @@
+/** Below this the accuracy disc is smaller than the position dot itself, so
+    drawing it adds nothing. */
+const MIN_ACCURACY_M = 25;
+/** Above this we are almost certainly on a desktop IP-derived fix. A disc
+    that size would swamp the coastline the user is trying to read, so we
+    keep the dot and drop the halo. */
+const MAX_ACCURACY_M = 20_000;
+
+/**
+ * Whether the accuracy halo is worth drawing for this fix.
+ *
+ * Lives apart from the Leaflet layer so the threshold policy stays testable
+ * without a DOM.
+ */
+export function shouldDrawAccuracy(accuracyM: number): boolean {
+  return (
+    Number.isFinite(accuracyM) &&
+    accuracyM >= MIN_ACCURACY_M &&
+    accuracyM <= MAX_ACCURACY_M
+  );
+}

--- a/packages/web/src/utils/userPositionLayer.ts
+++ b/packages/web/src/utils/userPositionLayer.ts
@@ -1,0 +1,47 @@
+import L from "leaflet";
+import type { UserPosition } from "../hooks/useGeolocation";
+import { shouldDrawAccuracy } from "./accuracy";
+
+/**
+ * Idempotently reflect `position` onto the map as a blue dot plus an
+ * accuracy halo. Passing null removes the layer. Shared by the explore and
+ * planner maps so the "you are here" marker looks the same in both.
+ */
+export function syncUserPositionLayer(
+  map: L.Map,
+  layerRef: { current: L.LayerGroup | null },
+  position: UserPosition | null,
+): void {
+  if (!position) {
+    layerRef.current?.remove();
+    layerRef.current = null;
+    return;
+  }
+
+  const latlng: [number, number] = [position.lat, position.lon];
+  layerRef.current?.remove();
+
+  const group = L.layerGroup();
+  if (shouldDrawAccuracy(position.accuracyM)) {
+    L.circle(latlng, {
+      radius: position.accuracyM,
+      color: "#3b82f6",
+      weight: 1,
+      opacity: 0.5,
+      fillColor: "#3b82f6",
+      fillOpacity: 0.12,
+      interactive: false,
+    }).addTo(group);
+  }
+  L.circleMarker(latlng, {
+    radius: 6,
+    color: "#ffffff",
+    weight: 2,
+    fillColor: "#3b82f6",
+    fillOpacity: 1,
+    interactive: false,
+  }).addTo(group);
+
+  group.addTo(map);
+  layerRef.current = group;
+}


### PR DESCRIPTION
## Pourquoi

La géolocalisation n'existait que sous une forme : un recentrage automatique à la première visite, enfoui dans `App.tsx`, déclenché seulement si l'utilisateur n'avait aucun spot sauvegardé. Aucun moyen de la redemander ensuite, et `/plan` n'en avait pas du tout.

## Ce que ça change

Un FAB "centrer sur ma position" en haut à droite des deux cartes, et le mécanisme extrait dans un hook réutilisable.

Le hook `useGeolocation` ne porte aucune politique : `locate()` résout avec le fix obtenu, donc chaque page décide si elle recentre.

- Explore garde son recentrage première visite, toujours conditionné à l'absence de spot actif, et honore en plus tout clic explicite.
- `/plan` ne recentre que sur clic, jamais tout seul, puisque l'utilisateur y trace une route et qu'un déplacement de caméra subi y serait hostile.

Le fix porte un `stamp` monotone. Sans lui, un second appui sur le bouton après avoir baladé la carte ne recentrerait pas quand le navigateur rend une position identique depuis son cache, l'effet ne voyant aucun changement de dépendance.

La position s'affiche en pastille bleue avec halo de précision, partagée par les deux cartes. Le halo est masqué sous 25 m, où il serait plus petit que la pastille, et au-delà de 20 km, où un fix desktop dérivé de l'IP noierait la côte sous un disque géant.

Les échecs (refus, indisponible, timeout) s'affichent en bulle à côté du bouton. Elle est dérivée du statut, sans timer ni dialogue bloquant : une permission refusée ne doit pas interrompre quelqu'un en pleine construction de route.

La requête automatique de première visite passe en `enableHighAccuracy: false`, réveiller le GPS sans que l'utilisateur ait rien demandé étant un mauvais échange pour un simple cadrage de région. Le bouton, lui, demande la haute précision.

## Vérifications

- 79 tests web verts (68 avant, 11 ajoutés sur les helpers purs : mapping des codes d'erreur, copy sans tiret cadratin, seuils du halo)
- `tsc --noEmit` propre
- ESLint à 27 problèmes, exactement le niveau de `dev`, aucune régression introduite
- `npm run build` OK

## À tester à la main

- Explore et `/plan` : le bouton recentre, la pastille et le halo apparaissent
- Refuser la permission : la bulle explique, rien ne bloque
- `/plan` : vérifier qu'aucun recentrage ne se déclenche tout seul pendant le tracé
- App Android dev : la géoloc en TWA passe par la permission Chrome au niveau OS, à valider sur device réel

🤖 Generated with [Claude Code](https://claude.com/claude-code)