### PR TITLE
fix: bandeau de plan tactile, CORS retiré, rate limiting recalibré

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -50,7 +50,14 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette.routing import Mount, Route
 
-from security import ALLOWED_ORIGINS, RateLimitMiddleware, SecurityHeadersMiddleware
+from security import (
+    ALLOWED_ORIGINS,
+    TRUSTED_PROXY_HOPS,
+    RateLimitMiddleware,
+    SecurityHeadersMiddleware,
+    bucket_id,
+    forwarded_hop_count,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -455,6 +462,30 @@ async def _icon_redirect(request: Request) -> RedirectResponse:
 
 async def _api_archetypes(_request: Request) -> JSONResponse:
     return JSONResponse(list_archetypes_metadata())
+
+
+async def _api_client_debug(request: Request) -> JSONResponse:
+    """Report how this deployment sees the caller, for rate-limit diagnosis.
+
+    The rate limiter keys on the client address taken from the last
+    ``X-Forwarded-For`` hop. Whether that address is the real caller or a
+    fixed proxy address is a property of the hosting platform, and it cannot
+    be observed from outside: a single-bucket-for-everyone bug looks exactly
+    like "you share a NAT with someone busy". Two callers on different
+    networks comparing ``bucket`` here tell the two apart in one request each.
+
+    ``forwarded_hops == 0`` is the alarm: the platform strips the header, the
+    fallback address is an internal proxy, and every caller shares one bucket.
+    Returns no address, only a fingerprint of the caller's own.
+    """
+    return JSONResponse(
+        {
+            "bucket": bucket_id(request.scope),
+            "forwarded_hops": forwarded_hop_count(request.scope),
+            "trusted_hops": TRUSTED_PROXY_HOPS,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 async def _api_passage(request: Request) -> JSONResponse:
@@ -1000,6 +1031,7 @@ def build_app(mcp_app: Any) -> Starlette:
             Route("/", _index),
             *[Route(path, _icon_redirect, methods=["GET"]) for path in _ICON_REDIRECTS],
             Route("/api/v1/archetypes", _api_archetypes, methods=["GET"]),
+            Route("/api/v1/_client", _api_client_debug, methods=["GET"]),
             Route("/api/v1/passage", _api_passage, methods=["POST"]),
             Route("/api/v1/passage-by-eta", _api_passage_by_eta, methods=["POST"]),
             Route("/api/v1/marine/marc", _api_marc_overlay, methods=["GET"]),

--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -13,6 +13,7 @@ Space can diverge without a code change.
 
 from __future__ import annotations
 
+import hashlib
 import math
 import os
 import time
@@ -24,32 +25,39 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 # --------------------------------------------------------------------- CORS
 
-# Browsers are the only callers CORS constrains: MCP clients (Claude, Le Chat,
-# ...) reach /mcp server-to-server and never send an Origin. So this list only
-# has to cover the web app's own origins.
+# No allowlist here, and that is a deliberate, measured decision — not an
+# oversight. Do not "fix" this by reinstating one without re-running the
+# checks below.
 #
-# ohmywind.fr is canonical; openwind.fr is kept as a 301 source, and a browser
-# that followed the redirect still carries the *original* origin on the
-# subsequent XHR, so both families must be listed. localhost covers `vite dev`
-# (5173) and `vite preview` (4173) against a live backend.
-DEFAULT_ALLOWED_ORIGINS = [
-    "https://ohmywind.fr",
-    "https://www.ohmywind.fr",
-    "https://dev.ohmywind.fr",
-    "https://openwind.fr",
-    "https://www.openwind.fr",
-    "https://dev.openwind.fr",
-    "http://localhost:5173",
-    "http://localhost:4173",
-]
-
-ALLOWED_ORIGINS = [
-    o.strip()
-    for o in os.environ.get("OPENWIND_ALLOWED_ORIGINS", ",".join(DEFAULT_ALLOWED_ORIGINS)).split(
-        ","
-    )
-    if o.strip()
-]
+# An allowlist was implemented and shipped to the dev Space, then found to be
+# inert: Hugging Face's edge proxy answers CORS preflights itself and rewrites
+# the CORS headers on every response, so nothing the application decides ever
+# reaches the browser. Measured on the deployed Space:
+#
+#   OPTIONS /api/v1/passage
+#     Origin: https://evil.example.com          -> 200 + acao: evil.example.com
+#     Access-Control-Request-Method: DELETE     -> allow-methods: DELETE
+#
+# DELETE is not in this app's allowed methods, and Starlette answers a
+# disallowed preflight with 400 (verified locally against this exact code).
+# Getting a 200 that echoes DELETE proves the request never reached us. The
+# edge also stamps `access-control-expose-headers: *` on plain 404s, a header
+# this app never sets.
+#
+# Keeping a restrictive list would have been worse than having none: it reads
+# as an active control in code review and in the threat model, while providing
+# zero protection in production. False assurance is the real hazard.
+#
+# The protection that *does* hold on this platform is the rate limiter below,
+# which lives in the container and is out of the edge's reach.
+#
+# IF THIS EVER MOVES OFF HUGGING FACE (Fly, Modal, VPS): re-add an allowlist.
+# Application-level CORS is effective everywhere the edge does not pre-empt
+# it. The origins to use are ohmywind.fr and www/dev variants, plus the
+# openwind.fr family which is kept as a 301 source (a browser that followed
+# the redirect still sends the original origin on the subsequent XHR), plus
+# http://localhost:5173 and :4173 for `vite dev` / `vite preview`.
+ALLOWED_ORIGINS = ["*"]
 
 
 # ----------------------------------------------------------------- client IP
@@ -90,6 +98,29 @@ def resolve_client_ip(scope: Scope, *, hops: int = TRUSTED_PROXY_HOPS) -> str:
 
     client = scope.get("client")
     return client[0] if client else "unknown"
+
+
+def forwarded_hop_count(scope: Scope) -> int:
+    """Number of entries in X-Forwarded-For, 0 when the header is absent."""
+    for name, value in scope.get("headers", ()):
+        if name == b"x-forwarded-for":
+            return len([p for p in value.decode("latin-1").split(",") if p.strip()])
+    return 0
+
+
+def bucket_id(scope: Scope) -> str:
+    """Short, stable fingerprint of the rate-limit key for this caller.
+
+    Exists to answer one operational question that cannot be settled from
+    outside: does the platform's edge forward the real client address, or do
+    all callers collapse into a single bucket? Two clients on different
+    networks comparing this value settle it in one request each.
+
+    Only ever reports the caller's own bucket, and never the address itself.
+    Unsalted on purpose: a salt would change on every process restart and
+    would make two clients' readings incomparable, which is the whole point.
+    """
+    return hashlib.sha256(resolve_client_ip(scope).encode()).hexdigest()[:8]
 
 
 # -------------------------------------------------------------- rate limiter
@@ -178,8 +209,21 @@ class _SlidingWindowCounter:
 # legitimate MCP session doing many tool calls is never throttled.
 DEFAULT_LIMITED_PATHS = ("/api/v1/passage", "/api/v1/passage-by-eta")
 
+# 30 requests per 60s, not per 300s. The bucket key is an IP, so everyone
+# behind one NAT shares it: a marina wifi, an office, a mobile carrier on
+# CGNAT. We hit this for real during validation — three clients on one public
+# IP exhausted a 5-minute budget and a legitimate first request was refused.
+#
+# Shortening the window keeps the same instantaneous ceiling while making an
+# accidental block cost 60s instead of 300s. It is also the right shape for
+# the actual threat: a human iterating on a route makes a handful of requests
+# per minute, a scripted loop makes hundreds per second, and only the latter
+# should ever see a 429.
+#
+# The web client posts a `forecast_cache`, so its requests are served without
+# any Open-Meteo call. Being generous here costs us almost nothing upstream.
 RATE_LIMIT_MAX_REQUESTS = int(os.environ.get("OPENWIND_RATE_LIMIT_REQUESTS", "30"))
-RATE_LIMIT_WINDOW_S = float(os.environ.get("OPENWIND_RATE_LIMIT_WINDOW_S", "300"))
+RATE_LIMIT_WINDOW_S = float(os.environ.get("OPENWIND_RATE_LIMIT_WINDOW_S", "60"))
 RATE_LIMIT_MAX_IPS = int(os.environ.get("OPENWIND_RATE_LIMIT_MAX_IPS", "5000"))
 
 
@@ -223,7 +267,12 @@ class RateLimitMiddleware:
         response = JSONResponse(
             {"error": "rate limit exceeded, retry shortly"},
             status_code=429,
-            headers={"Retry-After": str(retry_after)},
+            headers={
+                "Retry-After": str(retry_after),
+                # Lets a support conversation distinguish "you share an IP with
+                # a busy neighbour" from "everyone lands in one bucket".
+                "X-RateLimit-Bucket": bucket_id(scope),
+            },
         )
         await response(scope, receive, send)
 

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -203,7 +203,7 @@ def client():
     return TestClient(app.build_app(_StubMcpApp()))
 
 
-def test_preflight_from_allowed_origin_is_accepted(client) -> None:
+def test_preflight_from_the_web_app_origin_is_accepted(client) -> None:
     resp = client.options(
         "/api/v1/passage",
         headers={
@@ -213,36 +213,22 @@ def test_preflight_from_allowed_origin_is_accepted(client) -> None:
         },
     )
     assert resp.status_code == 200
-    assert resp.headers["access-control-allow-origin"] == "https://ohmywind.fr"
+    assert resp.headers["access-control-allow-origin"] == "*"
 
 
-def test_preflight_from_legacy_domain_is_accepted(client) -> None:
-    # openwind.fr is 301'd to ohmywind.fr, but a browser mid-migration still
-    # sends the original origin on the XHR that follows.
-    resp = client.options(
-        "/api/v1/passage",
-        headers={
-            "Origin": "https://openwind.fr",
-            "Access-Control-Request-Method": "POST",
-        },
-    )
-    assert resp.headers.get("access-control-allow-origin") == "https://openwind.fr"
+def test_cors_is_deliberately_open(client) -> None:
+    """Guards the decision, not an accident.
 
+    An allowlist was implemented and deployed, then removed: Hugging Face's
+    edge answers preflights itself and rewrites CORS headers, so the app's
+    verdict never reached a browser. Keeping an inert allowlist would have
+    read as an active control while protecting nothing.
 
-def test_preflight_from_unknown_origin_is_refused(client) -> None:
-    resp = client.options(
-        "/api/v1/passage",
-        headers={
-            "Origin": "https://evil.example.com",
-            "Access-Control-Request-Method": "POST",
-        },
-    )
-    assert "access-control-allow-origin" not in resp.headers
-
-
-def test_no_wildcard_origin_anywhere(client) -> None:
-    resp = client.get("/api/v1/archetypes", headers={"Origin": "https://evil.example.com"})
-    assert resp.headers.get("access-control-allow-origin") != "*"
+    If this assertion ever fails because someone re-added a list, that is the
+    moment to re-check whether the platform still pre-empts CORS (see the
+    reproduction in security.py) rather than to just update the test.
+    """
+    assert security.ALLOWED_ORIGINS == ["*"]
 
 
 def test_security_headers_present(client) -> None:
@@ -283,8 +269,9 @@ def test_rate_limited_response_carries_retry_after_and_cors(monkeypatch) -> None
 
     assert resp.status_code == 429
     assert int(resp.headers["retry-after"]) >= 1
-    # Without this the browser reports an opaque CORS error instead of the 429.
-    assert resp.headers["access-control-allow-origin"] == "https://ohmywind.fr"
+    # Without this the browser reports an opaque CORS error instead of the 429,
+    # and the user never sees the real reason or the retry delay.
+    assert resp.headers["access-control-allow-origin"] == "*"
     assert "rate limit" in resp.json()["error"]
 
     # The assertion above on ``retry-after`` is NOT enough on its own, and that
@@ -350,15 +337,59 @@ def _init_with_limit(max_requests: int):
     return _init
 
 
-# ------------------------------------------------------------- allowlist
+# -------------------------------------------------- bucket diagnostics
 
 
-def test_default_allowlist_covers_both_domains_and_has_no_wildcard() -> None:
-    assert "*" not in security.ALLOWED_ORIGINS
-    for origin in (
-        "https://ohmywind.fr",
-        "https://dev.ohmywind.fr",
-        "https://openwind.fr",
-        "https://dev.openwind.fr",
-    ):
-        assert origin in security.ALLOWED_ORIGINS
+def test_bucket_id_is_stable_and_short() -> None:
+    scope = _scope(**{"x-forwarded-for": "1.2.3.4, 203.0.113.7"})
+    assert security.bucket_id(scope) == security.bucket_id(scope)
+    assert len(security.bucket_id(scope)) == 8
+
+
+def test_bucket_id_differs_between_clients() -> None:
+    a = security.bucket_id(_scope(**{"x-forwarded-for": "203.0.113.7"}))
+    b = security.bucket_id(_scope(**{"x-forwarded-for": "203.0.113.8"}))
+    assert a != b
+
+
+def test_bucket_id_leaks_no_address() -> None:
+    assert "203.0.113.7" not in security.bucket_id(_scope(**{"x-forwarded-for": "203.0.113.7"}))
+
+
+def test_bucket_id_ignores_a_spoofed_prefix() -> None:
+    # Same property as the rate-limit key: it is the same function.
+    plain = security.bucket_id(_scope(**{"x-forwarded-for": "203.0.113.7"}))
+    spoofed = security.bucket_id(_scope(**{"x-forwarded-for": "9.9.9.9, 203.0.113.7"}))
+    assert plain == spoofed
+
+
+def test_forwarded_hop_count() -> None:
+    assert security.forwarded_hop_count(_scope()) == 0
+    assert security.forwarded_hop_count(_scope(**{"x-forwarded-for": "1.1.1.1"})) == 1
+    assert security.forwarded_hop_count(_scope(**{"x-forwarded-for": "1.1.1.1, 2.2.2.2"})) == 2
+
+
+def test_rate_limited_response_exposes_the_bucket(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    app = _load_app()
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(1))
+    client = TestClient(app.build_app(_StubMcpApp()))
+
+    client.post("/api/v1/passage", json={})
+    resp = client.post("/api/v1/passage", json={})
+    assert resp.status_code == 429
+    assert len(resp.headers["x-ratelimit-bucket"]) == 8
+
+
+def test_client_debug_route_reports_hops_without_leaking_the_address(client) -> None:
+    resp = client.get("/api/v1/_client", headers={"X-Forwarded-For": "9.9.9.9, 203.0.113.7"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["forwarded_hops"] == 2
+    assert body["trusted_hops"] == security.TRUSTED_PROXY_HOPS
+    assert len(body["bucket"]) == 8
+    # forwarded_hops == 0 in production would mean every caller shares one
+    # bucket; the whole point of the route is to make that visible.
+    assert "203.0.113.7" not in resp.text
+    assert "9.9.9.9" not in resp.text

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -91,10 +91,25 @@ function fmtTime(iso: string) {
 // Renders the exact same HeroCell as the desktop sidebar block
 // (Distance / Durée / Arrivée) inside a single glass strip, so both
 // surfaces are visually and structurally identical.
-function PlanHeroStats({ passage }: { passage: PassageReport }) {
+function PlanHeroStats({ passage, onOpen }: { passage: PassageReport; onOpen?: () => void }) {
+  // `pointer-events-auto` is load-bearing: the wrapper below sets
+  // `pointer-events-none` so map gestures pass through the empty space around
+  // this strip. Without re-enabling it here, a tap on the strip itself fell
+  // through to Leaflet and silently appended a waypoint to the route being
+  // edited — the banner looked inert while quietly corrupting the plan.
   return (
     <div
-      className="rounded-xl px-3.5 py-2.5 grid grid-cols-3 gap-3"
+      role="button"
+      tabIndex={0}
+      aria-label="Voir le détail du passage"
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen?.();
+        }
+      }}
+      className="pointer-events-auto cursor-pointer rounded-xl px-3.5 py-2.5 grid grid-cols-3 gap-3"
       style={{ background: "var(--ow-surface-glass)", backdropFilter: "blur(8px)", border: "1px solid var(--ow-line-2)" }}
     >
       <HeroCell label="Distance" value={fr1(passage.distance_nm)} unit="nm" />
@@ -873,7 +888,7 @@ export function PlanPage() {
               drawer. Complexity is read from the colored route itself. */}
           {passage && planMode === "single" && !isStale && (
             <div className="lg:hidden absolute bottom-2 left-2 right-2 z-[400] pointer-events-none">
-              <PlanHeroStats passage={passage} />
+              <PlanHeroStats passage={passage} onOpen={() => drawerRef.current?.expand()} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Suites de la phase 0, toutes remontées par la QA ou par l'usage réel sur dev.

## J5, le blocage QA

Le conteneur de l'overlay mobile porte `pointer-events-none` pour laisser passer les gestes de carte autour du bandeau. Rien ne le réactivait sur le bandeau lui-même : un tap traversait jusqu'à Leaflet et **ajoutait silencieusement un waypoint à la route en cours d'édition**. Le bandeau semblait inerte tout en corrompant le plan.

Corrigé par `pointer-events-auto`, et le tap ouvre le tiroir de détail, ce que le doc QA attendait déjà. Le défaut est identique sur `main`, ce n'est donc pas une régression du lot, mais il bloquait la promotion.

## CORS retiré, parce qu'il était inerte

Mesuré sur le Space déployé :

```
OPTIONS /api/v1/passage
  Origin: https://evil.example.com       -> 200 + acao: evil.example.com
  Access-Control-Request-Method: DELETE  -> allow-methods: DELETE
```

`DELETE` n'est pas dans les méthodes autorisées de l'app, et Starlette répond 400 à un préflight refusé, vérifié en local sur ce même code. Un 200 qui renvoie `DELETE` en écho prouve que la requête n'atteint jamais le conteneur. L'edge appose aussi `access-control-expose-headers: *` sur de simples 404, en-tête que l'app ne pose nulle part.

Garder une allowlist inerte aurait été pire que ne pas en avoir : elle se lit comme un contrôle actif en revue et dans le modèle de menace, sans rien protéger. La reproduction complète reste dans `security.py`, avec la consigne de la restaurer le jour où on quitte HF.

## Rate limiting, 30 / 60 s

Le faux positif s'est produit pour de vrai : trois clients derrière la même IP publique ont vidé le budget de 5 minutes, et une première requête légitime s'est fait refuser. La clé étant une IP, tout un wifi de capitainerie ou un opérateur en CGNAT partagent un compteur.

Fenêtre raccourcie : même plafond instantané, mais un blocage accidentel coûte 60 s au lieu de 300 s. Le front envoie de toute façon un `forecast_cache`, donc ses requêtes ne déclenchent aucun appel Open-Meteo.

La copy annonçait « patientez une minute » en dur pendant que le serveur renvoyait `Retry-After: 202`. On lit maintenant l'en-tête et on annonce le vrai délai.

## Diagnostic ajouté

`GET /api/v1/_client` retourne une empreinte de la clé de bucket et le nombre de hops `X-Forwarded-For`, sans jamais renvoyer d'adresse. Il répond à une question qu'on ne peut pas trancher de l'extérieur : la plateforme transmet-elle l'IP réelle, ou tout le monde partage-t-il un seul compteur ? Les deux cas produisent exactement le même symptôme vu du client. `forwarded_hops` à 0 serait l'alarme.

**C'est la vérification à faire dès que dev a rebuild**, avant toute promotion vers `main`.

## Vérifications

339 tests Python, 115 tests web, build OK, ruff propre, lint web inchangé (26 problèmes, tous pré-existants sur `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)