### PR TITLE
refacto: rebrand cosmétique OpenWind vers OhMyWind (phase A)

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -60,12 +60,16 @@ jobs:
           # Space, rewrite the HF card frontmatter and the advertised endpoint so
           # the two Spaces are visually distinct on the dashboard and demos hit dev.
           README=/tmp/hf-build/README.md
+          # NB: the title / heading patterns below match the committed README
+          # verbatim. sed reports nothing when a pattern misses, so any edit to
+          # those two lines in packages/hf-space/README.md must be mirrored here
+          # or the dev Space silently stops being distinguishable from prod.
           sed -i \
-            -e 's/^title: OpenWind MCP$/title: OpenWind MCP (dev)/' \
+            -e 's/^title: OhMyWind MCP$/title: OhMyWind MCP (dev)/' \
             -e 's/^colorFrom: blue$/colorFrom: gray/' \
             -e 's/^colorTo: indigo$/colorTo: yellow/' \
             -e 's/^short_description: .*/short_description: (dev) French Atlantic + Med sailing planner via MCP./' \
-            -e 's/^# OpenWind MCP ⛵$/# OpenWind MCP (dev) ⛵/' \
+            -e 's/^# OhMyWind MCP ⛵$/# OhMyWind MCP (dev) ⛵/' \
             -e 's#qdonnars-openwind-mcp\.hf\.space#qdonnars-openwind-mcp-dev.hf.space#g' \
             -e 's/on `main`/on `dev`/g' \
             "$README"
@@ -76,7 +80,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GIT_USER_NAME: openwind-ci
-          GIT_USER_EMAIL: ci@openwind.fr
+          GIT_USER_EMAIL: ci@ohmywind.fr
         run: |
           set -euo pipefail
           if [ -z "${HF_TOKEN:-}" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# OpenWind — Working Notes
+# OhMyWind — Working Notes
 
 ## Mission
 
@@ -16,7 +16,7 @@ The web app is **strictly standalone** — it never proposes "talk to an assista
 - `packages/web/` — React 19 + TypeScript + Vite, deployed to **Cloudflare Pages** on **ohmywind.fr** (preview `dev` → **dev.ohmywind.fr**)
 - `packages/data-adapters/` — Python lib, pure domain logic (marine data adapters, polars, routing, complexity)
 - `packages/mcp-core/` — Python lib, FastMCP server definition (cloud-agnostic, redeployable anywhere)
-- `packages/hf-space/` — Thin Gradio wrapper for Hugging Face Spaces deployment, served at **mcp.openwind.fr**
+- `packages/hf-space/` — Wrapper Hugging Face Spaces : app **Starlette + uvicorn** en Docker (aucun Gradio), porte la landing, les endpoints REST, CORS et le rate-limit. Servi aujourd'hui sur `qdonnars-openwind-mcp.hf.space` ; le passage à **mcp.ohmywind.fr** (Worker Cloudflare) est la phase B du plan de rebrand.
 
 Plan d'exécution détaillé : `plan/` (local, non-tracké).
 

--- a/FEEDBACK_TODO.md
+++ b/FEEDBACK_TODO.md
@@ -1,4 +1,4 @@
-# OpenWind — TODO retours Hisse & Oh
+# OhMyWind — TODO retours Hisse & Oh
 
 Synthèse des retours du fil H&O (9–19 mai 2026).
 Croisé avec les commits récents et la PR #142 (UX polish, mai 2026).
@@ -49,7 +49,7 @@ Légende : @pseudo = auteur du retour sur H&O.
 
 ## Outillage / plomberie (chantiers techniques)
 
-- [ ] Re-sync HF Space (mcp.openwind.fr) après merge PR #142 — sinon le motor/fallback ne tourne pas en prod
+- [ ] Re-sync HF Space (mcp.ohmywind.fr) après merge PR #142 — sinon le motor/fallback ne tourne pas en prod
 - [ ] Staging HF Space (preview backend) pour tester les branches Cloudflare Pages bout en bout
 - [ ] Analytics : Plausible / Cloudflare Web Analytics + Sentry (suggestion Tinqueen)
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 > **Talk to your LLM. Cast off with confidence.**
 >
-> OpenWind turns any MCP-capable assistant (Claude, Le Chat, Cursor, Goose,
+> OhMyWind turns any MCP-capable assistant (Claude, Le Chat, Cursor, Goose,
 > Zed, Continue) into a sailing planner for the French Atlantic and
 > Mediterranean coasts. Ask in plain language. Get a per-leg ETA, a 1‑5
 > complexity score, high-precision tidal currents on the Atlantic
 > (SHOM Atlas C2D and MARC PREVIMER), and a deep-link to the full plan.
 > Free, keyless, open source.
 
-[**openwind.fr**](https://openwind.fr) · [MCP endpoint](https://qdonnars-openwind-mcp.hf.space/mcp) · MIT
+[**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://qdonnars-openwind-mcp.hf.space/mcp) · MIT
 
-![OpenWind passage plan rendered in the web app](docs/screenshots/plan.png)
+![OhMyWind passage plan rendered in the web app](docs/screenshots/plan.png)
 
 ---
 
@@ -28,12 +28,12 @@ https://qdonnars-openwind-mcp.hf.space/mcp
 > *"Demain matin, Marseille → Porquerolles, sur un Sun Odyssey 36. Bonne
 > idée ? Combien de temps et c'est tendu comment ?"*
 
-**3.** Your assistant calls the OpenWind tools and answers in plain language.
+**3.** Your assistant calls the OhMyWind tools and answers in plain language.
 On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix)
 (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam) you
-also get a live, interactive widget: the [openwind.fr](https://openwind.fr)
+also get a live, interactive widget: the [ohmywind.fr](https://ohmywind.fr)
 plan view rendered inline. On hosts that don't (Cursor, Le Chat, terminal),
-the assistant hands you the same plan as an [openwind.fr](https://openwind.fr)
+the assistant hands you the same plan as an [ohmywind.fr](https://ohmywind.fr)
 deep-link. No account. No API key. No credit card.
 
 > **First time with MCP?** It takes 2 minutes. Pick your client on
@@ -45,7 +45,7 @@ deep-link. No account. No API key. No credit card.
 > add it under **Connectors → Add connector → Custom MCP connector** and paste
 > the endpoint above.
 
-## Why OpenWind
+## Why OhMyWind
 
 |                              |                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------|
@@ -65,12 +65,12 @@ Four MCP tools, all async, all keyless:
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Seven descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft` itself. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out, and the LLM picks the calmest slot. |
-| `read_me`                 | Returns OpenWind's calculation methodology. Call it when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1‑5 complexity + ohmywind.fr deep-link, in one call. Pass `latest_departure` to compare every hourly window up to 14 days out, and the LLM picks the calmest slot. |
+| `read_me`                 | Returns OhMyWind's calculation methodology. Call it when the user asks how things are computed. |
 
 `plan_passage` declares an MCP Apps UI resource (`ui://openwind/plan-passage`)
 on its `_meta`. Hosts that support [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix)
-render the live `openwind.fr/plan?…` view in a sandboxed iframe automatically,
+render the live `ohmywind.fr/plan?…` view in a sandboxed iframe automatically,
 with no host-specific CSS and no vendor lock-in. Hosts without MCP Apps support
 silently get the structured payload + the `openwind_url` deep-link.
 
@@ -81,7 +81,7 @@ packages/
 ├── data-adapters/   # pure domain logic (forecast adapters, polars, routing, complexity)
 ├── mcp-core/        # FastMCP server (cloud-agnostic, no Gradio, no HF deps)
 ├── hf-space/        # ~20-line Docker wrapper for Hugging Face Spaces
-└── web/             # React 19 + Vite app deployed to GitHub Pages (openwind.fr)
+└── web/             # React 19 + Vite app deployed to GitHub Pages (ohmywind.fr)
 ```
 
 `mcp-core` stays deployment-agnostic. Re-deploying on Fly, Modal, or a VPS is
@@ -101,7 +101,7 @@ uv run ruff check .
 cd packages/hf-space
 uv run python app.py   # serves :7860, point any MCP client at /mcp
 
-# Web app (openwind.fr)
+# Web app (ohmywind.fr)
 cd packages/web
 npm install
 npm run dev            # vite dev server
@@ -159,7 +159,7 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 
 Wind & sea: [Open-Meteo](https://open-meteo.com/) (CC BY 4.0). Hosting:
 [Hugging Face Spaces](https://huggingface.co/spaces). Map tiles on
-[openwind.fr](https://openwind.fr): [CARTO](https://carto.com/) /
+[ohmywind.fr](https://ohmywind.fr): [CARTO](https://carto.com/) /
 [OpenStreetMap](https://www.openstreetmap.org/copyright).
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
-# OpenWind — Architecture
+# OhMyWind — Architecture
 
 ## Mental model
 
-OpenWind is **not a router**. It is a thin set of MCP tools the LLM orchestrates
+OhMyWind is **not a router**. It is a thin set of MCP tools the LLM orchestrates
 to plan a sailing passage. The intelligence — picking waypoints, choosing a
 weather window, judging "is this a good day to go?" — lives in the LLM, not
 on the server.
@@ -56,7 +56,7 @@ A typical Claude Desktop conversation produces this tool sequence:
    for the Mediterranean. Claude reads wind, gusts, and (when relevant) Hs.
 3. **Plan the passage.** `plan_passage(waypoints, departure, archetype)`
    returns, in a single call: per-segment timing (TWA, polar speed,
-   warnings), a 1-5 complexity score, and an `openwind.fr/plan?...`
+   warnings), a 1-5 complexity score, and an `ohmywind.fr/plan?...`
    deep-link. The server fetches one wind bundle per segment (single-pass
    approximation; no convergence loop). When the caller passes
    `latest_departure`, the same call sweeps hourly windows over the route
@@ -64,7 +64,7 @@ A typical Claude Desktop conversation produces this tool sequence:
 4. **Render & narrate.** The tool declares
    `_meta.ui.resourceUri = ui://openwind/plan-passage`, so MCP-Apps-aware
    hosts (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman,
-   MCPJam) auto-render the live openwind.fr/plan view in a sandboxed
+   MCPJam) auto-render the live ohmywind.fr/plan view in a sandboxed
    iframe. Hosts without MCP Apps support fall back to a text summary
    (ETA / complexity / warnings) plus the `openwind_url` deep-link. If the
    user later asks "how is this computed?", the LLM calls `read_me` and
@@ -79,12 +79,16 @@ LLM produces the verdict.
 | ----------------- | ---------------------------------------- | --------------------- |
 | `openwind-data`   | `httpx`, stdlib                          | `mcp`, `gradio`, HF   |
 | `openwind-mcp-core` | `mcp[cli]`, `openwind-data`            | `gradio`, HF          |
-| `hf-space/`       | `gradio`, `openwind-mcp-core`            | —                     |
+| `hf-space/`       | `starlette`, `uvicorn`, `openwind-mcp-core`, `huggingface_hub` | —  |
+
+The wrapper does **not** use Gradio: it is a plain Starlette app served by
+uvicorn in a Docker Space. `huggingface_hub` appears only there, to pull the
+tidal atlas at build time and to push feedback.
 
 `build_server()` in `openwind_mcp_core.server` is the single factory used by:
 
 - the local stdio runner (`packages/mcp-core/scripts/run_local.py`)
-- the future HF Spaces wrapper (`packages/hf-space/app.py`, Sprint 4)
+- the HF Spaces wrapper (`packages/hf-space/app.py`)
 - any future deployment (Fly.io, Modal, self-host)
 
 Re-deploying anywhere = writing a new wrapper that calls `build_server()`.
@@ -121,5 +125,5 @@ Re-deploying anywhere = writing a new wrapper that calls `build_server()`.
   optimization, no tide planning.
 - Not a scoring engine — no `find_best_window()`, no numerical comparison
   across days. The LLM compares; we provide ingredients.
-- Not a chat UI — the web app at `openwind.fr` is read-only, populated from a
+- Not a chat UI — the web app at `ohmywind.fr` is read-only, populated from a
   pre-computed `/plan?...` URL. Conversation happens in the MCP client.

--- a/docs/marc_atlas_format.md
+++ b/docs/marc_atlas_format.md
@@ -2,7 +2,7 @@
 
 Reconnaissance du FTP Ifremer `MARC_L1-ATLAS-AHRMONIQUES` (atlas PREVIMER de
 composantes harmoniques de hauteurs et courants de marée) pour préparer
-l'intégration dans OpenWind.
+l'intégration dans OhMyWind.
 
 Source : `ftp.ifremer.fr/MARC_L1-ATLAS-AHRMONIQUES/` (auth requise, login `ext-marc_atlasharmo`).
 Documentation primaire : `2013_04_15_fiche_produit_atlas_V0.pdf` (téléchargé hors repo).

--- a/docs/methodologie.md
+++ b/docs/methodologie.md
@@ -1,4 +1,4 @@
-# OpenWind — Méthodologie
+# OhMyWind — Méthodologie
 
 > **Note** : ce document est destiné à être affiché aux utilisateurs (extrait
 > dans le tool MCP `read_me`, footer du frontend web, README repo). Il est
@@ -53,7 +53,7 @@ marée. Rapport Ifremer, 89 p.
 
 ### Cascade de routing courants
 
-À chaque waypoint, OpenWind utilise la donnée la plus précise disponible :
+À chaque waypoint, OhMyWind utilise la donnée la plus précise disponible :
 
 ```
 si point ∈ emprise MARC valide  →  MARC (résolution la plus fine si overlap)
@@ -108,10 +108,10 @@ les zones MARC.
 - **MARC est un produit V0 figé en 2013** : pas de mise à jour de la
   constante harmonique depuis. Les amplitudes/phases sont stables dans le
   temps (variation millimétrique sur 10 ans).
-- **OpenWind n'est pas un routeur** : pas d'optimisation, pas de
+- **OhMyWind n'est pas un routeur** : pas d'optimisation, pas de
   `find_best_window`. On surface les données brutes (courants, étales, marnage,
   coefficient) et le LLM client rédige le conseil.
-- **OpenWind ne remplace pas un atlas SHOM ou une carte papier** pour la nav
+- **OhMyWind ne remplace pas un atlas SHOM ou une carte papier** pour la nav
   précise dans une passe étroite. C'est un outil de planification, pas de
   pilotage.
 

--- a/docs/qa/user-journeys.md
+++ b/docs/qa/user-journeys.md
@@ -42,9 +42,9 @@ Outils: navigateur piloté (Chrome DevTools MCP) pour le web, émulateur Android
 - Étapes: basculer l'icône lune, recharger la page, rebasculer.
 - Attendu: bascule immédiate de toute l'UI (carte comprise), préférence persistée au rechargement.
 
-### J7. Bandeau rebrand OpenWind → OhMyWind
+### J7. Bandeau rebrand OhMyWind → OhMyWind
 - Étapes: premier affichage: lire le bandeau; cliquer la croix; recharger.
-- Attendu: texte mentionne la redirection openwind.fr et l'open source; la croix ferme le bandeau; il ne réapparaît pas après rechargement.
+- Attendu: texte mentionne la redirection ohmywind.fr et l'open source; la croix ferme le bandeau; il ne réapparaît pas après rechargement.
 
 ### J8. Android: plein écran TWA et permissions
 - Précondition: app installée (adb), assetlinks à jour sur l'hôte visé.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -3,8 +3,8 @@
 Hero assets referenced from the READMEs and the Starlette landing of the HF
 Space.
 
-- `plan.png` the OpenWind passage view on
-  [openwind.fr](https://openwind.fr) (5 waypoints, ETA, complexity score).
+- `plan.png` the OhMyWind passage view on
+  [ohmywind.fr](https://ohmywind.fr) (5 waypoints, ETA, complexity score).
   Used as the hero image in the root README, the HF Space README, and the
   Starlette landing. Replace by `plan.gif` (animated demo) later update
   the `<img src="…">` in

--- a/packages/data-adapters/README.md
+++ b/packages/data-adapters/README.md
@@ -1,6 +1,6 @@
 # openwind-data
 
-Pure Python domain logic for OpenWind: marine data adapters, polars, routing, complexity scoring.
+Pure Python domain logic for OhMyWind: marine data adapters, polars, routing, complexity scoring.
 
 Cloud-agnostic no dependency on Gradio, FastMCP, or any deployment runtime. Reused by `openwind-mcp-core` and any future deployment wrapper.
 

--- a/packages/data-adapters/docs/boat-archetypes.md
+++ b/packages/data-adapters/docs/boat-archetypes.md
@@ -1,6 +1,6 @@
 # Boat archetypes — V1 polars and assumptions
 
-OpenWind ships 7 archetypes covering the bulk of French cruising fleets, from
+OhMyWind ships 7 archetypes covering the bulk of French cruising fleets, from
 small trailerable cruisers to bluewater 50-footers and a racer-cruiser.
 The LLM client is expected to map a user's commercial boat name (e.g. *"Sun
 Odyssey 32"*) onto the closest archetype using the fields exposed by

--- a/packages/data-adapters/pyproject.toml
+++ b/packages/data-adapters/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openwind-data"
 version = "0.1.0"
-description = "Marine data adapters, polars, routing, and complexity scoring for OpenWind"
+description = "Marine data adapters, polars, routing, and complexity scoring for OhMyWind"
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.27",

--- a/packages/data-adapters/src/openwind_data/__init__.py
+++ b/packages/data-adapters/src/openwind_data/__init__.py
@@ -1,4 +1,4 @@
-"""OpenWind domain logic — marine adapters, polars, routing, complexity."""
+"""OhMyWind domain logic — marine adapters, polars, routing, complexity."""
 
 from openwind_data.adapters.base import (
     ForecastBundle,

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -1,5 +1,5 @@
 ---
-title: OpenWind MCP
+title: OhMyWind MCP
 emoji: ⛵
 colorFrom: blue
 colorTo: indigo
@@ -10,14 +10,14 @@ license: mit
 short_description: French Atlantic + Mediterranean sailing planner via MCP.
 ---
 
-# OpenWind MCP ⛵
+# OhMyWind MCP ⛵
 
 > **Talk to your LLM. Cast off with confidence.**
 >
 > Turns any MCP-capable assistant into a sailing planner for the French
 > Atlantic and Mediterranean coasts. Free, keyless, open source.
 
-![OpenWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png)
+![OhMyWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png)
 
 ---
 
@@ -34,10 +34,10 @@ https://qdonnars-openwind-mcp.hf.space/mcp
 > *"I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey
 > 36. How long is the passage and how tricky is it?"*
 
-**3.** Your assistant calls the OpenWind tools and answers in plain language.
+**3.** Your assistant calls the OhMyWind tools and answers in plain language.
 On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix)
 (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam) you
-also get the live [openwind.fr](https://openwind.fr) plan view rendered
+also get the live [ohmywind.fr](https://ohmywind.fr) plan view rendered
 inline. On hosts that don't (Cursor, Le Chat, terminal), the assistant hands
 you the same plan as a deep-link instead. No account. No API key. No credit
 card.
@@ -50,7 +50,7 @@ card.
 > other MCP-compatible host. In Le Chat, add it under **Connectors → Add
 > connector → Custom MCP connector** and paste the endpoint above.
 
-## Why OpenWind
+## Why OhMyWind
 
 - **Free and keyless.** Wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).
 - **Mediterranean-tuned.** AROME 1.3 km by default, catches thermals and mistral. ICON-EU → ECMWF → GFS for longer reach.
@@ -65,8 +65,8 @@ card.
 |---------------------------|---------------------------------------------------------------------------|
 | `list_boat_archetypes`    | Seven descriptive archetypes; the LLM maps "Sun Odyssey 36" → `cruiser_30ft`. |
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
-| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + openwind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
-| `read_me`                 | Returns OpenWind's calculation methodology. Call it when the user asks how things are computed. |
+| `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + ohmywind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
+| `read_me`                 | Returns OhMyWind's calculation methodology. Call it when the user asks how things are computed. |
 | `feedback`                | Structured channel for the LLM to report a problem or a suggestion about a tool interaction. |
 
 ## About this Space
@@ -74,16 +74,18 @@ card.
 > ⚠️ This Space uses the **Docker SDK** (not Gradio). It does **not** carry
 > the HF MCP badge and isn't listed in
 > `huggingface.co/spaces?filter=mcp-server`. Discoverability lives at
-> [openwind.fr](https://openwind.fr) instead.
+> [ohmywind.fr](https://ohmywind.fr) instead.
 
 **Source of truth:** <https://github.com/qdonnars/ohmywind>. This Space is
 auto-deployed by GitHub Actions from `packages/hf-space/` on `main`. Don't
 commit directly to the Space repo; your changes will be overwritten at the
 next push.
 
-The Space wrapper is intentionally minimal (~20 lines in `app.py`). All logic
-lives in `openwind-mcp-core` and `openwind-data` upstream, re-deployable on
-Fly, Modal, or a VPS by writing a different wrapper.
+The wrapper carries the HTTP surface (landing page, REST endpoints, CORS,
+rate limiting) and nothing else. All domain logic lives in `openwind-mcp-core`
+and `openwind-data` upstream, re-deployable on Fly, Modal, or a VPS by writing
+a different wrapper. Neither upstream package imports Gradio or
+`huggingface_hub`.
 
 ## Cold-start
 

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -1,4 +1,4 @@
-"""HF Space entry point — serves the OpenWind FastMCP server over HTTP.
+"""HF Space entry point — serves the OhMyWind FastMCP server over HTTP.
 
 This wrapper is intentionally thin. All tools live in ``openwind_mcp_core``
 (which itself imports ``openwind_data``). Re-deploying on Fly/Modal/VPS = a
@@ -77,16 +77,16 @@ LANDING_HTML = """<!doctype html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>OpenWind MCP — talk to your LLM, cast off with confidence</title>
-  <link rel="icon" type="image/svg+xml" href="https://openwind.fr/favicon.svg">
-  <link rel="icon" type="image/png" sizes="192x192" href="https://openwind.fr/icon-192.png">
-  <link rel="icon" type="image/png" sizes="512x512" href="https://openwind.fr/icon-512.png">
-  <link rel="apple-touch-icon" href="https://openwind.fr/icon-192.png">
-  <meta name="description" content="OpenWind MCP — free, keyless sailing planner for the French Atlantic and Mediterranean coasts.">
-  <meta property="og:title" content="OpenWind MCP">
+  <title>OhMyWind MCP — talk to your LLM, cast off with confidence</title>
+  <link rel="icon" type="image/svg+xml" href="https://ohmywind.fr/favicon.svg">
+  <link rel="icon" type="image/png" sizes="192x192" href="https://ohmywind.fr/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="https://ohmywind.fr/icon-512.png">
+  <link rel="apple-touch-icon" href="https://ohmywind.fr/icon-192.png">
+  <meta name="description" content="OhMyWind MCP — free, keyless sailing planner for the French Atlantic and Mediterranean coasts.">
+  <meta property="og:title" content="OhMyWind MCP">
   <meta property="og:description" content="Talk to your LLM. Cast off with confidence. Free, keyless sailing planner via MCP.">
-  <meta property="og:image" content="https://openwind.fr/icon-512.png">
-  <meta property="og:url" content="https://openwind.fr">
+  <meta property="og:image" content="https://ohmywind.fr/icon-512.png">
+  <meta property="og:url" content="https://ohmywind.fr">
   <meta name="twitter:card" content="summary">
   <style>
     :root {
@@ -173,14 +173,14 @@ LANDING_HTML = """<!doctype html>
   </style>
 </head>
 <body>
-  <h1>OpenWind MCP <span class="badge">running</span></h1>
+  <h1>OhMyWind MCP <span class="badge">running</span></h1>
   <p class="lede">Talk to your LLM. Cast off with confidence.<br>
     A free, keyless, open-source sailing planner for the French Atlantic and
     Mediterranean coasts. Exposed as an MCP server so any compatible
     assistant can use it.</p>
 
   <img class="hero" src="https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png"
-       alt="OpenWind passage plan: 5 waypoints, 48.6 nm, ETA 21:24, complexity 3 of 5.">
+       alt="OhMyWind passage plan: 5 waypoints, 48.6 nm, ETA 21:24, complexity 3 of 5.">
 
   <h2>Connect it to your assistant</h2>
   <p>Pick yours below — under a minute, no install, no API key.</p>
@@ -190,10 +190,10 @@ LANDING_HTML = """<!doctype html>
     <ol>
       <li>Open <a href="https://claude.ai/settings/connectors" target="_blank" rel="noopener">claude.ai → Settings → Connectors</a>.</li>
       <li>Scroll to the bottom and click <strong>Add custom connector</strong>.</li>
-      <li>Set <strong>Name</strong>: <code>OpenWind</code>.</li>
+      <li>Set <strong>Name</strong>: <code>OhMyWind</code>.</li>
       <li>Paste this in <strong>Remote MCP server URL</strong>:
         <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
-      <li>Click <strong>Add</strong>. In any new chat, OpenWind shows up in the
+      <li>Click <strong>Add</strong>. In any new chat, OhMyWind shows up in the
         <strong>Search and tools</strong> menu — toggle it on.</li>
     </ol>
   </details>
@@ -206,13 +206,13 @@ LANDING_HTML = """<!doctype html>
         <strong>Connecteurs</strong> (in English:
         <strong>Intelligence</strong> &rarr; <strong>Connectors</strong>),
         then click <strong>Add MCP server</strong>.</li>
-      <li>Set <strong>Name</strong>: <code>OpenWind</code> &middot; <strong>Auth</strong>: <code>None</code>.</li>
+      <li>Set <strong>Name</strong>: <code>OhMyWind</code> &middot; <strong>Auth</strong>: <code>None</code>.</li>
       <li>Paste this in <strong>URL</strong>:
         <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
-      <li>Save, then enable the OpenWind toggle inside any conversation.</li>
+      <li>Save, then enable the OhMyWind toggle inside any conversation.</li>
       <li>Le Chat doesn&rsquo;t (yet) support the MCP Apps spec, so the
         widget won&rsquo;t render inline &mdash; the assistant will hand you
-        an <a href="https://openwind.fr">openwind.fr</a> deep-link instead.</li>
+        an <a href="https://ohmywind.fr">ohmywind.fr</a> deep-link instead.</li>
     </ol>
   </details>
 
@@ -223,22 +223,22 @@ LANDING_HTML = """<!doctype html>
       <li>Open <a href="https://chatgpt.com/#settings/Connectors" target="_blank" rel="noopener">ChatGPT → Settings → Connectors</a>.</li>
       <li>In <strong>Advanced</strong>, turn on <strong>Developer mode</strong>.</li>
       <li>Back in <strong>Connectors</strong>, click <strong>Create</strong>.</li>
-      <li>Set <strong>Name</strong>: <code>OpenWind</code> · <strong>Authentication</strong>: <code>No authentication</code>.</li>
+      <li>Set <strong>Name</strong>: <code>OhMyWind</code> · <strong>Authentication</strong>: <code>No authentication</code>.</li>
       <li>Paste this in <strong>MCP server URL</strong>:
         <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
       <li>Trust the connector and save. Activate it in a chat via
-        <strong>+ → Developer connectors → OpenWind</strong>.</li>
+        <strong>+ → Developer connectors → OhMyWind</strong>.</li>
     </ol>
   </details>
 
   <h2>Then ask, in your own words</h2>
   <blockquote>I'm leaving Marseille tomorrow morning for Porquerolles on a Sun Odyssey 36.
     How long is the passage and how tricky is it?</blockquote>
-  <p>Your assistant calls the OpenWind tools and answers in plain language.
+  <p>Your assistant calls the OhMyWind tools and answers in plain language.
     On hosts that support the
     <a href="https://modelcontextprotocol.io/extensions/client-matrix" target="_blank" rel="noopener">MCP Apps spec</a>
     (Claude, Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam),
-    the live <a href="https://openwind.fr">openwind.fr</a> plan view also
+    the live <a href="https://ohmywind.fr">ohmywind.fr</a> plan view also
     renders inline as a sandboxed iframe. On hosts that don&rsquo;t (Cursor,
     Le Chat, terminal), the assistant hands you the same plan as a deep-link
     instead.</p>
@@ -247,7 +247,7 @@ LANDING_HTML = """<!doctype html>
   <blockquote>Marseille &rarr; Porquerolles, same boat &mdash; show me the
     calmest departure between Saturday morning and Monday evening.</blockquote>
 
-  <h2>Why OpenWind</h2>
+  <h2>Why OhMyWind</h2>
   <ul class="perks">
     <li><strong>Free &amp; keyless.</strong> Wind + sea via
       <a href="https://open-meteo.com">Open-Meteo</a> (CC BY 4.0).</li>
@@ -260,7 +260,7 @@ LANDING_HTML = """<!doctype html>
 
   <h2>Four tools</h2>
   <p>The workhorse is <code>plan_passage</code>: one call returns timing, a
-    1-5 complexity score, and an <a href="https://openwind.fr">openwind.fr</a>
+    1-5 complexity score, and an <a href="https://ohmywind.fr">ohmywind.fr</a>
     deep-link. It declares an MCP Apps UI resource, so supporting hosts also
     render the live plan view in a sandboxed iframe. Pass
     <code>latest_departure</code> and it walks every hourly window up to 14
@@ -270,11 +270,11 @@ LANDING_HTML = """<!doctype html>
     assistant pick a boat, sample the forecast ad hoc, or explain the math
     behind a result.</p>
   <p>Don&rsquo;t want to wire an MCP host? You can also drive everything by
-    hand at <a href="https://openwind.fr/plan">openwind.fr/plan</a> &mdash;
+    hand at <a href="https://ohmywind.fr/plan">ohmywind.fr/plan</a> &mdash;
     click your route, pick a boat, slide the departure.</p>
 
   <h2>Source</h2>
-  <p>Project site: <a href="https://openwind.fr">openwind.fr</a> &middot;
+  <p>Project site: <a href="https://ohmywind.fr">ohmywind.fr</a> &middot;
     GitHub: <a href="https://github.com/qdonnars/ohmywind">qdonnars/ohmywind</a>
     (MIT).</p>
 
@@ -435,14 +435,14 @@ async def _index(_request) -> HTMLResponse:
 # Connector pickers in chat hosts (Claude, etc.) often scrape the server
 # URL's favicon / og:image to badge the connector. Our app responded 404
 # on /favicon.ico and the host fell back to HuggingFace branding. Redirect
-# every common icon probe to the OpenWind PNG/SVG hosted on openwind.fr.
+# every common icon probe to the OhMyWind PNG/SVG hosted on ohmywind.fr.
 _ICON_REDIRECTS = {
-    "/favicon.ico": "https://openwind.fr/favicon.svg",
-    "/favicon.svg": "https://openwind.fr/favicon.svg",
-    "/icon-192.png": "https://openwind.fr/icon-192.png",
-    "/icon-512.png": "https://openwind.fr/icon-512.png",
-    "/apple-touch-icon.png": "https://openwind.fr/icon-192.png",
-    "/apple-touch-icon-precomposed.png": "https://openwind.fr/icon-192.png",
+    "/favicon.ico": "https://ohmywind.fr/favicon.svg",
+    "/favicon.svg": "https://ohmywind.fr/favicon.svg",
+    "/icon-192.png": "https://ohmywind.fr/icon-192.png",
+    "/icon-512.png": "https://ohmywind.fr/icon-512.png",
+    "/apple-touch-icon.png": "https://ohmywind.fr/icon-192.png",
+    "/apple-touch-icon-precomposed.png": "https://ohmywind.fr/icon-192.png",
 }
 
 

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -1,10 +1,10 @@
 # openwind-mcp-core
 
-Cloud-agnostic FastMCP server for OpenWind. Exposes 5 tools:
+Cloud-agnostic FastMCP server for OhMyWind. Exposes 5 tools:
 
 - `list_boat_archetypes` descriptive list, no server-side mapping
 - `get_marine_forecast` wind + sea around a point/window
-- `plan_passage` end-to-end timing + complexity + openwind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
+- `plan_passage` end-to-end timing + complexity + ohmywind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
 - `read_me` calculation methodology (polars, efficiency, VMG, defaults)
 - `feedback` structured channel for the LLM to report a problem or a suggestion; the sink is injected by the deployment wrapper, so the core stays cloud-agnostic
 
@@ -80,7 +80,7 @@ The client should call `list_boat_archetypes` (to map → `cruiser_40ft`)
 then `plan_passage` once with the waypoints, departure, and chosen archetype.
 The response includes timing, complexity, and an `openwind_url` deep-link.
 On hosts that support the [MCP Apps spec](https://modelcontextprotocol.io/extensions/client-matrix),
-the openwind.fr/plan view is also rendered inline as an iframe widget; on
+the ohmywind.fr/plan view is also rendered inline as an iframe widget; on
 hosts that don't, the deep-link is the user-facing fallback.
 
 > First request after inactivity may incur ~5s of cold-start once deployed

--- a/packages/mcp-core/pyproject.toml
+++ b/packages/mcp-core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openwind-mcp-core"
 version = "0.1.0"
-description = "Cloud-agnostic FastMCP server for OpenWind — sailing planner tools."
+description = "Cloud-agnostic FastMCP server for OhMyWind — sailing planner tools."
 requires-python = ">=3.12"
 dependencies = [
     # MCP Apps support requires:

--- a/packages/mcp-core/scripts/run_local.py
+++ b/packages/mcp-core/scripts/run_local.py
@@ -1,4 +1,4 @@
-"""Run the OpenWind MCP server over stdio for local Claude Desktop integration.
+"""Run the OhMyWind MCP server over stdio for local Claude Desktop integration.
 
 Usage (in claude_desktop_config.json):
 

--- a/packages/mcp-core/src/openwind_mcp_core/__init__.py
+++ b/packages/mcp-core/src/openwind_mcp_core/__init__.py
@@ -1,4 +1,4 @@
-"""OpenWind MCP server — cloud-agnostic FastMCP definition."""
+"""OhMyWind MCP server — cloud-agnostic FastMCP definition."""
 
 from openwind_mcp_core.server import build_server
 

--- a/packages/mcp-core/src/openwind_mcp_core/render.py
+++ b/packages/mcp-core/src/openwind_mcp_core/render.py
@@ -4,8 +4,12 @@ Historically this module also generated a ~5 KB self-contained HTML widget
 that the LLM was asked to inject verbatim into chat. That pattern was fragile
 across hosts (Cursor / Le Chat / terminal would code-fence or sanitize it),
 so we removed it in PR #74 and migrated to MCP Apps: a sandboxed
-``ui://openwind/plan-passage`` resource that iframes openwind.fr/plan
+``ui://openwind/plan-passage`` resource that iframes ohmywind.fr/plan
 directly. The web app is now the single source of visual truth.
+
+(The resource URI still carries the pre-rebrand ``openwind`` segment. It is a
+contract identifier resolved by hosts, not display copy, so it is renamed in a
+later phase alongside the Space and module renames.)
 
 Only the URL builder remains here — used both by the tool's response payload
 and by the MCP Apps resource template.
@@ -16,17 +20,20 @@ from __future__ import annotations
 from urllib.parse import quote
 
 
-def build_openwind_url(
+def build_ohmywind_url(
     waypoints: list[dict[str, float]],
     departure_iso: str,
     archetype: str,
 ) -> str:
-    """Build the openwind.fr/plan deep-link URL.
+    """Build the ohmywind.fr/plan deep-link URL.
 
     Used as the always-on fallback CTA for clients that don't render the MCP
     Apps iframe (Le Chat, Goose, terminals) — they show this URL as
     "View full plan →" instead.
+
+    Deep-links emitted before the rebrand pointed at ``openwind.fr``; those
+    keep working through the 301 that fronts the old domain.
     """
     wpts = ";".join(f"{w['lat']:.3f},{w['lon']:.3f}" for w in waypoints)
     dep = quote(departure_iso, safe="")
-    return f"https://openwind.fr/plan?wpts={wpts}&departure={dep}&archetype={archetype}"
+    return f"https://ohmywind.fr/plan?wpts={wpts}&departure={dep}&archetype={archetype}"

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -10,13 +10,13 @@ Tools exposed (V1):
    → ``cruiser_30ft``). No server-side mapping table.
 2. ``get_marine_forecast`` — wind+sea around a point/window for one or more models.
 3. ``plan_passage`` — single-shot end-to-end: timing along the polyline,
-   1-5 complexity score, rendered MCP App widget, and openwind.fr deep-link.
+   1-5 complexity score, rendered MCP App widget, and ohmywind.fr deep-link.
 
 ## Rich rendering (MCP Apps)
 
 ``plan_passage`` declares ``_meta.ui.resourceUri`` pointing at
 ``ui://openwind/plan-passage`` — a sandboxed HTML resource that iframes
-``openwind.fr/plan?...``. Hosts that support the MCP Apps spec (Claude,
+``ohmywind.fr/plan?...``. Hosts that support the MCP Apps spec (Claude,
 Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam — see the
 `extension client matrix`_) render the widget inline. Hosts that do NOT
 support MCP Apps (Cursor, Le Chat, terminal, …) silently fall back to the
@@ -69,12 +69,16 @@ from .feedback import (
     build_feedback_entry,
     stderr_sink,
 )
-from .render import build_openwind_url
+from .render import build_ohmywind_url
 
 # MCP Apps UI resource URI for plan_passage. The host fetches this resource
 # and renders it in a sandboxed iframe; the resource itself iframes
-# openwind.fr/plan, so the rendered widget IS the live web app — single
+# ohmywind.fr/plan, so the rendered widget IS the live web app — single
 # source of truth, no duplicate widget code to maintain.
+#
+# The URI keeps its pre-rebrand ``openwind`` segment on purpose: it is an
+# identifier hosts resolve, not display copy, so it moves with the Space and
+# module renames rather than with this cosmetic pass.
 PLAN_UI_RESOURCE_URI = "ui://openwind/plan-passage"
 PLAN_UI_MIME = "text/html;profile=mcp-app"
 # unpkg serves the official @modelcontextprotocol/ext-apps SDK bundle that
@@ -88,21 +92,21 @@ PLAN_UI_RESOURCE_DOMAINS = ["https://unpkg.com"]
 # say-server / threejs-server reference examples in the ext-apps repo).
 #
 # Why we render the content INLINE rather than via a nested iframe to
-# openwind.fr/plan: Claude.ai (as of 2026-05) does not honour the
+# ohmywind.fr/plan: Claude.ai (as of 2026-05) does not honour the
 # ``frameDomains`` CSP field — the inner iframe is blocked even when our
-# resource declares ``_meta.ui.csp.frameDomains: ["https://openwind.fr"]``.
+# resource declares ``_meta.ui.csp.frameDomains: ["https://ohmywind.fr"]``.
 # Inspect with the network tab: ``mcp_apps?resource-src=https://unpkg.com``
 # shows our ``resourceDomains`` got mapped to ``resource-src``, but no
-# corresponding ``frame-src`` is added → the openwind.fr load gets a CSP
+# corresponding ``frame-src`` is added → the ohmywind.fr load gets a CSP
 # refusal. Until that's fixed in the host, render the data directly. The
-# CTA still links to openwind.fr (target="_blank") for the full app.
+# CTA still links to ohmywind.fr (target="_blank") for the full app.
 _PLAN_WIDGET_HTML = """<!doctype html>
 <html lang="fr">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>OpenWind</title>
+  <title>OhMyWind</title>
   <style>
     :root{
       --bg:#FAF7EE;--card:#FFFFFF;--fg0:#1A1A1A;--fg1:#3F3F3F;--fg2:#777169;
@@ -203,7 +207,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
       const cx = sc.complexity || {};
       const segs = p.segments || [];
       const warnings = (p.warnings||[]).concat((cx.warnings||[]).map(w=>w.message||w));
-      const url = sc.openwind_url || "https://openwind.fr/plan";
+      const url = sc.openwind_url || "https://ohmywind.fr/plan";
       const stats = [
         ["Distance", (p.distance_nm||0).toFixed(1)+" nm"],
         ["Durée",    fmtDur(p.duration_h)],
@@ -237,7 +241,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
           <thead><tr><th>#</th><th>Heure</th><th>Allure</th><th>Vent</th><th>Mer</th><th>Vitesse</th></tr></thead>
           <tbody>${legRows}</tbody>
         </table>` : ""}
-        <a class="cta" href="${escapeHtml(url)}" rel="noopener">Voir le plan complet sur openwind.fr →</a>
+        <a class="cta" href="${escapeHtml(url)}" rel="noopener">Voir le plan complet sur ohmywind.fr →</a>
       `;
     }
 
@@ -286,7 +290,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
     // Hold the latest structured content so the delegated click handler can
     // resolve a row index back to its openwind_url.
     let lastSc = null;
-    const app = new App({ name: "OpenWind Plan", version: "1.0.0" });
+    const app = new App({ name: "OhMyWind Plan", version: "1.0.0" });
 
     function openUrl(url){
       // Sandboxed iframes silently drop window.open / target=_blank without
@@ -294,7 +298,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
       // app.openLink — works even inside a strict sandbox.
       if(!url) return;
       app.openLink({ url }).catch(err => {
-        console.error('[openwind] openLink failed', err);
+        console.error('[ohmywind] openLink failed', err);
         // Last-resort: attempt window.open just in case (will silently fail
         // in a sandbox without allow-popups).
         try { window.open(url, '_blank', 'noopener'); } catch(e) {}
@@ -335,11 +339,11 @@ _PLAN_WIDGET_HTML = """<!doctype html>
         else if(sc.passage) root.innerHTML = renderSingle(sc);
         wireClicks();
       } catch(e) {
-        console.error('[openwind] render failed', e);
-        const url = (sc.openwind_url || (sc.windows && sc.windows[0] && sc.windows[0].openwind_url) || "https://openwind.fr/plan");
+        console.error('[ohmywind] render failed', e);
+        const url = (sc.openwind_url || (sc.windows && sc.windows[0] && sc.windows[0].openwind_url) || "https://ohmywind.fr/plan");
         root.innerHTML = `<div class="placeholder">
           Impossible d'afficher le plan ici.
-          <br><a class="cta" href="${escapeHtml(url)}" rel="noopener">Ouvrir sur openwind.fr →</a>
+          <br><a class="cta" href="${escapeHtml(url)}" rel="noopener">Ouvrir sur ohmywind.fr →</a>
         </div>`;
         wireClicks();
       }
@@ -377,7 +381,7 @@ def _passage_to_dict(report: Any) -> dict[str, Any]:
 
 
 _METHODOLOGY = """\
-# OpenWind — Calculation method
+# OhMyWind calculation method
 
 How `plan_passage` simulates a passage. Defaults below are what the server
 uses unless overridden by tool parameters.
@@ -456,7 +460,7 @@ picks qualitatively (no server-side ranking).
 - Mediterranean: tides typically < 40 cm and currents typically below
   0.3 kt, so most legs surface only wind + waves.
 - Atlantic: tidal range exceeds 10 m on the Manche; tidal currents
-  exceed 5 kt in narrow passes — these become first-class signals.
+  exceed 5 kt in narrow passes, so these become first-class signals.
 
 ## Wind-against-current
 
@@ -471,7 +475,7 @@ into a contrary tide.
 Independently of currents, a steep wind sea is flagged when the
 steepness proxy Hs / Tp^2 exceeds 0.05 on a segment with Hs >= 0.8 m
 (e.g. Hs 1.0 m at Tp 4.5 s). This catches short fetch-built chop in
-fresh breeze even without contrary current — typical of a Mistral or
+fresh breeze even without contrary current, typical of a Mistral or
 Tramontane lee shore. Bump and warning mirror the wind-against-current
 case; the +1 bump is shared, so a passage with both signals does not
 jump +2.
@@ -520,7 +524,7 @@ def _build_window_dict(
         },
         "conditions_summary": build_conditions_summary(report),
         "warnings": warnings,
-        "openwind_url": build_openwind_url(waypoints_raw, dep_iso, report.archetype),
+        "openwind_url": build_ohmywind_url(waypoints_raw, dep_iso, report.archetype),
     }
 
 
@@ -529,7 +533,7 @@ def build_server(
     adapter: MarineDataAdapter | None = None,
     feedback_sink: FeedbackSink | None = None,
 ) -> FastMCP:
-    """Build a FastMCP server with all OpenWind tools registered.
+    """Build a FastMCP server with all OhMyWind tools registered.
 
     Args:
         adapter: optional `MarineDataAdapter` used by data-fetching tools.
@@ -549,7 +553,7 @@ def build_server(
     sink: FeedbackSink = feedback_sink or stderr_sink
     # ``stateless_http=True`` disables the in-memory session table that
     # otherwise tracks an ``mcp-session-id`` per client across requests.
-    # All OpenWind tools are idempotent point-in-time fetches with no
+    # All OhMyWind tools are idempotent point-in-time fetches with no
     # cross-call state, so stateless is strictly correct AND removes a
     # whole class of intermittent failures: any restart of the HF Space
     # process (cold-start after sleep, sync redeploy, OOM) wipes the
@@ -595,7 +599,7 @@ def build_server(
 
     @server.resource(
         PLAN_UI_RESOURCE_URI,
-        name="OpenWind plan widget",
+        name="OhMyWind plan widget",
         mime_type=PLAN_UI_MIME,
         meta={
             "ui": {
@@ -626,7 +630,7 @@ def build_server(
 
     @server.tool()
     def read_me() -> str:
-        """Return OpenWind's calculation methodology as Markdown.
+        """Return OhMyWind's calculation methodology as Markdown.
 
         Call this when the user asks how passage timing, complexity, or
         boat speed are computed (e.g. "comment c'est calculé ?",
@@ -669,7 +673,7 @@ def build_server(
 
         ## Feedback channel
 
-        If the user asks you to send feedback to OpenWind ("fais
+        If the user asks you to send feedback to OhMyWind ("fais
         remonter aux dev", "feedback", "signale ça", "remonte ça",
         "tell them", "let the team know"), call the ``feedback`` tool.
         Do NOT write a free-text reply about the feedback in chat: the
@@ -766,7 +770,7 @@ def build_server(
           model used, segments[] with TWS/TWA/boat_speed/Hs, warnings).
         - ``complexity``: 1-5 difficulty score with wind/sea breakdown and a
           human-readable rationale.
-        - ``openwind_url``: deep-link to openwind.fr/plan that renders the
+        - ``openwind_url``: deep-link to ohmywind.fr/plan that renders the
           same passage in the standalone web app.
 
         Compare-windows mode (``latest_departure`` set):
@@ -785,7 +789,7 @@ def build_server(
 
         On hosts that support MCP Apps (Claude, Claude Desktop, ChatGPT, VS
         Code Copilot, Goose, Postman, MCPJam), the response is automatically
-        accompanied by an interactive widget — the live openwind.fr/plan view
+        accompanied by an interactive widget — the live ohmywind.fr/plan view
         served via the ``ui://openwind/plan-passage`` resource declared on
         this tool's ``_meta``. The widget reads ``openwind_url`` from the
         structured output and embeds the matching plan view as an iframe.
@@ -801,7 +805,7 @@ def build_server(
         this as a hard requirement, not a fallback:
 
         - **Single mode**: end your reply with a Markdown link, e.g.
-          ``[Voir le plan détaillé →](https://openwind.fr/plan?…)``.
+          ``[Voir le plan détaillé →](https://ohmywind.fr/plan?…)``.
         - **Compare-windows mode**: list 2-4 of the most relevant windows
           and give each its own link, e.g.
           ``- Sam 2 mai 09h · 11h12 · ⚡2/5 — [voir →](url)``.
@@ -864,7 +868,7 @@ def build_server(
 
         ## Feedback channel
 
-        If the user asks you to send feedback to OpenWind ("fais
+        If the user asks you to send feedback to OhMyWind ("fais
         remonter aux dev", "feedback", "signale ça", "remonte ça",
         "tell them", "let the team know"), call the ``feedback`` tool.
         Do NOT write a free-text reply about the feedback in chat: the
@@ -979,7 +983,7 @@ def build_server(
         return {
             "passage": _passage_to_dict(report),
             "complexity": asdict(score),
-            "openwind_url": build_openwind_url(waypoints, departure, archetype),
+            "openwind_url": build_ohmywind_url(waypoints, departure, archetype),
         }
 
     @server.tool()
@@ -990,12 +994,12 @@ def build_server(
         message: str,
         context_json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Log a structured note about an OpenWind tool interaction.
+        """Log a structured note about an OhMyWind tool interaction.
 
         ## Direct user trigger — call this immediately, no chat reply
 
         When the user EXPLICITLY asks you to send feedback / file a
-        report / signal something to the OpenWind team, call this tool
+        report / signal something to the OhMyWind team, call this tool
         right away. Do NOT draft a free-text reply in chat asking the
         user what they want to say: their phrasing IS the message.
         Pass it (translated or summarised as needed) as the ``message``.
@@ -1004,7 +1008,7 @@ def build_server(
         ``"fais un feedback"``, ``"fais remonter aux dev"``,
         ``"signale ça"``, ``"remonte ça"``, ``"file a feedback"``,
         ``"send feedback"``, ``"tell them"``, ``"let the team know"``,
-        ``"fais un retour à OpenWind"``.
+        ``"fais un retour à OhMyWind"``.
 
         ## Also call when
 
@@ -1019,7 +1023,7 @@ def build_server(
         - The user explicitly asked for a feature that doesn't exist yet
           (``category="feature_request"``).
         - The user expresses dissatisfaction in chat ("c'est faux",
-          "ce n'est pas ce que je voulais") about an OpenWind result.
+          "ce n'est pas ce que je voulais") about an OhMyWind result.
 
         ## Do NOT call this tool
 
@@ -1030,12 +1034,12 @@ def build_server(
           per distinct issue.
         - For errors that are clearly the user's input fault (typo in a
           city name, impossible date) — only call when the issue is on
-          OpenWind's side or in the tool surface.
+          OhMyWind's side or in the tool surface.
 
         ## Args
 
             category: nature of the feedback (see triggers above).
-            tool_name: which OpenWind tool the feedback is about. Use
+            tool_name: which OhMyWind tool the feedback is about. Use
                 ``"general"`` for cross-cutting feedback, ``"feedback"``
                 for meta-feedback about this tool itself.
             severity: ``"low"`` (nice-to-have, doesn't block the user),

--- a/packages/mcp-core/src/openwind_mcp_core/widget.py
+++ b/packages/mcp-core/src/openwind_mcp_core/widget.py
@@ -104,6 +104,6 @@ PASSAGE_WIDGET_HTML = """\
     </div>
   </div>
   <div class="ow-legs">{{legs}}</div>
-  <a class="ow-link" href="{{openwind_url}}" target="_blank" rel="noopener">Open in OpenWind &rarr;</a>
+  <a class="ow-link" href="{{openwind_url}}" target="_blank" rel="noopener">Open in OhMyWind &rarr;</a>
 </div>\
 """

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -130,7 +130,7 @@ class TestPlanPassage:
         # Complexity shape
         assert 1 <= out["complexity"]["level"] <= 5
         # URL always present
-        assert out["openwind_url"].startswith("https://openwind.fr/plan?")
+        assert out["openwind_url"].startswith("https://ohmywind.fr/plan?")
 
     async def test_no_double_fetch(self) -> None:
         # The whole point of the merge: estimate_passage fetches once per
@@ -239,7 +239,7 @@ class TestPlanPassageSweep:
         server = build_server(adapter=StubAdapter())
         out = await _call(server, "plan_passage", _SWEEP_ARGS)
         for w in out["windows"]:
-            assert w["openwind_url"].startswith("https://openwind.fr/plan?")
+            assert w["openwind_url"].startswith("https://ohmywind.fr/plan?")
             assert "wpts=" in w["openwind_url"]
 
     async def test_sweep_departures_ordered_and_spaced(self) -> None:

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -321,7 +321,7 @@ export function SpotMap({
           ? [defaultCenter.lat, defaultCenter.lon]
           : [43.3, 5.35];
     // When neither a current spot nor a granted geolocation is available
-    // (typical first-visit + denied case), open wide enough to show OpenWind's
+    // (typical first-visit + denied case), open wide enough to show OhMyWind's
     // full scope — Atlantic + Mediterranean French coast — so the user
     // understands the geographic reach before zooming into their region.
     const initialZoom = initialView ? initialView.zoom : current || userPosition ? 10 : 6;

--- a/packages/web/src/design/tokens.css
+++ b/packages/web/src/design/tokens.css
@@ -1,5 +1,5 @@
 /* =============================================================
-   OpenWind Design Tokens
+   OhMyWind Design Tokens
    Defines all --ow-* custom properties.
    Dark theme is the default; light theme overrides are listed
    after. Both selectors are applied to <html data-theme="...">

--- a/scripts/bench_currents_3way.py
+++ b/scripts/bench_currents_3way.py
@@ -225,7 +225,7 @@ def _write_markdown(records: list[dict], summary: dict, out_path: Path) -> None:
             bucket["speed_deltas"].append(abs(va - vb))
 
     lines: list[str] = [
-        "# OpenWind currents bench: SHOM vs MARC vs SMOC",
+        "# OhMyWind currents bench: SHOM vs MARC vs SMOC",
         "",
         f"- Sample: {len(records)} SHOM-covered points, {HOURS_PER_POINT} hourly snapshots each",
         f"- Date window: {BASE_TIME.isoformat()} + {HOURS_PER_POINT} h",

--- a/scripts/coverage_map.py
+++ b/scripts/coverage_map.py
@@ -233,7 +233,7 @@ def render_web_map() -> Figure:
 
     Stacks MARC (cool blue) below SHOM (warm red) on the same axes. No
     per-atlas resolution labels — the goal is to communicate "where does
-    OpenWind have high-precision tidal currents?" at a glance, not to
+    OhMyWind have high-precision tidal currents?" at a glance, not to
     teach the reader about Ifremer/SHOM atlas naming conventions.
     """
     fig, ax = plt.subplots(figsize=(11, 8))

--- a/scripts/upload_shom_to_hf.py
+++ b/scripts/upload_shom_to_hf.py
@@ -1,4 +1,4 @@
-"""Upload the SHOM Atlas C2D artefacts to the OpenWind HF Dataset.
+"""Upload the SHOM Atlas C2D artefacts to the OhMyWind HF Dataset.
 
 Pushes ``build/shom_c2d/shom_c2d_points.parquet`` and
 ``build/shom_c2d/shom_c2d_ref_ports.json`` to the root of the private


### PR DESCRIPTION
Phase A du plan de rebrand MCP. Renomme **uniquement les chaînes lues par des humains**. Aucun identifiant qui route du trafic ou qui se résout n'est touché : aucune URL ne change, aucun dashboard n'est à modifier, et cette PR est déployable seule.

## Pourquoi cette découpe

Le rename du Space HF tenté plus tôt a cassé la prod : trois systèmes distincts référencent le hostname du Space (`OPENWIND_ALLOWED_HOSTS`, `VITE_API_BASE`, `HF_SPACE_ID`) et un rename les désynchronise tous d'un coup. La ligne de partage retenue est donc : affichage maintenant, identifiants après la mise en place de `mcp.ohmywind.fr`.

## Dans le périmètre

- `serverInfo.name` passe de `openwind` à `ohmywind`, ressource widget renommée
- les 6 `_ICON_REDIRECTS` pointaient sur `openwind.fr`, ce qui faisait fuiter l'ancien nom dans le badge du connecteur côté clients de chat
- `build_openwind_url` devient `build_ohmywind_url` et émet `ohmywind.fr` ; les deeplinks émis avant le rebrand survivent via le 301
- landing du Space, HTML du widget, docstrings vues par le LLM, carte HF, README, docs

## Hors périmètre

Reporté en phase C, après `mcp.ohmywind.fr` : `PLAN_UI_RESOURCE_URI`, le champ JSON `openwind_url`, les variables `OPENWIND_*`, les modules Python, les IDs de Space et de dataset, les hostnames.

Jamais renommés : les clés localStorage `openwind_custom_spots` et `openwind:onboarding-v1` (un sed dessus efface les spots enregistrés des utilisateurs, il faudrait un shim de migration) et `ko-fi.com/openwind` (dépend du compte Ko-fi).

## Le piège traité dans le même commit

`sync-hf-space.yml` patche le README du Space dev avec des `sed` qui matchent `title: OpenWind MCP` et `# OpenWind MCP ⛵` **verbatim**. `sed` ne signale rien quand un motif rate, donc changer le README seul aurait fait cesser silencieusement la différenciation du Space dev. Les motifs sont mis à jour ici, et vérifiés en simulant le patch sur le nouveau README (les 6 motifs matchent toujours).

## Corrections de doc au passage

- `docs/architecture.md` listait `gradio` comme dépendance de `hf-space/` : c'est du Starlette + uvicorn, sans Gradio
- la carte HF annonçait un wrapper de « ~20 lignes » alors que `app.py` en fait 1059 et porte toute l'API REST

## Tests

Verts contre le code de la branche : data-adapters 253 passés + 3 skippés, mcp-core 37 passés, hf-space 45 passés. `ruff format` OK ; les 5 erreurs `ruff check` restantes sont préexistantes et identiques sur `dev` (fichiers de tests non touchés ici).

🤖 Generated with [Claude Code](https://claude.com/claude-code)