### PR TITLE
feat(registry): manifeste server.json et republication sur tag

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,75 @@
+name: Publish to MCP Registry
+
+# Republishes server.json to the official MCP Registry when a release tag is
+# pushed. The registry is a metadata index: it stores the endpoint URL and the
+# server's identity, not any artefact. Keeping this on tags rather than on
+# every push to main means the registry only ever advertises versions we
+# deliberately cut.
+#
+# The namespace `fr.ohmywind/*` is earned by DNS: a TXT record on ohmywind.fr
+# carries the public half of an Ed25519 key, and this job signs with the
+# private half. Losing that key means losing the namespace, so it lives in
+# repo secrets and in the operator's vault, nowhere else.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (defaults to server.json's)"
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Align server.json with the tag
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ] && [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if [ -n "$VERSION" ]; then
+            # The registry rejects re-publishing an existing version, so the tag
+            # is the source of truth rather than whatever the file happens to
+            # say. jq rather than an inline heredoc: a heredoc nested in a YAML
+            # block scalar depends on how YAML strips indentation, which is a
+            # silly thing to make a release depend on.
+            jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
+            mv server.json.tmp server.json
+            echo "server.json version -> $VERSION"
+          fi
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help | head -3
+
+      - name: Authenticate by domain
+        env:
+          MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_REGISTRY_PRIVATE_KEY:-}" ]; then
+            echo "::error::MCP_REGISTRY_PRIVATE_KEY secret is not set"
+            exit 1
+          fi
+          mcp-publisher login dns --domain ohmywind.fr --private-key "$MCP_REGISTRY_PRIVATE_KEY"
+
+      - name: Publish
+        run: mcp-publisher publish
+
+      - name: Confirm it is live
+        run: |
+          set -euo pipefail
+          # Publishing succeeding is not the same as the entry being queryable.
+          sleep 5
+          curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=fr.ohmywind/sailing-planner" \
+            | python -c "import json,sys; d=json.load(sys.stdin); print([s.get('name') for s in d.get('servers', [])])"

--- a/packages/mcp-core/tests/test_registry_manifest.py
+++ b/packages/mcp-core/tests/test_registry_manifest.py
@@ -1,0 +1,68 @@
+"""The registry manifest must keep matching what we actually serve.
+
+``server.json`` is what directories, clients and articles copy from. Once an
+entry is published, the URL inside it gets duplicated into places we do not
+control, so a drift between this file and the real endpoint is expensive in a
+way most config drift is not: republishing fixes the registry, not the copies.
+
+Offline on purpose. A network check would fail in CI for reasons unrelated to
+the manifest, and the drift being guarded against is between two files in this
+repo, not between us and the registry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST = REPO_ROOT / "server.json"
+
+# The namespace is earned by a DNS TXT record on this exact domain. Publishing
+# under any other prefix would be rejected, so the two must agree.
+AUTH_DOMAIN = "ohmywind.fr"
+EXPECTED_NAMESPACE = "fr.ohmywind"
+PUBLIC_ENDPOINT = "https://mcp.ohmywind.fr/mcp"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_namespace_matches_the_domain_we_can_prove(manifest) -> None:
+    namespace, _, _ = manifest["name"].partition("/")
+    assert namespace == EXPECTED_NAMESPACE
+    # Reverse-DNS of the domain that carries the proof record.
+    assert ".".join(reversed(AUTH_DOMAIN.split("."))) == namespace
+
+
+def test_description_fits_the_registry_limit(manifest) -> None:
+    """100 characters, enforced by the schema and easy to blow past."""
+    assert 0 < len(manifest["description"]) <= 100
+
+
+def test_the_advertised_endpoint_is_the_public_one(manifest) -> None:
+    """Never a ``*.hf.space`` URL.
+
+    The whole point of fronting the Spaces with our own domain was so that the
+    published address survives a change of backend. Publishing the Space
+    hostname would hand that guarantee back.
+    """
+    remotes = manifest["remotes"]
+    assert [r["url"] for r in remotes] == [PUBLIC_ENDPOINT]
+    assert all(r["type"] == "streamable-http" for r in remotes)
+    assert "hf.space" not in MANIFEST.read_text(encoding="utf-8")
+
+
+def test_the_readme_advertises_the_same_endpoint() -> None:
+    """The README is what directories mirror, so the two must not diverge."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert PUBLIC_ENDPOINT in readme
+
+
+def test_version_is_semver_ish(manifest) -> None:
+    parts = manifest["version"].split("-")[0].split(".")
+    assert len(parts) == 3 and all(p.isdigit() for p in parts), manifest["version"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "fr.ohmywind/sailing-planner",
+  "title": "OhMyWind",
+  "description": "Sailing passage planner for the French Atlantic and Mediterranean. Free, no API key.",
+  "version": "1.0.0",
+  "websiteUrl": "https://ohmywind.fr",
+  "repository": {
+    "url": "https://github.com/qdonnars/ohmywind",
+    "source": "github"
+  },
+  "icons": [
+    {
+      "src": "https://ohmywind.fr/icon-512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.ohmywind.fr/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Prépare l'inscription au registre officiel MCP. Rien ne se publie au merge : la publication se déclenche sur un tag `v*`, et il manque encore l'enregistrement DNS et le secret de dépôt.

## Le manifeste

Le registre est un index de **métadonnées** : il stocke l'identité du serveur et l'URL du endpoint, pas d'artefact. Pour un serveur distant, il n'y a donc rien à publier sur npm ou PyPI.

```json
{
  "name": "fr.ohmywind/sailing-planner",
  "remotes": [{ "type": "streamable-http", "url": "https://mcp.ohmywind.fr/mcp" }]
}
```

Le nom vient de l'**authentification par domaine** : un TXT sur `ohmywind.fr` porte la moitié publique d'une clé Ed25519, la publication signe avec la privée. C'est plus fort qu'un `io.github.qdonnars/*` générique, le nom porte la marque.

L'URL déclarée n'est **jamais** un `*.hf.space`. C'est tout l'intérêt du Worker posé aujourd'hui : une fois publiée, cette adresse est recopiée dans des fiches d'annuaires, des articles et des configs utilisateur qu'on ne contrôle pas. Republier corrige le registre, pas les copies.

Validé contre le schéma officiel `2025-12-11`. Piège à connaître : le champ `description` est plafonné à **100 caractères**.

## Le workflow

Sur tag plutôt qu'à chaque push sur `main`, pour que le registre n'annonce que des versions coupées volontairement. Il aligne la version du manifeste sur le tag, le registre refusant de republier une version existante.

`jq` plutôt qu'un heredoc Python imbriqué dans le bloc YAML : faire dépendre une release de la façon dont YAML rogne l'indentation serait absurde. Une étape finale interroge le registre pour vérifier que l'entrée est réellement interrogeable, publier avec succès n'étant pas la même chose.

## Les garde-fous

Cinq tests hors ligne, parce que la dérive à craindre est entre deux fichiers de ce repo, pas entre nous et le registre :

- le namespace correspond au reverse-DNS du domaine qu'on sait prouver
- la description tient sous la limite du schéma
- l'endpoint est le public, et le fichier ne contient aucun `hf.space`
- le README annonce le même endpoint, puisque c'est lui que les annuaires mirrorent

## Ce qu'il reste à faire côté dashboard

**1. L'enregistrement TXT** sur la zone `ohmywind.fr` :

```
Type    TXT
Name    @
Content v=MCPv1; k=ed25519; p=JYHZHvHgz9lkd8ZlEZ98GEJ0kPuQLT5VCa2ccgHIg1Q=
Proxy   DNS only
```

**2. Le secret de dépôt** `MCP_REGISTRY_PRIVATE_KEY` dans Settings → Secrets → Actions. La clé privée est générée localement dans `~/.ohmywind/mcp-registry-key.pem`, en permissions 600, et doit rejoindre le coffre : la perdre, c'est perdre le namespace définitivement.

Tant que ce secret est absent, l'IDE signale un avertissement sur le workflow, ce qui est attendu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)