### PR TITLE
feat(web): recherche contextualisée par proximité, via Photon

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -28,6 +28,11 @@
     <!-- Canonical -->
     <link rel="canonical" href="https://ohmywind.fr/">
 
+    <!-- Geocoders used by the search box. Opening the TLS connection at page
+         load removes the ~200 ms handshake from the first keystroke. -->
+    <link rel="preconnect" href="https://photon.komoot.io" crossorigin>
+    <link rel="preconnect" href="https://geocoding-api.open-meteo.com" crossorigin>
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="apple-touch-icon" sizes="192x192" href="/icon-192.png">

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -206,10 +206,12 @@ function App() {
         <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
           {/* Locate FAB — anchored to the overlay rather than to the map, so
               it rides up and down as the data panel grows and shrinks
-              instead of ending up buried under it. Sits flush on the pills
-              band, whose 48 px height matches the button exactly. Out of
+              instead of ending up buried under it. The 16 px offset is
+              measured from the solid table below, not from the pills band,
+              which is transparent over the map: the button straddles the
+              pills and keeps the same gap to the panel as on /plan. Out of
               flow, so it does not push the pills around. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="top-0 right-3" />
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="-top-4 right-3" />
           {spot ? (
             <>
               <div className="shrink-0">

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -206,9 +206,10 @@ function App() {
         <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
           {/* Locate FAB — anchored to the overlay rather than to the map, so
               it rides up and down as the data panel grows and shrinks
-              instead of ending up buried under it. Out of flow, so it does
-              not disturb the pills row it floats above. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="-top-16 right-3" />
+              instead of ending up buried under it. Sits flush on the pills
+              band, whose 48 px height matches the button exactly. Out of
+              flow, so it does not push the pills around. */}
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="top-0 right-3" />
           {spot ? (
             <>
               <div className="shrink-0">

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -151,7 +151,16 @@ function App() {
       className="h-screen flex flex-col overflow-hidden"
       style={{ background: 'var(--ow-bg-0)', color: 'var(--ow-fg-0)' }}
     >
-      <Header onSelectSpot={setSpot} />
+      {/* Search proximity reference: the granted position first, else the
+          spot the user is looking at. When neither is known we send no bias
+          at all rather than defaulting to the Med, which would sink Atlantic
+          results for a first-time visitor on the Channel. */}
+      <Header
+        onSelectSpot={setSpot}
+        nearLat={userPosition?.lat ?? spot?.latitude ?? null}
+        nearLon={userPosition?.lon ?? spot?.longitude ?? null}
+        savedSpots={customSpots}
+      />
       <RebrandBanner />
 
       {/* Map fills the entire space; pills + table are an overlay floating
@@ -187,10 +196,6 @@ function App() {
           <img src="/compass.png" alt="" width="88" height="88" className="select-none" draggable={false} />
         </a>
 
-        {/* Locate FAB — top right, opposite the compass, clear of the
-            bottom data overlay. */}
-        <LocateButton status={geolocStatus} onClick={handleLocate} className="top-3 right-3" />
-
         {/* Bottom overlay: pills (fixed at top of overlay) + scrollable table
             below. Pills sit in a ``shrink-0`` band so vertical scroll inside
             the data area never sweeps them away. The data area provides a
@@ -199,6 +204,11 @@ function App() {
             scrolls (otherwise the hour row drifts away when the user scrolls
             down through GFS/ECMWF rows). */}
         <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
+          {/* Locate FAB — anchored to the overlay rather than to the map, so
+              it rides up and down as the data panel grows and shrinks
+              instead of ending up buried under it. Out of flow, so it does
+              not disturb the pills row it floats above. */}
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="-top-16 right-3" />
           {spot ? (
             <>
               <div className="shrink-0">

--- a/packages/web/src/api/coordinates.test.ts
+++ b/packages/web/src/api/coordinates.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseCoordinates, formatCoordinates } from "./coordinates";
+
+describe("parseCoordinates", () => {
+  it("reads a decimal pair", () => {
+    expect(parseCoordinates("48.39, -4.49")).toEqual({ lat: 48.39, lon: -4.49 });
+    expect(parseCoordinates("  43.29 5.37 ")).toEqual({ lat: 43.29, lon: 5.37 });
+  });
+
+  it("reads French comma decimals", () => {
+    expect(parseCoordinates("48,39 -4,49")).toEqual({ lat: 48.39, lon: -4.49 });
+    expect(parseCoordinates("48,39, -4,49")).toEqual({ lat: 48.39, lon: -4.49 });
+  });
+
+  it("reads degrees and decimal minutes, the form used on charts", () => {
+    const parsed = parseCoordinates("48°23.4'N 4°29.7'W");
+    expect(parsed?.lat).toBeCloseTo(48.39, 2);
+    expect(parsed?.lon).toBeCloseTo(-4.495, 3);
+  });
+
+  it("reads degrees minutes seconds", () => {
+    const parsed = parseCoordinates("48°23'24\"N 4°29'42\"W");
+    expect(parsed?.lat).toBeCloseTo(48.39, 2);
+    expect(parsed?.lon).toBeCloseTo(-4.495, 3);
+  });
+
+  it("accepts the French O for Ouest", () => {
+    const parsed = parseCoordinates("47°38,5' N 3°21,0' O");
+    expect(parsed?.lon).toBeLessThan(0);
+  });
+
+  it("accepts hemisphere letters before the numbers", () => {
+    const parsed = parseCoordinates("N 48 23.4 W 004 29.7");
+    expect(parsed?.lat).toBeCloseTo(48.39, 2);
+    expect(parsed?.lon).toBeCloseTo(-4.495, 3);
+  });
+
+  it("rejects place names that merely contain numbers", () => {
+    expect(parseCoordinates("Route 66")).toBeNull();
+    expect(parseCoordinates("Saint-Martin")).toBeNull();
+    expect(parseCoordinates("Port 2000")).toBeNull();
+  });
+
+  it("rejects out-of-range values", () => {
+    expect(parseCoordinates("120.5, 4.2")).toBeNull();
+    expect(parseCoordinates("48.3, 200.1")).toBeNull();
+  });
+});
+
+describe("formatCoordinates", () => {
+  it("echoes back in degrees and decimal minutes, French style", () => {
+    expect(formatCoordinates(48.39, -4.495)).toBe("48°23,4' N 4°29,7' O");
+  });
+
+  it("marks southern and eastern hemispheres", () => {
+    expect(formatCoordinates(-33.5, 18.25)).toBe("33°30,0' S 18°15,0' E");
+  });
+});

--- a/packages/web/src/api/coordinates.ts
+++ b/packages/web/src/api/coordinates.ts
@@ -1,0 +1,120 @@
+/**
+ * Recognise coordinates typed straight into the search box.
+ *
+ * Sailors routinely carry a position off a chart, a logbook or another crew's
+ * message rather than a place name, most often in degrees plus decimal
+ * minutes. Making those first-class saves a detour through a converter.
+ *
+ * Supported: decimal pairs ("48.39, -4.49", French comma decimals included),
+ * and degrees/minutes/seconds or degrees/decimal-minutes carrying explicit
+ * hemisphere letters ("48°23.4'N 4°29.7'W", "N 48 23 24 W 004 29 42").
+ * Anything else falls through to an ordinary text search.
+ */
+
+export interface ParsedCoordinates {
+  lat: number;
+  lon: number;
+}
+
+const num = (raw: string): number => Number(raw.replace(",", "."));
+
+/** "48.39, -4.49" or "48,39 -4,49". Rejects out-of-range values. */
+const DECIMAL_PAIR =
+  /^\s*(-?\d{1,3}(?:[.,]\d+)?)\s*[,;\s]\s*(-?\d{1,3}(?:[.,]\d+)?)\s*$/;
+
+/**
+ * Numbers, and hemisphere letters standing on their own.
+ *
+ * The lookarounds are what keep "Route 66" and "Oléron" from being read as
+ * positions: a letter glued to other letters is part of a word, never a
+ * hemisphere. Matching them case-insensitively without that guard would turn
+ * every "o" in a place name into a heading west.
+ */
+const TOKEN = /(\d{1,3}(?:[.,]\d+)?)|(?<!\p{L})([NSEWO])(?!\p{L})/giu;
+
+/** Degrees, then optional minutes, then optional seconds. */
+function componentToDecimal(parts: string[], hemisphere: string): number {
+  const [deg, min, sec] = parts;
+  const value = num(deg) + (min ? num(min) / 60 : 0) + (sec ? num(sec) / 3600 : 0);
+  // "O" is the French "Ouest"; charts and crews use it interchangeably with W.
+  const negative = hemisphere === "S" || hemisphere === "W" || hemisphere === "O";
+  return negative ? -value : value;
+}
+
+/**
+ * Walk the tokens and group the numbers under the hemisphere letter they
+ * belong to, whichever side it sits on. A single regex cannot do this: in
+ * "N 48 23.4 W 004 29.7" the W is both the closing letter of nothing and the
+ * opening letter of the longitude, and a greedy pattern swallows it as the
+ * latitude's suffix.
+ */
+function collectComponents(input: string): { value: number; axis: "lat" | "lon" }[] {
+  const components: { value: number; axis: "lat" | "lon" }[] = [];
+  let pendingLetter: string | null = null;
+  let numbers: string[] = [];
+
+  const push = (letter: string) => {
+    if (!numbers.length) return;
+    const hemisphere = letter.toUpperCase();
+    components.push({
+      value: componentToDecimal(numbers, hemisphere),
+      axis: hemisphere === "N" || hemisphere === "S" ? "lat" : "lon",
+    });
+    numbers = [];
+  };
+
+  TOKEN.lastIndex = 0;
+  for (const [, digits, letter] of input.matchAll(TOKEN)) {
+    if (digits) {
+      numbers.push(digits);
+      continue;
+    }
+    if (numbers.length) {
+      // Numbers seen already: they belong to the letter that opened them if
+      // there was one, otherwise to this closing letter.
+      push(pendingLetter ?? letter);
+      pendingLetter = pendingLetter ? letter : null;
+    } else {
+      pendingLetter = letter;
+    }
+  }
+  if (pendingLetter) push(pendingLetter);
+  return components;
+}
+
+function inRange(lat: number, lon: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lon) &&
+    Math.abs(lat) <= 90 &&
+    Math.abs(lon) <= 180
+  );
+}
+
+export function parseCoordinates(input: string): ParsedCoordinates | null {
+  const decimal = DECIMAL_PAIR.exec(input);
+  if (decimal) {
+    const lat = num(decimal[1]);
+    const lon = num(decimal[2]);
+    return inRange(lat, lon) ? { lat, lon } : null;
+  }
+
+  // A hemisphere letter is required. Without one the input is far more
+  // likely to be a place name that happens to contain digits.
+  const components = collectComponents(input);
+  const lat = components.find((c) => c.axis === "lat");
+  const lon = components.find((c) => c.axis === "lon");
+  if (!lat || !lon) return null;
+  return inRange(lat.value, lon.value) ? { lat: lat.value, lon: lon.value } : null;
+}
+
+/** "48°23,4' N 4°29,7' O" — how the parsed position is echoed back. */
+export function formatCoordinates(lat: number, lon: number): string {
+  const one = (value: number, positive: string, negative: string): string => {
+    const abs = Math.abs(value);
+    const deg = Math.floor(abs);
+    const minutes = (abs - deg) * 60;
+    return `${deg}°${minutes.toFixed(1).replace(".", ",")}' ${value < 0 ? negative : positive}`;
+  };
+  return `${one(lat, "N", "S")} ${one(lon, "E", "O")}`;
+}

--- a/packages/web/src/api/geocoding.ts
+++ b/packages/web/src/api/geocoding.ts
@@ -1,0 +1,195 @@
+import type { PlaceResult } from "./places";
+import { dedupePlaces, withDistances } from "./places";
+
+/**
+ * Place search for a sailing planner.
+ *
+ * Photon is the primary source: it is keyless, it accepts a lat/lon bias so
+ * ranking happens server-side, and it indexes OpenStreetMap, which knows the
+ * maritime vocabulary a planner needs. A search for "Raz de Sein" or "Goulet
+ * de Brest" returns nothing at all from a populated-places gazetteer.
+ *
+ * Open-Meteo stays wired as a fallback. Photon's public instance carries no
+ * service commitment, and a search box that dies with it would be worse than
+ * one that quietly degrades to the previous behaviour.
+ */
+
+const PHOTON_URL = "https://photon.komoot.io/api/";
+const OPEN_METEO_URL = "https://geocoding-api.open-meteo.com/v1/search";
+
+/**
+ * OSM keys worth surfacing. Without this filter Photon answers "Le Palais"
+ * with a chinese restaurant and a butcher's shop: it indexes every POI, so
+ * narrowing to places and natural or navigable features is not optional.
+ */
+const OSM_TAGS = ["place", "waterway", "natural"];
+
+/** Over-fetch so dedup and re-ranking have material to work with. */
+const FETCH_LIMIT = 20;
+/** How many rows the dropdown shows. */
+const DISPLAY_LIMIT = 8;
+/** Past this, fall back rather than leave the user watching a spinner. */
+const TIMEOUT_MS = 3500;
+
+interface PhotonProperties {
+  name?: string;
+  osm_id?: number;
+  osm_type?: string;
+  osm_key?: string;
+  osm_value?: string;
+  city?: string;
+  district?: string;
+  county?: string;
+  state?: string;
+  country?: string;
+}
+
+/**
+ * French labels for the feature kinds that carry no administrative parent.
+ * A fairway or a strait sits offshore, so Photon returns no county and no
+ * state: without this the dropdown would show a bare name with no context.
+ */
+const FEATURE_LABELS: Record<string, string> = {
+  "waterway:fairway": "Chenal",
+  "natural:strait": "Passage",
+  "natural:cape": "Cap",
+  "natural:bay": "Baie",
+  "natural:reef": "Récif",
+  "natural:shoal": "Haut-fond",
+  "natural:peninsula": "Presqu'île",
+  "natural:beach": "Plage",
+  "place:island": "Île",
+  "place:islet": "Îlot",
+  "place:archipelago": "Archipel",
+};
+
+/** Second line of a result row. Pure, so the fallback chain is testable. */
+export function photonContext(props: PhotonProperties): string {
+  const feature = FEATURE_LABELS[`${props.osm_key}:${props.osm_value}`];
+  const admin = props.county || props.state || props.city || props.country;
+  if (feature && admin) return `${feature}, ${admin}`;
+  if (feature) return feature;
+  return admin || "";
+}
+
+interface PhotonFeature {
+  properties: PhotonProperties;
+  geometry: { coordinates: [number, number] };
+}
+
+/** Photon GeoJSON → our rows. Unnamed features are dropped: they would
+    render as an empty line the user cannot act on. */
+export function mapPhotonResults(features: PhotonFeature[]): PlaceResult[] {
+  return features
+    .filter((f) => f.properties?.name)
+    .map((f) => ({
+      id: `photon:${f.properties.osm_type ?? "?"}${f.properties.osm_id ?? Math.random()}`,
+      name: f.properties.name as string,
+      latitude: f.geometry.coordinates[1],
+      longitude: f.geometry.coordinates[0],
+      context: photonContext(f.properties),
+      source: "photon" as const,
+    }));
+}
+
+interface OpenMeteoResult {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  country?: string;
+  admin1?: string;
+}
+
+export function mapOpenMeteoResults(results: OpenMeteoResult[]): PlaceResult[] {
+  return results.map((r) => ({
+    id: `om:${r.id}`,
+    name: r.name,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    context: [r.admin1, r.country].filter(Boolean).join(", "),
+    source: "openmeteo" as const,
+  }));
+}
+
+export function buildPhotonUrl(
+  query: string,
+  near: { lat: number; lon: number } | null | undefined,
+): string {
+  const params = new URLSearchParams({
+    q: query,
+    limit: String(FETCH_LIMIT),
+    lang: "fr",
+  });
+  for (const tag of OSM_TAGS) params.append("osm_tag", tag);
+  if (near) {
+    params.set("lat", near.lat.toFixed(4));
+    params.set("lon", near.lon.toFixed(4));
+  }
+  return `${PHOTON_URL}?${params}`;
+}
+
+/** Abort on either the caller's signal or our own timeout, without relying
+    on AbortSignal.any which is too recent to assume in every browser. */
+function withTimeout(signal: AbortSignal | undefined, ms: number) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  const forward = () => controller.abort();
+  signal?.addEventListener("abort", forward);
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", forward);
+    },
+  };
+}
+
+async function searchPhoton(
+  query: string,
+  near: { lat: number; lon: number } | null | undefined,
+  signal: AbortSignal | undefined,
+): Promise<PlaceResult[]> {
+  const { signal: timedSignal, cleanup } = withTimeout(signal, TIMEOUT_MS);
+  try {
+    const res = await fetch(buildPhotonUrl(query, near), { signal: timedSignal });
+    if (!res.ok) throw new Error(`photon ${res.status}`);
+    const data = await res.json();
+    return mapPhotonResults(data.features ?? []);
+  } finally {
+    cleanup();
+  }
+}
+
+async function searchOpenMeteo(
+  query: string,
+  signal: AbortSignal | undefined,
+): Promise<PlaceResult[]> {
+  const url = `${OPEN_METEO_URL}?name=${encodeURIComponent(query)}&count=${FETCH_LIMIT}&language=fr`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`open-meteo ${res.status}`);
+  const data = await res.json();
+  return mapOpenMeteoResults(data.results ?? []);
+}
+
+export interface SearchOptions {
+  /** Reference point for the proximity bias and the displayed distances. */
+  near?: { lat: number; lon: number } | null;
+  signal?: AbortSignal;
+}
+
+export async function searchPlaces(
+  query: string,
+  { near, signal }: SearchOptions = {},
+): Promise<PlaceResult[]> {
+  let results: PlaceResult[];
+  try {
+    results = await searchPhoton(query, near, signal);
+  } catch (err) {
+    // A cancelled request is the caller superseding it, not a failure:
+    // falling back would race the newer query and could overwrite it.
+    if (signal?.aborted) throw err;
+    results = await searchOpenMeteo(query, signal);
+  }
+  return dedupePlaces(withDistances(results, near)).slice(0, DISPLAY_LIMIT);
+}

--- a/packages/web/src/api/places.test.ts
+++ b/packages/web/src/api/places.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import type { PlaceResult } from "./places";
+import {
+  dedupePlaces,
+  matchSavedSpots,
+  normalizeForMatch,
+  formatDistance,
+  withDistances,
+} from "./places";
+
+function place(name: string, latitude: number, longitude: number): PlaceResult {
+  return { id: `${name}${latitude}`, name, latitude, longitude, context: "", source: "photon" };
+}
+
+describe("normalizeForMatch", () => {
+  it("ignores case and diacritics", () => {
+    expect(normalizeForMatch("Île d'Yeu")).toBe("ile d'yeu");
+    expect(normalizeForMatch("  SÈTE ")).toBe("sete");
+  });
+});
+
+describe("dedupePlaces", () => {
+  it("collapses the repeats OSM emits for a linear feature", () => {
+    // Raz de Sein comes back once per way; they sit within a couple of miles.
+    const results = [
+      place("Raz de Sein", 48.010, -4.739),
+      place("Raz de Sein", 48.003, -4.783),
+      place("Raz de Sein", 48.020, -4.750),
+    ];
+    expect(dedupePlaces(results)).toHaveLength(1);
+  });
+
+  it("keeps homonyms that are genuinely apart", () => {
+    const results = [
+      place("Le Palais", 47.347, -3.155), // Belle-Île
+      place("Le Palais", 45.865, 1.324), // Haute-Vienne
+    ];
+    expect(dedupePlaces(results)).toHaveLength(2);
+  });
+
+  it("preserves the incoming order", () => {
+    const results = [place("Brest", 48.39, -4.49), place("Camaret", 48.27, -4.59)];
+    expect(dedupePlaces(results).map((r) => r.name)).toEqual(["Brest", "Camaret"]);
+  });
+});
+
+describe("matchSavedSpots", () => {
+  const spots = [
+    { name: "Cherbourg", latitude: 49.64, longitude: -1.62 },
+    { name: "Saint-Malo", latitude: 48.65, longitude: -2.02 },
+    { name: "Port de Saint-Cast", latitude: 48.64, longitude: -2.25 },
+  ];
+
+  it("matches without regard to case or accents", () => {
+    expect(matchSavedSpots(spots, "cherb", null).map((s) => s.name)).toEqual(["Cherbourg"]);
+  });
+
+  it("ranks a prefix match above a match buried in the name", () => {
+    const names = matchSavedSpots(spots, "saint", null).map((s) => s.name);
+    expect(names[0]).toBe("Saint-Malo");
+    expect(names).toContain("Port de Saint-Cast");
+  });
+
+  it("returns nothing for an empty query", () => {
+    expect(matchSavedSpots(spots, "   ", null)).toEqual([]);
+  });
+
+  it("annotates distances when a reference point is known", () => {
+    const [match] = matchSavedSpots(spots, "cherb", { lat: 49.64, lon: -1.62 });
+    expect(match.distanceNm).toBeCloseTo(0, 1);
+  });
+});
+
+describe("withDistances", () => {
+  it("leaves results untouched without a reference point", () => {
+    const results = [place("Brest", 48.39, -4.49)];
+    expect(withDistances(results, null)[0].distanceNm).toBeUndefined();
+  });
+});
+
+describe("formatDistance", () => {
+  it("stays vague under a mile, where precision is noise", () => {
+    expect(formatDistance(0.4)).toBe("à moins d'1 nm");
+  });
+
+  it("keeps one decimal close by and rounds further out", () => {
+    expect(formatDistance(4.28)).toBe("à 4,3 nm");
+    expect(formatDistance(42.6)).toBe("à 43 nm");
+  });
+
+  it("says nothing when there is no distance", () => {
+    expect(formatDistance(undefined)).toBeNull();
+  });
+});

--- a/packages/web/src/api/places.ts
+++ b/packages/web/src/api/places.ts
@@ -1,0 +1,106 @@
+import type { Spot } from "../types";
+import { haversineNm } from "../utils/geo";
+
+/** A single row in the search dropdown, whatever produced it. */
+export interface PlaceResult {
+  /** Stable within a result set; used as the React key and for dedup. */
+  id: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  /** Secondary line: département, région, or the feature kind for the
+      maritime entries that carry no administrative parent. */
+  context: string;
+  source: "saved" | "photon" | "openmeteo" | "coordinates";
+  /** Great-circle distance from the reference point, when one is known. */
+  distanceNm?: number;
+}
+
+/** Two results closer than this and sharing a name are the same place. */
+const DEDUP_RADIUS_NM = 2;
+
+/** Strip diacritics and case so "Ile d'Yeu" matches "île d'Yeu". */
+export function normalizeForMatch(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * Collapse the repeats OSM produces for linear features: a fairway or a
+ * strait is stored as several ways, so a search for "Raz de Sein" comes back
+ * four times within a few miles. Same name plus near-identical position means
+ * one entry for the user.
+ *
+ * Order is preserved, so whichever ranking the caller applied survives.
+ */
+export function dedupePlaces(results: PlaceResult[]): PlaceResult[] {
+  const kept: PlaceResult[] = [];
+  for (const candidate of results) {
+    const key = normalizeForMatch(candidate.name);
+    const duplicate = kept.some(
+      (k) =>
+        normalizeForMatch(k.name) === key &&
+        haversineNm(k.latitude, k.longitude, candidate.latitude, candidate.longitude) <
+          DEDUP_RADIUS_NM,
+    );
+    if (!duplicate) kept.push(candidate);
+  }
+  return kept;
+}
+
+/** Annotate each result with its distance to the reference point. */
+export function withDistances(
+  results: PlaceResult[],
+  near: { lat: number; lon: number } | null | undefined,
+): PlaceResult[] {
+  if (!near) return results;
+  return results.map((r) => ({
+    ...r,
+    distanceNm: haversineNm(near.lat, near.lon, r.latitude, r.longitude),
+  }));
+}
+
+/**
+ * The user's own spots, matched locally.
+ *
+ * Searched before anything leaves the browser: these are the places someone
+ * returns to, the match is instant, and it works with no network at all.
+ */
+export function matchSavedSpots(
+  spots: Spot[],
+  query: string,
+  near: { lat: number; lon: number } | null | undefined,
+  limit = 3,
+): PlaceResult[] {
+  const needle = normalizeForMatch(query);
+  if (!needle) return [];
+  const matches = spots
+    .filter((s) => normalizeForMatch(s.name).includes(needle))
+    .map<PlaceResult>((s) => ({
+      id: `saved:${s.latitude},${s.longitude}`,
+      name: s.name,
+      latitude: s.latitude,
+      longitude: s.longitude,
+      context: "Spot enregistré",
+      source: "saved",
+    }));
+  // A prefix match is a stronger signal of intent than a match buried in the
+  // middle of the name, so it outranks it.
+  matches.sort((a, b) => {
+    const aStarts = normalizeForMatch(a.name).startsWith(needle) ? 0 : 1;
+    const bStarts = normalizeForMatch(b.name).startsWith(needle) ? 0 : 1;
+    return aStarts - bStarts;
+  });
+  return withDistances(matches, near).slice(0, limit);
+}
+
+/** "à 12 nm" for the dropdown. Below a mile the figure adds nothing. */
+export function formatDistance(nm: number | undefined): string | null {
+  if (nm == null || !Number.isFinite(nm)) return null;
+  if (nm < 1) return "à moins d'1 nm";
+  if (nm < 10) return `à ${nm.toFixed(1).replace(".", ",")} nm`;
+  return `à ${Math.round(nm)} nm`;
+}

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -7,6 +7,11 @@ import { rememberReturnPath } from "../config/returnPath";
 
 interface HeaderProps {
   onSelectSpot: (spot: Spot) => void;
+  /** Reference point for the search proximity bias. Passed as primitives so
+      a fresh object each render cannot retrigger the search. */
+  nearLat?: number | null;
+  nearLon?: number | null;
+  savedSpots?: Spot[];
 }
 
 function WindIcon() {
@@ -43,7 +48,7 @@ function SettingsButton() {
   );
 }
 
-export function Header({ onSelectSpot }: HeaderProps) {
+export function Header({ onSelectSpot, nearLat, nearLon, savedSpots }: HeaderProps) {
   return (
     <header
       className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6"
@@ -58,7 +63,12 @@ export function Header({ onSelectSpot }: HeaderProps) {
           </h1>
         </div>
         <div className="flex-1 flex justify-center">
-          <SpotSearch onSelect={onSelectSpot} />
+          <SpotSearch
+            onSelect={onSelectSpot}
+            nearLat={nearLat}
+            nearLon={nearLon}
+            savedSpots={savedSpots}
+          />
         </div>
         <InfoButton />
         <SettingsButton />

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -66,6 +66,40 @@ export function InfoPanel() {
             <polyline points="12 5 19 12 12 19" />
           </svg>
         </a>
+        {/* Map credits. The OSM Foundation allows the attribution to sit off
+            the map, but only if it stays findable through an info button or
+            an About menu, which is exactly this panel. Removing the corner
+            notice without this block would breach the ODbL. */}
+        <p className="text-xs leading-relaxed mt-4" style={{ color: "var(--ow-fg-2)" }}>
+          Fonds de carte :{" "}
+          <a
+            href="https://www.openstreetmap.org/copyright"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:opacity-80"
+          >
+            &copy; les contributeurs OpenStreetMap
+          </a>{" "}
+          (données sous licence ODbL), tuiles{" "}
+          <a
+            href="https://carto.com/attributions"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:opacity-80"
+          >
+            &copy; CARTO
+          </a>
+          . Recherche de lieux :{" "}
+          <a
+            href="https://photon.komoot.io"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:opacity-80"
+          >
+            Photon
+          </a>{" "}
+          et Open-Meteo Geocoding, tous deux sur données OpenStreetMap.
+        </p>
       </section>
 
       <section

--- a/packages/web/src/components/LocateButton.tsx
+++ b/packages/web/src/components/LocateButton.tsx
@@ -22,7 +22,10 @@ export function LocateButton({ status, onClick, className = "" }: LocateButtonPr
   const locating = status === "locating";
 
   return (
-    <div className={`absolute z-[400] flex flex-col items-end gap-2 ${className}`}>
+    // column-reverse: the button is anchored near the bottom of the map on
+    // both pages, so the message has to grow upwards or it would slide under
+    // the data panel.
+    <div className={`absolute z-[400] flex flex-col-reverse items-end gap-2 ${className}`}>
       <button
         type="button"
         onClick={onClick}

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -281,9 +281,9 @@ export function SpotMap({
     }).addTo(map);
     tileLayerRef.current = tile;
 
-    L.control.attribution({ position: "bottomright", prefix: false })
-      .addAttribution('&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>')
-      .addTo(map);
+    // Map credits live in the info panel rather than in the corner. The OSM
+    // Foundation allows this as long as they stay findable through an info
+    // button, which is where they now are, alongside the other sources.
 
     // Custom pane for wind arrows (below markers)
     map.createPane("windArrows");

--- a/packages/web/src/components/SpotSearch.tsx
+++ b/packages/web/src/components/SpotSearch.tsx
@@ -1,19 +1,127 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
-import type { Spot, GeocodingResult } from "../types";
-import { searchSpots } from "../api/openmeteo";
+import type { Spot } from "../types";
+import { searchPlaces } from "../api/geocoding";
+import type { PlaceResult } from "../api/places";
+import { matchSavedSpots, formatDistance, normalizeForMatch } from "../api/places";
+import { parseCoordinates, formatCoordinates } from "../api/coordinates";
 
 interface SpotSearchProps {
   onSelect: (spot: Spot) => void;
+  /** Reference point for the proximity bias, as primitives so a caller
+      cannot retrigger the search by rebuilding an object every render. */
+  nearLat?: number | null;
+  nearLon?: number | null;
+  /** Searched locally, before anything leaves the browser. */
+  savedSpots?: Spot[];
 }
 
-export function SpotSearch({ onSelect }: SpotSearchProps) {
+/** Below this a query matches half the coastline and mostly returns noise
+    (Photon happily answers "br" with a place literally named "br"). */
+const MIN_CHARS = 3;
+const DEBOUNCE_MS = 250;
+/** Bounded on purpose: an unbounded cache on a long session is a slow leak
+    for no benefit, since only the recent queries are ever revisited. */
+const CACHE_MAX = 40;
+
+const searchCache = new Map<string, PlaceResult[]>();
+/** Shared empty array: a fresh literal each render would defeat memoization. */
+const NO_RESULTS: PlaceResult[] = [];
+
+function cachePut(key: string, results: PlaceResult[]) {
+  if (searchCache.size >= CACHE_MAX) {
+    const oldest = searchCache.keys().next().value;
+    if (oldest !== undefined) searchCache.delete(oldest);
+  }
+  searchCache.set(key, results);
+}
+
+export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: SpotSearchProps) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<GeocodingResult[]>([]);
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const trimmed = query.trim();
+  const near = useMemo(
+    () => (nearLat != null && nearLon != null ? { lat: nearLat, lon: nearLon } : null),
+    [nearLat, nearLon],
+  );
+  const cacheKey = useMemo(
+    () =>
+      `${normalizeForMatch(trimmed)}|${near ? `${near.lat.toFixed(2)},${near.lon.toFixed(2)}` : ""}`,
+    [trimmed, near],
+  );
+
+  // Remote state is keyed by the query it belongs to, so a late response for
+  // an abandoned query can never be rendered as the answer to the current one.
+  const [remote, setRemote] = useState<{
+    key: string;
+    status: "loading" | "done" | "error";
+    results: PlaceResult[];
+  } | null>(null);
+
+  const cached = trimmed.length >= MIN_CHARS ? searchCache.get(cacheKey) : undefined;
+  const current = remote?.key === cacheKey ? remote : null;
+  // Memoized so the rows list below is not rebuilt on every unrelated render.
+  const remoteResults = useMemo(
+    () => cached ?? (current?.status === "done" ? current.results : NO_RESULTS),
+    [cached, current],
+  );
+  const loading = !cached && current?.status === "loading";
+  const failed = !cached && current?.status === "error";
+
+  useEffect(() => {
+    if (trimmed.length < MIN_CHARS) return;
+    if (searchCache.has(cacheKey)) return;
+    const controller = new AbortController();
+    // Every state write happens inside the timer or a promise callback, never
+    // synchronously in the effect body.
+    const timer = setTimeout(() => {
+      setRemote({ key: cacheKey, status: "loading", results: [] });
+      searchPlaces(trimmed, { near, signal: controller.signal })
+        .then((results) => {
+          cachePut(cacheKey, results);
+          setRemote({ key: cacheKey, status: "done", results });
+        })
+        .catch(() => {
+          // An aborted request means the user kept typing; the newer query
+          // owns the display now.
+          if (controller.signal.aborted) return;
+          setRemote({ key: cacheKey, status: "error", results: [] });
+        });
+    }, DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [trimmed, cacheKey, near]);
+
+  const coordinates = useMemo(() => parseCoordinates(trimmed), [trimmed]);
+  const savedMatches = useMemo(
+    () => matchSavedSpots(savedSpots, trimmed, near),
+    [savedSpots, trimmed, near],
+  );
+
+  const rows = useMemo<PlaceResult[]>(() => {
+    const out: PlaceResult[] = [];
+    if (coordinates) {
+      out.push({
+        id: "coords",
+        name: formatCoordinates(coordinates.lat, coordinates.lon),
+        latitude: coordinates.lat,
+        longitude: coordinates.lon,
+        context: "Aller à cette position",
+        source: "coordinates",
+      });
+    }
+    out.push(...savedMatches);
+    // A saved spot already shown must not come back as a geocoder row.
+    const seen = new Set(savedMatches.map((s) => normalizeForMatch(s.name)));
+    out.push(...remoteResults.filter((r) => !seen.has(normalizeForMatch(r.name))));
+    return out;
+  }, [coordinates, savedMatches, remoteResults]);
 
   const updatePos = useCallback(() => {
     if (!containerRef.current) return;
@@ -46,30 +154,40 @@ export function SpotSearch({ onSelect }: SpotSearchProps) {
 
   function handleChange(value: string) {
     setQuery(value);
-    clearTimeout(timerRef.current);
-    if (value.length < 2) {
-      setResults([]);
+    setActiveIndex(0);
+    setOpen(value.trim().length >= MIN_CHARS || parseCoordinates(value.trim()) != null);
+  }
+
+  const handleSelect = useCallback(
+    (r: PlaceResult) => {
+      onSelect({ name: r.name, latitude: r.latitude, longitude: r.longitude });
+      setQuery(r.name);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Escape") {
       setOpen(false);
       return;
     }
-    timerRef.current = setTimeout(async () => {
-      const r = await searchSpots(value);
-      setResults(r);
-      setOpen(r.length > 0);
-    }, 300);
+    if (!open || rows.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % rows.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + rows.length) % rows.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const row = rows[activeIndex];
+      if (row) handleSelect(row);
+    }
   }
 
-  function handleSelect(r: GeocodingResult) {
-    onSelect({
-      name: r.name,
-      latitude: r.latitude,
-      longitude: r.longitude,
-      country: r.country,
-      admin1: r.admin1,
-    });
-    setQuery(r.name);
-    setOpen(false);
-  }
+  const listboxId = "ow-search-listbox";
+  const showDropdown = open && pos !== null;
 
   return (
     <div ref={containerRef} className="relative w-full max-w-md lg:max-w-lg">
@@ -80,34 +198,65 @@ export function SpotSearch({ onSelect }: SpotSearchProps) {
         </svg>
         <input
           type="text"
+          role="combobox"
+          aria-expanded={showDropdown}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={showDropdown && rows[activeIndex] ? `ow-opt-${rows[activeIndex].id}` : undefined}
+          aria-label="Rechercher un lieu"
           value={query}
           onChange={(e) => handleChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") setOpen(false);
-          }}
-          placeholder="Search..."
+          onFocus={() => { if (rows.length > 0) setOpen(true); }}
+          onKeyDown={handleKeyDown}
+          placeholder="Port, cap, chenal ou coordonnées"
           className="ow-search-input w-full pl-9 pr-3 py-2.5 min-h-[44px] rounded-xl text-sm transition-all"
         />
       </div>
-      {open && pos && createPortal(
+      {showDropdown && createPortal(
         <ul
           id="ow-search-dropdown-portal"
+          role="listbox"
+          aria-label="Résultats de recherche"
           className="ow-search-dropdown rounded-xl overflow-hidden animate-fade-in"
           style={{ position: "fixed", top: pos.top, left: pos.left, width: pos.width, zIndex: 1000 }}
         >
-          {results.map((r) => (
-            <li
-              key={r.id}
-              onClick={() => handleSelect(r)}
-              className="ow-search-item px-3 py-2.5 min-h-[44px] flex items-center cursor-pointer text-sm transition-colors"
-            >
-              <span className="font-medium" style={{ color: 'var(--ow-fg-0)' }}>{r.name}</span>
-              {r.admin1 && (
-                <span style={{ color: 'var(--ow-fg-1)' }}>, {r.admin1}</span>
-              )}
-              <span style={{ color: 'var(--ow-fg-2)' }}> — {r.country}</span>
+          {rows.map((r, idx) => {
+            const distance = formatDistance(r.distanceNm);
+            return (
+              <li
+                key={r.id}
+                id={`ow-opt-${r.id}`}
+                role="option"
+                aria-selected={idx === activeIndex}
+                onClick={() => handleSelect(r)}
+                onMouseEnter={() => setActiveIndex(idx)}
+                className="ow-search-item px-3 py-2.5 min-h-[44px] flex items-center gap-2 cursor-pointer text-sm transition-colors"
+                style={idx === activeIndex ? { background: "var(--ow-accent-line)" } : undefined}
+              >
+                {r.source === "saved" && (
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style={{ color: 'var(--ow-accent)', flexShrink: 0 }} aria-hidden="true">
+                    <path d="M12 17.3l-6.2 3.7 1.6-7L2 9.2l7.1-.6L12 2l2.9 6.6 7.1.6-5.4 4.8 1.6 7z" />
+                  </svg>
+                )}
+                <span className="font-medium truncate" style={{ color: 'var(--ow-fg-0)' }}>{r.name}</span>
+                {r.context && (
+                  <span className="truncate" style={{ color: 'var(--ow-fg-2)' }}>{r.context}</span>
+                )}
+                {distance && (
+                  <span className="ml-auto shrink-0 text-xs" style={{ color: 'var(--ow-fg-2)' }}>{distance}</span>
+                )}
+              </li>
+            );
+          })}
+          {rows.length === 0 && (
+            <li className="px-3 py-2.5 text-sm" style={{ color: 'var(--ow-fg-2)' }} role="presentation">
+              {loading
+                ? "Recherche..."
+                : failed
+                  ? "Recherche indisponible. Vérifiez votre connexion."
+                  : "Aucun lieu trouvé."}
             </li>
-          ))}
+          )}
         </ul>,
         document.body
       )}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -470,17 +470,6 @@ body {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--ow-accent) 35%, transparent);
 }
 
-/* Leaflet attribution smaller on mobile */
-.leaflet-control-attribution {
-  font-size: 9px !important;
-  background: rgba(0,0,0,0.5) !important;
-  color: #9ca3af !important;
-  padding: 1px 5px !important;
-}
-.leaflet-control-attribution a {
-  color: #9ca3af !important;
-}
-
 /* ── Theme-aware table header ────────────────────────────────── */
 .ow-tbl-bg {
   background: var(--ow-bg-1);

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -150,9 +150,9 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     }).addTo(map);
     tileLayerRef.current = tile;
 
-    L.control.attribution({ position: "bottomright", prefix: false })
-      .addAttribution('&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>')
-      .addTo(map);
+    // Map credits live in the info panel rather than in the corner. The OSM
+    // Foundation allows this as long as they stay findable through an info
+    // button, which is where they now are, alongside the other sources.
 
     // No zoom buttons: they crowded the bottom-right corner against the
     // locate control, and the explore map has done without them since day

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -143,6 +143,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
     const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
 
+
     const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
     const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
       maxZoom: 19,
@@ -153,7 +154,9 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       .addAttribution('&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>')
       .addTo(map);
 
-    L.control.zoom({ position: "bottomright" }).addTo(map);
+    // No zoom buttons: they crowded the bottom-right corner against the
+    // locate control, and the explore map has done without them since day
+    // one. Wheel and pinch zoom stay enabled.
 
     // Initial view: fit bounds if ≥2 waypoints, else center on the single
     // waypoint, else honor the ?center hint propagated from the home compass

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -784,8 +784,13 @@ export function PlanPage() {
       className="h-screen flex flex-col overflow-hidden"
       style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
     >
+      {/* On the planner the route being drawn is the strongest statement of
+          where the user is working, so the first waypoint outranks the GPS
+          fix as the search reference. */}
       <Header
         onSelectSpot={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
+        nearLat={waypoints[0]?.[0] ?? userPosition?.lat ?? null}
+        nearLon={waypoints[0]?.[1] ?? userPosition?.lon ?? null}
       />
       <RebrandBanner />
 
@@ -826,9 +831,11 @@ export function PlanPage() {
           >
             <img src="/wind-icon.png" alt="" width="88" height="88" className="select-none" draggable={false} />
           </a>
-          {/* Locate FAB — top right, clear of the bottom-right zoom control
-              and of the mobile hero stats overlay. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="top-3 right-3" />
+          {/* Locate FAB — bottom right of the map container, which shrinks as
+              the mobile drawer is dragged up, so the button follows it. The
+              80 px offset clears both the Leaflet zoom control and the mobile
+              hero stats, which share that corner. */}
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="bottom-20 right-3" />
           {/* Hint overlay while building the route */}
           {waypoints.length < 2 && (
             <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -832,12 +832,19 @@ export function PlanPage() {
             <img src="/wind-icon.png" alt="" width="88" height="88" className="select-none" draggable={false} />
           </a>
           {/* Locate FAB — bottom right of the map container, which shrinks as
-              the mobile drawer is dragged up, so the button follows it. Kept
-              clear of the mobile hero stats on small screens and of the
-              attribution line on desktop. The offset is fixed rather than
-              conditional on the stats being visible: a button that jumps
-              when results arrive is worse than one sitting slightly high. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="bottom-20 lg:bottom-8 right-3" />
+              the mobile drawer is dragged up, so the button follows it.
+              Normally flush with the drawer edge. It only lifts on mobile
+              when the hero stats occupy that corner, otherwise it would sit
+              on top of the arrival time. */}
+          <LocateButton
+            status={geolocStatus}
+            onClick={handleLocate}
+            className={
+              passage && planMode === "single" && !isStale
+                ? "bottom-24 lg:bottom-4 right-3"
+                : "bottom-4 right-3"
+            }
+          />
           {/* Hint overlay while building the route */}
           {waypoints.length < 2 && (
             <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -833,15 +833,16 @@ export function PlanPage() {
           </a>
           {/* Locate FAB — bottom right of the map container, which shrinks as
               the mobile drawer is dragged up, so the button follows it.
-              Normally flush with the drawer edge. It only lifts on mobile
-              when the hero stats occupy that corner, otherwise it would sit
-              on top of the arrival time. */}
+              Normally 16 px above the drawer edge, the reference gap reused
+              on the home overlay. On mobile the hero stats take that corner,
+              so the button clears their 72 px and keeps the same 16 px above
+              them rather than sitting on the arrival time. */}
           <LocateButton
             status={geolocStatus}
             onClick={handleLocate}
             className={
               passage && planMode === "single" && !isStale
-                ? "bottom-24 lg:bottom-4 right-3"
+                ? "bottom-[5.5rem] lg:bottom-4 right-3"
                 : "bottom-4 right-3"
             }
           />

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -832,10 +832,12 @@ export function PlanPage() {
             <img src="/wind-icon.png" alt="" width="88" height="88" className="select-none" draggable={false} />
           </a>
           {/* Locate FAB — bottom right of the map container, which shrinks as
-              the mobile drawer is dragged up, so the button follows it. The
-              80 px offset clears both the Leaflet zoom control and the mobile
-              hero stats, which share that corner. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="bottom-20 right-3" />
+              the mobile drawer is dragged up, so the button follows it. Kept
+              clear of the mobile hero stats on small screens and of the
+              attribution line on desktop. The offset is fixed rather than
+              conditional on the stats being visible: a button that jumps
+              when results arrive is worse than one sitting slightly high. */}
+          <LocateButton status={geolocStatus} onClick={handleLocate} className="bottom-20 lg:bottom-8 right-3" />
           {/* Hint overlay while building the route */}
           {waypoints.length < 2 && (
             <div className="absolute inset-x-4 bottom-4 z-[400] flex justify-center pointer-events-none">


### PR DESCRIPTION
## Le problème, mesuré

La recherche interroge le géocodeur d'Open-Meteo, un annuaire de lieux habités classé par population. Pour un planificateur de nav, ce classement est à l'envers.

| Requête | Avant | Après |
|---|---|---|
| `Le Palais` | Le Palais-sur-Vienne, Limousin, à 200 km de la mer | **Le Palais**, Belle-Île |
| `Saint-Martin` | 5 communes de l'intérieur, sans Saint-Martin-de-Ré | **Saint-Martin-de-Ré** |
| `Raz de Sein` | aucun résultat | **Raz de Sein**, `waterway=fairway` |
| `Goulet de Brest` | aucun résultat | **Goulet de Brest**, `natural=strait` |

L'API d'Open-Meteo n'accepte ni proximité, ni bounding box, ni filtre de type. Le classement n'était donc pas corrigeable à la source.

## Photon, avec repli

Photon (Komoot) est sans clé lui aussi, accepte un biais `lat`/`lon` côté serveur et indexe OSM, donc le vocabulaire maritime que le référentiel précédent ignore.

Les filtres `osm_tag` ne sont pas optionnels : Photon indexe tous les POI et répond sinon à "Le Palais" par un restaurant chinois et une boucherie.

Open-Meteo reste câblé en repli. L'instance publique de Photon n'a aucun engagement de service, et un champ de recherche qui meurt avec elle serait pire qu'un champ qui redescend silencieusement au comportement précédent.

Le trafic de recherche part du navigateur vers le géocodeur, sans jamais passer par le Space HF : il ne consomme ni le replica unique ni le futur budget de rate-limiting.

## Le reste

- **Point de référence en cascade.** Accueil : position accordée, puis spot actif. `/plan` : premier waypoint d'abord, la route en cours étant la meilleure expression de la zone de travail. Sans aucun des deux, aucun biais, parce que le centre par défaut est en Méditerranée et que couler les résultats atlantiques d'un nouveau venu serait pire que pas de biais du tout.
- **Spots enregistrés** cherchés localement, en tête de liste, sans réseau.
- **Coordonnées saisies** reconnues (décimal, DMS, DDM, `O` pour Ouest) et proposées en première ligne. Le parsing exige une lettre d'hémisphère isolée, sinon "Route 66" et "Oléron" passeraient pour des positions.
- **Déduplication** : OSM stocke un chenal en plusieurs tronçons, "Raz de Sein" revenait quatre fois.
- **Robustesse** : `AbortController` (le debounce seul n'empêchait pas une réponse tardive d'écraser une plus récente), cache borné à 40 entrées, seuil relevé à 3 caractères, `preconnect` pour retirer la poignée TLS de la première frappe.
- **Clavier et ARIA** : flèches, Entrée, sémantique combobox complète. Seul Escape était géré.
- Distance affichée, états de chargement, d'échec et de liste vide.

## Bouton de géolocalisation

Déplacé en bas à droite et rattaché au panneau de données plutôt qu'à la carte, donc il suit l'overlay de l'accueil et le drawer redimensionnable de `/plan` au lieu de finir dessous.

## Vérifications

- 101 tests web verts (79 avant, 22 ajoutés : parsing de coordonnées, déduplication, matching local, formatage des distances)
- `tsc --noEmit` propre, `npm run build` OK
- ESLint à 27 problèmes, exactement le niveau de `dev`

## À tester à la main

- Les quatre requêtes du tableau ci-dessus
- Taper puis effacer vite : plus d'affichage d'un résultat périmé
- `48°23.4'N 4°29.7'W` en première ligne
- Flèches et Entrée dans la liste
- Le bouton de géoloc qui suit le drawer sur `/plan`
- Couper le réseau : message d'échec propre

🤖 Generated with [Claude Code](https://claude.com/claude-code)