### PR TITLE
feat(web): routage client + arrivée animée sur /plan

### DIFF
--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -1,0 +1,27 @@
+import App from "./App";
+import { PlanPage } from "./routes/PlanPage";
+import { MethodologiePage } from "./routes/MethodologiePage";
+import { ConfigPage } from "./routes/ConfigPage";
+import { useRouter } from "./router";
+
+/**
+ * Path to page, resolved client-side.
+ *
+ * Lives apart from `main.tsx` so the entry point keeps exporting nothing and
+ * fast refresh stays happy.
+ */
+export function Routes() {
+  const { path, search } = useRouter();
+
+  // Keyed on the full URL so a navigation remounts the page, which is what
+  // the pages already expect: each reads its query string once, at mount.
+  // What changes versus the previous full document load is everything around
+  // it. The shell, the theme and the parsed script all survive, so switching
+  // mode no longer blanks the app.
+  const key = path + search;
+
+  if (path === "/plan") return <PlanPage key={key} />;
+  if (path === "/methodologie") return <MethodologiePage key={key} />;
+  if (path === "/config") return <ConfigPage key={key} />;
+  return <App key={key} />;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,10 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./App";
-import { PlanPage } from "./routes/PlanPage";
-import { MethodologiePage } from "./routes/MethodologiePage";
-import { ConfigPage } from "./routes/ConfigPage";
+import { Routes } from "./Routes";
 import { ThemeProvider } from "./design/theme";
 import { registerSW } from "virtual:pwa-register";
 
@@ -15,29 +12,10 @@ if (spaRedirect) {
   window.history.replaceState(null, "", spaRedirect);
 }
 
-// Normalise trailing slashes: GitHub Pages adds them automatically when a
-// matching directory exists under public/ (e.g. ``public/methodologie/`` for
-// the coverage map asset), which turns ``/methodologie`` into ``/methodologie/``
-// during the 404→SPA redirect dance. Strip the trailing slash so route
-// matches stay simple.
-const rawPath = window.location.pathname;
-const path = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
-const isPlan = path === "/plan";
-const isMethodologie = path === "/methodologie";
-const isConfig = path === "/config";
-
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
-      {isPlan ? (
-        <PlanPage />
-      ) : isMethodologie ? (
-        <MethodologiePage />
-      ) : isConfig ? (
-        <ConfigPage />
-      ) : (
-        <App />
-      )}
+      <Routes />
     </ThemeProvider>
   </StrictMode>
 );

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -71,6 +71,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
   const dragLineRef = useRef<L.Polyline | null>(null);
   const segLabelsRef = useRef<L.Tooltip[]>([]);
   const userLayerRef = useRef<L.LayerGroup | null>(null);
+  const flyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onViewChangeRef = useRef(onViewChange);
   useEffect(() => { onViewChangeRef.current = onViewChange; }, [onViewChange]);
   const livePositionsRef = useRef<[number, number][]>(waypoints);
@@ -167,12 +168,36 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     // locate control, and the explore map has done without them since day
     // one. Wheel and pinch zoom stay enabled.
 
-    // Initial view: fit bounds if ≥2 waypoints, else center on the single
-    // waypoint, else honor the ?center hint propagated from the home compass
-    // FAB. Falls back to a France-wide view rather than the Riviera so users
-    // landing on /plan from anywhere on the coast aren't whisked to the Med.
-    if (waypoints.length >= 2) {
-      map.fitBounds(L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon))), { padding: [40, 40] });
+    // Initial view. Falls back to a France-wide view rather than the Riviera
+    // so users landing on /plan from anywhere on the coast aren't whisked to
+    // the Med.
+    //
+    // When the explore map handed a camera over AND a route is waiting, we
+    // open on the handed camera and animate to the route rather than cutting
+    // straight to it. The move is what tells the user the map travelled
+    // somewhere, instead of leaving them to work out that the coastline
+    // changed under them.
+    const routeBounds =
+      waypoints.length >= 2
+        ? L.latLngBounds(waypoints.map(([lat, lon]) => L.latLng(lat, lon)))
+        : null;
+
+    if (initialCenter && waypoints.length >= 1) {
+      map.setView([initialCenter[0], initialCenter[1]], initialZoom ?? 8);
+      // Deferred by a frame: flying before the container has its final size
+      // lands on the wrong bounds, and PlanMap is mounted inside a flex row
+      // that settles just after.
+      const flyTimer = setTimeout(() => {
+        map.invalidateSize();
+        if (routeBounds) {
+          map.flyToBounds(routeBounds, { padding: [40, 40], duration: 1.2 });
+        } else {
+          map.flyTo([waypoints[0][0], waypoints[0][1]], 10, { duration: 1.2 });
+        }
+      }, 80);
+      flyTimerRef.current = flyTimer;
+    } else if (routeBounds) {
+      map.fitBounds(routeBounds, { padding: [40, 40] });
     } else if (waypoints.length === 1) {
       map.setView([waypoints[0][0], waypoints[0][1]], 10);
     } else if (initialCenter) {
@@ -207,6 +232,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
     setTimeout(() => map.invalidateSize(), 100);
 
     return () => {
+      if (flyTimerRef.current) clearTimeout(flyTimerRef.current);
       ro.disconnect();
       map.off("zoomend", onZoomEnd);
       segLabelsRef.current = [];

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Minimal client-side routing, no dependency.
+ *
+ * The app used to read `window.location.pathname` once at boot, so every
+ * internal link was a full document load: React remounted, and the Leaflet
+ * instance was destroyed and rebuilt. Switching between the forecast and the
+ * planner went black and back, which reads as leaving the app rather than
+ * changing view inside it.
+ *
+ * Links are intercepted at the document level rather than replaced by a
+ * `<Link>` component. Ordinary `<a href="/plan">` markup keeps working, stays
+ * middle-clickable and copyable, and still resolves if the script fails.
+ */
+
+/** GitHub Pages appended trailing slashes when a matching directory existed
+    under public/. Strip it so route matching stays a plain comparison. */
+function normalisePath(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+function currentLocation(): { path: string; search: string } {
+  return { path: normalisePath(window.location.pathname), search: window.location.search };
+}
+
+/** Whether this click should be handled in-app rather than by the browser. */
+function isInAppNavigation(e: MouseEvent, anchor: HTMLAnchorElement): boolean {
+  // Modified clicks mean "open elsewhere" and must reach the browser.
+  if (e.defaultPrevented) return false;
+  if (e.button !== 0) return false;
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return false;
+  if (anchor.target && anchor.target !== "_self") return false;
+  if (anchor.hasAttribute("download")) return false;
+  const href = anchor.getAttribute("href");
+  // Same-origin absolute paths only. External links, anchors and mailto go
+  // to the browser untouched.
+  return !!href && href.startsWith("/") && !href.startsWith("//");
+}
+
+export function useRouter(): { path: string; search: string } {
+  const [location, setLocation] = useState(currentLocation);
+
+  useEffect(() => {
+    const sync = () => setLocation(currentLocation());
+
+    const onPopState = () => sync();
+
+    const onClick = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      const anchor = target.closest("a");
+      if (!anchor || !isInAppNavigation(e, anchor)) return;
+      const href = anchor.getAttribute("href")!;
+      e.preventDefault();
+      // Re-clicking the current URL should do nothing rather than remount.
+      if (href === window.location.pathname + window.location.search) return;
+      window.history.pushState(null, "", href);
+      window.scrollTo(0, 0);
+      sync();
+    };
+
+    window.addEventListener("popstate", onPopState);
+    // Bubble phase, so React's own handlers on the anchor (e.g. remembering
+    // the page to return to from /config) have already run.
+    document.addEventListener("click", onClick);
+    return () => {
+      window.removeEventListener("popstate", onPopState);
+      document.removeEventListener("click", onClick);
+    };
+  }, []);
+
+  return location;
+}
+
+export { normalisePath };


### PR DESCRIPTION
Deux causes distinctes à la rupture ressentie en changeant de mode, traitées ensemble.

## 1. Il n'y avait aucun routeur

[main.tsx](packages/web/src/main.tsx) lisait `window.location.pathname` une seule fois au démarrage. Chaque lien interne était donc un chargement de document complet : JS re-parsé, React remonté, instance Leaflet détruite puis reconstruite. D'où le noir suivi du réaffichage, qui se lit comme un départ de l'app plutôt qu'un changement de vue à l'intérieur.

Routage client minimal ajouté, sans dépendance, dans [router.tsx](packages/web/src/router.tsx).

**Les liens sont interceptés au niveau du document** plutôt que remplacés par un composant `<Link>`. Le markup `<a href="/plan">` existant continue de marcher, reste clic-milieu-able et copiable, et résout encore si le script échoue. Aucune page à réécrire.

**Les clics modifiés partent au navigateur** : ctrl, cmd, shift, alt, bouton auxiliaire, `target`, `download`. Ouvrir dans un nouvel onglet doit continuer de faire ce qu'on attend.

**L'écoute est en phase de bouillonnement**, pour que les handlers React posés sur les ancres tournent d'abord. C'est ce qui préserve la mémorisation de la page de retour depuis `/config`.

**Les pages restent montées par clé sur l'URL complète.** Chacune lit sa query string une fois, au montage, et ce contrat ne change pas : je ne voulais pas transformer un changement de navigation en refonte du cycle de vie des pages. Ce qui change, c'est tout ce qui l'entoure, la coquille, le thème et le script survivant à la navigation.

## 2. L'arrivée sur /plan coupait au cadrage

Avec un itinéraire en mémoire, la carte sautait directement sur la route. Elle ouvre désormais sur la vue transmise par l'accueil puis anime vers la route avec `flyToBounds`. Le mouvement est ce qui dit à l'utilisateur que la carte a voyagé, au lieu de le laisser déduire que la côte a changé sous ses yeux.

Le vol est différé d'une frame : voler avant que le conteneur ait sa taille finale atterrit sur de mauvaises bornes, et la carte est montée dans une rangée flex qui se stabilise juste après.

## Ce que ça ne fait pas

`SpotMap` et `PlanMap` restent deux instances Leaflet distinctes, donc la carte se démonte et se remonte quand même. Les tuiles viennent du cache HTTP, donc c'est rapide, mais il subsiste un bref redessin. La continuité totale demanderait une instance unique partagée entre les deux modes avec échange de couches, ce qui est une refacto profonde de deux composants de 700 et 450 lignes, à mener avec la phase 4 du plan.

## Vérifications

- 112 tests web verts, `tsc --noEmit` propre, `npm run build` OK
- ESLint stable à 27 problèmes

## À tester en priorité

Le routage touche toute la navigation, donc au-delà du confort visuel :

- Les quatre routes : `/`, `/plan`, `/config`, `/methodologie`
- Le bouton retour du navigateur, dans les deux sens
- `/config` puis retour : doit revenir sur la page d'origine, pas sur `/`
- Ctrl-clic et clic-milieu sur un lien interne : nouvel onglet
- Un lien externe, la page méthodologie en contient
- Rechargement direct sur `/plan?...` : doit toujours fonctionner
- En PWA installée, où la navigation passe par le service worker