### PR TITLE
fix(data): traiter le 429 d'Open-Meteo au lieu de le laisser fuir en 500

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/base.py
+++ b/packages/data-adapters/src/openwind_data/adapters/base.py
@@ -65,6 +65,29 @@ class ForecastHorizonError(RuntimeError):
         )
 
 
+class UpstreamRateLimitError(RuntimeError):
+    """Raised when Open-Meteo answers 429.
+
+    Distinct from *our own* rate limiter, which protects this service from its
+    callers. This one means the weather API is refusing *us*, and the caller
+    can do nothing beyond waiting. Conflating the two produces the worst
+    possible message: telling users to slow down when the bottleneck is
+    upstream and unrelated to anything they did.
+
+    Open-Meteo counts against the caller's IP rather than an account, so on
+    shared egress (Hugging Face Spaces, cloud NAT) the quota can be consumed
+    by an unrelated tenant. That is why ``reason`` is surfaced verbatim: it
+    names which counter tripped, which is the only way to tell "wait a moment"
+    apart from "this address is done for the day".
+    """
+
+    def __init__(self, reason: str = "", retry_after_s: float | None = None) -> None:
+        self.reason = reason
+        self.retry_after_s = retry_after_s
+        detail = f" ({reason})" if reason else ""
+        super().__init__(f"upstream weather service rate limit reached{detail}")
+
+
 @dataclass(frozen=True, slots=True)
 class WindPoint:
     time: datetime

--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -13,6 +13,7 @@ from openwind_data.adapters.base import (
     ForecastHorizonError,
     SeaPoint,
     SeaSeries,
+    UpstreamRateLimitError,
     WindPoint,
     WindSeries,
 )
@@ -67,9 +68,25 @@ CACHE_MAX_ENTRIES = 64
 # A passage routes 12+ sub-segments through `asyncio.gather`, each fetching wind
 # + sea; without pacing, that's 24 simultaneous requests on the HF Space's
 # shared egress IP, which Open-Meteo rate-limits. The lock serialises starts
-# (cache hits stay free); 0.1 s ≈ 10 req/s, well under the public-API quota.
-# Disable in tests with `http_min_interval_s=0`.
+# (cache hits stay free). Disable in tests with `http_min_interval_s=0`.
+#
+# 0.1 s is 10 req/s, which is not "well under" the free quota as an earlier
+# version of this comment claimed — it is exactly it, since the free tier
+# allows 600/min. The margin only exists while we are alone on the egress IP,
+# and on a shared Space we are not: the quota is counted per IP, so a
+# co-tenant's traffic eats into ours. Lower this if 429s become routine.
 DEFAULT_HTTP_MIN_INTERVAL_S = 0.1
+
+# One retry on an upstream 429, and only when the wait is short.
+#
+# Open-Meteo's per-IP counters run at three scales, and only the shortest is
+# worth waiting out inline: a minutely bucket drains in seconds, while an
+# hourly or daily one leaves the address unusable far longer than any request
+# should block. So we honour Retry-After when it is small, guess briefly when
+# the header is absent, and give up immediately when it says the wait is long.
+# Sleeping through a daily quota would just turn a fast error into a timeout.
+RATE_LIMIT_RETRY_DEFAULT_WAIT_S = 0.5
+RATE_LIMIT_RETRY_MAX_WAIT_S = 2.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,6 +145,29 @@ class OpenMeteoAdapter:
             if wait > 0:
                 await asyncio.sleep(wait)
             self._last_http_at = time.monotonic()
+
+    async def _get_paced(
+        self, client: httpx.AsyncClient, url: str, params: dict[str, Any]
+    ) -> httpx.Response:
+        """Paced GET with a single bounded retry on an upstream 429.
+
+        Returns the 429 response unretried when the advertised wait is long;
+        the caller turns it into ``UpstreamRateLimitError`` so the reason
+        reaches the user instead of being slept through.
+        """
+        await self._pace_http()
+        resp = await client.get(url, params=params)
+        if resp.status_code != 429:
+            return resp
+
+        advertised = _retry_after_seconds(resp)
+        wait = RATE_LIMIT_RETRY_DEFAULT_WAIT_S if advertised is None else advertised
+        if wait > RATE_LIMIT_RETRY_MAX_WAIT_S:
+            return resp
+
+        await asyncio.sleep(wait)
+        await self._pace_http()
+        return await client.get(url, params=params)
 
     async def fetch(
         self,
@@ -226,8 +266,7 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
-        await self._pace_http()
-        resp = await client.get(FORECAST_URL, params=params)
+        resp = await self._get_paced(client, FORECAST_URL, params)
         try:
             _raise_for_status_with_horizon(resp, model, start)
         except _OffCoverageError:
@@ -253,8 +292,7 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
-        await self._pace_http()
-        resp = await client.get(MARINE_URL, params=params)
+        resp = await self._get_paced(client, MARINE_URL, params)
         try:
             _raise_for_status_with_horizon(resp, "open-meteo-marine", start)
         except _OffCoverageError:
@@ -382,8 +420,7 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
-        await self._pace_http()
-        resp = await client.get(FORECAST_URL, params=params)
+        resp = await self._get_paced(client, FORECAST_URL, params)
         try:
             _raise_for_status_with_horizon(resp, model, start)
         except _OffCoverageError:
@@ -408,14 +445,47 @@ class OpenMeteoAdapter:
             "start_date": start.date().isoformat(),
             "end_date": end.date().isoformat(),
         }
-        await self._pace_http()
-        resp = await client.get(MARINE_URL, params=params)
+        resp = await self._get_paced(client, MARINE_URL, params)
         try:
             _raise_for_status_with_horizon(resp, "open-meteo-marine", start)
         except _OffCoverageError:
             return [SeaSeries(points=()) for _ in points]
         elems = _as_coord_list(resp.json(), len(points))
         return [_parse_sea(el, start, end) for el in elems]
+
+
+def _error_reason(resp: httpx.Response) -> str:
+    """Open-Meteo's ``reason`` field, or "" when the body is not its JSON.
+
+    Worth extracting rather than discarding: on a 429 it names the counter
+    that tripped ("Minutely API request limit exceeded", "Daily API request
+    limit exceeded"), which is the difference between retrying in a moment and
+    knowing the egress IP is spent for the day.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("reason", "")).strip()
+
+
+def _retry_after_seconds(resp: httpx.Response) -> float | None:
+    """``Retry-After`` in seconds, or None when absent or not a delay.
+
+    Only the delta-seconds form is honoured. The HTTP-date form is legal but
+    Open-Meteo does not use it, and parsing it would mean trusting our clock
+    against theirs to decide how long to sleep.
+    """
+    raw = (resp.headers.get("Retry-After") or "").strip()
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
 
 
 def _raise_for_status_with_horizon(
@@ -437,7 +507,14 @@ def _raise_for_status_with_horizon(
         in ``estimate_passage`` can advance to the next model. We signal it
         by raising a sentinel; the caller converts to empty
         ``WindSeries(points=())``.
+
+    A 429 becomes ``UpstreamRateLimitError``. Without this it reached callers
+    as a raw ``HTTPStatusError`` carrying the full upstream URL: a 500 on the
+    REST route and, over MCP, an unactionable wall of query string that told
+    the model nothing about whether to wait or give up.
     """
+    if resp.status_code == 429:
+        raise UpstreamRateLimitError(_error_reason(resp), _retry_after_seconds(resp))
     if resp.status_code == 400:
         try:
             payload = resp.json()

--- a/packages/data-adapters/tests/test_openmeteo_rate_limit.py
+++ b/packages/data-adapters/tests/test_openmeteo_rate_limit.py
@@ -1,0 +1,147 @@
+"""Upstream 429 handling.
+
+Before this, a 429 from Open-Meteo reached callers as a raw ``HTTPStatusError``
+carrying the full query string. On the REST route that surfaced as a bare 500;
+over MCP the model received the upstream URL and gave up, because nothing in
+the message said whether to wait or to stop.
+
+The distinction that matters throughout: this is the weather API refusing *us*,
+not our own limiter refusing a caller. The counter is per egress IP, so on a
+shared host a co-tenant can spend it and no amount of slowing down on our side
+helps.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+import respx
+
+from openwind_data.adapters.base import UpstreamRateLimitError
+from openwind_data.adapters.openmeteo import (
+    FORECAST_URL,
+    MARINE_URL,
+    OpenMeteoAdapter,
+)
+
+# Aligned on the shared fixtures' window, so a retried call yields real points
+# rather than an empty slice that would hide whether the retry worked.
+START = datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
+END = datetime(2026, 4, 26, 23, 0, tzinfo=UTC)
+
+# Shape of a real Open-Meteo rejection: the body names the counter that tripped.
+MINUTELY = {"error": True, "reason": "Minutely API request limit exceeded. Please try again later."}
+DAILY = {"error": True, "reason": "Daily API request limit exceeded. Please try again tomorrow."}
+
+
+def _adapter() -> OpenMeteoAdapter:
+    # Pacing off: these tests are about retry behaviour, not about the 0.1 s
+    # spacing, and leaving it on only makes them slower.
+    return OpenMeteoAdapter(http_min_interval_s=0)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_429_becomes_a_typed_error_carrying_the_reason() -> None:
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(429, json=DAILY))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(429, json=DAILY))
+
+    with pytest.raises(UpstreamRateLimitError) as excinfo:
+        await _adapter().fetch(43.3, 5.36, START, END)
+
+    err = excinfo.value
+    assert "Daily API request limit exceeded" in err.reason
+    # The message is what the LLM and the web client both read.
+    assert "upstream weather service rate limit reached" in str(err)
+    # And it must not be mistakable for our own limiter's wording.
+    assert "rate limit exceeded" not in str(err)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_a_short_retry_after_is_waited_out_and_the_call_succeeds(
+    forecast_marseille_arome, marine_porquerolles
+) -> None:
+    """The minutely bucket drains in seconds, so one retry rescues the call."""
+    forecast = respx.get(FORECAST_URL).mock(
+        side_effect=[
+            httpx.Response(429, json=MINUTELY, headers={"Retry-After": "1"}),
+            httpx.Response(200, json=forecast_marseille_arome),
+        ]
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    bundle = await _adapter().fetch(43.3, 5.36, START, END)
+
+    assert forecast.call_count == 2
+    assert any(series.points for series in bundle.wind_by_model.values())
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_a_long_retry_after_fails_fast_instead_of_sleeping() -> None:
+    """A daily quota must not be slept through.
+
+    Waiting an advertised hour would convert a fast, explainable error into a
+    request that hangs until something else times it out, and the user would
+    learn nothing.
+    """
+    forecast = respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(429, json=DAILY, headers={"Retry-After": "3600"})
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(429, json=DAILY))
+
+    with pytest.raises(UpstreamRateLimitError) as excinfo:
+        await _adapter().fetch(43.3, 5.36, START, END)
+
+    assert forecast.call_count == 1
+    assert excinfo.value.retry_after_s == 3600
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_retries_once_when_no_retry_after_header_is_sent(
+    forecast_marseille_arome, marine_porquerolles
+) -> None:
+    """Open-Meteo often omits the header; absence should not mean "give up"."""
+    forecast = respx.get(FORECAST_URL).mock(
+        side_effect=[
+            httpx.Response(429, json=MINUTELY),
+            httpx.Response(200, json=forecast_marseille_arome),
+        ]
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    bundle = await _adapter().fetch(43.3, 5.36, START, END)
+
+    assert forecast.call_count == 2
+    assert any(series.points for series in bundle.wind_by_model.values())
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_a_persistent_429_is_not_retried_forever() -> None:
+    """Exactly one extra attempt, never a loop against a service refusing us."""
+    forecast = respx.get(FORECAST_URL).mock(return_value=httpx.Response(429, json=MINUTELY))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(429, json=MINUTELY))
+
+    with pytest.raises(UpstreamRateLimitError):
+        await _adapter().fetch(43.3, 5.36, START, END)
+
+    assert forecast.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_a_body_that_is_not_open_meteo_json_still_yields_a_usable_error() -> None:
+    """Edges and proxies answer 429 with HTML; the error must survive that."""
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(429, text="<html>429</html>"))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(429, text="<html>429</html>"))
+
+    with pytest.raises(UpstreamRateLimitError) as excinfo:
+        await _adapter().fetch(43.3, 5.36, START, END)
+
+    assert excinfo.value.reason == ""
+    assert "upstream weather service rate limit reached" in str(excinfo.value)

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -28,7 +28,7 @@ from typing import Any
 import httpx
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
-from openwind_data.adapters.base import ForecastHorizonError
+from openwind_data.adapters.base import ForecastHorizonError, UpstreamRateLimitError
 from openwind_data.adapters.cache_backed import CacheBackedAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
@@ -584,6 +584,8 @@ async def _api_passage(request: Request) -> JSONResponse:
                 {"error": "upstream weather service did not respond in time"},
                 status_code=503,
             )
+        except UpstreamRateLimitError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
 
         # Sweep is partial-tolerant: estimate_passage_windows skips windows
         # that hit ForecastHorizonError. Compute the expected count to surface
@@ -681,6 +683,8 @@ async def _api_passage(request: Request) -> JSONResponse:
             {"error": "upstream weather service did not respond in time"},
             status_code=503,
         )
+    except UpstreamRateLimitError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=503)
 
     complexity = score_complexity(passage)
 
@@ -773,6 +777,8 @@ async def _api_passage_by_eta(request: Request) -> JSONResponse:
             {"error": "upstream weather service did not respond in time"},
             status_code=503,
         )
+    except UpstreamRateLimitError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=503)
 
     complexity = score_complexity(plan.report)
 

--- a/packages/hf-space/tests/test_api_by_eta.py
+++ b/packages/hf-space/tests/test_api_by_eta.py
@@ -184,3 +184,19 @@ class TestUpstreamFailures:
         resp = await app._api_passage_by_eta(_FakeRequest(_body()))
         assert resp.status_code == 503
         assert "did not respond in time" in _payload(resp)["error"]
+
+    async def test_upstream_rate_limit_is_a_503_not_a_500(self, monkeypatch) -> None:
+        # Open-Meteo refusing *us* is not the caller's fault and not a bug on
+        # our side. Before this it escaped as a raw HTTPStatusError, so the
+        # route answered 500 with no body and the front could say nothing.
+        async def _stub(*_args, **_kwargs):
+            raise app.UpstreamRateLimitError("Minutely API request limit exceeded.")
+
+        monkeypatch.setattr(app, "estimate_passage_for_arrival", _stub)
+        resp = await app._api_passage_by_eta(_FakeRequest(_body()))
+        assert resp.status_code == 503
+        error = _payload(resp)["error"]
+        assert "upstream weather service rate limit reached" in error
+        # The upstream reason rides along: it is the only way to tell a
+        # minutely bucket (wait a moment) from a daily one (spent for today).
+        assert "Minutely API request limit exceeded." in error

--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -47,3 +47,22 @@ describe("formatRetryDelay", () => {
     }
   });
 });
+
+// The two rate limits must never be confused in the UI. Ours is about the
+// caller's pace and slowing down fixes it. Open-Meteo's is counted per egress
+// IP and can be spent by another tenant of the same host, so telling the user
+// to slow down would be both wrong and useless.
+describe("upstream vs own rate limit", () => {
+  it("blames nobody when the weather service throttles us", () => {
+    const msg = friendlyError("upstream weather service rate limit reached (Daily API request limit exceeded.)");
+    expect(msg).toContain("service météo");
+    expect(msg).toContain("pas lié à votre usage");
+    expect(msg).not.toContain("Trop de calculs");
+  });
+
+  it("still blames the pace when it is our own limiter", () => {
+    const msg = friendlyError("rate limit exceeded, retry shortly, retry in 30s");
+    expect(msg).toContain("Trop de calculs");
+    expect(msg).not.toContain("service météo");
+  });
+});

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -89,6 +89,14 @@ export function friendlyError(raw: string): string {
     // HF Spaces' shared egress is jittery and Open-Meteo occasionally pauses.
     return "Le service météo a mis trop de temps à répondre. Réessayez dans quelques instants.";
   }
+  if (/upstream weather service rate limit/i.test(raw)) {
+    // Open-Meteo throttling US, not the user throttling us. Deliberately worded
+    // so nobody reads it as "you clicked too fast": the quota is counted per
+    // egress IP and can be spent by an unrelated tenant of the same host, so
+    // slowing down changes nothing. Distinct from the /rate limit exceeded/
+    // rule above, which is our own limiter and IS about the caller's pace.
+    return "Le service météo limite temporairement nos requêtes. Ce n'est pas lié à votre usage, réessayez dans quelques minutes.";
+  }
   if (/Erreur serveur 5\d\d/.test(raw) || /HTTP 5\d\d/.test(raw)) {
     return "Le serveur météo est indisponible. Réessayez dans quelques instants.";
   }


### PR DESCRIPTION
## Ce que ça ne fait pas

**Ça ne rétablit pas le service dev.** La cause est ailleurs, et elle est établie : Open-Meteo compte son quota **par IP**, les Spaces mutualisent leur IP sortante, donc le quota peut être consommé par un locataire tiers. Vérifié en sondant les deux Spaces à la même seconde, même code, même requête : **prod répond 200, dev échoue**.

Ce que ça apporte, c'est de rendre la panne lisible au lieu de l'afficher comme un bug de notre côté.

## Le défaut

Un 429 amont tombait sur `resp.raise_for_status()` et remontait en `HTTPStatusError` brut. Côté REST : un 500 sans corps. Côté MCP : l'URL complète avec sa query string, dont le LLM ne pouvait rien tirer, aucune indication s'il fallait attendre, réessayer ou renoncer. Claude a simplement abandonné.

## Trois changements

**`UpstreamRateLimitError`, distincte de notre propre limiteur.** Les confondre produit le pire message possible : dire à quelqu'un de ralentir alors que le goulet est ailleurs et que son rythme n'y change rien. Deux tests web verrouillent la distinction dans la copie.

**Le champ `reason` d'Open-Meteo est remonté verbatim.** C'est lui qui nomme le compteur dépassé, à la minute, à l'heure ou au jour. C'est la seule façon de distinguer « attends un instant » de « cette IP est finie pour la journée ». On jetait ce corps de réponse, d'où l'impossibilité de trancher aujourd'hui entre mes deux hypothèses.

**Un réessai unique, borné.** `Retry-After` respecté quand il est court, 0,5 s deviné quand l'en-tête est absent, échec immédiat quand il annonce long. Dormir une heure sur un quota journalier transformerait une erreur rapide et explicable en requête qui pend jusqu'au timeout.

## Une hypothèse réfutée en chemin

J'ai d'abord soupçonné le limiteur de **concurrence** d'Open-Meteo, puisqu'un `plan_passage` tire une douzaine de requêtes simultanées. Test décisif : `get_marine_forecast`, qui n'en tire qu'une ou deux, échoue aussi. Ce n'est donc pas une rafale, c'est l'IP. Le sémaphore que j'allais écrire n'aurait rien réglé.

Un commentaire corrigé au passage : le rythme HTTP affirmait 10 req/s « well under the public-API quota ». C'est **exactement** le quota gratuit, 600/min, pas une marge.

## Tests

6 sur l'adaptateur, **vérifiés en échec sans le correctif**. 1 sur la route REST. 2 côté web sur la distinction entre les deux limites.

data-adapters 259 + 3 skippés, mcp-core 40, hf-space 88, web 124. ruff, eslint et `tsc -b` propres.

## Ensuite

Si le 429 revient une fois l'IP renouvelée, c'est structurel : dépendre d'une IP mutualisée pour un quota par IP est fragile par construction. La réponse durable serait la formule payante d'Open-Meteo, authentifiée par clé côté serveur, ce qui ne change rien au positionnement sans clé pour l'utilisateur. Décision de coût, à arbitrer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)