### PR TITLE
feat(web): consentement géoloc mémorisé + biais par le centre de carte

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -19,6 +19,8 @@ import { SpotMap } from "./components/SpotMap";
 import { Onboarding } from "./components/Onboarding";
 import { LocateButton } from "./components/LocateButton";
 import { useGeolocation } from "./hooks/useGeolocation";
+import { useMapCenter } from "./hooks/useMapCenter";
+import { hasDeclinedGeolocation } from "./config/geolocPreference";
 
 const DEFAULT_MAP_CENTER: { lat: number; lon: number } = { lat: 43.3, lon: 5.35 };
 
@@ -55,7 +57,8 @@ function App() {
   // to drop their first one. Returning users with saved spots resume on
   // their first favorite.
   const [spot, setSpot] = useState<Spot | null>(() => customSpots[0] ?? null);
-  const { position: userPosition, status: geolocStatus, locate } = useGeolocation();
+  const { position: userPosition, status: geolocStatus, attempt: geolocAttempt, locate } = useGeolocation();
+  const { center: mapCenter, onCenterChange } = useMapCenter();
   // Which fix the map is allowed to fly to. Set only on an explicit request
   // (first visit, or a tap on the locate button) so an incoming fix never
   // steals the viewport on its own.
@@ -117,6 +120,10 @@ function App() {
   // waking the GPS unprompted on a first visit is a poor trade.
   useEffect(() => {
     if (customSpots.length > 0) return;
+    // Someone who already refused should not be asked again, nor shown the
+    // same error bubble on every visit. The locate button still retries on
+    // demand, so changing one's mind in the browser settings is enough.
+    if (hasDeclinedGeolocation()) return;
     locate({ enableHighAccuracy: false, maximumAge: 5 * 60 * 1000 }).then((fix) => {
       // A spot picked while the fix was in flight means the user already
       // chose their focus — leave the viewport alone.
@@ -151,14 +158,15 @@ function App() {
       className="h-screen flex flex-col overflow-hidden"
       style={{ background: 'var(--ow-bg-0)', color: 'var(--ow-fg-0)' }}
     >
-      {/* Search proximity reference: the granted position first, else the
-          spot the user is looking at. When neither is known we send no bias
-          at all rather than defaulting to the Med, which would sink Atlantic
-          results for a first-time visitor on the Channel. */}
+      {/* Search proximity reference: the granted position first, else where
+          the map is currently looking, else the active spot. The viewport
+          matters because without it a search for "Brest" from a phone with
+          no position granted ranks Brest in Belarus and Brest in Croatia
+          alongside the Finistère one. */}
       <Header
         onSelectSpot={setSpot}
-        nearLat={userPosition?.lat ?? spot?.latitude ?? null}
-        nearLon={userPosition?.lon ?? spot?.longitude ?? null}
+        nearLat={userPosition?.lat ?? mapCenter?.lat ?? spot?.latitude ?? null}
+        nearLon={userPosition?.lon ?? mapCenter?.lon ?? spot?.longitude ?? null}
         savedSpots={customSpots}
       />
       <RebrandBanner />
@@ -172,6 +180,7 @@ function App() {
           customSpots={customSpots}
           userPosition={userPosition}
           flyToStamp={flyToStamp}
+          onCenterChange={onCenterChange}
           defaultCenter={DEFAULT_MAP_CENTER}
           onSelectSpot={setSpot}
           onAddSpot={(s) => { addSpot(s); setSpot(s); }}
@@ -211,7 +220,7 @@ function App() {
               which is transparent over the map: the button straddles the
               pills and keeps the same gap to the panel as on /plan. Out of
               flow, so it does not push the pills around. */}
-          <LocateButton status={geolocStatus} onClick={handleLocate} className="-top-4 right-3" />
+          <LocateButton status={geolocStatus} attempt={geolocAttempt} onClick={handleLocate} className="-top-4 right-3" />
           {spot ? (
             <>
               <div className="shrink-0">

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -41,8 +41,8 @@ function EmptyState() {
           style={{ background: 'var(--ow-accent)' }}
         />
         <span className="text-[12px] font-medium" style={{ color: 'var(--ow-fg-0)' }}>
-          <span className="lg:hidden">Appui long pour placer votre premier spot</span>
-          <span className="hidden lg:inline">Clic droit pour placer votre premier spot</span>
+          <span className="lg:hidden">Touchez la carte pour la météo, appui long pour enregistrer un spot</span>
+          <span className="hidden lg:inline">Cliquez la carte pour la météo, clic droit pour enregistrer un spot</span>
         </span>
       </div>
     </div>
@@ -133,6 +133,18 @@ function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Tap or left click on the map: show the forecast there without saving.
+  // Named by its coordinates rather than reverse-geocoded: the lookup is
+  // instant and offline, and a position is meaningful information at sea.
+  // Creating a spot stays a deliberate act (long press, or right click).
+  const handlePreviewSpot = useCallback((lat: number, lon: number) => {
+    setSpot({
+      name: `${lat.toFixed(3)}, ${lon.toFixed(3)}`,
+      latitude: lat,
+      longitude: lon,
+    });
+  }, []);
+
   // Explicit "centre sur moi": always honor it, spot selected or not.
   const handleLocate = useCallback(() => {
     locate().then((fix) => {
@@ -183,6 +195,7 @@ function App() {
           onCenterChange={onCenterChange}
           defaultCenter={DEFAULT_MAP_CENTER}
           onSelectSpot={setSpot}
+          onPreviewSpot={handlePreviewSpot}
           onAddSpot={(s) => { addSpot(s); setSpot(s); }}
           onRemoveSpot={(s) => { removeSpot(s); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) { setSpot(null); setForecasts([]); setSelectedHour(null); } }}
           onRenameSpot={(s, name) => { renameSpot(s, name); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) setSpot({ ...s, name }); }}

--- a/packages/web/src/components/LocateButton.tsx
+++ b/packages/web/src/components/LocateButton.tsx
@@ -1,11 +1,15 @@
+import { useState } from "react";
 import type { GeolocStatus } from "../hooks/useGeolocation";
 import { geolocMessage } from "../hooks/useGeolocation";
 
 interface LocateButtonProps {
   status: GeolocStatus;
+  /** Number of requests started so far. A dismissal applies to one attempt
+      only, so pressing the button again re-shows a message the user closed. */
+  attempt: number;
   onClick: () => void;
   /** Positioning is left to the host map so each page can dodge its own
-      overlays (drawer, hero stats, zoom control). */
+      overlays (drawer, hero stats, data table). */
   className?: string;
 }
 
@@ -13,12 +17,14 @@ interface LocateButtonProps {
  * "Centrer sur ma position" control, shared by the explore map and the
  * planner map. Failures surface as a bubble next to the button rather than
  * a blocking dialog: a refused permission should not interrupt someone who
- * is mid-route. The bubble is a pure function of the status, so it clears
- * itself as soon as the user retries rather than on a timer the user
- * cannot see.
+ * is mid-route, and it must be dismissable, since the user who just said no
+ * does not need the consequence spelled out at them until they act again.
  */
-export function LocateButton({ status, onClick, className = "" }: LocateButtonProps) {
+export function LocateButton({ status, attempt, onClick, className = "" }: LocateButtonProps) {
+  const [dismissedAttempt, setDismissedAttempt] = useState<number | null>(null);
+
   const message = geolocMessage(status);
+  const showMessage = message !== null && dismissedAttempt !== attempt;
   const locating = status === "locating";
 
   return (
@@ -54,10 +60,10 @@ export function LocateButton({ status, onClick, className = "" }: LocateButtonPr
         )}
       </button>
 
-      {message && (
-        <p
+      {showMessage && (
+        <div
           role="status"
-          className="max-w-[15rem] px-3 py-2 rounded-xl text-xs animate-fade-in"
+          className="max-w-[15rem] flex items-start gap-2 pl-3 pr-2 py-2 rounded-xl text-xs animate-fade-in"
           style={{
             background: "var(--ow-surface-glass)",
             backdropFilter: "blur(8px)",
@@ -65,8 +71,19 @@ export function LocateButton({ status, onClick, className = "" }: LocateButtonPr
             color: "var(--ow-fg-1)",
           }}
         >
-          {message}
-        </p>
+          <p className="flex-1">{message}</p>
+          <button
+            type="button"
+            onClick={() => setDismissedAttempt(attempt)}
+            aria-label="Fermer ce message"
+            className="shrink-0 w-6 h-6 -mt-0.5 flex items-center justify-center rounded-md transition-opacity hover:opacity-70"
+            style={{ color: "var(--ow-fg-2)" }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M5 5l14 14M19 5L5 19" />
+            </svg>
+          </button>
+        </div>
       )}
     </div>
   );

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -157,6 +157,9 @@ interface SpotMapProps {
   // separate from `userPosition` so the map draws the dot without deciding
   // when the viewport may be taken over: that policy lives in the page.
   flyToStamp?: number | null;
+  /** Fired when the user finishes panning or zooming. Feeds the search
+      proximity bias: where someone is looking is a statement of intent. */
+  onCenterChange?: (center: { lat: number; lon: number }) => void;
   defaultCenter?: { lat: number; lon: number };
   onSelectSpot: (spot: Spot) => void;
   onAddSpot: (spot: Spot) => void;
@@ -177,6 +180,7 @@ export function SpotMap({
   customSpots,
   userPosition,
   flyToStamp,
+  onCenterChange,
   defaultCenter,
   onSelectSpot,
   onAddSpot,
@@ -192,6 +196,10 @@ export function SpotMap({
   const markersRef = useRef<Map<string, L.CircleMarker>>(new Map());
   const arrowLayerRef = useRef<L.Marker | null>(null);
   const userLayerRef = useRef<L.LayerGroup | null>(null);
+  const onCenterChangeRef = useRef(onCenterChange);
+  useEffect(() => {
+    onCenterChangeRef.current = onCenterChange;
+  }, [onCenterChange]);
   const onSelectRef = useRef(onSelectSpot);
   onSelectRef.current = onSelectSpot;
   const onAddRef = useRef(onAddSpot);
@@ -290,6 +298,14 @@ export function SpotMap({
     map.getPane("windArrows")!.style.zIndex = "450";
 
     mapRef.current = map;
+
+    // Report the viewport once settled. `moveend` fires per gesture, not per
+    // frame, and the consumer rounds before storing, so panning does not
+    // churn React state.
+    map.on("moveend", () => {
+      const c = map.getCenter();
+      onCenterChangeRef.current?.({ lat: c.lat, lon: c.lng });
+    });
 
     // Long press detection via Pointer Events (covers mouse + touch, one event stream)
     const el = containerRef.current!;

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -162,6 +162,10 @@ interface SpotMapProps {
   onCenterChange?: (center: { lat: number; lon: number }) => void;
   defaultCenter?: { lat: number; lon: number };
   onSelectSpot: (spot: Spot) => void;
+  /** Plain tap or left click on the water: show the forecast there without
+      saving anything. Looking up conditions at a point should not oblige
+      the user to commit it to their favourites. */
+  onPreviewSpot?: (lat: number, lon: number) => void;
   onAddSpot: (spot: Spot) => void;
   onRemoveSpot: (spot: Spot) => void;
   onRenameSpot: (spot: Spot, name: string) => void;
@@ -183,6 +187,7 @@ export function SpotMap({
   onCenterChange,
   defaultCenter,
   onSelectSpot,
+  onPreviewSpot,
   onAddSpot,
   onRemoveSpot,
   onRenameSpot,
@@ -196,12 +201,21 @@ export function SpotMap({
   const markersRef = useRef<Map<string, L.CircleMarker>>(new Map());
   const arrowLayerRef = useRef<L.Marker | null>(null);
   const userLayerRef = useRef<L.LayerGroup | null>(null);
+  const previewLayerRef = useRef<L.CircleMarker | null>(null);
   const onCenterChangeRef = useRef(onCenterChange);
   useEffect(() => {
     onCenterChangeRef.current = onCenterChange;
   }, [onCenterChange]);
   const onSelectRef = useRef(onSelectSpot);
   onSelectRef.current = onSelectSpot;
+  const onPreviewRef = useRef(onPreviewSpot);
+  useEffect(() => {
+    onPreviewRef.current = onPreviewSpot;
+  }, [onPreviewSpot]);
+  /** A long press ends with a pointerup, which the browser follows with a
+      click. Without this the press that opened the "new spot" dialog would
+      also drop a preview underneath it. */
+  const suppressClickRef = useRef(false);
   const onAddRef = useRef(onAddSpot);
   onAddRef.current = onAddSpot;
   const onRemoveRef = useRef(onRemoveSpot);
@@ -241,6 +255,31 @@ export function SpotMap({
       tileLayerRef.current.setUrl(url);
     }
   }, [resolvedTheme]);
+
+  // A previewed point is not in customSpots, so the saved-spot markers never
+  // draw it. Without its own marker the panel would switch to a location the
+  // map does not show. Dashed and hollow, to read as provisional next to the
+  // solid saved spots.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    previewLayerRef.current?.remove();
+    previewLayerRef.current = null;
+    if (!current) return;
+    const saved = customSpots.some(
+      (s) => s.latitude === current.latitude && s.longitude === current.longitude,
+    );
+    if (saved) return;
+    previewLayerRef.current = L.circleMarker([current.latitude, current.longitude], {
+      radius: 9,
+      color: "#2dd4bf",
+      weight: 2.5,
+      dashArray: "4 3",
+      fillColor: "#2dd4bf",
+      fillOpacity: 0.25,
+      interactive: false,
+    }).addTo(map);
+  }, [current, customSpots]);
 
   // Draw the "you are here" dot whenever a fix is known.
   useEffect(() => {
@@ -299,6 +338,18 @@ export function SpotMap({
 
     mapRef.current = map;
 
+    // Plain click on the map background → preview the forecast there. Marker
+    // clicks never reach this handler: Leaflet paths default to
+    // bubblingMouseEvents: false, so selecting a saved spot stays distinct
+    // from previewing open water.
+    map.on("click", (e: L.LeafletMouseEvent) => {
+      if (suppressClickRef.current) {
+        suppressClickRef.current = false;
+        return;
+      }
+      onPreviewRef.current?.(e.latlng.lat, e.latlng.lng);
+    });
+
     // Report the viewport once settled. `moveend` fires per gesture, not per
     // frame, and the consumer rounds before storing, so panning does not
     // churn React state.
@@ -332,6 +383,7 @@ export function SpotMap({
       const editSpot = elementToSpotRef.current.get(target);
       if (editSpot) {
         pressTimerRef.current = setTimeout(() => {
+          suppressClickRef.current = true;
           setPendingEditRef.current(editSpot);
         }, 400);
         return;
@@ -343,6 +395,7 @@ export function SpotMap({
 
       // Press on the map background → add new spot
       pressTimerRef.current = setTimeout(async () => {
+        suppressClickRef.current = true;
         const rect = el.getBoundingClientRect();
         const point = L.point(startX - rect.left, startY - rect.top);
         const latlng = map.containerPointToLatLng(point);
@@ -354,6 +407,12 @@ export function SpotMap({
     const handlePointerUp = () => {
       activePointers = Math.max(0, activePointers - 1);
       cancelPress();
+      // The click that follows this pointerup runs first; clearing on the
+      // next tick means one press swallows exactly one click, and a later
+      // tap on the map is honoured normally.
+      setTimeout(() => {
+        suppressClickRef.current = false;
+      }, 0);
     };
 
     const handlePointerMove = (e: PointerEvent) => {

--- a/packages/web/src/components/SpotSearch.tsx
+++ b/packages/web/src/components/SpotSearch.tsx
@@ -238,13 +238,21 @@ export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: Spot
                     <path d="M12 17.3l-6.2 3.7 1.6-7L2 9.2l7.1-.6L12 2l2.9 6.6 7.1.6-5.4 4.8 1.6 7z" />
                   </svg>
                 )}
-                <span className="font-medium truncate" style={{ color: 'var(--ow-fg-0)' }}>{r.name}</span>
-                {r.context && (
-                  <span className="truncate" style={{ color: 'var(--ow-fg-2)' }}>{r.context}</span>
-                )}
-                {distance && (
-                  <span className="ml-auto shrink-0 text-xs" style={{ color: 'var(--ow-fg-2)' }}>{distance}</span>
-                )}
+                {/* Two lines rather than one: on a phone the single row left
+                    the name as "Br..." while the distance kept its full
+                    width. The name owns the first line outright, the region
+                    and the distance share the second, and min-w-0 is what
+                    actually lets truncate work inside a flex child. */}
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium" style={{ color: 'var(--ow-fg-0)' }}>{r.name}</div>
+                  {(r.context || distance) && (
+                    <div className="flex items-baseline gap-1.5 text-xs" style={{ color: 'var(--ow-fg-2)' }}>
+                      {r.context && <span className="truncate">{r.context}</span>}
+                      {r.context && distance && <span className="shrink-0">·</span>}
+                      {distance && <span className="shrink-0">{distance}</span>}
+                    </div>
+                  )}
+                </div>
               </li>
             );
           })}

--- a/packages/web/src/config/geolocPreference.ts
+++ b/packages/web/src/config/geolocPreference.ts
@@ -1,0 +1,42 @@
+/**
+ * Remembers that the user turned down location sharing.
+ *
+ * The browser already remembers the permission, but it never tells us
+ * whether it will prompt or refuse silently. Without our own record the app
+ * would fire an automatic request on every first-visit-like session and, on
+ * a device where the permission is denied at OS level, greet the user with
+ * the same error bubble each time.
+ *
+ * This flag only ever suppresses the *automatic* request. An explicit tap on
+ * the locate button always retries, because a user who changed their mind in
+ * the browser settings must not be locked out by a stale flag of ours. A
+ * successful fix clears it.
+ */
+
+const STORAGE_KEY = "ow_geoloc_declined_v1";
+
+export function hasDeclinedGeolocation(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    // Private browsing or storage disabled: behave as if nothing was
+    // refused, the worst case being one prompt the user can dismiss.
+    return false;
+  }
+}
+
+export function rememberGeolocationDecline(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    /* storage unavailable: the flag is a convenience, not a requirement */
+  }
+}
+
+export function clearGeolocationDecline(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/packages/web/src/hooks/useGeolocation.ts
+++ b/packages/web/src/hooks/useGeolocation.ts
@@ -1,4 +1,8 @@
 import { useCallback, useRef, useState } from "react";
+import {
+  clearGeolocationDecline,
+  rememberGeolocationDecline,
+} from "../config/geolocPreference";
 
 export interface UserPosition {
   lat: number;
@@ -71,6 +75,9 @@ const DEFAULT_OPTIONS: PositionOptions = {
 export function useGeolocation() {
   const [position, setPosition] = useState<UserPosition | null>(null);
   const [status, setStatus] = useState<GeolocStatus>("idle");
+  /** Counts started requests. Lets the UI tell a dismissed failure from a
+      fresh one, so retrying re-shows a message the user had closed. */
+  const [attempt, setAttempt] = useState(0);
   const stampRef = useRef(0);
   const inFlightRef = useRef<Promise<UserPosition | null> | null>(null);
 
@@ -85,6 +92,7 @@ export function useGeolocation() {
       if (inFlightRef.current) return inFlightRef.current;
 
       setStatus("locating");
+      setAttempt((n) => n + 1);
       const request = new Promise<UserPosition | null>((resolve) => {
         navigator.geolocation.getCurrentPosition(
           (pos) => {
@@ -97,10 +105,18 @@ export function useGeolocation() {
             };
             setPosition(next);
             setStatus("ready");
+            // The user granted it, possibly after changing their mind in the
+            // browser settings: a past refusal must not keep haunting them.
+            clearGeolocationDecline();
             resolve(next);
           },
           (err) => {
-            setStatus(statusFromErrorCode(err.code));
+            const failure = statusFromErrorCode(err.code);
+            setStatus(failure);
+            // Only an outright refusal is remembered. A timeout or a
+            // temporarily unavailable fix says nothing about consent and
+            // must not silence the automatic request forever.
+            if (failure === "denied") rememberGeolocationDecline();
             resolve(null);
           },
           { ...DEFAULT_OPTIONS, ...options },
@@ -115,5 +131,5 @@ export function useGeolocation() {
     [],
   );
 
-  return { position, status, locate };
+  return { position, status, attempt, locate };
 }

--- a/packages/web/src/hooks/useMapCenter.test.ts
+++ b/packages/web/src/hooks/useMapCenter.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { roundCenter } from "./useMapCenter";
+
+describe("roundCenter", () => {
+  it("keeps two decimals, about a kilometre", () => {
+    expect(roundCenter({ lat: 48.390512, lon: -4.486076 })).toEqual({
+      lat: 48.39,
+      lon: -4.49,
+    });
+  });
+
+  it("collapses nearby positions, so nudging the map does not re-render", () => {
+    const a = roundCenter({ lat: 43.2961, lon: 5.3699 });
+    const b = roundCenter({ lat: 43.2964, lon: 5.3702 });
+    expect(a).toEqual(b);
+  });
+
+  it("rounds negative longitudes away from zero the same way", () => {
+    expect(roundCenter({ lat: 12.005, lon: -4.494 }).lon).toBe(-4.49);
+    expect(roundCenter({ lat: 12.005, lon: -4.496 }).lon).toBe(-4.5);
+  });
+});

--- a/packages/web/src/hooks/useMapCenter.ts
+++ b/packages/web/src/hooks/useMapCenter.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react";
+
+/** ~1.1 km. Finer than that changes nothing for a search bias, and every
+    extra digit is a React render on every pan. */
+export function roundCenter(center: { lat: number; lon: number }): {
+  lat: number;
+  lon: number;
+} {
+  return {
+    lat: Math.round(center.lat * 100) / 100,
+    lon: Math.round(center.lon * 100) / 100,
+  };
+}
+
+/**
+ * Tracks where the map is looking, for pages that feed it to the search.
+ *
+ * The identity of the returned center is stable while the rounded position
+ * does not change, so nudging the map by a few metres does not re-render the
+ * page or invalidate the search cache.
+ */
+export function useMapCenter() {
+  const [center, setCenter] = useState<{ lat: number; lon: number } | null>(null);
+
+  const onCenterChange = useCallback((raw: { lat: number; lon: number }) => {
+    setCenter((prev) => {
+      const next = roundCenter(raw);
+      if (prev && prev.lat === next.lat && prev.lon === next.lon) return prev;
+      return next;
+    });
+  }, []);
+
+  return { center, onCenterChange };
+}

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -37,6 +37,9 @@ interface PlanMapProps {
   /** Drawn as a dot with an accuracy halo. Recentering stays the page's
       call, through the `recenter` imperative handle. */
   userPosition?: UserPosition | null;
+  /** Fired when the user finishes panning or zooming. Feeds the search
+      proximity bias: where someone is looking is a statement of intent. */
+  onCenterChange?: (center: { lat: number; lon: number }) => void;
 }
 
 function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon {
@@ -52,7 +55,7 @@ function waypointIcon(label: string, bg: string, deletable: boolean): L.DivIcon 
 }
 
 export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
-  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick, highlightedSegmentRange, initialCenter, userPosition }: PlanMapProps,
+  { waypoints, segments, isStale, onWptMove, onWptAdd, onWptDelete, onMapClick, highlightedSegmentRange, initialCenter, userPosition, onCenterChange }: PlanMapProps,
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -64,6 +67,8 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const dragLineRef = useRef<L.Polyline | null>(null);
   const segLabelsRef = useRef<L.Tooltip[]>([]);
   const userLayerRef = useRef<L.LayerGroup | null>(null);
+  const onCenterChangeRef = useRef(onCenterChange);
+  useEffect(() => { onCenterChangeRef.current = onCenterChange; }, [onCenterChange]);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
   const isDraggingRef = useRef(false);
   const onWptAddRef = useRef(onWptAdd);
@@ -184,6 +189,12 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     // threshold means legs appear/disappear as the scale changes.
     const onZoomEnd = () => drawSegLabels(map, livePositionsRef.current);
     map.on("zoomend", onZoomEnd);
+
+    // Report the settled viewport for the search proximity bias.
+    map.on("moveend", () => {
+      const c = map.getCenter();
+      onCenterChangeRef.current?.({ lat: c.lat, lon: c.lng });
+    });
 
     const ro = new ResizeObserver(() => map.invalidateSize());
     ro.observe(containerRef.current!);

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -22,6 +22,7 @@ import { activeModels, loadModelConfig } from "../config/modelConfig";
 import { effectivePolar, isPolarCustomized, loadPolarConfig, polarFingerprint } from "../config/polarConfig";
 import { LocateButton } from "../components/LocateButton";
 import { useGeolocation } from "../hooks/useGeolocation";
+import { useMapCenter } from "../hooks/useMapCenter";
 
 // Build the plan-time overrides payload from current /config preferences.
 // Read at request time (not at mount) so a /config tweak takes effect on the
@@ -307,7 +308,8 @@ function ResizableDesktopSidebar({
 export function PlanPage() {
   const mapRef = useRef<PlanMapHandle>(null);
 
-  const { position: userPosition, status: geolocStatus, locate } = useGeolocation();
+  const { position: userPosition, status: geolocStatus, attempt: geolocAttempt, locate } = useGeolocation();
+  const { center: mapCenter, onCenterChange } = useMapCenter();
   // On /plan the user is building a route, so a locate request is always
   // explicit: no first-visit auto-centering here.
   const handleLocate = useCallback(() => {
@@ -789,8 +791,8 @@ export function PlanPage() {
           fix as the search reference. */}
       <Header
         onSelectSpot={(spot) => mapRef.current?.recenter(spot.latitude, spot.longitude)}
-        nearLat={waypoints[0]?.[0] ?? userPosition?.lat ?? null}
-        nearLon={waypoints[0]?.[1] ?? userPosition?.lon ?? null}
+        nearLat={waypoints[0]?.[0] ?? userPosition?.lat ?? mapCenter?.lat ?? null}
+        nearLon={waypoints[0]?.[1] ?? userPosition?.lon ?? mapCenter?.lon ?? null}
       />
       <RebrandBanner />
 
@@ -816,6 +818,7 @@ export function PlanPage() {
             onMapClick={handleMapClick}
             initialCenter={isParsedOk(initialParsed) ? initialParsed.center : null}
             userPosition={userPosition}
+            onCenterChange={onCenterChange}
             highlightedSegmentRange={
               selectedLegIdx != null && passage
                 ? computeLegSegmentRanges(passage.segments as { start: { lat: number; lon: number } }[], waypoints)[selectedLegIdx] ?? null
@@ -839,6 +842,7 @@ export function PlanPage() {
               them rather than sitting on the arrival time. */}
           <LocateButton
             status={geolocStatus}
+            attempt={geolocAttempt}
             onClick={handleLocate}
             className={
               passage && planMode === "single" && !isStale


### PR DESCRIPTION
Trois retours d'usage sur `dev`, traités ensemble parce qu'ils se répondent.

## 1. Message d'échec fermable, refus mémorisé

Le message n'était pas fermable et revenait à chaque visite. Il porte maintenant une croix, et un refus explicite est mémorisé dans `localStorage`, ce qui empêche la requête automatique de première visite de se redéclencher.

Trois garde-fous :

- **Seul un refus est mémorisé.** Un timeout ou une position temporairement indisponible ne dit rien du consentement et ne doit pas éteindre la demande automatique pour toujours.
- **Le drapeau ne bloque jamais le clic explicite.** Sinon quelqu'un qui autorise la localisation dans les réglages de son navigateur resterait prisonnier d'un état périmé de notre côté. Un fix réussi efface le drapeau.
- **La fermeture vaut pour une tentative.** Le hook compte les requêtes, donc réappuyer sur le bouton réaffiche un message que l'utilisateur avait fermé, au lieu de le laisser sans retour.

## 2. Centre de la carte comme point de référence

Sans position accordée, une recherche "Brest" depuis un téléphone remontait le Brest de Biélorussie et celui de Croatie à côté de celui du Finistère. Le centre de la carte sert désormais de référence à défaut de position : c'est là que l'utilisateur regarde, donc ce qu'il cherche.

Cascade : position accordée, puis centre de carte, puis spot actif. Sur `/plan` le premier waypoint garde la priorité, la route en cours restant la meilleure expression de la zone de travail.

Le centre est arrondi à deux décimales, environ 1,1 km. Plus fin ne change rien à un biais de recherche et coûterait un rendu React à chaque déplacement de carte. L'événement écouté est `moveend`, une fois par geste, pas par image.

Si tu préfères que le viewport l'emporte toujours, même quand la position est connue, c'est une ligne à inverser dans la cascade. J'ai suivi ton ordre.

## 3. Ligne de résultat lisible sur mobile

La ligne unique écrasait le nom en "Br..." et la région en "Finis..." pendant que la distance gardait toute sa largeur. Le nom occupe maintenant sa propre ligne, la région et la distance partagent la seconde. Le `min-w-0` est ce qui rend `truncate` opérant dans un enfant flex, son absence était la cause réelle.

## Vérifications

- 104 tests web verts (101 avant, 3 ajoutés sur l'arrondi du centre)
- `tsc --noEmit` propre, `npm run build` OK
- ESLint stable à 27 problèmes

## À tester

- Refuser la position, fermer le message, recharger : plus de demande ni de message
- Réappuyer sur le bouton après avoir fermé : le message revient
- Autoriser ensuite dans les réglages du navigateur : le bouton marche sans vider le stockage
- Chercher "Brest" en ayant la carte sur la Bretagne, sans position accordée
- Un résultat à nom long sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)