### PR TITLE
feat(edge-proxy): Worker Cloudflare devant les Spaces MCP

### DIFF
--- a/packages/edge-proxy/README.md
+++ b/packages/edge-proxy/README.md
@@ -1,0 +1,74 @@
+# edge-proxy
+
+Cloudflare Worker that serves the MCP endpoint on our own domain.
+
+| Public URL | Origin |
+| --- | --- |
+| `https://mcp.ohmywind.fr/mcp` | `qdonnars-openwind-mcp.hf.space` |
+| `https://mcp-dev.ohmywind.fr/mcp` | `qdonnars-openwind-mcp-dev.hf.space` |
+
+## Why
+
+MCP clients store the endpoint URL in their config. While that URL is a
+`*.hf.space` hostname we do not own it, so anything that changes it breaks every
+client at once. That is not hypothetical: renaming the prod Space on 2026-08-01
+took the endpoint down, because three separate systems referenced the Space
+hostname and a rename desynchronised all of them.
+
+With the proxy in front, the Space name becomes an implementation detail. Moving
+to Fly, Scaleway or a VPS later is one edit to `ORIGINS` in `src/index.js`, and
+no user changes anything.
+
+This also unblocks listing in the official MCP registry: the URL published there
+gets copied into directories, articles and user configs we do not control, so it
+has to be one we can keep.
+
+## Deploy
+
+Dashboard: Workers & Pages -> Create -> Worker, paste `src/index.js`, deploy,
+then attach both routes from `wrangler.toml` under the Worker's Settings ->
+Domains & Routes.
+
+Or with wrangler, from this directory:
+
+```sh
+npx wrangler deploy
+```
+
+The routes in `wrangler.toml` are applied on deploy. `zone_name` must stay
+`ohmywind.fr`.
+
+## Coupled configuration
+
+Two Space variables have to match this proxy. Getting either wrong produces a
+failure that does not name its cause.
+
+| Variable | Value | If wrong |
+| --- | --- | --- |
+| `OPENWIND_ALLOWED_HOSTS` | must list the public hostname **and** keep the `*.hf.space` one | `421 Invalid Host header` on `/mcp` |
+| `OPENWIND_TRUSTED_PROXY_HOPS` | `2` | every user shares one rate-limit bucket, so 429s unrelated to real usage |
+
+The `*.hf.space` hostname stays in `OPENWIND_ALLOWED_HOSTS` because that is the
+Host the proxy presents upstream. Removing it cuts the proxy off.
+
+`TRUSTED_PROXY_HOPS` is 2 because the chain reaching the app is
+`<client>, <cloudflare egress>`: Cloudflare adds one hop in front of Hugging
+Face. The Worker overwrites `X-Forwarded-For` with `CF-Connecting-IP` so that
+chain is exactly two entries whatever the caller sends, which is what makes the
+count safe to hard-code.
+
+## Order of operations when cutting over
+
+1. Add the public hostname to `OPENWIND_ALLOWED_HOSTS` **before** any traffic
+   reaches it.
+2. Deploy the Worker and attach the routes.
+3. Verify `mcp-dev.ohmywind.fr` answers an MCP `initialize`.
+4. Only then set `OPENWIND_TRUSTED_PROXY_HOPS=2` on both Spaces.
+5. Point `VITE_API_BASE` at the public hostnames in Cloudflare Pages and
+   redeploy. It is a build-time variable, so it needs a new build.
+
+## Not handled here
+
+Free Spaces sleep after 48 h of inactivity, so a first request after a long
+quiet spell wakes a cold container. The proxy cannot help with that; a scheduled
+ping keeps the Space warm instead.

--- a/packages/edge-proxy/src/index.js
+++ b/packages/edge-proxy/src/index.js
@@ -1,0 +1,84 @@
+/**
+ * Reverse proxy putting our own domain in front of the MCP Spaces.
+ *
+ * Why this exists: MCP clients store the endpoint URL in their config. As long
+ * as that URL is a `*.hf.space` hostname, we do not control it, and anything
+ * that changes it (renaming the Space, moving off Hugging Face) breaks every
+ * client at once. Fronting the Spaces with `mcp.ohmywind.fr` makes the backend
+ * an implementation detail: changing it is one edit to ORIGINS below.
+ *
+ * Hugging Face routes Spaces by Host header, so the proxy has to present the
+ * origin's own hostname upstream. That happens implicitly: the runtime derives
+ * `Host` from the request URL, so rewriting the URL's hostname is enough. There
+ * is no way to set `Host` directly in a Worker, and no need to.
+ */
+
+// Public hostname -> Space hostname. The only place the backend is named.
+const ORIGINS = {
+  "mcp.ohmywind.fr": "qdonnars-openwind-mcp.hf.space",
+  "mcp-dev.ohmywind.fr": "qdonnars-openwind-mcp-dev.hf.space",
+};
+
+export default {
+  async fetch(request) {
+    const incoming = new URL(request.url);
+    const origin = ORIGINS[incoming.hostname];
+    if (!origin) {
+      // A route was attached to a hostname this map does not know about.
+      // Failing loudly beats proxying somewhere unintended.
+      return new Response("Unknown host\n", {
+        status: 404,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const upstreamUrl = new URL(request.url);
+    upstreamUrl.protocol = "https:";
+    upstreamUrl.hostname = origin;
+    upstreamUrl.port = "";
+
+    // Constructing a new Request is what makes the headers mutable; the
+    // incoming request's are frozen. Method, body and the body's streaming
+    // nature are carried over, so SSE and chunked responses still stream.
+    const upstream = new Request(upstreamUrl, request);
+
+    // Collapse X-Forwarded-For to the single address Cloudflare vouches for.
+    //
+    // Cloudflare *appends* the real client to whatever XFF the caller sent, so
+    // a caller can pad the list and shift the positions the origin counts from.
+    // The Space resolves the client IP by counting entries from the right
+    // (OPENWIND_TRUSTED_PROXY_HOPS), so a padded list means a wrong rate-limit
+    // key. Overwriting with CF-Connecting-IP makes the chain reaching the app
+    // exactly `<client>, <cloudflare egress>`: deterministic, and unspoofable
+    // because CF-Connecting-IP is set by the edge, not by the caller.
+    //
+    // This is what pins OPENWIND_TRUSTED_PROXY_HOPS to 2 on both Spaces. Left
+    // at 1, the app reads Cloudflare's egress IP and every user in the world
+    // shares one rate-limit bucket.
+    const clientIp = request.headers.get("CF-Connecting-IP");
+    if (clientIp) {
+      upstream.headers.set("X-Forwarded-For", clientIp);
+    } else {
+      upstream.headers.delete("X-Forwarded-For");
+    }
+
+    // `manual` keeps 3xx responses as data instead of chasing them ourselves,
+    // which would drop the Host rewrite on the follow-up request.
+    const response = await fetch(upstream, { redirect: "manual" });
+
+    // A redirect whose Location still names the Space would hand the origin
+    // hostname straight back to the client, undoing the whole point of this
+    // proxy. Rewrite it back to the public hostname.
+    const location = response.headers.get("Location");
+    if (location && location.includes(origin)) {
+      const rewritten = new Response(response.body, response);
+      rewritten.headers.set(
+        "Location",
+        location.replaceAll(origin, incoming.hostname),
+      );
+      return rewritten;
+    }
+
+    return response;
+  },
+};

--- a/packages/edge-proxy/wrangler.toml
+++ b/packages/edge-proxy/wrangler.toml
@@ -1,0 +1,12 @@
+name = "ohmywind-mcp-proxy"
+main = "src/index.js"
+compatibility_date = "2026-08-01"
+
+# Both public hostnames hit the same script; the origin is picked from the
+# incoming Host in src/index.js. The DNS records they need are AAAA 100::,
+# proxied (orange cloud): the address is a discard prefix, only there to give
+# Cloudflare something to attach the route to.
+routes = [
+  { pattern = "mcp.ohmywind.fr/*", zone_name = "ohmywind.fr" },
+  { pattern = "mcp-dev.ohmywind.fr/*", zone_name = "ohmywind.fr" },
+]


### PR DESCRIPTION
Phase B du plan de rebrand. Sert le MCP sur **`mcp.ohmywind.fr`** et **`mcp-dev.ohmywind.fr`** au lieu d'un hostname `*.hf.space` qu'on ne possède pas.

DNS déjà en place et vérifié : les deux sous-domaines résolvent sur l'anycast Cloudflare et renvoient 522/523, donc le nuage orange est bon et il ne manque que le Worker.

## Pourquoi

Les clients MCP stockent l'URL du endpoint dans leur config. Tant que c'est un `*.hf.space`, tout ce qui la change casse tous les clients d'un coup. Ce n'est pas théorique : le rename du Space prod ce matin a coupé l'endpoint, parce que trois systèmes distincts référencent ce hostname et qu'un rename les désynchronise tous.

Avec le proxy devant, le nom du Space devient un détail d'implémentation. Un déménagement vers Fly, Scaleway ou un VPS se fera en une ligne de `ORIGINS`, sans que personne ne touche sa config.

C'est aussi le prérequis dur du référencement : l'URL publiée au registre officiel MCP est recopiée dans des annuaires, des articles et des configs qu'on ne contrôle pas. Republier corrige le registre, pas les copies.

## Deux points de conception

**Le `Host` amont vient de l'URL réécrite**, pas d'un header posé à la main. Un Worker ne peut pas définir `Host` directement, et n'en a pas besoin : le runtime le dérive de l'URL.

**`X-Forwarded-For` est écrasé par `CF-Connecting-IP`.** Cloudflare *ajoute* le vrai client à la suite de ce que l'appelant a envoyé, donc un appelant peut rembourrer la liste et décaler les positions que l'origine compte depuis la droite. En repartant de `CF-Connecting-IP`, la chaîne qui atteint l'app vaut exactement `<client>, <egress Cloudflare>` quoi que l'appelant raconte. C'est ce qui rend `OPENWIND_TRUSTED_PROXY_HOPS=2` sûr à figer plutôt que d'être une valeur au jugé.

Les redirections dont le `Location` nomme encore le Space sont réécrites vers le hostname public, sinon le proxy rendrait l'origine au client et perdrait tout son intérêt.

## Déploiement

Volontairement manuel, mais le code est versionné : de l'infra qui n'existe que dans un dashboard, c'est exactement le mode de panne qu'on vient de subir. Le [README](packages/edge-proxy/README.md) documente l'ordre de bascule et les deux variables de Space couplées, avec le symptôme précis de chaque erreur.

## Ce que ça ne fait pas

Les Spaces gratuits s'endorment après 48 h. Le proxy n'y peut rien, il faudra un ping programmé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)