### PR TITLE
fix(security): le nombre de hops de confiance se mérite par requête

### DIFF
--- a/packages/edge-proxy/README.md
+++ b/packages/edge-proxy/README.md
@@ -40,16 +40,65 @@ The routes in `wrangler.toml` are applied on deploy. `zone_name` must stay
 
 ## Coupled configuration
 
-Two Space variables have to match this proxy. Getting either wrong produces a
-failure that does not name its cause.
+Three Space variables have to match this proxy. Getting any of them wrong
+produces a failure that does not name its cause.
 
 | Variable | Value | If wrong |
 | --- | --- | --- |
 | `OPENWIND_ALLOWED_HOSTS` | must list the public hostname **and** keep the `*.hf.space` one | `421 Invalid Host header` on `/mcp` |
 | `OPENWIND_TRUSTED_PROXY_HOPS` | `2` | every user shares one rate-limit bucket, so 429s unrelated to real usage |
+| `OPENWIND_EDGE_SECRET` | same value as this Worker's `EDGE_SHARED_SECRET` | the rate limiter can be bypassed, silently |
 
 The `*.hf.space` hostname stays in `OPENWIND_ALLOWED_HOSTS` because that is the
 Host the proxy presents upstream. Removing it cuts the proxy off.
+
+### Why the shared secret exists
+
+The Space stays reachable on its `*.hf.space` hostname, and that path skips
+this proxy entirely. A caller taking it can send their own `X-Forwarded-For`;
+with `OPENWIND_TRUSTED_PROXY_HOPS=2` the origin counts two from the right and
+lands on the forged entry, so every request gets a fresh rate-limit bucket.
+Measured working against production on 2026-08-01.
+
+So the extra hop is not granted to a deployment, it is granted per request, to
+traffic that proves it came through here. This Worker strips any inbound
+`X-OhMyWind-Edge` and sets its own from `EDGE_SHARED_SECRET`; the origin
+compares it in constant time and treats everything else as direct, where the
+rightmost entry is the one Hugging Face appended and cannot be forged.
+
+Leaving `OPENWIND_EDGE_SECRET` unset breaks nothing: the origin falls back to
+the deployment-wide hop count and warns at startup. A rate limiter is an
+availability control, so it fails open on purpose. It does mean the bypass
+above stays open until the secret is set on both sides.
+
+### Setting or rotating the secret
+
+```sh
+openssl rand -hex 32                         # one value for all three places
+npx wrangler secret put EDGE_SHARED_SECRET   # from this directory
+```
+
+Then on **both** Spaces: Settings -> Variables and secrets -> New secret,
+`OPENWIND_EDGE_SECRET`, same value. Adding a secret restarts the Space.
+
+**Deploy this Worker before the Space picks up the matching code.** The Space
+redeploys itself on a push to `main` or `dev`; this Worker does not. Ship them
+the other way round and proxied traffic arrives without attestation, gets
+treated as direct, and every user behind the proxy keys on Cloudflare's egress
+address — one shared bucket, 429s for everyone. The reverse order is harmless:
+a Worker sending a header the origin does not yet read changes nothing.
+
+Verify with the diagnostic route, which reports what the origin decided
+without ever echoing an address:
+
+```sh
+# Direct, with and without a forged header: the bucket must NOT move
+curl -s https://qdonnars-openwind-mcp.hf.space/api/v1/_client
+curl -s https://qdonnars-openwind-mcp.hf.space/api/v1/_client -H 'X-Forwarded-For: 1.1.1.1'
+
+# Through this proxy: via_edge true, hops_applied 2, same bucket as above
+curl -s https://mcp.ohmywind.fr/api/v1/_client
+```
 
 `TRUSTED_PROXY_HOPS` is 2 because the chain reaching the app is
 `<client>, <cloudflare egress>`: Cloudflare adds one hop in front of Hugging

--- a/packages/edge-proxy/src/index.js
+++ b/packages/edge-proxy/src/index.js
@@ -20,7 +20,7 @@ const ORIGINS = {
 };
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     const incoming = new URL(request.url);
     const origin = ORIGINS[incoming.hostname];
     if (!origin) {
@@ -60,6 +60,21 @@ export default {
       upstream.headers.set("X-Forwarded-For", clientIp);
     } else {
       upstream.headers.delete("X-Forwarded-For");
+    }
+
+    // Vouch for this request, so the origin knows the chain above was written
+    // by us and can safely count two hops from the right.
+    //
+    // Without proof, the origin cannot tell our traffic apart from someone
+    // calling the Space directly on its *.hf.space hostname with a
+    // hand-written X-Forwarded-For — and that caller would get to pick their
+    // own rate-limit bucket, which was measured working on 2026-08-01.
+    //
+    // The delete is not optional: strip whatever the caller sent before
+    // setting ours, otherwise the header proves nothing.
+    upstream.headers.delete("X-OhMyWind-Edge");
+    if (env?.EDGE_SHARED_SECRET) {
+      upstream.headers.set("X-OhMyWind-Edge", env.EDGE_SHARED_SECRET);
     }
 
     // `manual` keeps 3xx responses as data instead of chasing them ourselves,

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -56,7 +56,10 @@ from security import (
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
     bucket_id,
+    came_through_edge,
     forwarded_hop_count,
+    trusted_hops_for,
+    warn_if_edge_secret_missing,
 )
 
 _logger = logging.getLogger(__name__)
@@ -482,7 +485,13 @@ async def _api_client_debug(request: Request) -> JSONResponse:
         {
             "bucket": bucket_id(request.scope),
             "forwarded_hops": forwarded_hop_count(request.scope),
+            # What the deployment is configured for, versus what this request
+            # actually earned. They diverge when the caller reached the Space
+            # directly instead of through the edge proxy, which is exactly the
+            # case that must not get the longer hop count.
             "trusted_hops": TRUSTED_PROXY_HOPS,
+            "hops_applied": trusted_hops_for(request.scope),
+            "via_edge": came_through_edge(request.scope),
         },
         headers={"Cache-Control": "no-store"},
     )
@@ -1069,6 +1078,8 @@ def build_app(mcp_app: Any) -> Starlette:
 
 def main() -> None:
     global _feedback_scheduler
+    logging.basicConfig(level=logging.INFO)
+    warn_if_edge_secret_missing()
     _feedback_scheduler = _build_feedback_scheduler()
     server = build_server(feedback_sink=_hf_feedback_sink)
     server.settings.transport_security = TransportSecuritySettings(

--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -14,6 +14,8 @@ Space can diverge without a code change.
 from __future__ import annotations
 
 import hashlib
+import hmac
+import logging
 import math
 import os
 import time
@@ -22,6 +24,8 @@ from collections.abc import Iterable
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_logger = logging.getLogger(__name__)
 
 # --------------------------------------------------------------------- CORS
 
@@ -76,13 +80,71 @@ ALLOWED_ORIGINS = ["*"]
 # stacked ahead of HF (each extra hop shifts the real client one place left).
 TRUSTED_PROXY_HOPS = max(1, int(os.environ.get("OPENWIND_TRUSTED_PROXY_HOPS", "1")))
 
+# Counting from the right is only safe while the chain length is what we think
+# it is. The Cloudflare Worker in ``packages/edge-proxy`` rewrites
+# X-Forwarded-For to the address Cloudflare vouches for, which is what pins
+# TRUSTED_PROXY_HOPS to 2 in production.
+#
+# But the Space stays directly reachable on its ``*.hf.space`` hostname, and
+# that path bypasses the Worker's sanitising. With hops=2 and a hand-written
+# ``X-Forwarded-For``, the chain becomes ``<forged>, <real>`` and the app reads
+# the forged entry — a fresh rate-limit bucket per request, measured live on
+# 2026-08-01.
+#
+# So the hop count is not a property of the deployment, it is a property of
+# each request: only traffic carrying the shared secret the Worker injects has
+# earned the extra hop. Everything else is treated as direct, where the
+# rightmost entry is the one HF appended and cannot be forged.
+EDGE_SECRET = os.environ.get("OPENWIND_EDGE_SECRET", "")
+_EDGE_HEADER = b"x-ohmywind-edge"
 
-def resolve_client_ip(scope: Scope, *, hops: int = TRUSTED_PROXY_HOPS) -> str:
+
+def came_through_edge(scope: Scope) -> bool:
+    """True when this request carries our edge proxy's shared secret."""
+    if not EDGE_SECRET:
+        return False
+    for name, value in scope.get("headers", ()):
+        if name == _EDGE_HEADER:
+            return hmac.compare_digest(value.decode("latin-1"), EDGE_SECRET)
+    return False
+
+
+def trusted_hops_for(scope: Scope) -> int:
+    """How many proxy hops to trust for this particular request."""
+    if not EDGE_SECRET:
+        # Unconfigured: keep the deployment-wide setting. A rate limiter is an
+        # availability control, and the convention for those is to fail open.
+        # Failing closed here would mean every request behind the proxy keys on
+        # Cloudflare's egress address, collapsing all users into one bucket:
+        # that turns a hardening gap into an outage. The startup warning below
+        # makes the gap loud instead of silent.
+        return TRUSTED_PROXY_HOPS
+    return TRUSTED_PROXY_HOPS if came_through_edge(scope) else 1
+
+
+def warn_if_edge_secret_missing() -> None:
+    """Log once at startup when the hop count is trusted without proof."""
+    if TRUSTED_PROXY_HOPS > 1 and not EDGE_SECRET:
+        _logger.warning(
+            "OPENWIND_TRUSTED_PROXY_HOPS=%d but OPENWIND_EDGE_SECRET is unset: "
+            "the rate-limit key can be forged by calling this host directly "
+            "with an X-Forwarded-For header. Set the secret on both this "
+            "deployment and the edge proxy.",
+            TRUSTED_PROXY_HOPS,
+        )
+
+
+def resolve_client_ip(scope: Scope, *, hops: int | None = None) -> str:
     """Best-effort real client IP, resistant to X-Forwarded-For spoofing.
 
     Reads the raw header rather than ``scope["client"]`` because uvicorn has
     already rewritten the latter to the spoofable leftmost entry.
+
+    ``hops`` defaults to what this request has earned (see
+    ``trusted_hops_for``); pass it explicitly only in tests.
     """
+    if hops is None:
+        hops = trusted_hops_for(scope)
     forwarded = ""
     for name, value in scope.get("headers", ()):
         if name == b"x-forwarded-for":

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -412,3 +412,87 @@ def test_client_debug_route_reports_hops_without_leaking_the_address(client) -> 
     # bucket; the whole point of the route is to make that visible.
     assert "203.0.113.7" not in resp.text
     assert "9.9.9.9" not in resp.text
+
+
+# --------------------------------------------------- edge proxy attestation
+
+
+def _edge_scope(secret: str | None, xff: str) -> dict:
+    headers = {"x-forwarded-for": xff}
+    if secret is not None:
+        headers["x-ohmywind-edge"] = secret
+    return _scope(**headers)
+
+
+def test_direct_caller_cannot_buy_extra_hops(monkeypatch) -> None:
+    """The live bypass of 2026-08-01, as a test.
+
+    With TRUSTED_PROXY_HOPS=2 and no attestation, a caller reaching the Space
+    directly could send any X-Forwarded-For and land on `<forged>, <real>`,
+    where counting two from the right reads the forged entry. One header, one
+    fresh rate-limit bucket per request.
+    """
+    monkeypatch.setattr(security, "EDGE_SECRET", "s3cret")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+
+    keys = {
+        security.resolve_client_ip(_edge_scope(None, f"{spoof}, 203.0.113.7"))
+        for spoof in ("1.1.1.1", "2.2.2.2", "3.3.3.3")
+    }
+    assert keys == {"203.0.113.7"}
+
+
+def test_edge_traffic_still_reads_the_real_client(monkeypatch) -> None:
+    monkeypatch.setattr(security, "EDGE_SECRET", "s3cret")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+    scope = _edge_scope("s3cret", "203.0.113.7, 10.0.0.9")
+    assert security.resolve_client_ip(scope) == "203.0.113.7"
+
+
+def test_wrong_secret_is_treated_as_direct(monkeypatch) -> None:
+    monkeypatch.setattr(security, "EDGE_SECRET", "s3cret")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+    scope = _edge_scope("not-the-secret", "1.1.1.1, 203.0.113.7")
+    assert security.resolve_client_ip(scope) == "203.0.113.7"
+    assert security.came_through_edge(scope) is False
+
+
+def test_unconfigured_secret_never_attests(monkeypatch) -> None:
+    monkeypatch.setattr(security, "EDGE_SECRET", "")
+    assert security.came_through_edge(_edge_scope("anything", "1.1.1.1")) is False
+
+
+def test_unconfigured_secret_fails_open(monkeypatch) -> None:
+    """A rate limiter is an availability control, so it fails open.
+
+    Failing closed would key every proxied request on the edge's egress
+    address, collapsing all users into one bucket: an outage, traded for a
+    hardening gap. The startup warning covers the gap instead.
+    """
+    monkeypatch.setattr(security, "EDGE_SECRET", "")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+    assert security.trusted_hops_for(_edge_scope(None, "1.1.1.1, 2.2.2.2")) == 2
+
+
+def test_startup_warns_when_hops_are_trusted_without_proof(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(security, "EDGE_SECRET", "")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+    with caplog.at_level("WARNING"):
+        security.warn_if_edge_secret_missing()
+    assert "OPENWIND_EDGE_SECRET" in caplog.text
+
+
+def test_no_warning_when_correctly_configured(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(security, "EDGE_SECRET", "s3cret")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 2)
+    with caplog.at_level("WARNING"):
+        security.warn_if_edge_secret_missing()
+    assert caplog.text == ""
+
+
+def test_single_hop_deployment_is_unaffected(monkeypatch) -> None:
+    # Default posture: no proxy in front, nothing to attest, rightmost wins.
+    monkeypatch.setattr(security, "EDGE_SECRET", "")
+    monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 1)
+    scope = _edge_scope(None, "1.1.1.1, 203.0.113.7")
+    assert security.resolve_client_ip(scope) == "203.0.113.7"


### PR DESCRIPTION
Ferme un contournement du rate limiting **actuellement actif en production**.

## Le défaut

Le Space reste joignable en direct sur `*.hf.space`, et ce chemin court-circuite le Worker. Avec `OPENWIND_TRUSTED_PROXY_HOPS=2`, un appelant direct qui écrit son propre `X-Forwarded-For` produit la chaîne `<forgé>, <réel>` : compter deux depuis la droite lit l'entrée forgée. Mesuré en prod :

```
XFF: 1.1.1.1 -> bucket f1412386
XFF: 2.2.2.2 -> bucket 1e956110
XFF: 3.3.3.3 -> bucket 3e5d9903
```

Un compteur neuf par requête, donc plus de rate limiting du tout sur ce chemin. L'URL `*.hf.space` est publique.

Le réglage `2` n'est pourtant pas faux : il est correct pour le trafic du Worker, qui écrase `X-Forwarded-For` avec `CF-Connecting-IP`. L'erreur était d'en faire une propriété du **déploiement** alors que c'est une propriété de chaque **requête**.

## Le correctif

Le Worker atteste son trafic avec un secret partagé, le Space n'accorde le hop supplémentaire qu'aux requêtes qui le présentent. Le reste est traité comme direct, où l'entrée la plus à droite est celle ajoutée par Hugging Face et ne peut pas être forgée.

Le Worker supprime tout `X-OhMyWind-Edge` entrant avant de poser le sien, sans quoi l'en-tête ne prouverait rien. Comparaison en temps constant côté Space.

Aucun appelant n'est cassé : les URL `*.hf.space` continuent de marcher, elles sont simplement limitées sur leur IP réelle.

**Secret absent** : on retombe sur le réglage global et on avertit au démarrage. Un rate limiter est un contrôle de disponibilité, la convention est de faillir en ouvert. Faillir en fermé enfermerait tous les utilisateurs du proxy dans le bucket de l'egress Cloudflare, soit une panne échangée contre un durcissement.

## Vérifié en local sur le serveur réel

```
direct + 3 usurpations -> même bucket, hops_applied 1
edge, secret valide    -> même bucket, hops_applied 2, via_edge true
secret invalide        -> traité comme direct, hops_applied 1
```

395 tests Python, ruff propre, syntaxe Worker validée.

`/api/v1/_client` expose désormais `hops_applied` et `via_edge`, pour que la vérification après déploiement soit une commande et pas une déduction.

## ⚠️ Ordre de déploiement

**Déployer le Worker AVANT de merger cette PR.**

Le Space se redéploie tout seul sur un push, le Worker non. Dans l'autre sens, le trafic proxifié arrive sans attestation, est traité comme direct, et tous les utilisateurs partagent le bucket de l'egress Cloudflare : des 429 pour tout le monde.

```sh
cd packages/edge-proxy && npx wrangler deploy
```

L'ordre inverse est inoffensif : un Worker qui envoie un en-tête que l'origine ne lit pas encore ne change rien.

Le tableau « Coupled configuration » du README d'edge-proxy est à jour avec le nouveau secret, son symptôme en cas d'oubli, et la procédure de rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)