### PR TITLE
fix(web): revérifier le service worker à chaque navigation interne

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { Routes } from "./Routes";
 import { ThemeProvider } from "./design/theme";
-import { registerSW } from "virtual:pwa-register";
+import { registerServiceWorker } from "./sw";
 
 // GitHub Pages 404.html redirect: restore original path stored in sessionStorage
 const spaRedirect = sessionStorage.getItem("spa_redirect");
@@ -23,4 +23,4 @@ createRoot(document.getElementById("root")!).render(
 // Register the service worker so the app shell is installable and offline-
 // resilient. Silent by design: `registerType: 'autoUpdate'` swaps in the new
 // SW on the next load, and we intentionally render no update-toast today.
-registerSW({ immediate: true });
+registerServiceWorker();

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { checkForAppUpdate } from "./sw";
 
 /**
  * Minimal client-side routing, no dependency.
@@ -42,7 +43,12 @@ export function useRouter(): { path: string; search: string } {
   const [location, setLocation] = useState(currentLocation);
 
   useEffect(() => {
-    const sync = () => setLocation(currentLocation());
+    const sync = () => {
+      setLocation(currentLocation());
+      // Navigations no longer hit the network, so this is now the only
+      // regular occasion to notice a deploy. Throttled and best-effort.
+      checkForAppUpdate();
+    };
 
     const onPopState = () => sync();
 

--- a/packages/web/src/sw.test.ts
+++ b/packages/web/src/sw.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { shouldCheckForUpdate } from "./sw";
+
+describe("shouldCheckForUpdate", () => {
+  it("checks on the first navigation of a session", () => {
+    expect(shouldCheckForUpdate(1_000_000, 0)).toBe(true);
+  });
+
+  it("skips a burst of navigations", () => {
+    // Back, forward, back in a few seconds must not fire three requests.
+    const now = 1_000_000;
+    expect(shouldCheckForUpdate(now + 2_000, now)).toBe(false);
+    expect(shouldCheckForUpdate(now + 59_000, now)).toBe(false);
+  });
+
+  it("checks again once the interval has elapsed", () => {
+    const now = 1_000_000;
+    expect(shouldCheckForUpdate(now + 60_000, now)).toBe(true);
+    expect(shouldCheckForUpdate(now + 600_000, now)).toBe(true);
+  });
+});

--- a/packages/web/src/sw.ts
+++ b/packages/web/src/sw.ts
@@ -1,0 +1,49 @@
+import { registerSW } from "virtual:pwa-register";
+
+/**
+ * Service worker registration, plus an update check the router can trigger.
+ *
+ * Before client-side routing, every mode switch was a full navigation, which
+ * gave the browser a natural occasion to look for a new service worker. Now
+ * that navigations stop after the first load, a long session could sit on a
+ * stale worker indefinitely and never pick up a deploy. Checking on each
+ * in-app navigation restores roughly the old cadence.
+ */
+
+let registration: ServiceWorkerRegistration | undefined;
+let lastCheckedAt = 0;
+
+/** Navigations can come in bursts (back, forward, back). One network check a
+    minute is plenty to catch a deploy without hammering the origin. */
+const MIN_INTERVAL_MS = 60_000;
+
+/** Pure, so the throttle is testable without a service worker or a clock. */
+export function shouldCheckForUpdate(now: number, lastAt: number): boolean {
+  return now - lastAt >= MIN_INTERVAL_MS;
+}
+
+export function registerServiceWorker(): void {
+  registerSW({
+    immediate: true,
+    onRegisteredSW(_swScriptUrl, r) {
+      registration = r;
+    },
+  });
+}
+
+/**
+ * Ask the browser whether a newer worker exists.
+ *
+ * Safe to call on every navigation: throttled, and failures are swallowed.
+ * An update found here is applied on the next load, per the `autoUpdate`
+ * registration, so nothing is swapped under the running page.
+ */
+export function checkForAppUpdate(): void {
+  if (!registration) return;
+  const now = Date.now();
+  if (!shouldCheckForUpdate(now, lastCheckedAt)) return;
+  lastCheckedAt = now;
+  // Rejects when offline, or when the origin is unreachable. Neither is
+  // worth surfacing: the app keeps running on what it already has.
+  registration.update().catch(() => {});
+}


### PR DESCRIPTION
Régression que j'ai introduite avec le routage client (#183), déjà en production via #179.

## Le problème

Avant le routage client, chaque changement de mode était une navigation complète, ce qui donnait au navigateur une occasion naturelle de chercher un nouveau service worker. Maintenant que les navigations s'arrêtent après le premier chargement, une session longue peut rester indéfiniment sur un worker périmé et ne jamais voir un déploiement.

Ce n'est pas ce qui a cassé l'affichage sur mobile aujourd'hui, cette panne venait de `dev.openwind.fr` qui renvoie 522 depuis le renommage du domaine de dev. Mais c'est un vrai recul du cycle de mise à jour, et il valait mieux le corriger avant qu'il ne morde.

## Le correctif

Le routeur déclenche une vérification à chaque navigation interne, ce qui restaure à peu près l'ancienne cadence.

Bridé à une requête par minute : aller-retour-aller dans l'historique ne doit pas déclencher trois appels réseau. Les échecs sont avalés, hors ligne ou origine injoignable ne valent pas d'être remontés, l'app continue de tourner sur ce qu'elle a déjà.

Une mise à jour trouvée ici s'applique au chargement suivant, conformément à l'enregistrement `autoUpdate`. Rien n'est échangé sous la page en cours, ce qui évite qu'un ancien bundle demande un asset que le nouveau cache vient de purger.

L'enregistrement sort de `main.tsx` vers `sw.ts`, pour que la référence au registration soit accessible sans exporter depuis le point d'entrée.

## Vérifications

- 115 tests web verts (112 avant, 3 ajoutés sur le bridage)
- `tsc --noEmit` propre, `npm run build` OK
- ESLint stable à 27 problèmes

## À tester

- Naviguer entre les modes, vérifier dans l'onglet réseau qu'un appel à `sw.js` part au plus une fois par minute
- Déployer pendant une session ouverte, naviguer, puis recharger : la nouvelle version doit être prise
- Hors ligne : la navigation doit rester silencieuse, sans erreur en console

🤖 Generated with [Claude Code](https://claude.com/claude-code)