### PR TITLE
fix(web): dire le vrai délai d'attente après un 429

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -1015,6 +1015,12 @@ def build_app(mcp_app: Any) -> Starlette:
                 allow_origins=ALLOWED_ORIGINS,
                 allow_methods=["GET", "POST", "OPTIONS"],
                 allow_headers=["Content-Type"],
+                # Retry-After is set on our 429s, but a cross-origin fetch only
+                # sees the CORS-safelisted response headers unless the server
+                # opts the rest in here. Without this the web app cannot tell
+                # the user how long to wait and has to guess — which is how the
+                # copy ended up hard-coding "une minute" for a 5-minute window.
+                expose_headers=["Retry-After"],
             ),
             Middleware(SecurityHeadersMiddleware),
             Middleware(RateLimitMiddleware),

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -287,6 +287,29 @@ def test_rate_limited_response_carries_retry_after_and_cors(monkeypatch) -> None
     assert resp.headers["access-control-allow-origin"] == "https://ohmywind.fr"
     assert "rate limit" in resp.json()["error"]
 
+    # The assertion above on ``retry-after`` is NOT enough on its own, and that
+    # gap shipped once: TestClient reads the raw response, so it sees the header
+    # whether or not the browser would. A cross-origin fetch only gets the
+    # CORS-safelisted response headers plus whatever the server explicitly
+    # exposes, so without this the web app reads null and has to invent a delay.
+    exposed = {h.strip().lower() for h in resp.headers["access-control-expose-headers"].split(",")}
+    assert "retry-after" in exposed
+
+
+def test_retry_after_never_exceeds_the_configured_window(monkeypatch) -> None:
+    """The advertised delay must stay inside the window it is derived from.
+
+    Guards the copy contract the web app depends on: it renders whatever we
+    send here, so an out-of-range value becomes a wrong promise on screen.
+    """
+    counter = security._SlidingWindowCounter(max_requests=2, window_s=300.0, max_tracked_ips=10)
+    assert counter.check("1.2.3.4", now=1000.0) is None
+    assert counter.check("1.2.3.4", now=1001.0) is None
+
+    retry_after = counter.check("1.2.3.4", now=1002.0)
+    assert retry_after is not None
+    assert 1 <= retry_after <= 300
+
 
 def test_get_routes_and_mcp_are_not_rate_limited(monkeypatch) -> None:
     from starlette.testclient import TestClient

--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { formatRetryDelay, friendlyError } from "./passage";
+
+// Regression guard for the dev incident of 2026-08-01: the rate-limit copy
+// hard-coded "une minute" while the server ran a 300 s window, so the user
+// waited a minute, retried, and got the exact same message. The delay must
+// always come from the server's Retry-After, never from a constant here.
+describe("rate-limit copy", () => {
+  it("reports the delay the server actually asked for", () => {
+    const msg = friendlyError("rate limit exceeded, retry shortly, retry in 240s");
+    expect(msg).toContain("4 minutes");
+    expect(msg).not.toContain("une minute");
+  });
+
+  it("never hard-codes a delay when the server sent none", () => {
+    const msg = friendlyError("rate limit exceeded, retry shortly");
+    // Vague on purpose: guessing is what produced a message that contradicted
+    // the server. Anything numeric here would be invented.
+    expect(msg).toContain("quelques minutes");
+    expect(msg).not.toMatch(/\d/);
+  });
+
+  it("still recognises the rate-limit case at all", () => {
+    const msg = friendlyError("rate limit exceeded, retry shortly");
+    expect(msg).toContain("Trop de calculs");
+  });
+});
+
+describe("formatRetryDelay", () => {
+  it("uses seconds below a minute", () => {
+    expect(formatRetryDelay(45)).toBe("Patientez 45 secondes avant de relancer.");
+  });
+
+  it("rounds minutes up so the retry cannot be premature", () => {
+    // 250 s is 4 min 10 s: rounding down would send the user back one message
+    // too early, which is the failure mode this whole change exists to kill.
+    expect(formatRetryDelay(250)).toBe("Patientez 5 minutes avant de relancer.");
+  });
+
+  it("keeps the singular for exactly one minute", () => {
+    expect(formatRetryDelay(60)).toBe("Patientez 1 minute avant de relancer.");
+  });
+
+  it("falls back when the header is absent or nonsensical", () => {
+    for (const value of [null, 0, -5, Number.NaN]) {
+      expect(formatRetryDelay(value)).toBe("Patientez quelques minutes avant de relancer.");
+    }
+  });
+});

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -13,6 +13,32 @@ export interface PlanOverrides {
   polar?: PolarData;
 }
 
+// Render a Retry-After delay as a French sentence. Rounds up: telling someone
+// to wait 4 minutes when 4 min 10 s remain earns a second error message.
+export function formatRetryDelay(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds) || seconds <= 0) {
+    return "Patientez quelques minutes avant de relancer.";
+  }
+  if (seconds < 60) {
+    return `Patientez ${Math.ceil(seconds)} secondes avant de relancer.`;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return `Patientez ${minutes} minute${minutes > 1 ? "s" : ""} avant de relancer.`;
+}
+
+// Extract the error message from a non-OK response, carrying the Retry-After
+// delay along when the server sent one. It travels inside the message string
+// because every call site funnels through `friendlyError(e.message)`.
+async function toError(res: Response): Promise<Error> {
+  const err = (await res.json().catch(() => ({}))) as Record<string, string>;
+  const message = err["error"] ?? `Erreur serveur ${res.status}`;
+  const retryAfter = res.status === 429 ? res.headers.get("Retry-After") : null;
+  if (retryAfter && /^\d+$/.test(retryAfter.trim())) {
+    return new Error(`${message}, retry in ${retryAfter.trim()}s`);
+  }
+  return new Error(message);
+}
+
 // Translate known backend error messages to actionable French. Returns the
 // original string if no rule matches, so unknown errors stay debuggable.
 export function friendlyError(raw: string): string {
@@ -34,7 +60,17 @@ export function friendlyError(raw: string): string {
     return "Trop de waypoints sur cette route. Retirez-en quelques-uns pour la simplifier.";
   }
   if (/rate limit exceeded/i.test(raw)) {
-    return "Trop de calculs lancés coup sur coup. Patientez une minute avant de relancer.";
+    // The server owns the delay: the window is configurable per environment,
+    // so never hard-code one here. The previous copy promised "une minute"
+    // against a 300 s window, so the user waited, retried, and got the exact
+    // same error. When the header is missing we stay vague rather than lie.
+    //
+    // The suffix is appended by `toError` and is not adjacent to the server's
+    // own wording ("rate limit exceeded, retry shortly"), so it is matched
+    // separately rather than as an optional tail of the pattern above.
+    const retryIn = /retry in (\d+)s/i.exec(raw);
+    const seconds = retryIn ? Number(retryIn[1]) : null;
+    return `Trop de calculs lancés coup sur coup. ${formatRetryDelay(seconds)}`;
   }
   if (/unknown archetype/i.test(raw)) {
     return "Type de bateau inconnu. Sélectionnez un archétype dans la liste.";
@@ -81,10 +117,7 @@ export async function fetchPassage(params: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({})) as Record<string, string>;
-    throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
-  }
+  if (!res.ok) throw await toError(res);
   return res.json() as Promise<PassageResponse>;
 }
 
@@ -117,10 +150,7 @@ export async function fetchPassageWindows(params: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({})) as Record<string, string>;
-    throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
-  }
+  if (!res.ok) throw await toError(res);
   return res.json() as Promise<MultiWindowResponse>;
 }
 
@@ -147,10 +177,7 @@ export async function fetchPassageByEta(params: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({})) as Record<string, string>;
-    throw new Error(err["error"] ?? `Erreur serveur ${res.status}`);
-  }
+  if (!res.ok) throw await toError(res);
   return res.json() as Promise<PassageByEtaResponse>;
 }
 


### PR DESCRIPTION
Vu en dev : « Trop de calculs lancés coup sur coup. Patientez une minute avant de relancer. » Sauf que la fenêtre serveur est de **300 s**. On attend une minute, on relance, on retombe sur le même message.

Le Space dev tourne sur les défauts (seule `OPENWIND_ALLOWED_HOSTS` y est définie), donc **30 requêtes / 300 s** sur `/api/v1/passage` et `/api/v1/passage-by-eta`. En QA, une trentaine de clics en cinq minutes, c'est vite atteint.

## Trois défauts, dont un qui rendait le test existant trompeur

1. **La copie codait un délai en dur** au lieu de lire celui que le serveur envoie.
2. **`Retry-After` était invisible du navigateur.** Le serveur le pose correctement, mais `CORSMiddleware` n'avait pas d'`expose_headers` : un fetch cross-origin ne voit que les en-têtes CORS-safelistés. Le client lisait `null` et n'avait d'autre choix que de deviner.
3. **Le test qui assertait `Retry-After` passait quand même.** Le `TestClient` Starlette lit la réponse brute et ne modélise pas le filtrage du navigateur, donc l'assertion donnait une confiance que la prod ne méritait pas.

Le troisième point est le vrai sujet : le test couvrait la ligne sans couvrir le comportement.

## Ce qui change

- `expose_headers=["Retry-After"]` côté serveur
- le délai transite dans le message d'erreur, ce qui garde `friendlyError(string)` intact pour les deux call sites de `PlanPage`
- sans en-tête, la copie reste volontairement vague au lieu d'inventer un chiffre
- arrondi au supérieur : 4 min 10 s affiche 5 minutes, sinon on renvoie l'utilisateur un message trop tôt

## Tests

- `access-control-expose-headers` contient `retry-after` sur le 429. **Vérifié en échec sans le correctif** (`KeyError`), pour ne pas ajouter une assertion vide de plus.
- `Retry-After` reste borné par la fenêtre configurée.
- `passage.test.ts` interdit tout délai en dur côté client : le cas « pas d'en-tête » assert explicitement l'absence de chiffre dans le message.

hf-space 46 passés, web 122 passés sur 14 fichiers, eslint et `tsc -b` propres.

## Hors périmètre

Le réglage 30 / 300 s lui-même. Il est volontairement serré (un sweep compte pour une requête mais fanoute jusqu'à 14 jours d'appels Open-Meteo) et il est per-IP. Si la QA est gênée, `OPENWIND_RATE_LIMIT_REQUESTS` se change côté dashboard du Space dev, sans déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)