### PR TITLE
fix: phase 0 refacto — durcissement du serveur public + hygiène repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,15 @@ dist-ssr
 # Local scratch / browser exports / non-tracked working files
 /tmp/
 
+# Source archives for the offline atlas builds (SHOM C2D and friends). The
+# runtime never reads these: the Space pulls the derived Parquet/JSON from the
+# HF Dataset. Extracted working copies live under build/, already ignored.
+*.7z
+
+# Working drafts and captures that are not part of the published docs
+/marketing-drafts/*.png
+/docs/screenshots/viz.png
+
 # Test artifacts
 test-results/
 eval_screenshots.ts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,14 +23,16 @@ on the server.
         │   ├── plan_passage    (single + compare-      │
         │   │                    windows mode; declares │
         │   │                    MCP Apps UI resource)  │
-        │   └── read_me                                 │
+        │   ├── read_me                                 │
+        │   └── feedback        (sink injected by the   │
+        │                        deployment wrapper)    │
         └────────────┬─────────────────────────────────┘
                      │ pure Python calls
         ┌────────────▼─────────────────────────────────┐
         │  openwind-data       (no network framework)  │
         │   • adapters/openmeteo.py   (httpx, keyless) │
         │   • routing/geometry.py     (haversine, …)   │
-        │   • routing/archetypes.py   (5 polars JSON)  │
+        │   • routing/archetypes.py   (7 polars JSON)  │
         │   • routing/passage.py      (timing + derate)│
         │   • routing/complexity.py   (1-5 score)      │
         └────────────┬─────────────────────────────────┘

--- a/packages/data-adapters/src/openwind_data/routing/__init__.py
+++ b/packages/data-adapters/src/openwind_data/routing/__init__.py
@@ -9,6 +9,7 @@ from openwind_data.routing.archetypes import (
 from openwind_data.routing.complexity import ComplexityScore, score_complexity
 from openwind_data.routing.geometry import (
     EARTH_RADIUS_NM,
+    MAX_WAYPOINTS,
     Point,
     Segment,
     bearing,
@@ -17,14 +18,16 @@ from openwind_data.routing.geometry import (
     midpoint,
     normalize_twa,
     segment_route,
+    validate_point,
+    validate_waypoints,
 )
 from openwind_data.routing.passage import (
     EtaPassagePlan,
     NoModelCoveredError,
     PassageReport,
     SegmentReport,
-    _build_conditions_summary,
     best_vmg_upwind,
+    build_conditions_summary,
     estimate_passage,
     estimate_passage_for_arrival,
     estimate_passage_windows,
@@ -32,6 +35,7 @@ from openwind_data.routing.passage import (
 
 __all__ = [
     "EARTH_RADIUS_NM",
+    "MAX_WAYPOINTS",
     "BoatPolar",
     "ComplexityScore",
     "EtaPassagePlan",
@@ -40,9 +44,9 @@ __all__ = [
     "Point",
     "Segment",
     "SegmentReport",
-    "_build_conditions_summary",
     "bearing",
     "best_vmg_upwind",
+    "build_conditions_summary",
     "estimate_passage",
     "estimate_passage_for_arrival",
     "estimate_passage_windows",
@@ -55,4 +59,6 @@ __all__ = [
     "normalize_twa",
     "score_complexity",
     "segment_route",
+    "validate_point",
+    "validate_waypoints",
 ]

--- a/packages/data-adapters/src/openwind_data/routing/geometry.py
+++ b/packages/data-adapters/src/openwind_data/routing/geometry.py
@@ -13,6 +13,12 @@ from itertools import pairwise
 
 EARTH_RADIUS_NM = 3440.065
 
+# Upper bound on route complexity accepted at the public boundary. Well above
+# any realistic hand-drawn coastal route (the web map has no client-side cap),
+# but low enough that a hostile caller cannot inflate the corridor sampling
+# fan-out. The sweep fan-out is bounded separately by ``MAX_SWEEP_WINDOWS``.
+MAX_WAYPOINTS = 50
+
 
 @dataclass(frozen=True, slots=True)
 class Point:
@@ -26,6 +32,41 @@ class Segment:
     end: Point
     distance_nm: float
     bearing_deg: float
+
+
+def validate_waypoints(points: list[Point]) -> None:
+    """Reject routes that are out of range, non-finite, or unreasonably long.
+
+    Called at the public boundary (REST handlers and MCP tools) so both shells
+    surface the same wording. ``Point`` itself stays unvalidated on purpose:
+    the engines build interpolated points internally and must not pay a
+    validation cost per sub-segment.
+
+    NaN and infinity are rejected explicitly — plain range comparisons let NaN
+    through (every comparison against NaN is false), and it would only surface
+    much later as an opaque upstream error.
+
+    Raises:
+        ValueError: fewer than 2 points, more than ``MAX_WAYPOINTS``, or any
+            coordinate non-finite or outside [-90, 90] / [-180, 180].
+    """
+    if len(points) < 2:
+        raise ValueError("at least 2 waypoints required")
+    if len(points) > MAX_WAYPOINTS:
+        raise ValueError(f"too many waypoints: {len(points)} (max {MAX_WAYPOINTS})")
+    for i, p in enumerate(points):
+        if not math.isfinite(p.lat) or not -90.0 <= p.lat <= 90.0:
+            raise ValueError(f"waypoint {i}: lat={p.lat} out of range [-90, 90]")
+        if not math.isfinite(p.lon) or not -180.0 <= p.lon <= 180.0:
+            raise ValueError(f"waypoint {i}: lon={p.lon} out of range [-180, 180]")
+
+
+def validate_point(lat: float, lon: float) -> None:
+    """Single-point variant of ``validate_waypoints`` for forecast endpoints."""
+    if not math.isfinite(lat) or not -90.0 <= lat <= 90.0:
+        raise ValueError(f"lat={lat} out of range [-90, 90]")
+    if not math.isfinite(lon) or not -180.0 <= lon <= 180.0:
+        raise ValueError(f"lon={lon} out of range [-180, 180]")
 
 
 def _angular_distance_rad(a: Point, b: Point) -> float:

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -140,7 +140,7 @@ def _categorize_twa(twa_deg: float) -> str:
         return "portant"
 
 
-def _build_conditions_summary(report: PassageReport) -> dict:
+def build_conditions_summary(report: PassageReport) -> dict:
     tws = [s.tws_kn for s in report.segments]
     counts: dict[str, int] = {}
     for s in report.segments:

--- a/packages/data-adapters/tests/test_geometry_validation.py
+++ b/packages/data-adapters/tests/test_geometry_validation.py
@@ -1,0 +1,88 @@
+"""Boundary validation for waypoints and single points.
+
+These guards run at the public boundary (REST handlers + MCP tools), so their
+exact messages are part of the contract the web client's ``friendlyError``
+matches on. Changing the wording here means changing ``web/src/api/passage.ts``
+in the same commit.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from openwind_data.routing.geometry import (
+    MAX_WAYPOINTS,
+    Point,
+    validate_point,
+    validate_waypoints,
+)
+
+MARSEILLE = Point(43.30, 5.35)
+PORQUEROLLES = Point(43.00, 6.20)
+
+
+def test_valid_route_passes() -> None:
+    validate_waypoints([MARSEILLE, PORQUEROLLES])
+
+
+def test_extremes_are_inclusive() -> None:
+    validate_waypoints([Point(-90.0, -180.0), Point(90.0, 180.0)])
+
+
+def test_single_waypoint_rejected() -> None:
+    with pytest.raises(ValueError, match="at least 2 waypoints required"):
+        validate_waypoints([MARSEILLE])
+
+
+def test_message_for_too_few_is_byte_identical_to_legacy_rest_wording() -> None:
+    # The web maps /at least 2 waypoints/i; keep it verbatim.
+    with pytest.raises(ValueError) as excinfo:
+        validate_waypoints([])
+    assert str(excinfo.value) == "at least 2 waypoints required"
+
+
+@pytest.mark.parametrize("lat", [999.0, 90.1, -90.1, -1e9])
+def test_out_of_range_lat_rejected(lat: float) -> None:
+    with pytest.raises(ValueError, match=r"waypoint 0: lat=.* out of range \[-90, 90\]"):
+        validate_waypoints([Point(lat, 5.35), PORQUEROLLES])
+
+
+@pytest.mark.parametrize("lon", [180.5, -180.5, 1e9])
+def test_out_of_range_lon_rejected(lon: float) -> None:
+    with pytest.raises(ValueError, match=r"waypoint 1: lon=.* out of range \[-180, 180\]"):
+        validate_waypoints([MARSEILLE, Point(43.0, lon)])
+
+
+def test_offending_index_is_reported() -> None:
+    with pytest.raises(ValueError, match="waypoint 2:"):
+        validate_waypoints([MARSEILLE, PORQUEROLLES, Point(91.0, 6.0)])
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+def test_non_finite_rejected(bad: float) -> None:
+    # json.loads accepts the bare NaN/Infinity literals, so these really can
+    # arrive from a POST body. Plain range comparisons let NaN through.
+    with pytest.raises(ValueError, match="out of range"):
+        validate_waypoints([Point(bad, 5.35), PORQUEROLLES])
+    with pytest.raises(ValueError, match="out of range"):
+        validate_waypoints([MARSEILLE, Point(43.0, bad)])
+
+
+def test_waypoint_count_capped() -> None:
+    route = [Point(43.0 + i * 0.001, 5.0) for i in range(MAX_WAYPOINTS + 1)]
+    with pytest.raises(ValueError, match=f"too many waypoints: {MAX_WAYPOINTS + 1}"):
+        validate_waypoints(route)
+
+
+def test_waypoint_count_at_cap_allowed() -> None:
+    validate_waypoints([Point(43.0 + i * 0.001, 5.0) for i in range(MAX_WAYPOINTS)])
+
+
+def test_validate_point_accepts_and_rejects() -> None:
+    validate_point(43.30, 5.35)
+    with pytest.raises(ValueError, match=r"lat=999.0 out of range"):
+        validate_point(999.0, 5.35)
+    with pytest.raises(ValueError, match=r"lon=999.0 out of range"):
+        validate_point(43.30, 999.0)

--- a/packages/hf-space/.ruff.toml
+++ b/packages/hf-space/.ruff.toml
@@ -1,0 +1,13 @@
+# hf-space ships via Docker, not as an installable package, so it has no
+# pyproject to carry a [tool.ruff] table. Without this file ruff falls back to
+# its defaults here (line-length 88) and formats this package differently from
+# the two it vendors. Keep in sync with packages/*/pyproject.toml.
+line-length = 100
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "I", "B", "UP", "N", "RUF"]
+# RUF001 on top of the shared ignore: app.py embeds the landing page as an HTML
+# string, and its CSS uses typographic glyphs (the "›" disclosure chevron) on
+# purpose. They are content, not confusable identifiers.
+ignore = ["E501", "RUF001"]

--- a/packages/hf-space/Dockerfile
+++ b/packages/hf-space/Dockerfile
@@ -33,7 +33,9 @@ RUN --mount=type=secret,id=HF_TOKEN,required=false \
     sh -c 'if [ -f /run/secrets/HF_TOKEN ]; then export HF_TOKEN="$(cat /run/secrets/HF_TOKEN)"; fi; \
            python /tmp/fetch_atlases.py'
 
-COPY app.py /app/app.py
+# security.py is imported by app.py at boot — a missing COPY here is a hard
+# crash on startup, not a degraded mode.
+COPY app.py security.py /app/
 
 EXPOSE 7860
 

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -17,7 +17,7 @@ short_description: French Atlantic + Mediterranean sailing planner via MCP.
 > Turns any MCP-capable assistant into a sailing planner for the French
 > Atlantic and Mediterranean coasts. Free, keyless, open source.
 
-![OpenWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/openwind/main/docs/screenshots/plan.png)
+![OpenWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png)
 
 ---
 
@@ -59,7 +59,7 @@ card.
 - **Client-agnostic.** One HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
 - **Open source, MIT.** Self-host on Fly, Modal, or your own VPS in minutes.
 
-## Four tools
+## Five tools
 
 | Tool                      | What it does                                                              |
 |---------------------------|---------------------------------------------------------------------------|
@@ -67,6 +67,7 @@ card.
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
 | `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
 | `read_me`                 | Returns OpenWind's calculation methodology. Call it when the user asks how things are computed. |
+| `feedback`                | Structured channel for the LLM to report a problem or a suggestion about a tool interaction. |
 
 ## About this Space
 
@@ -75,7 +76,7 @@ card.
 > `huggingface.co/spaces?filter=mcp-server`. Discoverability lives at
 > [openwind.fr](https://openwind.fr) instead.
 
-**Source of truth:** <https://github.com/qdonnars/openwind>. This Space is
+**Source of truth:** <https://github.com/qdonnars/ohmywind>. This Space is
 auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Don't
 commit directly to the Space repo; your changes will be overwritten at the
 next push.

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -5,14 +5,13 @@ This wrapper is intentionally thin. All tools live in ``openwind_mcp_core``
 different Dockerfile that runs the same ``build_server()`` factory.
 
 Transport: ``streamable-http`` on port 7860 (HF Spaces default). Clients
-connect to ``https://qdonnars-openwind-mcp.hf.space``. (Custom domain
-``mcp.openwind.fr`` deferred — HF gates custom domains behind PRO; see
-``plan/04-backlog.md``.)
+connect to ``https://qdonnars-openwind-mcp.hf.space``. A custom domain on the
+Space is deferred: HF gates those behind a PRO subscription.
 
-Trade-off explicitly accepted (cf. ``plan/04-backlog.md``): HF Docker SDK
-Spaces do not get the ``MCP`` badge or the one-click connector flow that
-Gradio ``mcp_server=True`` Spaces get. Discoverability is via the project
-website, not via the HF catalog. Re-evaluate if traffic plateaus.
+Trade-off explicitly accepted: HF Docker SDK Spaces do not get the ``MCP``
+badge or the one-click connector flow that Gradio ``mcp_server=True`` Spaces
+get. Discoverability is via the project website, not via the HF catalog.
+Re-evaluate if traffic plateaus.
 """
 
 from __future__ import annotations
@@ -35,10 +34,10 @@ from openwind_data.currents.marc_atlas import MarcAtlasRegistry
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 from openwind_data.routing.archetypes import BoatPolar, list_archetypes_metadata
 from openwind_data.routing.complexity import score_complexity
-from openwind_data.routing.geometry import Point
+from openwind_data.routing.geometry import Point, validate_point, validate_waypoints
 from openwind_data.routing.passage import (
     NoModelCoveredError,
-    _build_conditions_summary,
+    build_conditions_summary,
     estimate_passage,
     estimate_passage_for_arrival,
     estimate_passage_windows,
@@ -50,6 +49,8 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette.routing import Mount, Route
+
+from security import ALLOWED_ORIGINS, RateLimitMiddleware, SecurityHeadersMiddleware
 
 _logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ LANDING_HTML = """<!doctype html>
     Mediterranean coasts. Exposed as an MCP server so any compatible
     assistant can use it.</p>
 
-  <img class="hero" src="https://raw.githubusercontent.com/qdonnars/openwind/main/docs/screenshots/plan.png"
+  <img class="hero" src="https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png"
        alt="OpenWind passage plan: 5 waypoints, 48.6 nm, ETA 21:24, complexity 3 of 5.">
 
   <h2>Connect it to your assistant</h2>
@@ -274,7 +275,7 @@ LANDING_HTML = """<!doctype html>
 
   <h2>Source</h2>
   <p>Project site: <a href="https://openwind.fr">openwind.fr</a> &middot;
-    GitHub: <a href="https://github.com/qdonnars/openwind">qdonnars/openwind</a>
+    GitHub: <a href="https://github.com/qdonnars/ohmywind">qdonnars/ohmywind</a>
     (MIT).</p>
 
   <p class="footnote">First request after inactivity may take a few seconds
@@ -477,8 +478,14 @@ async def _api_passage(request: Request) -> JSONResponse:
     except (TypeError, IndexError, ValueError) as exc:
         return JSONResponse({"error": f"invalid waypoints: {exc}"}, status_code=422)
 
-    if len(waypoints) < 2:
-        return JSONResponse({"error": "at least 2 waypoints required"}, status_code=422)
+    # Bounds are checked before any upstream call: an out-of-range point used
+    # to reach Open-Meteo and come back as a misleading "forecast horizon
+    # exceeded". Message passed through verbatim so "at least 2 waypoints
+    # required" stays byte-identical for the front's error mapping.
+    try:
+        validate_waypoints(waypoints)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
 
     efficiency: float = body.get("efficiency", 0.75)
     try:
@@ -545,7 +552,6 @@ async def _api_passage(request: Request) -> JSONResponse:
         # Sweep is partial-tolerant: estimate_passage_windows skips windows
         # that hit ForecastHorizonError. Compute the expected count to surface
         # a meta-warning if some were dropped.
-        from datetime import timedelta as _td
         expected_windows = (
             int((latest_departure - departure).total_seconds() / 3600 / sweep_interval) + 1
         )
@@ -569,7 +575,7 @@ async def _api_passage(request: Request) -> JSONResponse:
                     "tws_max_kn": round(score.tws_max_kn, 1),
                     "rationale": score.rationale,
                 },
-                "conditions_summary": _build_conditions_summary(report),
+                "conditions_summary": build_conditions_summary(report),
                 "warnings": list(report.warnings) + [w.message for w in score.warnings],
                 "passage": _to_json(report),
                 "complexity_full": _to_json(score),
@@ -582,7 +588,7 @@ async def _api_passage(request: Request) -> JSONResponse:
                 f"(horizon dépassé) — affichage des {len(windows)} restantes."
             )
         if target_eta_dt is not None:
-            tol = _td(hours=2).total_seconds()
+            tol = timedelta(hours=2).total_seconds()
             target_utc = target_eta_dt.astimezone(UTC)
             filtered = [
                 w for w in windows
@@ -668,8 +674,14 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
     except (TypeError, IndexError, ValueError) as exc:
         return JSONResponse({"error": f"invalid waypoints: {exc}"}, status_code=422)
 
-    if len(waypoints) < 2:
-        return JSONResponse({"error": "at least 2 waypoints required"}, status_code=422)
+    # Bounds are checked before any upstream call: an out-of-range point used
+    # to reach Open-Meteo and come back as a misleading "forecast horizon
+    # exceeded". Message passed through verbatim so "at least 2 waypoints
+    # required" stays byte-identical for the front's error mapping.
+    try:
+        validate_waypoints(waypoints)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
 
     try:
         efficiency = float(body.get("efficiency", 0.75))
@@ -801,7 +813,7 @@ def _build_feedback_scheduler() -> Any | None:
             _FEEDBACK_EVERY_MIN,
         )
         return scheduler
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         _logger.warning("openwind.feedback: scheduler init failed: %s", exc)
         return None
 
@@ -858,6 +870,10 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
             {"error": f"missing or invalid query params (lat, lon, start, end): {exc}"},
             status_code=422,
         )
+    try:
+        validate_point(lat, lon)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
     step_minutes = 60
     if "step_minutes" in request.query_params:
         try:
@@ -964,6 +980,40 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
     )
 
 
+def build_app(mcp_app: Any) -> Starlette:
+    """Assemble the parent Starlette app around a mounted FastMCP app.
+
+    Split out of ``main`` so tests can exercise routing and middleware without
+    booting uvicorn or a real MCP session manager.
+    """
+    return Starlette(
+        routes=[
+            Route("/", _index),
+            *[Route(path, _icon_redirect, methods=["GET"]) for path in _ICON_REDIRECTS],
+            Route("/api/v1/archetypes", _api_archetypes, methods=["GET"]),
+            Route("/api/v1/passage", _api_passage, methods=["POST"]),
+            Route("/api/v1/passage-by-eta", _api_passage_by_eta, methods=["POST"]),
+            Route("/api/v1/marine/marc", _api_marc_overlay, methods=["GET"]),
+            Mount("/", app=mcp_app),
+        ],
+        # Order matters: the first entry is the outermost wrapper. CORS sits
+        # outside the limiter so a 429 still carries the Access-Control-Allow-*
+        # headers — otherwise the browser reports an opaque CORS failure and
+        # the real cause never reaches the user.
+        middleware=[
+            Middleware(
+                CORSMiddleware,
+                allow_origins=ALLOWED_ORIGINS,
+                allow_methods=["GET", "POST", "OPTIONS"],
+                allow_headers=["Content-Type"],
+            ),
+            Middleware(SecurityHeadersMiddleware),
+            Middleware(RateLimitMiddleware),
+        ],
+        lifespan=mcp_app.router.lifespan_context,
+    )
+
+
 def main() -> None:
     global _feedback_scheduler
     _feedback_scheduler = _build_feedback_scheduler()
@@ -982,27 +1032,7 @@ def main() -> None:
     # so we must hand the inner lifespan to the parent — without this the MCP
     # endpoint returns 500 because the streamable-http session manager never
     # initialised.
-    mcp_app = server.streamable_http_app()
-    app = Starlette(
-        routes=[
-            Route("/", _index),
-            *[Route(path, _icon_redirect, methods=["GET"]) for path in _ICON_REDIRECTS],
-            Route("/api/v1/archetypes", _api_archetypes, methods=["GET"]),
-            Route("/api/v1/passage", _api_passage, methods=["POST"]),
-            Route("/api/v1/passage-by-eta", _api_passage_by_eta, methods=["POST"]),
-            Route("/api/v1/marine/marc", _api_marc_overlay, methods=["GET"]),
-            Mount("/", app=mcp_app),
-        ],
-        middleware=[
-            Middleware(
-                CORSMiddleware,
-                allow_origins=["*"],
-                allow_methods=["GET", "POST", "OPTIONS"],
-                allow_headers=["Content-Type"],
-            )
-        ],
-        lifespan=mcp_app.router.lifespan_context,
-    )
+    app = build_app(server.streamable_http_app())
     # Run uvicorn explicitly (rather than ``server.run(transport=...)``) so we
     # can enable ``proxy_headers``/``forwarded_allow_ips``. HF terminates TLS
     # at the edge; without these flags ASGI sees ``http`` + the internal Host

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -368,6 +368,7 @@ def _parse_polar(raw: Any) -> BoatPolar | None:
     if len(tws) < 2 or len(twa) < 2:
         raise ValueError("polar must have >= 2 TWS and >= 2 TWA entries")
     from itertools import pairwise
+
     if any(a >= b for a, b in pairwise(tws)):
         raise ValueError("polar tws_kn must be strictly ascending")
     if any(a >= b for a, b in pairwise(twa)):
@@ -385,9 +386,7 @@ def _parse_polar(raw: Any) -> BoatPolar | None:
             )
         for j, v in enumerate(row):
             if v < 0 or v > 30:
-                raise ValueError(
-                    f"polar boat_speed_kn[{i}][{j}]={v} out of range [0, 30]"
-                )
+                raise ValueError(f"polar boat_speed_kn[{i}][{j}]={v} out of range [0, 30]")
     # Optional motor config. Both fields must be set together; either alone
     # is dropped silently so a half-filled web form never silently changes
     # the simulation (matches the frontend / backend "both or neither" rule).
@@ -530,9 +529,15 @@ async def _api_passage(request: Request) -> JSONResponse:
 
         try:
             reports = await estimate_passage_windows(
-                waypoints, departure, latest_departure, body["archetype"],
-                sweep_interval_hours=sweep_interval, efficiency=efficiency, model="auto",
-                polar_override=polar_override, model_chain=model_chain,
+                waypoints,
+                departure,
+                latest_departure,
+                body["archetype"],
+                sweep_interval_hours=sweep_interval,
+                efficiency=efficiency,
+                model="auto",
+                polar_override=polar_override,
+                model_chain=model_chain,
                 adapter=cache_adapter,
             )
         except KeyError as exc:
@@ -564,22 +569,24 @@ async def _api_passage(request: Request) -> JSONResponse:
             # drill-down ("click a row → see detail") needs zero re-fetch.
             # The summary fields above (`complexity` partial, `conditions_summary`,
             # `duration_h`, `distance_nm`) stay for compact table rendering.
-            windows.append({
-                "departure": report.departure_time.isoformat(),
-                "arrival": report.arrival_time.isoformat(),
-                "duration_h": round(report.duration_h, 2),
-                "distance_nm": round(report.distance_nm, 1),
-                "complexity": {
-                    "level": score.level,
-                    "label": score.label,
-                    "tws_max_kn": round(score.tws_max_kn, 1),
-                    "rationale": score.rationale,
-                },
-                "conditions_summary": build_conditions_summary(report),
-                "warnings": list(report.warnings) + [w.message for w in score.warnings],
-                "passage": _to_json(report),
-                "complexity_full": _to_json(score),
-            })
+            windows.append(
+                {
+                    "departure": report.departure_time.isoformat(),
+                    "arrival": report.arrival_time.isoformat(),
+                    "duration_h": round(report.duration_h, 2),
+                    "distance_nm": round(report.distance_nm, 1),
+                    "complexity": {
+                        "level": score.level,
+                        "label": score.label,
+                        "tws_max_kn": round(score.tws_max_kn, 1),
+                        "rationale": score.rationale,
+                    },
+                    "conditions_summary": build_conditions_summary(report),
+                    "warnings": list(report.warnings) + [w.message for w in score.warnings],
+                    "passage": _to_json(report),
+                    "complexity_full": _to_json(score),
+                }
+            )
 
         meta_warnings: list[str] = []
         if skipped_count > 0:
@@ -591,7 +598,8 @@ async def _api_passage(request: Request) -> JSONResponse:
             tol = timedelta(hours=2).total_seconds()
             target_utc = target_eta_dt.astimezone(UTC)
             filtered = [
-                w for w in windows
+                w
+                for w in windows
                 if abs((datetime.fromisoformat(w["arrival"]) - target_utc).total_seconds()) <= tol
             ]
             if not filtered:
@@ -602,24 +610,31 @@ async def _api_passage(request: Request) -> JSONResponse:
             else:
                 windows = filtered
 
-        return JSONResponse({
-            "mode": "multi_window",
-            "sweep": {
-                "earliest": departure.isoformat(),
-                "latest": latest_departure.isoformat(),
-                "interval_hours": sweep_interval,
-                "window_count": len(windows),
-            },
-            "windows": windows,
-            "meta_warnings": meta_warnings,
-            "forecast_updated_at": datetime.now(UTC).isoformat(),
-        })
+        return JSONResponse(
+            {
+                "mode": "multi_window",
+                "sweep": {
+                    "earliest": departure.isoformat(),
+                    "latest": latest_departure.isoformat(),
+                    "interval_hours": sweep_interval,
+                    "window_count": len(windows),
+                },
+                "windows": windows,
+                "meta_warnings": meta_warnings,
+                "forecast_updated_at": datetime.now(UTC).isoformat(),
+            }
+        )
 
     # Single mode.
     try:
         passage = await estimate_passage(
-            waypoints, departure, body["archetype"], efficiency=efficiency, model="auto",
-            polar_override=polar_override, model_chain=model_chain,
+            waypoints,
+            departure,
+            body["archetype"],
+            efficiency=efficiency,
+            model="auto",
+            polar_override=polar_override,
+            model_chain=model_chain,
             adapter=cache_adapter,
         )
     except KeyError as exc:
@@ -638,11 +653,13 @@ async def _api_passage(request: Request) -> JSONResponse:
 
     complexity = score_complexity(passage)
 
-    return JSONResponse({
-        "passage": _to_json(passage),
-        "complexity": _to_json(complexity),
-        "forecast_updated_at": datetime.now(UTC).isoformat(),
-    })
+    return JSONResponse(
+        {
+            "passage": _to_json(passage),
+            "complexity": _to_json(complexity),
+            "forecast_updated_at": datetime.now(UTC).isoformat(),
+        }
+    )
 
 
 async def _api_passage_by_eta(request: Request) -> JSONResponse:
@@ -728,20 +745,20 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
 
     complexity = score_complexity(plan.report)
 
-    return JSONResponse({
-        "passage": _to_json(plan.report),
-        "complexity": _to_json(complexity),
-        "eta": {"target_arrival": plan.target_arrival.isoformat()},
-        "forecast_updated_at": datetime.now(UTC).isoformat(),
-    })
+    return JSONResponse(
+        {
+            "passage": _to_json(plan.report),
+            "complexity": _to_json(complexity),
+            "eta": {"target_arrival": plan.target_arrival.isoformat()},
+            "forecast_updated_at": datetime.now(UTC).isoformat(),
+        }
+    )
 
 
 # Module-level MARC registry — loaded once at import. Empty registry when
 # MARC_ATLAS_DIR is unset or the dataset wasn't pulled (build without
 # HF_TOKEN secret), so the overlay endpoint silently returns covered=false.
-_MARC_REGISTRY = MarcAtlasRegistry.from_directory(
-    os.environ.get("MARC_ATLAS_DIR", "")
-)
+_MARC_REGISTRY = MarcAtlasRegistry.from_directory(os.environ.get("MARC_ATLAS_DIR", ""))
 # SHOM Atlas C2D registry — same lifecycle as MARC. Empty when SHOM_C2D_DIR
 # is unset or the dataset doesn't ship the SHOM artefacts. When populated,
 # SHOM takes priority for currents on covered points; SHOM ships no tide
@@ -879,9 +896,7 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
         try:
             step_minutes = int(request.query_params["step_minutes"])
         except ValueError:
-            return JSONResponse(
-                {"error": "step_minutes must be an integer"}, status_code=422
-            )
+            return JSONResponse({"error": "step_minutes must be an integer"}, status_code=422)
         if step_minutes < 5 or step_minutes > 360:
             return JSONResponse(
                 {"error": "step_minutes must be between 5 and 360"}, status_code=422
@@ -895,9 +910,7 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
         return JSONResponse({"error": "end must be after start"}, status_code=422)
     span_days = (end - start).total_seconds() / 86400
     if span_days > 30:
-        return JSONResponse(
-            {"error": "time window must be at most 30 days"}, status_code=422
-        )
+        return JSONResponse({"error": "time window must be at most 30 days"}, status_code=422)
 
     marc_loaded = bool(_MARC_REGISTRY.atlases)
     shom_covers = _SHOM_REGISTRY.covers(lat, lon)
@@ -923,9 +936,7 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
     # MARC because SHOM C2D ships no height series.
     h_result = _MARC_REGISTRY.predict_height_series(lat, lon, times) if cell else None
     marc_c_result = _MARC_REGISTRY.predict_current_series(lat, lon, times) if cell else None
-    shom_c_result = (
-        _SHOM_REGISTRY.predict_current_series(lat, lon, times) if shom_covers else None
-    )
+    shom_c_result = _SHOM_REGISTRY.predict_current_series(lat, lon, times) if shom_covers else None
 
     # Cascade for currents: SHOM > MARC. atlas_resolution_m and z0_hydro_m
     # stay on MARC because SHOM resolution varies per cartouche and SHOM
@@ -967,9 +978,7 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
         if source.lower().startswith("shom_c2d_"):
             payload["current_source"] = source.lower()
         elif cell and atlas_resolution_m:
-            payload["current_source"] = (
-                f"marc_{cell.atlas_name.lower()}_{atlas_resolution_m}m"
-            )
+            payload["current_source"] = f"marc_{cell.atlas_name.lower()}_{atlas_resolution_m}m"
         else:
             payload["current_source"] = source.lower()
     elif h_result is not None and cell and atlas_resolution_m:

--- a/packages/hf-space/fetch_atlases.py
+++ b/packages/hf-space/fetch_atlases.py
@@ -46,14 +46,11 @@ def main() -> None:
 
     target_path = Path(target)
     marc_atlases = sorted(
-        p.name
-        for p in target_path.iterdir()
-        if p.is_dir() and (p / "metadata.json").exists()
+        p.name for p in target_path.iterdir() if p.is_dir() and (p / "metadata.json").exists()
     )
-    shom_present = (
-        (target_path / "shom_c2d_points.parquet").exists()
-        and (target_path / "shom_c2d_ref_ports.json").exists()
-    )
+    shom_present = (target_path / "shom_c2d_points.parquet").exists() and (
+        target_path / "shom_c2d_ref_ports.json"
+    ).exists()
     print(f"Atlas dataset cached at {target}")
     print(f"  MARC atlases: {marc_atlases or '<none>'}")
     print(f"  SHOM Atlas C2D: {'present' if shom_present else '<absent>'}")

--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -1,0 +1,264 @@
+"""Deployment-side hardening for the public Space: CORS allowlist, per-IP
+rate limiting, security headers.
+
+This lives in ``hf-space/`` on purpose. It is infrastructure for *this*
+deployment, not domain logic — a Fly.io or Modal wrapper would solve the same
+problems with that platform's primitives (edge WAF, per-route quotas) and
+would not import this module. Keeping it out of ``mcp-core`` is what makes the
+cloud-agnostic promise real rather than nominal.
+
+Everything is configurable by environment variable so the dev Space and prod
+Space can diverge without a code change.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from collections import OrderedDict, deque
+from collections.abc import Iterable
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# --------------------------------------------------------------------- CORS
+
+# Browsers are the only callers CORS constrains: MCP clients (Claude, Le Chat,
+# ...) reach /mcp server-to-server and never send an Origin. So this list only
+# has to cover the web app's own origins.
+#
+# ohmywind.fr is canonical; openwind.fr is kept as a 301 source, and a browser
+# that followed the redirect still carries the *original* origin on the
+# subsequent XHR, so both families must be listed. localhost covers `vite dev`
+# (5173) and `vite preview` (4173) against a live backend.
+DEFAULT_ALLOWED_ORIGINS = [
+    "https://ohmywind.fr",
+    "https://www.ohmywind.fr",
+    "https://dev.ohmywind.fr",
+    "https://openwind.fr",
+    "https://www.openwind.fr",
+    "https://dev.openwind.fr",
+    "http://localhost:5173",
+    "http://localhost:4173",
+]
+
+ALLOWED_ORIGINS = [
+    o.strip()
+    for o in os.environ.get("OPENWIND_ALLOWED_ORIGINS", ",".join(DEFAULT_ALLOWED_ORIGINS)).split(
+        ","
+    )
+    if o.strip()
+]
+
+
+# ----------------------------------------------------------------- client IP
+
+# uvicorn runs with ``forwarded_allow_ips="*"`` (required: HF terminates TLS at
+# the edge, and without it every redirect and scheme is wrong). In that mode
+# uvicorn's ProxyHeadersMiddleware trusts every hop and takes the *leftmost*
+# X-Forwarded-For entry — which is whatever the client chose to send. So
+# ``request.client.host`` is attacker-controlled and unusable as a rate-limit
+# key: `curl -H 'X-Forwarded-For: <random>'` would mint a fresh bucket per
+# request.
+#
+# The only entry we can trust is the one appended by the proxy directly in
+# front of us, i.e. the rightmost. ``OPENWIND_TRUSTED_PROXY_HOPS`` says how
+# many proxies sit in front of the app; raise it if another CDN is ever
+# stacked ahead of HF (each extra hop shifts the real client one place left).
+TRUSTED_PROXY_HOPS = max(1, int(os.environ.get("OPENWIND_TRUSTED_PROXY_HOPS", "1")))
+
+
+def resolve_client_ip(scope: Scope, *, hops: int = TRUSTED_PROXY_HOPS) -> str:
+    """Best-effort real client IP, resistant to X-Forwarded-For spoofing.
+
+    Reads the raw header rather than ``scope["client"]`` because uvicorn has
+    already rewritten the latter to the spoofable leftmost entry.
+    """
+    forwarded = ""
+    for name, value in scope.get("headers", ()):
+        if name == b"x-forwarded-for":
+            forwarded = value.decode("latin-1")
+            break
+
+    parts = [p.strip() for p in forwarded.split(",") if p.strip()]
+    if parts:
+        # -hops == rightmost when a single proxy fronts us. Clamp so a
+        # misconfigured hop count degrades to "most trustworthy available"
+        # instead of silently reading the spoofable end of the list.
+        return parts[-hops] if len(parts) >= hops else parts[0]
+
+    client = scope.get("client")
+    return client[0] if client else "unknown"
+
+
+# -------------------------------------------------------------- rate limiter
+
+
+class _SlidingWindowCounter:
+    """Fixed-memory sliding-window counter.
+
+    The Space runs a single replica, so an in-process counter is coherent and
+    Redis would be pure overhead. What it must not be is unbounded: a dict of
+    IP -> timestamps that only ever grows is a slow leak that eventually eats
+    the Space's RAM. Two guards, both applied on every request:
+
+    1. Expired entries are purged. The store is an ``OrderedDict`` kept in
+       last-activity order, so fully-expired entries pile up at the front and
+       the purge is O(number actually expired), not O(size).
+    2. A hard ceiling on tracked IPs, enforced by evicting the
+       least-recently-active entry.
+
+    A per-key deque never exceeds ``max_requests`` entries (it is trimmed
+    before every append), so total memory is bounded by
+    ``max_tracked_ips * max_requests`` timestamps.
+
+    No lock: asyncio is single-threaded and no ``await`` happens between the
+    read and the write below, so the section is atomic by construction.
+    """
+
+    def __init__(self, *, max_requests: int, window_s: float, max_tracked_ips: int) -> None:
+        self._max_requests = max_requests
+        self._window_s = window_s
+        self._max_tracked_ips = max_tracked_ips
+        self._hits: OrderedDict[str, deque[float]] = OrderedDict()
+
+    def _purge_expired(self, now: float) -> None:
+        cutoff = now - self._window_s
+        while self._hits:
+            key = next(iter(self._hits))
+            stamps = self._hits[key]
+            while stamps and stamps[0] <= cutoff:
+                stamps.popleft()
+            if stamps:
+                # Entries are ordered by last activity: if the least-recently
+                # active one still has live hits, none behind it can be empty.
+                break
+            self._hits.popitem(last=False)
+
+    def check(self, key: str, now: float | None = None) -> int | None:
+        """Record a hit and return None, or return Retry-After seconds if over.
+
+        A rejected request is deliberately *not* recorded: the window should
+        drain on schedule rather than extend itself while a client retries.
+        """
+        now = time.monotonic() if now is None else now
+        self._purge_expired(now)
+
+        stamps = self._hits.get(key)
+        if stamps is None:
+            stamps = deque()
+            self._hits[key] = stamps
+        else:
+            cutoff = now - self._window_s
+            while stamps and stamps[0] <= cutoff:
+                stamps.popleft()
+
+        self._hits.move_to_end(key)
+
+        if len(stamps) >= self._max_requests:
+            return max(1, math.ceil(stamps[0] + self._window_s - now))
+
+        stamps.append(now)
+        while len(self._hits) > self._max_tracked_ips:
+            self._hits.popitem(last=False)
+        return None
+
+    @property
+    def tracked_ips(self) -> int:
+        """Current store size. Exposed for tests and future observability."""
+        return len(self._hits)
+
+
+# Only the POST planners are limited. They are the sole routes that can fan out
+# into many upstream Open-Meteo calls (a sweep walks up to MAX_SWEEP_WINDOWS
+# departures), which is what actually needs protecting — both for our own CPU
+# and to stay a good citizen on a keyless public API. GET /archetypes is a
+# constant, /marine/marc reads local atlases, and /mcp is left alone so a
+# legitimate MCP session doing many tool calls is never throttled.
+DEFAULT_LIMITED_PATHS = ("/api/v1/passage", "/api/v1/passage-by-eta")
+
+RATE_LIMIT_MAX_REQUESTS = int(os.environ.get("OPENWIND_RATE_LIMIT_REQUESTS", "30"))
+RATE_LIMIT_WINDOW_S = float(os.environ.get("OPENWIND_RATE_LIMIT_WINDOW_S", "300"))
+RATE_LIMIT_MAX_IPS = int(os.environ.get("OPENWIND_RATE_LIMIT_MAX_IPS", "5000"))
+
+
+class RateLimitMiddleware:
+    """Per-IP sliding-window limit on the expensive POST routes."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        limited_paths: Iterable[str] = DEFAULT_LIMITED_PATHS,
+        max_requests: int = RATE_LIMIT_MAX_REQUESTS,
+        window_s: float = RATE_LIMIT_WINDOW_S,
+        max_tracked_ips: int = RATE_LIMIT_MAX_IPS,
+    ) -> None:
+        self.app = app
+        self._limited = frozenset(limited_paths)
+        self._counter = _SlidingWindowCounter(
+            max_requests=max_requests,
+            window_s=window_s,
+            max_tracked_ips=max_tracked_ips,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Preflight is never limited: an OPTIONS carries no body and no cost,
+        # and 429-ing it would surface in the browser as an opaque CORS
+        # failure rather than the real reason.
+        if (
+            scope["type"] != "http"
+            or scope.get("method") == "OPTIONS"
+            or scope.get("path") not in self._limited
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        retry_after = self._counter.check(resolve_client_ip(scope))
+        if retry_after is None:
+            await self.app(scope, receive, send)
+            return
+
+        response = JSONResponse(
+            {"error": "rate limit exceeded, retry shortly"},
+            status_code=429,
+            headers={"Retry-After": str(retry_after)},
+        )
+        await response(scope, receive, send)
+
+
+# ---------------------------------------------------------- security headers
+
+
+class SecurityHeadersMiddleware:
+    """Add the baseline response headers to every route.
+
+    ``X-Frame-Options: DENY`` is safe here: nothing this app serves over HTTP
+    is meant to be framed. The MCP Apps widget is delivered as an MCP resource
+    (``text/html;profile=mcp-app``) that the host inlines into its own
+    sandboxed iframe — it is never fetched from this origin.
+    """
+
+    HEADERS = (
+        (b"x-content-type-options", b"nosniff"),
+        (b"x-frame-options", b"DENY"),
+        (b"referrer-policy", b"strict-origin-when-cross-origin"),
+    )
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                present = {name.lower() for name, _ in headers}
+                headers.extend((k, v) for k, v in self.HEADERS if k not in present)
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)

--- a/packages/hf-space/tests/conftest.py
+++ b/packages/hf-space/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Put the hf-space package dir on sys.path for the whole test session.
+
+``app.py`` imports its sibling ``security`` module by bare name, which is how
+it resolves on the Space (the Dockerfile copies both into ``/app`` and runs
+``python /app/app.py``, so the script's own directory is sys.path[0]). Tests
+load ``app.py`` by path instead, so they have to reproduce that layout.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_HF_DIR = str(pathlib.Path(__file__).parents[1].resolve())
+if _HF_DIR not in sys.path:
+    sys.path.insert(0, _HF_DIR)

--- a/packages/hf-space/tests/test_api_passage_cache.py
+++ b/packages/hf-space/tests/test_api_passage_cache.py
@@ -48,7 +48,9 @@ def _corridor_cache(*, with_arome: bool = True) -> dict:
     n = len(times_ms)
 
     def wind() -> dict:
-        block = {"icon_eu": {"speed_kn": [10.0] * n, "direction_deg": [0.0] * n, "gust_kn": [None] * n}}
+        block = {
+            "icon_eu": {"speed_kn": [10.0] * n, "direction_deg": [0.0] * n, "gust_kn": [None] * n}
+        }
         if with_arome:
             block["meteofrance_arome_france"] = {
                 "speed_kn": [10.0] * n,
@@ -97,7 +99,7 @@ async def test_single_with_cache_returns_200_from_cache(monkeypatch) -> None:
     # Guard: if the handler ever instantiates the live adapter, fail loudly.
     import httpx
 
-    def _boom(*a, **k):  # noqa: ANN002, ANN003
+    def _boom(*a, **k):
         raise AssertionError("forecast_cache path must not hit Open-Meteo")
 
     monkeypatch.setattr(httpx.AsyncClient, "get", _boom)
@@ -112,7 +114,11 @@ async def test_single_with_cache_returns_200_from_cache(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_malformed_cache_returns_422(monkeypatch) -> None:
     resp = await app._api_passage(
-        _FakeRequest(_single_body(forecast_cache={"version": 999, "models": [], "times_ms": [], "points": []}))
+        _FakeRequest(
+            _single_body(
+                forecast_cache={"version": 999, "models": [], "times_ms": [], "points": []}
+            )
+        )
     )
     assert resp.status_code == 422
     assert "forecast_cache" in _resp_json(resp)["error"]
@@ -125,7 +131,7 @@ async def test_malformed_cache_returns_422(monkeypatch) -> None:
 async def test_single_passes_cache_adapter(monkeypatch) -> None:
     captured: dict = {}
 
-    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+    async def _stub(*args, **kwargs):
         captured["adapter"] = kwargs.get("adapter")
         captured["model_chain"] = kwargs.get("model_chain")
         raise app.NoModelCoveredError("stop here")  # short-circuit after capture
@@ -147,7 +153,7 @@ async def test_single_passes_cache_adapter(monkeypatch) -> None:
 async def test_sweep_passes_cache_adapter(monkeypatch) -> None:
     captured: dict = {}
 
-    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+    async def _stub(*args, **kwargs):
         captured["adapter"] = kwargs.get("adapter")
         return []
 
@@ -165,7 +171,7 @@ async def test_sweep_passes_cache_adapter(monkeypatch) -> None:
 async def test_by_eta_passes_cache_adapter(monkeypatch) -> None:
     captured: dict = {}
 
-    async def _stub(*args, **kwargs):  # noqa: ANN002, ANN003
+    async def _stub(*args, **kwargs):
         captured["adapter"] = kwargs.get("adapter")
         raise app.NoModelCoveredError("stop here")
 

--- a/packages/hf-space/tests/test_api_sweep.py
+++ b/packages/hf-space/tests/test_api_sweep.py
@@ -1,0 +1,98 @@
+"""Coverage for the sweep response assembly in ``_api_passage``.
+
+Written because the ``target_eta`` filtering branch had no test at all: a stray
+``timedelta`` reference in it survived the whole suite and would only have
+raised NameError in production, on the one request that sets ``target_eta``.
+The engine itself is stubbed out — what is under test here is the shell.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+_APP_PATH = (pathlib.Path(__file__).parents[1] / "app.py").resolve()
+_spec = importlib.util.spec_from_file_location("hf_app_sweep", _APP_PATH)
+app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(app)
+
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+MARSEILLE = [43.30, 5.35]
+PORQUEROLLES = [43.00, 6.20]
+
+
+class _FakeRequest:
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _sweep_body(**extra) -> dict:
+    body = {
+        "waypoints": [MARSEILLE, PORQUEROLLES],
+        "departure": DEPARTURE.isoformat(),
+        "latest_departure": (DEPARTURE + timedelta(hours=6)).isoformat(),
+        "sweep_interval_hours": 3,
+        "archetype": "cruiser_40ft",
+    }
+    body.update(extra)
+    return body
+
+
+def _payload(resp) -> dict:
+    return json.loads(bytes(resp.body))
+
+
+@pytest.fixture
+def no_windows(monkeypatch):
+    """Engine returns nothing, so the response assembly runs on its own."""
+
+    async def _stub(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(app, "estimate_passage_windows", _stub)
+
+
+@pytest.mark.asyncio
+async def test_sweep_without_target_eta_returns_multi_window(no_windows) -> None:
+    resp = await app._api_passage(_FakeRequest(_sweep_body()))
+    assert resp.status_code == 200
+    body = _payload(resp)
+    assert body["mode"] == "multi_window"
+    assert body["sweep"]["interval_hours"] == 3
+
+
+@pytest.mark.asyncio
+async def test_sweep_with_target_eta_reaches_the_filter(no_windows) -> None:
+    # The regression: this branch is the only one that touches timedelta.
+    target = (DEPARTURE + timedelta(hours=10)).isoformat()
+    resp = await app._api_passage(_FakeRequest(_sweep_body(target_eta=target)))
+    assert resp.status_code == 200
+    body = _payload(resp)
+    assert any("target_eta" in w for w in body["meta_warnings"])
+
+
+@pytest.mark.asyncio
+async def test_invalid_target_eta_returns_422() -> None:
+    resp = await app._api_passage(_FakeRequest(_sweep_body(target_eta="not-a-date")))
+    assert resp.status_code == 422
+    assert "target_eta" in _payload(resp)["error"]
+
+
+@pytest.mark.asyncio
+async def test_skipped_windows_surface_a_meta_warning(monkeypatch) -> None:
+    # estimate_passage_windows is partial-tolerant: it drops windows past the
+    # forecast horizon. The shell must tell the user some were dropped.
+    async def _stub(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(app, "estimate_passage_windows", _stub)
+    resp = await app._api_passage(_FakeRequest(_sweep_body()))
+    warnings = _payload(resp)["meta_warnings"]
+    assert any("ignorée" in w for w in warnings)

--- a/packages/hf-space/tests/test_api_validation.py
+++ b/packages/hf-space/tests/test_api_validation.py
@@ -1,0 +1,184 @@
+"""Input-bounds tests for the REST handlers.
+
+Same contract as ``mcp-core/tests/test_server_validation.py``: identical
+wording on both shells, and refusal before any upstream weather call. The
+handlers are driven with a minimal fake Request because hf-space has no
+pyproject (it ships via Docker).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from openwind_data.routing import MAX_WAYPOINTS
+
+_APP_PATH = (pathlib.Path(__file__).parents[1] / "app.py").resolve()
+_spec = importlib.util.spec_from_file_location("hf_app_validation", _APP_PATH)
+app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(app)
+
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+MARSEILLE = [43.30, 5.35]
+PORQUEROLLES = [43.00, 6.20]
+
+
+class _FakeRequest:
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+class _FakeQueryRequest:
+    def __init__(self, params: dict[str, str]) -> None:
+        self.query_params = params
+
+
+def _body(**extra) -> dict:
+    payload = {
+        "waypoints": [MARSEILLE, PORQUEROLLES],
+        "departure": DEPARTURE.isoformat(),
+        "archetype": "cruiser_40ft",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _error(resp) -> str:
+    return json.loads(bytes(resp.body))["error"]
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """Any upstream call during these tests is itself the bug."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("invalid input must be refused before any upstream fetch")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _boom)
+
+
+# ------------------------------------------------------------ POST /passage
+
+
+@pytest.mark.asyncio
+async def test_lat_out_of_range_returns_422() -> None:
+    resp = await app._api_passage(_FakeRequest(_body(waypoints=[[999, 5.35], PORQUEROLLES])))
+    assert resp.status_code == 422
+    assert "out of range [-90, 90]" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_lon_out_of_range_returns_422() -> None:
+    resp = await app._api_passage(_FakeRequest(_body(waypoints=[MARSEILLE, [43.0, 999]])))
+    assert resp.status_code == 422
+    assert "out of range [-180, 180]" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_nan_coordinate_returns_422() -> None:
+    # json.loads accepts the bare NaN literal, so this really is reachable
+    # from a hand-rolled POST body.
+    resp = await app._api_passage(
+        _FakeRequest(_body(waypoints=[[float("nan"), 5.35], PORQUEROLLES]))
+    )
+    assert resp.status_code == 422
+    assert "out of range" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_single_waypoint_message_unchanged() -> None:
+    # Byte-identical to the pre-existing wording: the web maps this string.
+    resp = await app._api_passage(_FakeRequest(_body(waypoints=[MARSEILLE])))
+    assert resp.status_code == 422
+    assert _error(resp) == "at least 2 waypoints required"
+
+
+@pytest.mark.asyncio
+async def test_too_many_waypoints_returns_422() -> None:
+    route = [[43.0 + i * 0.001, 5.0] for i in range(MAX_WAYPOINTS + 1)]
+    resp = await app._api_passage(_FakeRequest(_body(waypoints=route)))
+    assert resp.status_code == 422
+    assert "too many waypoints" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_waypoint_count_at_cap_is_not_rejected_by_bounds() -> None:
+    # Must fail for some *other* reason (no network here), never for the cap.
+    route = [[43.0 + i * 0.001, 5.0] for i in range(MAX_WAYPOINTS)]
+    with pytest.raises(AssertionError, match="before any upstream fetch"):
+        await app._api_passage(_FakeRequest(_body(waypoints=route)))
+
+
+# ----------------------------------------------------- POST /passage-by-eta
+
+
+@pytest.mark.asyncio
+async def test_by_eta_lat_out_of_range_returns_422() -> None:
+    resp = await app._api_passage_by_eta(
+        _FakeRequest(
+            {
+                "waypoints": [[999, 5.35], PORQUEROLLES],
+                "target_arrival": DEPARTURE.isoformat(),
+                "archetype": "cruiser_40ft",
+            }
+        )
+    )
+    assert resp.status_code == 422
+    assert "out of range [-90, 90]" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_by_eta_single_waypoint_message_unchanged() -> None:
+    resp = await app._api_passage_by_eta(
+        _FakeRequest(
+            {
+                "waypoints": [MARSEILLE],
+                "target_arrival": DEPARTURE.isoformat(),
+                "archetype": "cruiser_40ft",
+            }
+        )
+    )
+    assert resp.status_code == 422
+    assert _error(resp) == "at least 2 waypoints required"
+
+
+# --------------------------------------------------- GET /marine/marc
+
+
+@pytest.mark.asyncio
+async def test_marc_overlay_rejects_out_of_range_point() -> None:
+    resp = await app._api_marc_overlay(
+        _FakeQueryRequest(
+            {
+                "lat": "999",
+                "lon": "5.35",
+                "start": DEPARTURE.isoformat(),
+                "end": DEPARTURE.isoformat(),
+            }
+        )
+    )
+    assert resp.status_code == 422
+    assert "out of range [-90, 90]" in _error(resp)
+
+
+@pytest.mark.asyncio
+async def test_marc_overlay_rejects_out_of_range_lon() -> None:
+    resp = await app._api_marc_overlay(
+        _FakeQueryRequest(
+            {
+                "lat": "43.3",
+                "lon": "999",
+                "start": DEPARTURE.isoformat(),
+                "end": DEPARTURE.isoformat(),
+            }
+        )
+    )
+    assert resp.status_code == 422
+    assert "out of range [-180, 180]" in _error(resp)

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -1,0 +1,341 @@
+"""Unit tests for the deployment hardening in ``security.py``.
+
+Covers the three properties that matter operationally:
+  - the rate-limit store cannot grow without bound (it lives for the whole
+    life of a long-running Space process),
+  - the rate-limit key is not spoofable via X-Forwarded-For,
+  - the middleware stack is wired in the right order on the real app.
+
+Run from the mcp-core worktree venv:
+
+    cd packages/mcp-core && uv run --no-active python -m pytest ../hf-space/tests
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+import security  # sys.path prepared by conftest.py
+
+_HF_DIR = pathlib.Path(__file__).parents[1].resolve()
+
+
+def _load_app():
+    """Load app.py by path (hf-space has no pyproject; it ships via Docker)."""
+    spec = importlib.util.spec_from_file_location("hf_app", _HF_DIR / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _scope(path: str = "/api/v1/passage", method: str = "POST", **headers: str) -> dict:
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        "client": ("10.0.0.1", 12345),
+    }
+
+
+# ------------------------------------------------------------- client IP
+
+
+def test_client_ip_uses_rightmost_forwarded_hop() -> None:
+    # uvicorn's own middleware would pick 1.2.3.4 here (leftmost, client-set).
+    # Only the last hop was appended by a proxy we actually sit behind.
+    scope = _scope(**{"x-forwarded-for": "1.2.3.4, 203.0.113.7"})
+    assert security.resolve_client_ip(scope) == "203.0.113.7"
+
+
+def test_client_ip_ignores_spoofed_prefix() -> None:
+    """The whole point: a hostile client cannot mint a fresh bucket per call."""
+    real = "203.0.113.7"
+    keys = {
+        security.resolve_client_ip(_scope(**{"x-forwarded-for": f"{spoof}, {real}"}))
+        for spoof in ("1.1.1.1", "2.2.2.2", "3.3.3.3")
+    }
+    assert keys == {real}
+
+
+def test_client_ip_single_hop() -> None:
+    assert security.resolve_client_ip(_scope(**{"x-forwarded-for": "203.0.113.7"})) == "203.0.113.7"
+
+
+def test_client_ip_falls_back_to_peer_without_header() -> None:
+    assert security.resolve_client_ip(_scope()) == "10.0.0.1"
+
+
+def test_client_ip_clamps_when_hops_exceed_chain() -> None:
+    # Misconfigured hop count must degrade to the most trustworthy entry
+    # available, never to the spoofable end of the list.
+    scope = _scope(**{"x-forwarded-for": "1.2.3.4, 203.0.113.7"})
+    assert security.resolve_client_ip(scope, hops=5) == "1.2.3.4"
+
+
+def test_client_ip_unknown_when_no_header_and_no_peer() -> None:
+    scope = _scope()
+    scope["client"] = None
+    assert security.resolve_client_ip(scope) == "unknown"
+
+
+# --------------------------------------------------------- sliding window
+
+
+def _counter(**kw):
+    params = {"max_requests": 3, "window_s": 60.0, "max_tracked_ips": 100}
+    params.update(kw)
+    return security._SlidingWindowCounter(**params)
+
+
+def test_allows_up_to_the_limit_then_rejects() -> None:
+    c = _counter()
+    assert [c.check("ip", now=0.0) for _ in range(3)] == [None, None, None]
+    assert c.check("ip", now=0.0) is not None
+
+
+def test_retry_after_is_positive_seconds() -> None:
+    c = _counter()
+    for _ in range(3):
+        c.check("ip", now=0.0)
+    assert c.check("ip", now=10.0) == 50
+
+
+def test_window_slides() -> None:
+    c = _counter()
+    for _ in range(3):
+        c.check("ip", now=0.0)
+    assert c.check("ip", now=30.0) is not None
+    # Past the window, the old hits have aged out.
+    assert c.check("ip", now=61.0) is None
+
+
+def test_rejected_request_does_not_extend_the_ban() -> None:
+    c = _counter()
+    for _ in range(3):
+        c.check("ip", now=0.0)
+    for t in (10.0, 20.0, 30.0, 40.0, 50.0):
+        assert c.check("ip", now=t) is not None
+    assert c.check("ip", now=61.0) is None
+
+
+def test_buckets_are_per_ip() -> None:
+    c = _counter()
+    for _ in range(3):
+        c.check("a", now=0.0)
+    assert c.check("a", now=0.0) is not None
+    assert c.check("b", now=0.0) is None
+
+
+# ------------------------------------------------------- bounded memory
+
+
+def test_expired_entries_are_purged() -> None:
+    c = _counter()
+    for i in range(50):
+        c.check(f"ip-{i}", now=0.0)
+    assert c.tracked_ips == 50
+    # One request past the window purges every stale entry, not just its own.
+    c.check("fresh", now=100.0)
+    assert c.tracked_ips == 1
+
+
+def test_tracked_ips_never_exceeds_the_cap() -> None:
+    c = _counter(max_tracked_ips=10)
+    for i in range(1000):
+        # All within one window, so nothing expires: only the hard cap bounds it.
+        c.check(f"ip-{i}", now=1.0)
+    assert c.tracked_ips == 10
+
+
+def test_eviction_drops_the_least_recently_active() -> None:
+    c = _counter(max_tracked_ips=3)
+    c.check("old", now=0.0)
+    c.check("mid", now=1.0)
+    c.check("new", now=2.0)
+    c.check("recent-again", now=3.0)  # forces one eviction
+    # "old" was the least recently active, so it is the one that went.
+    assert c.tracked_ips == 3
+    assert c.check("old", now=3.0) is None  # fresh bucket == it was evicted
+    assert c.check("mid", now=3.0) is None
+
+
+def test_per_key_timestamps_stay_bounded() -> None:
+    c = _counter(max_requests=3)
+    for t in range(500):
+        c.check("ip", now=float(t))
+    assert len(c._hits["ip"]) <= 3
+
+
+# ------------------------------------------------- middleware, end to end
+
+
+class _StubMcpApp:
+    """Stands in for FastMCP's streamable-http app: a route and a no-op lifespan."""
+
+    class _Router:
+        @staticmethod
+        def lifespan_context(_app):
+            import contextlib
+
+            @contextlib.asynccontextmanager
+            async def _noop(_):
+                yield
+
+            return _noop(_app)
+
+    router = _Router()
+
+    async def __call__(self, scope, receive, send):
+        from starlette.responses import PlainTextResponse
+
+        await PlainTextResponse("mcp")(scope, receive, send)
+
+
+@pytest.fixture
+def client():
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    return TestClient(app.build_app(_StubMcpApp()))
+
+
+def test_preflight_from_allowed_origin_is_accepted(client) -> None:
+    resp = client.options(
+        "/api/v1/passage",
+        headers={
+            "Origin": "https://ohmywind.fr",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "https://ohmywind.fr"
+
+
+def test_preflight_from_legacy_domain_is_accepted(client) -> None:
+    # openwind.fr is 301'd to ohmywind.fr, but a browser mid-migration still
+    # sends the original origin on the XHR that follows.
+    resp = client.options(
+        "/api/v1/passage",
+        headers={
+            "Origin": "https://openwind.fr",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") == "https://openwind.fr"
+
+
+def test_preflight_from_unknown_origin_is_refused(client) -> None:
+    resp = client.options(
+        "/api/v1/passage",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_no_wildcard_origin_anywhere(client) -> None:
+    resp = client.get("/api/v1/archetypes", headers={"Origin": "https://evil.example.com"})
+    assert resp.headers.get("access-control-allow-origin") != "*"
+
+
+def test_security_headers_present(client) -> None:
+    resp = client.get("/api/v1/archetypes")
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+
+
+def test_security_headers_on_the_landing_page(client) -> None:
+    assert client.get("/").headers["x-content-type-options"] == "nosniff"
+
+
+def test_rate_limit_triggers_on_repeated_posts(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(3))
+    client = TestClient(app.build_app(_StubMcpApp()))
+
+    # Bodies are deliberately invalid: we are measuring the limiter, not the
+    # planner, and a 422 still counts as a request against the quota.
+    codes = [client.post("/api/v1/passage", json={}).status_code for _ in range(5)]
+    assert codes[:3] == [422, 422, 422]
+    assert codes[3:] == [429, 429]
+
+
+def test_rate_limited_response_carries_retry_after_and_cors(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(1))
+    client = TestClient(app.build_app(_StubMcpApp()))
+
+    headers = {"Origin": "https://ohmywind.fr"}
+    client.post("/api/v1/passage", json={}, headers=headers)
+    resp = client.post("/api/v1/passage", json={}, headers=headers)
+
+    assert resp.status_code == 429
+    assert int(resp.headers["retry-after"]) >= 1
+    # Without this the browser reports an opaque CORS error instead of the 429.
+    assert resp.headers["access-control-allow-origin"] == "https://ohmywind.fr"
+    assert "rate limit" in resp.json()["error"]
+
+
+def test_get_routes_and_mcp_are_not_rate_limited(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(1))
+    client = TestClient(app.build_app(_StubMcpApp()))
+
+    assert all(client.get("/api/v1/archetypes").status_code == 200 for _ in range(5))
+    # A legitimate MCP session issues many tool calls; throttling it would be
+    # far more damaging than the abuse we are guarding against.
+    assert all(client.get("/mcp-probe").status_code == 200 for _ in range(5))
+
+
+def test_preflight_is_never_rate_limited(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(1))
+    client = TestClient(app.build_app(_StubMcpApp()))
+
+    preflight = {
+        "Origin": "https://ohmywind.fr",
+        "Access-Control-Request-Method": "POST",
+    }
+    codes = [client.options("/api/v1/passage", headers=preflight).status_code for _ in range(5)]
+    assert codes == [200] * 5
+
+
+def _init_with_limit(max_requests: int):
+    """Patched __init__ pinning a small quota, so tests stay fast and explicit."""
+    original = security.RateLimitMiddleware.__init__
+
+    def _init(self, app, **kwargs):
+        kwargs["max_requests"] = max_requests
+        original(self, app, **kwargs)
+
+    return _init
+
+
+# ------------------------------------------------------------- allowlist
+
+
+def test_default_allowlist_covers_both_domains_and_has_no_wildcard() -> None:
+    assert "*" not in security.ALLOWED_ORIGINS
+    for origin in (
+        "https://ohmywind.fr",
+        "https://dev.ohmywind.fr",
+        "https://openwind.fr",
+        "https://dev.openwind.fr",
+    ):
+        assert origin in security.ALLOWED_ORIGINS

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -1,11 +1,12 @@
 # openwind-mcp-core
 
-Cloud-agnostic FastMCP server for OpenWind. Exposes 4 tools:
+Cloud-agnostic FastMCP server for OpenWind. Exposes 5 tools:
 
 - `list_boat_archetypes` descriptive list, no server-side mapping
 - `get_marine_forecast` wind + sea around a point/window
 - `plan_passage` end-to-end timing + complexity + openwind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
 - `read_me` calculation methodology (polars, efficiency, VMG, defaults)
+- `feedback` structured channel for the LLM to report a problem or a suggestion; the sink is injected by the deployment wrapper, so the core stays cloud-agnostic
 
 `build_server()` is the single factory; no Gradio, no `huggingface_hub`. The
 HF Spaces wrapper (Sprint 4) and any future deployment use the same factory.

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -45,9 +45,11 @@ from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 from openwind_data.routing import (
     BoatPolar,
     Point,
-    _build_conditions_summary,
+    build_conditions_summary,
     get_polar,
     list_archetypes,
+    validate_point,
+    validate_waypoints,
 )
 from openwind_data.routing import (
     estimate_passage as _estimate_passage,
@@ -516,7 +518,7 @@ def _build_window_dict(
             "tws_max_kn": round(score.tws_max_kn, 1),
             "rationale": score.rationale,
         },
-        "conditions_summary": _build_conditions_summary(report),
+        "conditions_summary": build_conditions_summary(report),
         "warnings": warnings,
         "openwind_url": build_openwind_url(waypoints_raw, dep_iso, report.archetype),
     }
@@ -673,6 +675,7 @@ def build_server(
         Do NOT write a free-text reply about the feedback in chat: the
         tool is the channel.
         """
+        validate_point(lat, lon)
         start_dt = datetime.fromisoformat(start)
         end_dt = datetime.fromisoformat(end)
         bundle = await fetch_adapter.fetch(lat, lon, start_dt, end_dt, models=models)
@@ -867,7 +870,24 @@ def build_server(
         Do NOT write a free-text reply about the feedback in chat: the
         tool is the channel.
         """
-        pts = [Point(w["lat"], w["lon"]) for w in waypoints]
+        # Same guards, same wording as the REST layer. FastMCP turns any
+        # exception raised in a tool into an isError result carrying str(exc),
+        # so the LLM reads the identical message a browser client would get.
+        try:
+            pts = [Point(float(w["lat"]), float(w["lon"])) for w in waypoints]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"invalid waypoints: {exc}") from exc
+        validate_waypoints(pts)
+
+        # Resolved up front so an unknown archetype reads as
+        # "unknown archetype: 'foo'" (REST's wording) rather than the bare
+        # KeyError string "'foo'" that get_polar surfaces from deep inside
+        # the engine.
+        try:
+            get_polar(archetype)
+        except KeyError as exc:
+            raise ValueError(f"unknown archetype: {exc}") from exc
+
         dep = datetime.fromisoformat(departure)
 
         # Motor override: clone the archetype polar with motor knobs set when

--- a/packages/mcp-core/tests/test_server_validation.py
+++ b/packages/mcp-core/tests/test_server_validation.py
@@ -1,0 +1,139 @@
+"""Boundary validation on the MCP surface.
+
+Mirror of the REST checks in ``hf-space/tests``: the same bad input must be
+refused with the same wording on both shells, and must be refused *before*
+any upstream weather call. The StubAdapter's fetch counter is what proves the
+second half.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from openwind_data.routing import MAX_WAYPOINTS
+from test_server import _BASE_PLAN_ARGS, StubAdapter
+
+from openwind_mcp_core import build_server
+
+
+def _args(**overrides) -> dict:
+    return {**_BASE_PLAN_ARGS, **overrides}
+
+
+async def _expect_error(server, name: str, args: dict) -> str:
+    """Call a tool expecting failure, and return the message the host sees."""
+    with pytest.raises(Exception) as excinfo:
+        await server.call_tool(name, args)
+    return str(excinfo.value)
+
+
+class TestPlanPassageBounds:
+    async def test_out_of_range_lat_refused(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        message = await _expect_error(
+            server,
+            "plan_passage",
+            _args(waypoints=[{"lat": 999, "lon": 5.35}, {"lat": 43.0, "lon": 6.2}]),
+        )
+        assert "out of range [-90, 90]" in message
+
+    async def test_out_of_range_lon_refused(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        message = await _expect_error(
+            server,
+            "plan_passage",
+            _args(waypoints=[{"lat": 43.3, "lon": 5.35}, {"lat": 43.0, "lon": 999}]),
+        )
+        assert "out of range [-180, 180]" in message
+
+    async def test_refused_before_any_upstream_fetch(self) -> None:
+        # Today an out-of-range point reaches Open-Meteo and comes back as a
+        # misleading "forecast horizon exceeded". Nothing should leave the
+        # process for a request we already know is invalid.
+        adapter = StubAdapter()
+        server = build_server(adapter=adapter)
+        await _expect_error(
+            server,
+            "plan_passage",
+            _args(waypoints=[{"lat": 999, "lon": 5.35}, {"lat": 43.0, "lon": 6.2}]),
+        )
+        assert adapter.fetch_calls == 0
+
+    async def test_single_waypoint_refused_with_rest_wording(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        message = await _expect_error(
+            server, "plan_passage", _args(waypoints=[{"lat": 43.3, "lon": 5.35}])
+        )
+        assert "at least 2 waypoints required" in message
+
+    async def test_too_many_waypoints_refused(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        route = [{"lat": 43.0 + i * 0.001, "lon": 5.0} for i in range(MAX_WAYPOINTS + 1)]
+        message = await _expect_error(server, "plan_passage", _args(waypoints=route))
+        assert "too many waypoints" in message
+
+    async def test_malformed_waypoint_refused(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        message = await _expect_error(
+            server,
+            "plan_passage",
+            _args(waypoints=[{"lat": 43.3}, {"lat": 43.0, "lon": 6.2}]),
+        )
+        assert "invalid waypoints" in message
+
+    async def test_valid_route_still_plans(self) -> None:
+        # Guard against the validation being too strict for real input.
+        server = build_server(adapter=StubAdapter())
+        out = await server.call_tool("plan_passage", _BASE_PLAN_ARGS)
+        payload = out[1] if isinstance(out, tuple) else out
+        assert "passage" in payload
+
+
+class TestUnknownArchetype:
+    async def test_message_matches_rest_wording(self) -> None:
+        # REST returns "unknown archetype: 'nope'"; MCP used to surface the
+        # bare KeyError string "'nope'" from deep inside the engine.
+        server = build_server(adapter=StubAdapter())
+        message = await _expect_error(server, "plan_passage", _args(archetype="nope"))
+        assert "unknown archetype" in message
+        assert "'nope'" in message
+
+    async def test_refused_before_any_upstream_fetch(self) -> None:
+        adapter = StubAdapter()
+        server = build_server(adapter=adapter)
+        await _expect_error(server, "plan_passage", _args(archetype="nope"))
+        assert adapter.fetch_calls == 0
+
+
+class TestForecastBounds:
+    async def test_get_marine_forecast_rejects_out_of_range_point(self) -> None:
+        adapter = StubAdapter()
+        server = build_server(adapter=adapter)
+        message = await _expect_error(
+            server,
+            "get_marine_forecast",
+            {
+                "lat": 999,
+                "lon": 5.35,
+                "start": datetime(2026, 5, 1, 6, 0, tzinfo=UTC).isoformat(),
+                "end": datetime(2026, 5, 1, 12, 0, tzinfo=UTC).isoformat(),
+            },
+        )
+        assert "lat=999" in message
+        assert "out of range" in message
+        assert adapter.fetch_calls == 0
+
+    async def test_get_marine_forecast_accepts_valid_point(self) -> None:
+        adapter = StubAdapter()
+        server = build_server(adapter=adapter)
+        await server.call_tool(
+            "get_marine_forecast",
+            {
+                "lat": 43.30,
+                "lon": 5.35,
+                "start": datetime(2026, 5, 1, 6, 0, tzinfo=UTC).isoformat(),
+                "end": datetime(2026, 5, 1, 12, 0, tzinfo=UTC).isoformat(),
+            },
+        )
+        assert adapter.fetch_calls == 1

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -27,6 +27,15 @@ export function friendlyError(raw: string): string {
   if (/at least 2 waypoints/i.test(raw)) {
     return "Placez au moins 2 waypoints sur la carte pour calculer une route.";
   }
+  if (/waypoint \d+: (lat|lon)=.* out of range/i.test(raw)) {
+    return "Un waypoint est hors des coordonnées valides. Replacez-le sur la carte.";
+  }
+  if (/too many waypoints/i.test(raw)) {
+    return "Trop de waypoints sur cette route. Retirez-en quelques-uns pour la simplifier.";
+  }
+  if (/rate limit exceeded/i.test(raw)) {
+    return "Trop de calculs lancés coup sur coup. Patientez une minute avant de relancer.";
+  }
   if (/unknown archetype/i.test(raw)) {
     return "Type de bateau inconnu. Sélectionnez un archétype dans la liste.";
   }

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -24,6 +24,7 @@ import { LocateButton } from "../components/LocateButton";
 import { useGeolocation } from "../hooks/useGeolocation";
 import { useMapView } from "../hooks/useMapView";
 import { parseMapView, mapViewQuery } from "../utils/mapViewParams";
+import { setCookie, clearCookie } from "../utils/cookies";
 
 // Build the plan-time overrides payload from current /config preferences.
 // Read at request time (not at mount) so a /config tweak takes effect on the
@@ -436,7 +437,7 @@ export function PlanPage() {
         const url = buildPlanUrl(wpts, resolvedDep, arch);
         window.history.replaceState(null, "", url);
         const ttl = 7 * 24 * 3600;
-        document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
+        setCookie("ow_last_trip", window.location.href, ttl);
         // Persist for next visit. Merge into existing cache so a previously
         // saved compare-mode result stays available.
         const prev = loadLastSimulation();
@@ -631,7 +632,7 @@ export function PlanPage() {
     clearLastSimulation();
     // Also expire the dormant ow_last_trip cookie so a future read (if we ever
     // wire it up) doesn't resurrect a stale plan.
-    document.cookie = "ow_last_trip=;max-age=0;path=/;SameSite=Lax";
+    clearCookie("ow_last_trip");
     setWaypoints([]);
     setPassage(null);
     setComplexity(null);
@@ -693,7 +694,7 @@ export function PlanPage() {
       const url = buildPlanUrl(waypoints, naiveDep, archetype);
       window.history.replaceState(null, "", url);
       const ttl = 7 * 24 * 3600;
-      document.cookie = `ow_last_trip=${encodeURIComponent(window.location.href)};max-age=${ttl};path=/;SameSite=Lax`;
+      setCookie("ow_last_trip", window.location.href, ttl);
       // Keep windows around so the user can switch back to compare mode and
       // see the table again without re-fetching the sweep.
       // setWindows(null) intentionally NOT called — user toggling back to

--- a/packages/web/src/utils/cookies.ts
+++ b/packages/web/src/utils/cookies.ts
@@ -1,0 +1,21 @@
+// Cookie helpers. Single place where the attribute string is built, so the
+// security flags cannot drift between call sites.
+
+// `Secure` restricts the cookie to HTTPS. It must be omitted on
+// http://localhost: a browser silently drops a Secure cookie set over plain
+// HTTP, which would make the local dev build behave differently from prod for
+// no good reason. Evaluated per call rather than at module load so tests and
+// SSR-less prerender paths never touch `window` at import time.
+function attributes(maxAgeSeconds: number): string {
+  const secure =
+    typeof window !== "undefined" && window.location.protocol === "https:" ? ";Secure" : "";
+  return `max-age=${maxAgeSeconds};path=/;SameSite=Lax${secure}`;
+}
+
+export function setCookie(name: string, value: string, maxAgeSeconds: number): void {
+  document.cookie = `${name}=${encodeURIComponent(value)};${attributes(maxAgeSeconds)}`;
+}
+
+export function clearCookie(name: string): void {
+  document.cookie = `${name}=;${attributes(0)}`;
+}


### PR DESCRIPTION
Phase 0 du plan de refacto : sécurité du serveur public et hygiène du repo.
Aucun changement de contrat public, hors les 422 nouvellement levées sur des entrées qui étaient invalides de toute façon.

## Ce qui était exploitable

| # | Sujet | État avant, vérifié en live sur le Space dev |
|---|---|---|
| 0.1 | CORS wildcard | `allow_origins=["*"]` renvoyait `access-control-allow-origin: https://evil.example.com` sur préflight |
| 0.2 | Aucun rate limiting | Sweep en boucle depuis une IP, sans plafond, sur une API amont keyless |
| 0.3 | Aucune borne d'entrée | `lat=999` partait chez Open-Meteo et revenait en 422 trompeur `forecast horizon exceeded` |
| 0.4 | Headers absents | Ni `nosniff`, ni `X-Frame-Options` ; cookie `ow_last_trip` sans `Secure` |

Faille non listée au plan, trouvée en route : **la clé de rate limiting était contournable**. `uvicorn.run(forwarded_allow_ips="*")` met `always_trust=True`, et dans ce mode uvicorn 0.46 prend l'entrée **la plus à gauche** de `X-Forwarded-For`, celle que le client choisit. Un limiteur keyé sur `request.client.host` se contournait donc avec un seul en-tête. Le middleware lit le header brut et prend le **dernier hop**, le seul ajouté par un proxy qu'on a réellement devant nous. Nombre de hops configurable via `OPENWIND_TRUSTED_PROXY_HOPS`.

## Le compteur est borné

Replica unique, donc compteur en mémoire, pas de Redis. Mais borné des deux côtés :
- purge des entrées expirées à chaque requête, en `O(expirées)` et non `O(taille)` grâce à un `OrderedDict` trié par dernière activité ;
- plafond dur de 5000 IP suivies, éviction de la moins récemment active ;
- deque par IP trimmé avant chaque append, donc mémoire totale bornée par `max_tracked_ips × max_requests` timestamps.

## Corrections au plan

- **0.5 était fondé sur une prémisse fausse.** `NoModelCoveredError` ne produit pas de 500 côté MCP : FastMCP transforme toute exception d'un tool en `CallToolResult(isError=True)`. Le défaut réel était le message d'archétype inconnu, qui remontait le `KeyError` nu `'foo'`. Aligné sur le wording REST.
- **0.8 était à moitié fait.** Les tools fantômes avaient déjà disparu, la fallback chain était à jour. Le trou restant : `feedback` n'était documenté nulle part.
- **`C2D.7z` fait 6,1 Mo, pas 600 Mo**, et est redondant avec `build/c2d/` déjà extrait.

## Bug attrapé au passage

Le retrait de l'import local `timedelta as _td` (0.7) a révélé qu'il restait un usage de `_td` plus bas, dans la branche `target_eta` du sweep. Aucun des 269 tests ne passait par là : ça n'aurait cassé qu'en prod, sur la seule requête qui pose `target_eta`. Corrigé, test de non-régression ajouté et vérifié en réintroduisant le bug.

## Critères de sortie

- [x] `OPTIONS` depuis une origin inconnue refusé (400, aucun ACAO) ; depuis `ohmywind.fr` et `openwind.fr` accepté
- [x] 429 au-delà du seuil sur POST répétés depuis la même IP, avec `Retry-After` et ACAO préservé
- [x] `lat=999` → 422 propre côté REST **et** côté MCP, en 10 ms, sans appel amont
- [x] 335 tests verts (266 avant, +69), ruff check et format propres
- [x] Smoke MCP live 10/10 sur données AROME réelles

## Variables d'environnement

Toutes ont un défaut sain, aucune action requise côté dashboard HF.

`OPENWIND_ALLOWED_ORIGINS`, `OPENWIND_TRUSTED_PROXY_HOPS` (1), `OPENWIND_RATE_LIMIT_REQUESTS` (30), `OPENWIND_RATE_LIMIT_WINDOW_S` (300), `OPENWIND_RATE_LIMIT_MAX_IPS` (5000).

## À vérifier après merge

Le Dockerfile copie désormais `security.py` en plus de `app.py`. Un oubli serait un crash au boot, pas une dégradation silencieuse. Smoke post-deploy prévu sur le Space dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)