### PR TITLE
fix(mcp): variabiliser le site cible des deeplinks par environnement

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -84,7 +84,7 @@ jobs:
             -e 's/^colorTo: indigo$/colorTo: yellow/' \
             -e 's/^short_description: .*/short_description: (dev) French Atlantic + Med sailing planner via MCP./' \
             -e 's/^# OhMyWind MCP ⛵$/# OhMyWind MCP (dev) ⛵/' \
-            -e 's#qdonnars-openwind-mcp\.hf\.space#qdonnars-openwind-mcp-dev.hf.space#g' \
+            -e 's#mcp\.ohmywind\.fr#mcp-dev.ohmywind.fr#g' \
             -e 's/on `main`/on `dev`/g' \
             "$README"
           echo "Patched dev README frontmatter:"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > (SHOM Atlas C2D and MARC PREVIMER), and a deep-link to the full plan.
 > Free, keyless, open source.
 
-[**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://qdonnars-openwind-mcp.hf.space/mcp) · MIT
+[**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://mcp.ohmywind.fr/mcp) · MIT
 
 ![OhMyWind passage plan rendered in the web app](docs/screenshots/plan.png)
 
@@ -20,7 +20,7 @@
 **1.** Open your MCP client and add the endpoint:
 
 ```
-https://qdonnars-openwind-mcp.hf.space/mcp
+https://mcp.ohmywind.fr/mcp
 ```
 
 **2.** Ask, in your own words:

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -26,7 +26,7 @@ short_description: French Atlantic + Mediterranean sailing planner via MCP.
 **1.** In your MCP client, add the endpoint:
 
 ```
-https://qdonnars-openwind-mcp.hf.space/mcp
+https://mcp.ohmywind.fr/mcp
 ```
 
 **2.** Ask, in your own words:

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -73,7 +73,10 @@ PORT = 7860
 # ``proxy_headers``, so we extend the allowed-hosts list to include the
 # Space hostname (overridable via env for future custom domains / migrations).
 DEFAULT_ALLOWED_HOSTS = [
+    # The Host the Worker presents upstream, and the public one a direct
+    # caller sends. Both must pass or one of the two paths 421s.
     "qdonnars-openwind-mcp.hf.space",
+    "mcp.ohmywind.fr",
 ]
 ALLOWED_HOSTS = [
     h.strip()
@@ -202,7 +205,7 @@ LANDING_HTML = """<!doctype html>
       <li>Scroll to the bottom and click <strong>Add custom connector</strong>.</li>
       <li>Set <strong>Name</strong>: <code>OhMyWind</code>.</li>
       <li>Paste this in <strong>Remote MCP server URL</strong>:
-        <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
+        <pre><code>https://mcp.ohmywind.fr/mcp</code></pre></li>
       <li>Click <strong>Add</strong>. In any new chat, OhMyWind shows up in the
         <strong>Search and tools</strong> menu — toggle it on.</li>
     </ol>
@@ -218,7 +221,7 @@ LANDING_HTML = """<!doctype html>
         then click <strong>Add MCP server</strong>.</li>
       <li>Set <strong>Name</strong>: <code>OhMyWind</code> &middot; <strong>Auth</strong>: <code>None</code>.</li>
       <li>Paste this in <strong>URL</strong>:
-        <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
+        <pre><code>https://mcp.ohmywind.fr/mcp</code></pre></li>
       <li>Save, then enable the OhMyWind toggle inside any conversation.</li>
       <li>Le Chat doesn&rsquo;t (yet) support the MCP Apps spec, so the
         widget won&rsquo;t render inline &mdash; the assistant will hand you
@@ -235,7 +238,7 @@ LANDING_HTML = """<!doctype html>
       <li>Back in <strong>Connectors</strong>, click <strong>Create</strong>.</li>
       <li>Set <strong>Name</strong>: <code>OhMyWind</code> · <strong>Authentication</strong>: <code>No authentication</code>.</li>
       <li>Paste this in <strong>MCP server URL</strong>:
-        <pre><code>https://qdonnars-openwind-mcp.hf.space/mcp</code></pre></li>
+        <pre><code>https://mcp.ohmywind.fr/mcp</code></pre></li>
       <li>Trust the connector and save. Activate it in a chat via
         <strong>+ → Developer connectors → OhMyWind</strong>.</li>
     </ol>

--- a/packages/mcp-core/src/openwind_mcp_core/render.py
+++ b/packages/mcp-core/src/openwind_mcp_core/render.py
@@ -17,7 +17,53 @@ and by the MCP Apps resource template.
 
 from __future__ import annotations
 
-from urllib.parse import quote
+import logging
+import os
+from urllib.parse import quote, urlsplit
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_WEB_BASE = "https://ohmywind.fr"
+
+# Which web app the deep-links point at, per environment.
+#
+# This was hard-coded to production, so the dev Space handed out production
+# links: every plan produced while testing sent the tester to the live site,
+# and nothing exercised the dev front end. The web app has had `VITE_API_BASE`
+# per environment from the start; this is the missing mirror of it.
+#
+# Set `OHMYWIND_WEB_BASE=https://dev.ohmywind.fr` on the dev Space. Unset, it
+# stays on production, so an unconfigured deployment behaves as before rather
+# than emitting links to nowhere.
+WEB_BASE_ENV_VAR = "OHMYWIND_WEB_BASE"
+
+
+def _resolve_web_base() -> str:
+    """Read and sanity-check the configured web base, else fall back.
+
+    A malformed value would be baked into every deep-link we hand out, so a bad
+    setting degrades to production rather than shipping broken URLs quietly.
+    """
+    raw = (os.environ.get(WEB_BASE_ENV_VAR) or "").strip().rstrip("/")
+    if not raw:
+        return DEFAULT_WEB_BASE
+    parts = urlsplit(raw)
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        _logger.warning(
+            "ohmywind: ignoring %s=%r (need an absolute http(s) URL), using %s",
+            WEB_BASE_ENV_VAR,
+            raw,
+            DEFAULT_WEB_BASE,
+        )
+        return DEFAULT_WEB_BASE
+    return raw
+
+
+WEB_BASE = _resolve_web_base()
+# Bare host for display, e.g. "dev.ohmywind.fr". The widget names the site it
+# is about to send you to, and naming production while linking to dev would be
+# worse than not naming it at all.
+WEB_HOST = urlsplit(WEB_BASE).netloc
 
 
 def build_ohmywind_url(
@@ -25,7 +71,7 @@ def build_ohmywind_url(
     departure_iso: str,
     archetype: str,
 ) -> str:
-    """Build the ohmywind.fr/plan deep-link URL.
+    """Build the ``/plan`` deep-link URL for the configured web app.
 
     Used as the always-on fallback CTA for clients that don't render the MCP
     Apps iframe (Le Chat, Goose, terminals) — they show this URL as
@@ -36,4 +82,4 @@ def build_ohmywind_url(
     """
     wpts = ";".join(f"{w['lat']:.3f},{w['lon']:.3f}" for w in waypoints)
     dep = quote(departure_iso, safe="")
-    return f"https://ohmywind.fr/plan?wpts={wpts}&departure={dep}&archetype={archetype}"
+    return f"{WEB_BASE}/plan?wpts={wpts}&departure={dep}&archetype={archetype}"

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -69,7 +69,7 @@ from .feedback import (
     build_feedback_entry,
     stderr_sink,
 )
-from .render import build_ohmywind_url
+from .render import WEB_BASE, WEB_HOST, build_ohmywind_url
 
 # MCP Apps UI resource URI for plan_passage. The host fetches this resource
 # and renders it in a sandboxed iframe; the resource itself iframes
@@ -213,7 +213,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
       const cx = sc.complexity || {};
       const segs = p.segments || [];
       const warnings = (p.warnings||[]).concat((cx.warnings||[]).map(w=>w.message||w));
-      const url = sc.openwind_url || "https://ohmywind.fr/plan";
+      const url = sc.openwind_url || "__WEB_BASE__/plan";
       const stats = [
         ["Distance", (p.distance_nm||0).toFixed(1)+" nm"],
         ["Durée",    fmtDur(p.duration_h)],
@@ -247,7 +247,7 @@ _PLAN_WIDGET_HTML = """<!doctype html>
           <thead><tr><th>#</th><th>Heure</th><th>Allure</th><th>Vent</th><th>Mer</th><th>Vitesse</th></tr></thead>
           <tbody>${legRows}</tbody>
         </table>` : ""}
-        <a class="cta" href="${escapeHtml(url)}" rel="noopener">Voir le plan complet sur ohmywind.fr →</a>
+        <a class="cta" href="${escapeHtml(url)}" rel="noopener">Voir le plan complet sur __WEB_HOST__ →</a>
       `;
     }
 
@@ -346,10 +346,10 @@ _PLAN_WIDGET_HTML = """<!doctype html>
         wireClicks();
       } catch(e) {
         console.error('[ohmywind] render failed', e);
-        const url = (sc.openwind_url || (sc.windows && sc.windows[0] && sc.windows[0].openwind_url) || "https://ohmywind.fr/plan");
+        const url = (sc.openwind_url || (sc.windows && sc.windows[0] && sc.windows[0].openwind_url) || "__WEB_BASE__/plan");
         root.innerHTML = `<div class="placeholder">
           Impossible d'afficher le plan ici.
-          <br><a class="cta" href="${escapeHtml(url)}" rel="noopener">Ouvrir sur ohmywind.fr →</a>
+          <br><a class="cta" href="${escapeHtml(url)}" rel="noopener">Ouvrir sur __WEB_HOST__ →</a>
         </div>`;
         wireClicks();
       }
@@ -632,7 +632,10 @@ def build_server(
         different framings, and the spec is young — and falls back to a
         deep-link CTA if no result arrives within 6 s.
         """
-        return _PLAN_WIDGET_HTML
+        # Substituted at serve time: the widget's fallback CTA has to name the
+        # same environment the deep-links point at, or a plan rendered on dev
+        # would hand the tester a link to production.
+        return _PLAN_WIDGET_HTML.replace("__WEB_BASE__", WEB_BASE).replace("__WEB_HOST__", WEB_HOST)
 
     @server.tool()
     def read_me() -> str:
@@ -810,8 +813,11 @@ def build_server(
         out so they can open the full app, share it, or bookmark it. Treat
         this as a hard requirement, not a fallback:
 
-        - **Single mode**: end your reply with a Markdown link, e.g.
-          ``[Voir le plan détaillé →](https://ohmywind.fr/plan?…)``.
+        - **Single mode**: end your reply with a Markdown link built from the
+          ``openwind_url`` field, e.g. ``[Voir le plan détaillé →](<openwind_url>)``.
+          Always use that value verbatim, never a URL you compose yourself: it
+          points at the environment this server is configured for, which is not
+          always the production site.
         - **Compare-windows mode**: list 2-4 of the most relevant windows
           and give each its own link, e.g.
           ``- Sam 2 mai 09h · 11h12 · ⚡2/5 — [voir →](url)``.

--- a/packages/mcp-core/tests/test_web_base.py
+++ b/packages/mcp-core/tests/test_web_base.py
@@ -1,0 +1,101 @@
+"""Deep-links must point at the environment the server runs in.
+
+The dev Space handed out production links: every plan produced while testing
+sent the tester to the live site, and the dev front end was never exercised by
+the thing meant to drive it. The web app has had ``VITE_API_BASE`` per
+environment from the start; this is the missing mirror of it.
+
+``render`` reads the variable at import, so each case reloads the module rather
+than trying to mutate an already-resolved constant.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import openwind_mcp_core.render as render_module
+
+
+def _reload_with(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    if value is None:
+        monkeypatch.delenv(render_module.WEB_BASE_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(render_module.WEB_BASE_ENV_VAR, value)
+    return importlib.reload(render_module)
+
+
+@pytest.fixture(autouse=True)
+def _restore_module():
+    """Leave the module resolved from the ambient env, whatever a test did."""
+    yield
+    importlib.reload(render_module)
+
+
+def _url(mod) -> str:
+    return mod.build_ohmywind_url(
+        [{"lat": 43.3, "lon": 5.36}], "2026-08-02T08:00:00Z", "cruiser_40ft"
+    )
+
+
+def test_defaults_to_production_when_unset(monkeypatch) -> None:
+    """An unconfigured deployment keeps the previous behaviour."""
+    mod = _reload_with(monkeypatch, None)
+    assert _url(mod).startswith("https://ohmywind.fr/plan?")
+
+
+def test_dev_base_produces_dev_links(monkeypatch) -> None:
+    mod = _reload_with(monkeypatch, "https://dev.ohmywind.fr")
+    assert _url(mod).startswith("https://dev.ohmywind.fr/plan?")
+    assert "//ohmywind.fr" not in _url(mod)
+
+
+def test_trailing_slash_does_not_double_up(monkeypatch) -> None:
+    """A base pasted from a browser bar usually carries one."""
+    mod = _reload_with(monkeypatch, "https://dev.ohmywind.fr/")
+    assert "//plan" not in _url(mod)
+    assert _url(mod).startswith("https://dev.ohmywind.fr/plan?")
+
+
+@pytest.mark.parametrize("bad", ["dev.ohmywind.fr", "ftp://dev.ohmywind.fr", "https://", "   "])
+def test_a_malformed_base_falls_back_instead_of_shipping_broken_links(monkeypatch, bad) -> None:
+    """The value is baked into every link we hand out, so it fails safe.
+
+    A missing scheme is the likely typo, and left unchecked it would produce
+    relative-looking URLs that no chat client can open.
+    """
+    mod = _reload_with(monkeypatch, bad)
+    assert _url(mod).startswith("https://ohmywind.fr/plan?")
+
+
+def test_host_is_exposed_for_display(monkeypatch) -> None:
+    """The widget names the site it links to; both must agree."""
+    mod = _reload_with(monkeypatch, "https://dev.ohmywind.fr")
+    assert mod.WEB_HOST == "dev.ohmywind.fr"
+
+
+@pytest.mark.asyncio
+async def test_the_widget_resource_names_the_same_environment(monkeypatch) -> None:
+    """End-to-end: the served HTML must carry no placeholder and no prod URL.
+
+    The widget's fallback CTA is a separate code path from the deep-link, so a
+    substitution missed there would show a production link inside a plan
+    rendered on dev — the exact split this change exists to close.
+    """
+    import openwind_mcp_core.server as server_module
+
+    monkeypatch.setenv(render_module.WEB_BASE_ENV_VAR, "https://dev.ohmywind.fr")
+    importlib.reload(render_module)
+    reloaded = importlib.reload(server_module)
+
+    server = reloaded.build_server(adapter=object())
+    contents = await server.read_resource(reloaded.PLAN_UI_RESOURCE_URI)
+    html = next(iter(contents)).content
+
+    assert "__WEB_BASE__" not in html and "__WEB_HOST__" not in html
+    assert "dev.ohmywind.fr" in html
+    assert "//ohmywind.fr" not in html
+
+    importlib.reload(render_module)
+    importlib.reload(server_module)


### PR DESCRIPTION
Le MCP dev distribuait des liens vers la **prod**. Le domaine était codé en dur dans `render.py` alors que tout le reste est variabilisé par environnement : chaque plan calculé pendant les tests renvoyait le testeur sur le site en production, et le front de dev n'était jamais exercé par ce qui est censé le piloter.

Le web a `VITE_API_BASE` par environnement depuis le début. Voici le miroir qui manquait côté serveur.

## Ce que ça change

`OHMYWIND_WEB_BASE`, à poser sur le Space dev avec `https://dev.ohmywind.fr`. Non défini, on reste sur la prod, donc un déploiement non configuré se comporte exactement comme avant plutôt que d'émettre des liens vers nulle part.

Une valeur malformée retombe aussi sur la prod, avec un avertissement en log. Elle serait gravée dans chaque lien qu'on distribue, donc autant échouer du bon côté : un schéma oublié est la faute probable, et non détectée elle produirait des URLs qu'aucun client de chat ne sait ouvrir.

**Le widget suit la même base, texte compris.** Nommer `ohmywind.fr` tout en pointant vers dev serait pire que ne rien nommer. La substitution a lieu au moment de servir la ressource, et un test de bout en bout vérifie qu'il ne reste ni placeholder ni URL de prod dans le HTML servi.

**L'instruction donnée au LLM citait une URL de prod en exemple**, ce qui l'encourageait à en composer une plutôt qu'à reprendre `openwind_url`. Reformulée pour exiger la valeur du champ.

## L'endpoint annoncé

Partout où on documente comment se connecter, l'URL devient `https://mcp.ohmywind.fr/mcp` au lieu du `.hf.space` : landing du Space, carte HF, README racine. C'est le sujet même du Worker déployé aujourd'hui.

Le `sed` du workflow est mis à jour **dans le même commit** pour réécrire vers `mcp-dev.ohmywind.fr`. Sans ça, la carte du Space dev annoncerait l'endpoint de prod, c'est-à-dire exactement le défaut que cette PR corrige par ailleurs. Motifs revérifiés par simulation sur le README modifié.

`DEFAULT_ALLOWED_HOSTS` accepte désormais les deux hostnames : le Worker présente celui du Space en amont, un appel direct présente le public.

## Tests

6 sur la résolution de la base, dont les cas malformés, plus 1 de bout en bout sur la ressource widget.

mcp-core 49, data-adapters 259 + 3 skippés, hf-space 96. ruff propre.

## À faire côté dashboard après merge

Poser `OHMYWIND_WEB_BASE = https://dev.ohmywind.fr` sur le Space dev. Sans cette variable, le correctif est inerte et les liens continueront de pointer vers la prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)