### PR TITLE
fix(mcp): renommer le serveur en ohmywind, oublié par la phase A

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -830,14 +830,14 @@ def _build_feedback_scheduler() -> Any | None:
     """
     if not _FEEDBACK_REPO:
         _logger.info(
-            "openwind.feedback: OPENWIND_FEEDBACK_DATASET_REPO unset, "
+            "ohmywind.feedback: OPENWIND_FEEDBACK_DATASET_REPO unset, "
             "feedback will only log to stderr"
         )
         return None
     token = os.environ.get("HF_TOKEN_FEEDBACK") or os.environ.get("HF_TOKEN")
     if not token:
         _logger.warning(
-            "openwind.feedback: HF_TOKEN_FEEDBACK / HF_TOKEN unset, "
+            "ohmywind.feedback: HF_TOKEN_FEEDBACK / HF_TOKEN unset, "
             "cannot push to %s — feedback will only log to stderr",
             _FEEDBACK_REPO,
         )
@@ -856,13 +856,13 @@ def _build_feedback_scheduler() -> Any | None:
             token=token,
         )
         _logger.info(
-            "openwind.feedback: CommitScheduler attached to %s (every=%d min)",
+            "ohmywind.feedback: CommitScheduler attached to %s (every=%d min)",
             _FEEDBACK_REPO,
             _FEEDBACK_EVERY_MIN,
         )
         return scheduler
     except Exception as exc:
-        _logger.warning("openwind.feedback: scheduler init failed: %s", exc)
+        _logger.warning("ohmywind.feedback: scheduler init failed: %s", exc)
         return None
 
 
@@ -875,7 +875,7 @@ def _hf_feedback_sink(entry: dict[str, Any]) -> None:
     append-only contract that CommitScheduler requires.
     """
     if _feedback_scheduler is None:
-        _logger.info("openwind.feedback (no sink): %s", entry)
+        _logger.info("ohmywind.feedback (no sink): %s", entry)
         return
     with _feedback_scheduler.lock:
         with _FEEDBACK_FILE.open("a", encoding="utf-8") as f:

--- a/packages/hf-space/pyproject.toml
+++ b/packages/hf-space/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openwind-hf-space"
 version = "0.1.0"
-description = "Thin Hugging Face Spaces wrapper serving the OpenWind MCP server and its REST API."
+description = "Hugging Face Spaces wrapper serving the OhMyWind MCP server and its REST API."
 requires-python = ">=3.12"
 
 # Until now these versions lived only in the Dockerfile's pip install line,

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -29,11 +29,11 @@ other MCP client (Goose, Continue, Zed) that accepts a stdio command.
 ```json
 {
   "mcpServers": {
-    "openwind": {
+    "ohmywind": {
       "command": "uv",
       "args": [
         "--directory",
-        "/ABSOLUTE/PATH/TO/openwind/packages/mcp-core",
+        "/ABSOLUTE/PATH/TO/ohmywind/packages/mcp-core",
         "run",
         "python",
         "scripts/run_local.py"
@@ -43,8 +43,8 @@ other MCP client (Goose, Continue, Zed) that accepts a stdio command.
 }
 ```
 
-Replace `/ABSOLUTE/PATH/TO/openwind` with your local repo path. Restart the
-client. The four tools should appear under the `openwind` server.
+Replace `/ABSOLUTE/PATH/TO/ohmywind` with your local repo path. Restart the
+client. The four tools should appear under the `ohmywind` server.
 
 ### Sanity check (without a chat client)
 

--- a/packages/mcp-core/scripts/run_local.py
+++ b/packages/mcp-core/scripts/run_local.py
@@ -4,7 +4,7 @@ Usage (in claude_desktop_config.json):
 
     {
       "mcpServers": {
-        "openwind": {
+        "ohmywind": {
           "command": "uv",
           "args": ["--directory", "/abs/path/to/packages/mcp-core",
                    "run", "python", "scripts/run_local.py"]

--- a/packages/mcp-core/src/openwind_mcp_core/feedback.py
+++ b/packages/mcp-core/src/openwind_mcp_core/feedback.py
@@ -56,7 +56,7 @@ class FeedbackSink(Protocol):
 
 def stderr_sink(entry: dict[str, Any]) -> None:
     """Default sink: log to stderr at INFO level."""
-    logger.info("openwind.feedback %s", entry)
+    logger.info("ohmywind.feedback %s", entry)
 
 
 def build_feedback_entry(

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -81,6 +81,12 @@ from .render import build_ohmywind_url
 # module renames rather than with this cosmetic pass.
 PLAN_UI_RESOURCE_URI = "ui://openwind/plan-passage"
 PLAN_UI_MIME = "text/html;profile=mcp-app"
+
+# The name clients display for this server. Named rather than inlined into the
+# FastMCP() call so a test can assert it: the cosmetic rebrand shipped with this
+# value still on the old brand, because the sweep that renamed everything else
+# matched "OpenWind" and "openwind.fr" and this one is lowercase and bare.
+SERVER_NAME = "ohmywind"
 # unpkg serves the official @modelcontextprotocol/ext-apps SDK bundle that
 # implements the ui/initialize -> ui/notifications/initialized handshake and
 # the ui/notifications/tool-result listener. Same CDN as the official
@@ -351,7 +357,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
 
     app.ontoolresult = render;
     try { await app.connect(); }
-    catch (e) { console.error('[openwind] MCP App connect failed', e); }
+    catch (e) { console.error('[ohmywind] MCP App connect failed', e); }
   </script>
 </body>
 </html>
@@ -569,7 +575,7 @@ def build_server(
     # Per the official MCP Python SDK README, this combo is the
     # recommended config for production deployments.
     server: FastMCP = FastMCP(
-        "openwind",
+        SERVER_NAME,
         stateless_http=True,
         json_response=True,
     )
@@ -1076,7 +1082,7 @@ def build_server(
         except Exception as exc:
             import logging as _logging
 
-            _logging.getLogger(__name__).warning("openwind.feedback sink failed: %s", exc)
+            _logging.getLogger(__name__).warning("ohmywind.feedback sink failed: %s", exc)
             ack = "buffered"
         return {
             "feedback_id": entry["feedback_id"],

--- a/packages/mcp-core/tests/test_branding.py
+++ b/packages/mcp-core/tests/test_branding.py
@@ -1,0 +1,94 @@
+"""Guards on the brand strings clients actually see.
+
+Written after the 2026-08-01 cosmetic rebrand shipped with the server name
+still on the old brand. The sweep that renamed everything else matched
+``OpenWind`` and ``openwind.fr``; ``FastMCP("openwind")`` is lowercase and
+bare, so it slipped through, and nothing failed. The commit message and the PR
+both claimed it was done.
+
+These assertions are cheap and they fail loudly. They exist because a rename
+verified by grepping is only as good as the grep.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from openwind_mcp_core import build_server
+from openwind_mcp_core.render import build_ohmywind_url
+from openwind_mcp_core.server import PLAN_UI_RESOURCE_URI, SERVER_NAME
+
+# Identifiers that legitimately still carry the pre-rebrand spelling. Each one
+# routes something or is resolved by something, so renaming it is a breaking
+# change scheduled with the Space and module renames, not a copy edit.
+DELIBERATE_LEGACY = {
+    PLAN_UI_RESOURCE_URI: "resource URI resolved by MCP Apps hosts",
+    "openwind_url": "field name in the tool's structuredContent",
+}
+
+
+def test_server_name_is_the_current_brand() -> None:
+    """The name clients display. This is the one that shipped wrong."""
+    server = build_server(adapter=object())
+    assert server.name == "ohmywind"
+    assert SERVER_NAME == "ohmywind"
+
+
+def test_deep_links_point_at_the_current_domain() -> None:
+    url = build_ohmywind_url([{"lat": 43.3, "lon": 5.4}], "2026-08-02T08:00:00Z", "cruiser_40ft")
+    assert url.startswith("https://ohmywind.fr/plan?")
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """ids() of the Constant nodes that are docstrings rather than data."""
+    docstrings = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                docstrings.add(id(first.value))
+    return docstrings
+
+
+def test_no_stale_brand_in_strings_shown_to_users() -> None:
+    """Scan every string literal in the package for the old brand.
+
+    Deliberately source-level rather than behavioural: the failure being
+    guarded against is a *missed* occurrence, so the check has to look at
+    everything rather than at the handful of values a test happens to call.
+
+    Docstrings and comments are excluded on purpose. They are prose for whoever
+    reads the repo, and several of them exist precisely to explain why an
+    identifier still carries the old spelling. String literals are what reaches
+    a user, so those are what this holds to the current brand.
+    """
+    package = Path(__file__).resolve().parents[1] / "src" / "openwind_mcp_core"
+    pattern = re.compile(r"[A-Za-z0-9_.-]*[Oo]pen[Ww]ind[A-Za-z0-9_.-]*")
+    found: dict[str, list[str]] = {}
+
+    for source in sorted(package.rglob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        docstrings = _docstring_nodes(tree)
+
+        leftovers: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in docstrings:
+                continue
+            text = node.value
+            for legacy in DELIBERATE_LEGACY:
+                text = text.replace(legacy, "")
+            leftovers.update(m.group(0) for m in pattern.finditer(text))
+
+        if leftovers:
+            found[source.name] = sorted(leftovers)
+
+    assert found == {}, f"pre-rebrand strings left in mcp-core: {found}"


### PR DESCRIPTION
La PR #185 affirmait renommer le nom du serveur MCP. **Elle ne l'a pas fait.** `FastMCP("openwind")` est en minuscules et sans point, alors que le balayage qui a renommé tout le reste ne portait que sur `OpenWind` en casse chameau, `openwind.fr` et `build_openwind_url`. La valeur est passée entre les mailles et rien n'a échoué.

C'était l'élément le plus visible de la phase A : `serverInfo.name` est ce que les clients affichent. Le prod sert donc encore `openwind` aujourd'hui, alors que la landing, les redirections d'icônes et les deeplinks sont bien passés à OhMyWind.

Effet de bord coûteux : ce champ me servait de discriminateur pour détecter les redéploiements. Comme il ne pouvait pas basculer, j'en ai conclu que les builds HF échouaient, alors qu'ils avaient réussi depuis le début. 80 minutes d'attente sur un signal impossible.

## Corrigé ici

Les cinq oublis, tous dus à la même cause de casse :

| Où | Quoi |
|---|---|
| `server.py` | le nom du serveur, extrait en `SERVER_NAME` |
| `server.py` | un troisième préfixe `console.error('[openwind]`, j'en avais renommé deux |
| `run_local.py` + `mcp-core/README.md` | la clé d'exemple `"openwind"` du tuto Claude Desktop, et le chemin de repo |
| `hf-space/pyproject.toml` | description « the OpenWind MCP server », et le « Thin wrapper » déjà faux ailleurs |
| 3 fichiers | les 7 préfixes de log `openwind.feedback` |

## Les garde-fous

`tests/test_branding.py` :

- **Le nom du serveur est assertable.** C'est la raison de l'extraction en `SERVER_NAME` plutôt qu'un littéral inliné dans l'appel `FastMCP()`.
- **Un scan de tous les littéraux de chaîne du package**, via l'AST pour exclure docstrings et commentaires. La distinction est volontaire : la prose explique légitimement pourquoi certains identifiants gardent l'ancienne graphie, alors que les littéraux partent chez l'utilisateur. Un `grep` ne sait pas faire cette différence, et c'est précisément ce qui a raté.
- Les exceptions assumées, l'URI de ressource `ui://openwind/plan-passage` et le champ JSON `openwind_url`, sont déclarées dans `DELIBERATE_LEGACY` avec leur justification. En ajouter une devient un choix visible plutôt qu'un oubli silencieux.

**Vérifié en échec** avec l'ancien nom réintroduit, sur les deux tests, avant de garder le correctif.

## Tests

mcp-core 40 passés, hf-space 87 passés, data-adapters 253 passés + 3 skippés. `ruff check` et `ruff format` propres.

## Note

Renommer `serverInfo.name` change ce que les clients affichent, pas la clé de configuration côté utilisateur, qui est choisie par lui. Aucune config existante ne casse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)