### PR TITLE
chore(ci): monter les actions aux majeures supportées

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     name: Python (data-adapters, mcp-core, hf-space)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9
         with:
           enable-cache: true
 
@@ -66,9 +66,9 @@ jobs:
     name: Web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pinned to an exact version: setup-uv only publishes a floating major
+      # tag up to v7, so `@v9` does not resolve at all.
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -31,7 +31,7 @@ jobs:
       HF_SPACE_ID_DEV: ${{ vars.HF_SPACE_ID_DEV || 'qdonnars/openwind-mcp-dev' }}
     steps:
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve target Space
         run: |


### PR DESCRIPTION
Chaque run de la CI que je viens d'ajouter porte une annotation GitHub : `actions/checkout@v4`, `actions/setup-node@v4` et `astral-sh/setup-uv@v5` ciblent Node 20, déprécié sur les runners et déjà forcé en Node 24.

C'est un avertissement aujourd'hui, une rupture à terme. Passage aux majeures courantes : `checkout@v7`, `setup-node@v7`, `setup-uv@v9`.

La CI de cette PR est elle-même la vérification : si une de ces versions n'existait pas ou changeait de contrat, le run échouerait ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)