### PR TITLE
Dev: annotations d'outils, retrait de feedback, tuto d'installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,39 @@ deep-link. No account. No API key. No credit card.
 > add it under **Connectors → Add connector → Custom MCP connector** and paste
 > the endpoint above.
 
+### If your client only speaks stdio
+
+Some hosts cannot reach a remote MCP server directly yet. Bridge it with
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote), which runs locally
+and forwards to the endpoint:
+
+```json
+{
+  "mcpServers": {
+    "ohmywind": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.ohmywind.fr/mcp"]
+    }
+  }
+}
+```
+
+Nothing else to configure: **no account, no API key, no OAuth, no credit
+card.** A client that asks you for credentials is guessing rather than reading
+the server, and you can leave those fields empty.
+
+### Ask it something real
+
+Three prompts, each exercising a different tool:
+
+- *"Quels bateaux tu connais ? J'ai un First 27."* maps your boat to a polar
+  archetype. The assistant chooses from the descriptions; there is no
+  server-side lookup table.
+- *"Le vent au cap Sicié samedi après-midi ?"* returns wind and sea at one
+  point, AROME first, in knots.
+- *"Meilleur créneau cette semaine pour Marseille → Porquerolles ?"* walks
+  every hourly departure up to 14 days out and compares them in one call.
+
 ## Why OhMyWind
 
 |                              |                                                                                              |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,9 +23,10 @@ on the server.
         │   ├── plan_passage    (single + compare-      │
         │   │                    windows mode; declares │
         │   │                    MCP Apps UI resource)  │
-        │   ├── read_me                                 │
-        │   └── feedback        (sink injected by the   │
-        │                        deployment wrapper)    │
+        │   └── read_me                                 │
+        │                                               │
+        │   All four are read-only. Nothing on the      │
+        │   public surface writes.                      │
         └────────────┬─────────────────────────────────┘
                      │ pure Python calls
         ┌────────────▼─────────────────────────────────┐
@@ -83,7 +84,7 @@ LLM produces the verdict.
 
 The wrapper does **not** use Gradio: it is a plain Starlette app served by
 uvicorn in a Docker Space. `huggingface_hub` appears only there, to pull the
-tidal atlas at build time and to push feedback.
+tidal atlas at build time.
 
 `build_server()` in `openwind_mcp_core.server` is the single factory used by:
 

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -77,7 +77,7 @@ asks you for credentials is guessing rather than reading the server.
 - **Client-agnostic.** One HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
 - **Open source, MIT.** Self-host on Fly, Modal, or your own VPS in minutes.
 
-## Five tools
+## Four tools
 
 | Tool                      | What it does                                                              |
 |---------------------------|---------------------------------------------------------------------------|
@@ -85,7 +85,6 @@ asks you for credentials is guessing rather than reading the server.
 | `get_marine_forecast`     | Wind + sea around a point/window, multi-model.                            |
 | `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + ohmywind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
 | `read_me`                 | Returns OhMyWind's calculation methodology. Call it when the user asks how things are computed. |
-| `feedback`                | Structured channel for the LLM to report a problem or a suggestion about a tool interaction. |
 
 ## About this Space
 

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -50,6 +50,24 @@ card.
 > other MCP-compatible host. In Le Chat, add it under **Connectors → Add
 > connector → Custom MCP connector** and paste the endpoint above.
 
+### If your client only speaks stdio
+
+Bridge it with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+
+```json
+{
+  "mcpServers": {
+    "ohmywind": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.ohmywind.fr/mcp"]
+    }
+  }
+}
+```
+
+Nothing else to configure: **no account, no API key, no OAuth.** A client that
+asks you for credentials is guessing rather than reading the server.
+
 ## Why OhMyWind
 
 - **Free and keyless.** Wind + sea data via [Open-Meteo](https://open-meteo.com) (CC BY 4.0).

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -17,12 +17,10 @@ Re-evaluate if traffic plateaus.
 from __future__ import annotations
 
 import dataclasses
-import json
 import logging
 import math
 import os
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -816,91 +814,6 @@ _SHOM_REGISTRY = ShomC2dRegistry.from_directory(os.environ.get("SHOM_C2D_DIR", "
 
 
 # ---------------------------------------------------------------------------
-# Feedback sink — pushes the `feedback` MCP tool's entries to a private HF
-# Dataset repo via CommitScheduler (background thread, batched every 10 min).
-# ---------------------------------------------------------------------------
-#
-# Required env on the Space:
-#   OPENWIND_FEEDBACK_DATASET_REPO  e.g. "Qdonnars/openwind-feedback"
-#   HF_TOKEN_FEEDBACK               write-scoped on the feedback dataset
-#                                   (separate Space secret so the read-scoped
-#                                   HF_TOKEN used at build time to pull the
-#                                   tidal atlas stays minimum-privilege).
-#                                   Falls back to HF_TOKEN if unset (handy
-#                                   for local dev with a single write token
-#                                   in .env).
-#
-# When the dataset repo or both tokens are missing, the sink degrades to a
-# stderr log — the tool still returns ack="thanks" so the LLM keeps a
-# uniform contract regardless of deployment.
-_FEEDBACK_FOLDER = Path(os.environ.get("OPENWIND_FEEDBACK_DIR", "/tmp/openwind-feedback"))
-_FEEDBACK_FILE = _FEEDBACK_FOLDER / "feedback.jsonl"
-_FEEDBACK_REPO = os.environ.get("OPENWIND_FEEDBACK_DATASET_REPO")
-_FEEDBACK_EVERY_MIN = int(os.environ.get("OPENWIND_FEEDBACK_EVERY_MIN", "10"))
-_feedback_scheduler: Any | None = None
-
-
-def _build_feedback_scheduler() -> Any | None:
-    """Lazy construct a CommitScheduler if the env is wired, else None.
-
-    Imported inside the function so module import doesn't fail when
-    huggingface_hub is missing in unrelated environments (tests, etc.).
-    """
-    if not _FEEDBACK_REPO:
-        _logger.info(
-            "ohmywind.feedback: OPENWIND_FEEDBACK_DATASET_REPO unset, "
-            "feedback will only log to stderr"
-        )
-        return None
-    token = os.environ.get("HF_TOKEN_FEEDBACK") or os.environ.get("HF_TOKEN")
-    if not token:
-        _logger.warning(
-            "ohmywind.feedback: HF_TOKEN_FEEDBACK / HF_TOKEN unset, "
-            "cannot push to %s — feedback will only log to stderr",
-            _FEEDBACK_REPO,
-        )
-        return None
-    try:
-        from huggingface_hub import CommitScheduler
-
-        _FEEDBACK_FOLDER.mkdir(parents=True, exist_ok=True)
-        scheduler = CommitScheduler(
-            repo_id=_FEEDBACK_REPO,
-            repo_type="dataset",
-            folder_path=str(_FEEDBACK_FOLDER),
-            path_in_repo="data",
-            every=_FEEDBACK_EVERY_MIN,
-            private=True,
-            token=token,
-        )
-        _logger.info(
-            "ohmywind.feedback: CommitScheduler attached to %s (every=%d min)",
-            _FEEDBACK_REPO,
-            _FEEDBACK_EVERY_MIN,
-        )
-        return scheduler
-    except Exception as exc:
-        _logger.warning("ohmywind.feedback: scheduler init failed: %s", exc)
-        return None
-
-
-def _hf_feedback_sink(entry: dict[str, Any]) -> None:
-    """Append one JSONL row inside the scheduler's lock.
-
-    The scheduler watches ``_FEEDBACK_FOLDER`` and pushes the file to the
-    dataset repo every ``every`` minutes. ``CommitScheduler.lock`` is a
-    threading lock — combine with the file's ``"a"`` mode for the
-    append-only contract that CommitScheduler requires.
-    """
-    if _feedback_scheduler is None:
-        _logger.info("ohmywind.feedback (no sink): %s", entry)
-        return
-    with _feedback_scheduler.lock:
-        with _FEEDBACK_FILE.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False))
-            f.write("\n")
-
-
 async def _api_marc_overlay(request: Request) -> JSONResponse:
     """Return MARC PREVIMER currents and tide-height predictions for a point.
 
@@ -1080,11 +993,9 @@ def build_app(mcp_app: Any) -> Starlette:
 
 
 def main() -> None:
-    global _feedback_scheduler
     logging.basicConfig(level=logging.INFO)
     warn_if_edge_secret_missing()
-    _feedback_scheduler = _build_feedback_scheduler()
-    server = build_server(feedback_sink=_hf_feedback_sink)
+    server = build_server()
     server.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=ALLOWED_HOSTS,

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -6,7 +6,6 @@ Cloud-agnostic FastMCP server for OhMyWind. Exposes 5 tools:
 - `get_marine_forecast` wind + sea around a point/window
 - `plan_passage` end-to-end timing + complexity + ohmywind.fr deep-link; declares an MCP Apps UI resource so supporting hosts auto-render the iframe widget. Optional compare-windows mode (sweep N hourly departures over the same route).
 - `read_me` calculation methodology (polars, efficiency, VMG, defaults)
-- `feedback` structured channel for the LLM to report a problem or a suggestion; the sink is injected by the deployment wrapper, so the core stays cloud-agnostic
 
 `build_server()` is the single factory; no Gradio, no `huggingface_hub`. The
 HF Spaces wrapper (Sprint 4) and any future deployment use the same factory.

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -62,14 +62,6 @@ from openwind_data.routing import (
     score_complexity as _score_complexity,
 )
 
-from .feedback import (
-    FeedbackCategory,
-    FeedbackSeverity,
-    FeedbackSink,
-    FeedbackToolName,
-    build_feedback_entry,
-    stderr_sink,
-)
 from .render import WEB_BASE, WEB_HOST, build_ohmywind_url
 
 # MCP Apps UI resource URI for plan_passage. The host fetches this resource
@@ -538,7 +530,6 @@ def _build_window_dict(
 def build_server(
     *,
     adapter: MarineDataAdapter | None = None,
-    feedback_sink: FeedbackSink | None = None,
 ) -> FastMCP:
     """Build a FastMCP server with all OhMyWind tools registered.
 
@@ -551,13 +542,7 @@ def build_server(
             ``MARC_ATLAS_DIR``. Either or both can be absent; the cascade
             degrades gracefully (SHOM > MARC > SMOC). Override the whole
             adapter in tests.
-        feedback_sink: optional callable invoked by the ``feedback`` tool
-            with the normalized entry dict. ``mcp-core`` stays cloud-agnostic
-            (no ``huggingface_hub`` import); the HF Spaces wrapper plugs in
-            a ``CommitScheduler``-backed sink that pushes to a private
-            dataset. Defaults to ``stderr_sink`` for local dev.
     """
-    sink: FeedbackSink = feedback_sink or stderr_sink
     # ``stateless_http=True`` disables the in-memory session table that
     # otherwise tracks an ``mcp-session-id`` per client across requests.
     # All OhMyWind tools are idempotent point-in-time fetches with no
@@ -699,13 +684,6 @@ def build_server(
 
         Note: the first request after inactivity may incur ~5s of cold-start.
 
-        ## Feedback channel
-
-        If the user asks you to send feedback to OhMyWind ("fais
-        remonter aux dev", "feedback", "signale ça", "remonte ça",
-        "tell them", "let the team know"), call the ``feedback`` tool.
-        Do NOT write a free-text reply about the feedback in chat: the
-        tool is the channel.
         """
         validate_point(lat, lon)
         start_dt = datetime.fromisoformat(start)
@@ -902,13 +880,6 @@ def build_server(
         cover the passage and ``model != "auto"``. The error message names the
         failing model and suggests longer-range alternatives.
 
-        ## Feedback channel
-
-        If the user asks you to send feedback to OhMyWind ("fais
-        remonter aux dev", "feedback", "signale ça", "remonte ça",
-        "tell them", "let the team know"), call the ``feedback`` tool.
-        Do NOT write a free-text reply about the feedback in chat: the
-        tool is the channel.
         """
         # Same guards, same wording as the REST layer. FastMCP turns any
         # exception raised in a tool into an isError result carrying str(exc),
@@ -1020,112 +991,6 @@ def build_server(
             "passage": _passage_to_dict(report),
             "complexity": asdict(score),
             "openwind_url": build_ohmywind_url(waypoints, departure, archetype),
-        }
-
-    @server.tool(
-        annotations=ToolAnnotations(
-            title="Send feedback",
-            readOnlyHint=False,
-            destructiveHint=False,
-            idempotentHint=False,
-            openWorldHint=False,
-        ),
-    )
-    def feedback(
-        category: FeedbackCategory,
-        tool_name: FeedbackToolName,
-        severity: FeedbackSeverity,
-        message: str,
-        context_json: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Log a structured note about an OhMyWind tool interaction.
-
-        ## Direct user trigger — call this immediately, no chat reply
-
-        When the user EXPLICITLY asks you to send feedback / file a
-        report / signal something to the OhMyWind team, call this tool
-        right away. Do NOT draft a free-text reply in chat asking the
-        user what they want to say: their phrasing IS the message.
-        Pass it (translated or summarised as needed) as the ``message``.
-
-        Trigger phrases (non-exhaustive, French + English):
-        ``"fais un feedback"``, ``"fais remonter aux dev"``,
-        ``"signale ça"``, ``"remonte ça"``, ``"file a feedback"``,
-        ``"send feedback"``, ``"tell them"``, ``"let the team know"``,
-        ``"fais un retour à OhMyWind"``.
-
-        ## Also call when
-
-        - A previous tool call returned an error you couldn't recover from,
-          or a result that contradicts what the user asked
-          (``category="wrong_result"``).
-        - A parameter description was unclear and you had to guess
-          (``category="unclear_param"``).
-        - You needed data that no current tool exposes
-          (``category="missing_data"`` — for example, official BMS
-          bulletins, port closures, fuel stops).
-        - The user explicitly asked for a feature that doesn't exist yet
-          (``category="feature_request"``).
-        - The user expresses dissatisfaction in chat ("c'est faux",
-          "ce n'est pas ce que je voulais") about an OhMyWind result.
-
-        ## Do NOT call this tool
-
-        - On routine successful calls. Silence is the right answer when
-          things work.
-        - As a chat acknowledgement. The user does not see your call.
-        - Multiple times for the same incident. One feedback per turn,
-          per distinct issue.
-        - For errors that are clearly the user's input fault (typo in a
-          city name, impossible date) — only call when the issue is on
-          OhMyWind's side or in the tool surface.
-
-        ## Args
-
-            category: nature of the feedback (see triggers above).
-            tool_name: which OhMyWind tool the feedback is about. Use
-                ``"general"`` for cross-cutting feedback, ``"feedback"``
-                for meta-feedback about this tool itself.
-            severity: ``"low"`` (nice-to-have, doesn't block the user),
-                ``"medium"`` (degrades the experience), ``"high"`` (broke
-                the user's workflow or returned a misleading result).
-            message: short free-text description, max ~2000 chars. Be
-                concrete: name the symptom, not the fix. Good: "passage
-                from Marseille to Calvi returned distance_nm=0 even
-                though waypoints are >100nm apart". Bad: "should fix
-                the distance bug".
-            context_json: optional dict with reproducer hints — the
-                input args you passed, the offending excerpt of the
-                response, the user's original phrasing. Capped at ~4000
-                chars after JSON serialisation.
-
-        ## Returns
-
-        ``{"feedback_id": <uuid hex>, "received_at": <iso8601>,
-        "ack": "thanks"}`` — never raises. If persistence fails on the
-        server side it is logged and ``ack`` reflects ``"buffered"``.
-        Do not surface the ack to the user; just continue the
-        conversation.
-        """
-        entry = build_feedback_entry(
-            category=category,
-            tool_name=tool_name,
-            severity=severity,
-            message=message,
-            context_json=context_json,
-        )
-        ack = "thanks"
-        try:
-            sink(entry)
-        except Exception as exc:
-            import logging as _logging
-
-            _logging.getLogger(__name__).warning("ohmywind.feedback sink failed: %s", exc)
-            ack = "buffered"
-        return {
-            "feedback_id": entry["feedback_id"],
-            "received_at": entry["received_at"],
-            "ack": ack,
         }
 
     return server

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -37,6 +37,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from openwind_data.adapters.base import MarineDataAdapter
 from openwind_data.adapters.openmeteo import AUTO_MODEL, OpenMeteoAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
@@ -637,7 +638,13 @@ def build_server(
         # would hand the tester a link to production.
         return _PLAN_WIDGET_HTML.replace("__WEB_BASE__", WEB_BASE).replace("__WEB_HOST__", WEB_HOST)
 
-    @server.tool()
+    @server.tool(
+        annotations=ToolAnnotations(
+            title="Calculation method",
+            readOnlyHint=True,
+            openWorldHint=False,
+        ),
+    )
     def read_me() -> str:
         """Return OhMyWind's calculation methodology as Markdown.
 
@@ -652,7 +659,13 @@ def build_server(
         """
         return _METHODOLOGY
 
-    @server.tool()
+    @server.tool(
+        annotations=ToolAnnotations(
+            title="Boat archetypes",
+            readOnlyHint=True,
+            openWorldHint=False,
+        ),
+    )
     def list_boat_archetypes() -> list[dict[str, Any]]:
         """List the 7 boat archetypes with descriptive metadata.
 
@@ -661,7 +674,13 @@ def build_server(
         """
         return [_archetype_summary(p) for p in list_archetypes()]
 
-    @server.tool()
+    @server.tool(
+        annotations=ToolAnnotations(
+            title="Marine forecast",
+            readOnlyHint=True,
+            openWorldHint=True,
+        ),
+    )
     async def get_marine_forecast(
         lat: float,
         lon: float,
@@ -722,6 +741,11 @@ def build_server(
         }
 
     @server.tool(
+        annotations=ToolAnnotations(
+            title="Plan a passage",
+            readOnlyHint=True,
+            openWorldHint=True,
+        ),
         meta={"ui": {"resourceUri": PLAN_UI_RESOURCE_URI}},
     )
     async def plan_passage(
@@ -998,7 +1022,15 @@ def build_server(
             "openwind_url": build_ohmywind_url(waypoints, departure, archetype),
         }
 
-    @server.tool()
+    @server.tool(
+        annotations=ToolAnnotations(
+            title="Send feedback",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    )
     def feedback(
         category: FeedbackCategory,
         tool_name: FeedbackToolName,

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -70,9 +70,11 @@ class TestBuildServer:
         server = build_server(adapter=StubAdapter())
         assert isinstance(server, FastMCP)
 
-    async def test_lists_five_tools(self) -> None:
-        # The V1 surface: 3 functional tools + read_me for methodology Q&A
-        # + feedback for LLM-side issue reporting.
+    async def test_lists_four_tools(self) -> None:
+        # The V1 surface: 3 functional tools + read_me for methodology Q&A.
+        # `feedback` was removed before publication: an unauthenticated,
+        # unrate-limited write endpoint on a public server ingests whatever a
+        # prompt injection decides to send, and we would be storing it.
         server = build_server(adapter=StubAdapter())
         tools = await server.list_tools()
         names = {t.name for t in tools}
@@ -81,7 +83,6 @@ class TestBuildServer:
             "list_boat_archetypes",
             "get_marine_forecast",
             "plan_passage",
-            "feedback",
         }
 
 
@@ -293,94 +294,6 @@ class TestPlanPassageSweep:
             raise AssertionError("expected an exception for oversized sweep")
         except Exception as exc:
             assert "336" in str(exc) or "cap" in str(exc).lower() or "windows" in str(exc).lower()
-
-
-class TestFeedback:
-    """The feedback tool is the LLM-side issue reporting channel.
-
-    Contract: the sink receives a normalised entry with stable keys; the
-    tool never raises (a failing sink degrades to ``ack="buffered"``);
-    the LLM-facing payload only exposes ``feedback_id``, ``received_at``,
-    and ``ack``."""
-
-    @staticmethod
-    def _args(**overrides: object) -> dict:
-        base = {
-            "category": "wrong_result",
-            "tool_name": "plan_passage",
-            "severity": "medium",
-            "message": "distance_nm=0 for Marseille -> Calvi",
-        }
-        base.update(overrides)
-        return base
-
-    async def test_feedback_listed(self) -> None:
-        server = build_server(adapter=StubAdapter())
-        tools = await server.list_tools()
-        names = {t.name for t in tools}
-        assert "feedback" in names
-
-    async def test_default_sink_does_not_raise(self) -> None:
-        # No sink provided → stderr_sink default. Tool returns ack="thanks".
-        server = build_server(adapter=StubAdapter())
-        out = await _call(server, "feedback", self._args())
-        assert out["ack"] == "thanks"
-        assert isinstance(out["feedback_id"], str) and len(out["feedback_id"]) > 0
-        assert isinstance(out["received_at"], str)
-
-    async def test_custom_sink_receives_normalised_entry(self) -> None:
-        captured: list[dict] = []
-
-        def sink(entry: dict) -> None:
-            captured.append(entry)
-
-        server = build_server(adapter=StubAdapter(), feedback_sink=sink)
-        await _call(
-            server,
-            "feedback",
-            self._args(context_json={"waypoints": [[43.3, 5.35], [42.5, 8.7]]}),
-        )
-        assert len(captured) == 1
-        e = captured[0]
-        assert {
-            "feedback_id",
-            "received_at",
-            "category",
-            "tool_name",
-            "severity",
-            "message",
-            "context_json",
-            "client_hint",
-        } <= e.keys()
-        assert e["category"] == "wrong_result"
-        assert e["tool_name"] == "plan_passage"
-        assert e["severity"] == "medium"
-        assert e["context_json"] == {"waypoints": [[43.3, 5.35], [42.5, 8.7]]}
-        assert e["client_hint"] is None
-
-    async def test_failing_sink_degrades_to_buffered(self) -> None:
-        def sink(_entry: dict) -> None:
-            raise RuntimeError("HF push failed")
-
-        server = build_server(adapter=StubAdapter(), feedback_sink=sink)
-        out = await _call(server, "feedback", self._args())
-        assert out["ack"] == "buffered"
-        # ID and timestamp still returned, so the LLM never sees a tool error.
-        assert isinstance(out["feedback_id"], str) and len(out["feedback_id"]) > 0
-
-    async def test_long_message_is_truncated(self) -> None:
-        captured: list[dict] = []
-        server = build_server(adapter=StubAdapter(), feedback_sink=captured.append)
-        await _call(server, "feedback", self._args(message="x" * 5000))
-        assert "[truncated]" in captured[0]["message"]
-        assert len(captured[0]["message"]) < 5000
-
-    async def test_response_does_not_leak_message(self) -> None:
-        # The tool response should be a thin ack — not echo back the
-        # user's full message (no point round-tripping it to the LLM).
-        server = build_server(adapter=StubAdapter())
-        out = await _call(server, "feedback", self._args(message="some private note"))
-        assert "some private note" not in str(out)
 
 
 class TestGetMarineForecast:

--- a/packages/mcp-core/tests/test_tool_annotations.py
+++ b/packages/mcp-core/tests/test_tool_annotations.py
@@ -1,0 +1,72 @@
+"""Every tool declares what it does to the world.
+
+Annotations drive how clients present a tool: read-only ones can be offered
+without a confirmation prompt, writing ones should not be. An unannotated tool
+is treated conservatively by some hosts and carelessly by others, which is the
+worst of both.
+
+They are also a hard requirement of Anthropic's connector directory, so this
+is the cheap groundwork for listing rather than a nicety.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openwind_mcp_core import build_server
+
+# The one tool that writes. Kept as data so the "nothing else writes" assertion
+# below reads as a decision rather than a magic string.
+WRITING_TOOLS = {"feedback"}
+
+
+@pytest.fixture
+async def tools():
+    return await build_server(adapter=object()).list_tools()
+
+
+async def test_every_tool_is_annotated(tools) -> None:
+    missing = [t.name for t in tools if t.annotations is None]
+    assert missing == [], f"tools with no annotations: {missing}"
+
+
+async def test_every_tool_has_a_display_title(tools) -> None:
+    """Without it, clients fall back to the raw function name."""
+    untitled = [t.name for t in tools if not (t.annotations and t.annotations.title)]
+    assert untitled == []
+
+
+async def test_only_the_feedback_tool_writes(tools) -> None:
+    """The assertion that earns its keep.
+
+    Adding a tool that mutates anything without flipping readOnlyHint would let
+    hosts run it unprompted. Failing here forces that to be a conscious choice
+    rather than an omission.
+    """
+    writing = {t.name for t in tools if t.annotations and t.annotations.readOnlyHint is False}
+    assert writing == WRITING_TOOLS
+
+
+async def test_the_writing_tool_is_neither_destructive_nor_idempotent(tools) -> None:
+    """``feedback`` appends one entry per call.
+
+    Not destructive, because it never replaces or removes anything. Not
+    idempotent, because calling it twice records twice — a host that assumed
+    otherwise could silently retry and double-log.
+    """
+    feedback = next(t for t in tools if t.name == "feedback")
+    assert feedback.annotations.destructiveHint is False
+    assert feedback.annotations.idempotentHint is False
+
+
+async def test_open_world_marks_the_tools_that_call_out(tools) -> None:
+    """Distinguishes a live upstream fetch from a lookup in a bundled table.
+
+    ``list_boat_archetypes`` and ``read_me`` are constants of this server;
+    the other two reach Open-Meteo, whose availability we do not control.
+    """
+    by_name = {t.name: t.annotations.openWorldHint for t in tools}
+    assert by_name["get_marine_forecast"] is True
+    assert by_name["plan_passage"] is True
+    assert by_name["list_boat_archetypes"] is False
+    assert by_name["read_me"] is False

--- a/packages/mcp-core/tests/test_tool_annotations.py
+++ b/packages/mcp-core/tests/test_tool_annotations.py
@@ -15,9 +15,11 @@ import pytest
 
 from openwind_mcp_core import build_server
 
-# The one tool that writes. Kept as data so the "nothing else writes" assertion
-# below reads as a decision rather than a magic string.
-WRITING_TOOLS = {"feedback"}
+# Nothing on this server writes. The feedback tool used to, and was removed
+# before publication: an unauthenticated, unrate-limited write endpoint on a
+# public server is an ingest channel for whatever a prompt injection decides
+# to send, and we would be storing it.
+WRITING_TOOLS: set[str] = set()
 
 
 @pytest.fixture
@@ -45,18 +47,6 @@ async def test_only_the_feedback_tool_writes(tools) -> None:
     """
     writing = {t.name for t in tools if t.annotations and t.annotations.readOnlyHint is False}
     assert writing == WRITING_TOOLS
-
-
-async def test_the_writing_tool_is_neither_destructive_nor_idempotent(tools) -> None:
-    """``feedback`` appends one entry per call.
-
-    Not destructive, because it never replaces or removes anything. Not
-    idempotent, because calling it twice records twice — a host that assumed
-    otherwise could silently retry and double-log.
-    """
-    feedback = next(t for t in tools if t.name == "feedback")
-    assert feedback.annotations.destructiveHint is False
-    assert feedback.annotations.idempotentHint is False
 
 
 async def test_open_world_marks_the_tools_that_call_out(tools) -> None:


### PR DESCRIPTION
Promotion de #198 uniquement. Le reste de `dev` est déjà en production depuis la MEP de ce soir, traitement du 429 compris.

## Ce qui part

**Le retrait de l'outil `feedback`**, et c'est la raison principale de promouvoir sans attendre. La production expose encore un endpoint d'écriture **public, non authentifié et non soumis au rate limiter** (`/mcp` en est exclu volontairement). Les logs du Space montrent qu'il est activement scanné : sondes sur `/.env`, `/.env.production`, `/.streamlit/secrets.toml`, tentatives de traversée de répertoire. Tout répond 404, mais laisser un puits d'écriture sur une cible déjà sondée n'a pas de raison d'être.

Le risque n'était pas seulement l'abus : l'outil acceptait 2000 caractères de message et 4000 de contexte, et sa docstring demandait au LLM de transmettre la formulation de l'utilisateur. N'importe quel contenu présent dans le contexte du modèle pouvait donc l'orienter vers un appel arbitraire, et nous faire stocker des données de tiers.

**Les annotations sur les quatre outils restants**, qui pilotent la façon dont les clients les présentent et conditionnent une éventuelle soumission à l'annuaire Anthropic. La surface publique devient entièrement en lecture seule, ce qui est un invariant verrouillé par un test.

**Le tuto d'installation** complété : bloc `mcp-remote` pour les hôtes stdio-only, mention explicite qu'il n'y a ni compte ni clé ni OAuth, et trois prompts d'exemple. C'est le texte que les annuaires mirroreront.

## Validation

Le Space dev ne peut pas exécuter le chemin `plan_passage` en ce moment : son IP de sortie est rationnée par Open-Meteo, sans rapport avec ce code. J'ai donc **exécuté le code de `dev` en local contre le vrai Open-Meteo** : quatre outils exposés, passage Marseille vers Porquerolles calculé en 41,0 nm et 14,4 h sur AROME, 5 tronçons, complexité 1/5, deeplink correct. Deux requêtes amont seulement grâce au regroupement des coordonnées.

Suites vertes : mcp-core 47, hf-space 96, data-adapters 259 + 3 skippés, web 124, ruff propre.

## Après merge

Aucune variable à poser. `OHMYWIND_WEB_BASE` doit rester **non défini** en production, son défaut est déjà la prod.

Le Space prod reconstruira, avec l'attente habituelle liée aux 5,6 Go d'atlas. Discriminateur de déploiement : `tools/list` doit renvoyer 4 outils annotés au lieu de 5 sans annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)