### PR TITLE
fix(hf-space): ne plus casser la page vitrine du Space avec X-Frame-Options

### DIFF
--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -283,16 +283,36 @@ class RateLimitMiddleware:
 class SecurityHeadersMiddleware:
     """Add the baseline response headers to every route.
 
-    ``X-Frame-Options: DENY`` is safe here: nothing this app serves over HTTP
-    is meant to be framed. The MCP Apps widget is delivered as an MCP resource
-    (``text/html;profile=mcp-app``) that the host inlines into its own
-    sandboxed iframe — it is never fetched from this origin.
+    Framing is restricted with CSP ``frame-ancestors`` rather than
+    ``X-Frame-Options``, and it is NOT a blanket deny. A Hugging Face Space
+    page (``huggingface.co/spaces/<owner>/<name>``) renders the Space inside
+    an iframe pointing at ``<slug>.hf.space``: that *is* the Space UI. A
+    ``DENY`` shipped here blanks the project's own landing page on the HF
+    catalogue, which is exactly what happened on 2026-08-01.
+
+    ``X-Frame-Options`` is deliberately absent. It cannot express an
+    allowlist (``ALLOW-FROM`` is dead), and while the CSP spec says
+    ``frame-ancestors`` supersedes it, sending both invites a browser that
+    honours the stricter one to break the page again. One header, one source
+    of truth.
+
+    The MCP Apps widget is unaffected either way: it travels as an MCP
+    resource (``text/html;profile=mcp-app``) that the host inlines into its
+    own sandboxed iframe, never fetched from this origin.
     """
+
+    # Overridable so a non-HF deployment can tighten this back to 'none'.
+    FRAME_ANCESTORS = os.environ.get(
+        "OPENWIND_FRAME_ANCESTORS", "'self' https://huggingface.co https://*.hf.space"
+    )
 
     HEADERS = (
         (b"x-content-type-options", b"nosniff"),
-        (b"x-frame-options", b"DENY"),
         (b"referrer-policy", b"strict-origin-when-cross-origin"),
+        (
+            b"content-security-policy",
+            f"frame-ancestors {FRAME_ANCESTORS}".encode("latin-1"),
+        ),
     )
 
     def __init__(self, app: ASGIApp) -> None:

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -234,12 +234,31 @@ def test_cors_is_deliberately_open(client) -> None:
 def test_security_headers_present(client) -> None:
     resp = client.get("/api/v1/archetypes")
     assert resp.headers["x-content-type-options"] == "nosniff"
-    assert resp.headers["x-frame-options"] == "DENY"
     assert resp.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+    assert "frame-ancestors" in resp.headers["content-security-policy"]
 
 
 def test_security_headers_on_the_landing_page(client) -> None:
     assert client.get("/").headers["x-content-type-options"] == "nosniff"
+
+
+def test_the_hf_space_page_can_still_frame_the_landing_page(client) -> None:
+    """Regression guard for the outage of 2026-08-01.
+
+    A Space's page on huggingface.co renders the app in an iframe pointing at
+    <slug>.hf.space. Shipping `X-Frame-Options: DENY` blanked the project's
+    own landing page on the HF catalogue. If this ever tightens back to a
+    blanket deny, that page breaks again with no error anywhere in our logs.
+    """
+    csp = client.get("/").headers["content-security-policy"]
+    assert "https://huggingface.co" in csp
+    assert "'none'" not in csp
+
+
+def test_x_frame_options_is_not_sent(client) -> None:
+    # frame-ancestors is the single source of truth. Sending both risks a
+    # browser honouring the stricter X-Frame-Options and re-breaking framing.
+    assert "x-frame-options" not in client.get("/").headers
 
 
 def test_rate_limit_triggers_on_repeated_posts(monkeypatch) -> None:


### PR DESCRIPTION
Correctif d'un défaut que j'ai introduit en phase 0 et qui est actuellement en prod.

## Le défaut

La page d'un Space sur huggingface.co affiche l'application **dans une iframe** pointant vers `<slug>.hf.space`. C'est le modèle même de HF Spaces. Le `X-Frame-Options: DENY` du durcissement blanchit donc la page vitrine du projet sur le catalogue HF :

```
Le chargement de « https://qdonnars-openwind-mcp.hf.space/ » dans un cadre
est refusé par la directive « X-Frame-Options » définie à « deny »
```

Le commentaire qui accompagnait l'en-tête affirmait que DENY était sûr « puisque rien ici n'est censé être iframé ». L'analyse portait sur le widget MCP Apps, qui est effectivement hors sujet, et manquait le cas évident. Le plan de phase 0 demandait pourtant explicitement de vérifier ce point avant de poser un deny global.

## Le correctif

CSP `frame-ancestors`, qui sait exprimer une allowlist là où `X-Frame-Options` ne le peut pas :

```
content-security-policy: frame-ancestors 'self' https://huggingface.co https://*.hf.space
```

La protection contre le clickjacking par un site tiers est conservée, seul le cas légitime est rouvert. Surchargeable via `OPENWIND_FRAME_ANCESTORS` pour qu'un déploiement hors HF resserre à `'none'`.

`X-Frame-Options` est **retiré**, pas ajusté. Il ne sait pas exprimer d'allowlist (`ALLOW-FROM` est mort), et bien que la spec CSP dise que `frame-ancestors` le supersède, envoyer les deux expose à ce qu'un navigateur honore le plus strict et recasse la page.

## Portée de l'incident

La page vitrine HF uniquement. L'URL directe du Space, l'endpoint `/mcp` et l'app web sur ohmywind.fr n'ont jamais été affectés.

## Vérifications

377 tests Python, ruff propre. En local sur le serveur réel :

```
content-security-policy: frame-ancestors 'self' https://huggingface.co https://*.hf.space
x-frame-options : absent
```

Test de non-régression ajouté : il vérifie que `huggingface.co` reste autorisé et qu'aucun `X-Frame-Options` ne repart. Sans ce garde-fou, un futur resserrage recasserait la vitrine sans qu'aucun log ne le signale.

**À promouvoir vers `main` dès merge**, le défaut est en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)