### PR TITLE
Dev: manifeste de registre MCP et republication sur tag

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,75 @@
+name: Publish to MCP Registry
+
+# Republishes server.json to the official MCP Registry when a release tag is
+# pushed. The registry is a metadata index: it stores the endpoint URL and the
+# server's identity, not any artefact. Keeping this on tags rather than on
+# every push to main means the registry only ever advertises versions we
+# deliberately cut.
+#
+# The namespace `fr.ohmywind/*` is earned by DNS: a TXT record on ohmywind.fr
+# carries the public half of an Ed25519 key, and this job signs with the
+# private half. Losing that key means losing the namespace, so it lives in
+# repo secrets and in the operator's vault, nowhere else.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (defaults to server.json's)"
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Align server.json with the tag
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ] && [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if [ -n "$VERSION" ]; then
+            # The registry rejects re-publishing an existing version, so the tag
+            # is the source of truth rather than whatever the file happens to
+            # say. jq rather than an inline heredoc: a heredoc nested in a YAML
+            # block scalar depends on how YAML strips indentation, which is a
+            # silly thing to make a release depend on.
+            jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
+            mv server.json.tmp server.json
+            echo "server.json version -> $VERSION"
+          fi
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help | head -3
+
+      - name: Authenticate by domain
+        env:
+          MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_REGISTRY_PRIVATE_KEY:-}" ]; then
+            echo "::error::MCP_REGISTRY_PRIVATE_KEY secret is not set"
+            exit 1
+          fi
+          mcp-publisher login dns --domain ohmywind.fr --private-key "$MCP_REGISTRY_PRIVATE_KEY"
+
+      - name: Publish
+        run: mcp-publisher publish
+
+      - name: Confirm it is live
+        run: |
+          set -euo pipefail
+          # Publishing succeeding is not the same as the entry being queryable.
+          sleep 5
+          curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=fr.ohmywind/sailing-planner" \
+            | python -c "import json,sys; d=json.load(sys.stdin); print([s.get('name') for s in d.get('servers', [])])"

--- a/packages/mcp-core/tests/test_registry_manifest.py
+++ b/packages/mcp-core/tests/test_registry_manifest.py
@@ -1,0 +1,68 @@
+"""The registry manifest must keep matching what we actually serve.
+
+``server.json`` is what directories, clients and articles copy from. Once an
+entry is published, the URL inside it gets duplicated into places we do not
+control, so a drift between this file and the real endpoint is expensive in a
+way most config drift is not: republishing fixes the registry, not the copies.
+
+Offline on purpose. A network check would fail in CI for reasons unrelated to
+the manifest, and the drift being guarded against is between two files in this
+repo, not between us and the registry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST = REPO_ROOT / "server.json"
+
+# The namespace is earned by a DNS TXT record on this exact domain. Publishing
+# under any other prefix would be rejected, so the two must agree.
+AUTH_DOMAIN = "ohmywind.fr"
+EXPECTED_NAMESPACE = "fr.ohmywind"
+PUBLIC_ENDPOINT = "https://mcp.ohmywind.fr/mcp"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_namespace_matches_the_domain_we_can_prove(manifest) -> None:
+    namespace, _, _ = manifest["name"].partition("/")
+    assert namespace == EXPECTED_NAMESPACE
+    # Reverse-DNS of the domain that carries the proof record.
+    assert ".".join(reversed(AUTH_DOMAIN.split("."))) == namespace
+
+
+def test_description_fits_the_registry_limit(manifest) -> None:
+    """100 characters, enforced by the schema and easy to blow past."""
+    assert 0 < len(manifest["description"]) <= 100
+
+
+def test_the_advertised_endpoint_is_the_public_one(manifest) -> None:
+    """Never a ``*.hf.space`` URL.
+
+    The whole point of fronting the Spaces with our own domain was so that the
+    published address survives a change of backend. Publishing the Space
+    hostname would hand that guarantee back.
+    """
+    remotes = manifest["remotes"]
+    assert [r["url"] for r in remotes] == [PUBLIC_ENDPOINT]
+    assert all(r["type"] == "streamable-http" for r in remotes)
+    assert "hf.space" not in MANIFEST.read_text(encoding="utf-8")
+
+
+def test_the_readme_advertises_the_same_endpoint() -> None:
+    """The README is what directories mirror, so the two must not diverge."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert PUBLIC_ENDPOINT in readme
+
+
+def test_version_is_semver_ish(manifest) -> None:
+    parts = manifest["version"].split("-")[0].split(".")
+    assert len(parts) == 3 and all(p.isdigit() for p in parts), manifest["version"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "fr.ohmywind/sailing-planner",
+  "title": "OhMyWind",
+  "description": "Sailing passage planner for the French Atlantic and Mediterranean. Free, no API key.",
+  "version": "1.0.0",
+  "websiteUrl": "https://ohmywind.fr",
+  "repository": {
+    "url": "https://github.com/qdonnars/ohmywind",
+    "source": "github"
+  },
+  "icons": [
+    {
+      "src": "https://ohmywind.fr/icon-512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.ohmywind.fr/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Aligne le dépôt sur ce qui est **déjà publié** au registre officiel : `fr.ohmywind/sailing-planner` v1.0.0 est en ligne et interrogeable depuis 23:00 UTC, publié manuellement une fois l'authentification par domaine acquise.

## Contenu

`server.json`, validé par le registre lui-même, le workflow de republication sur tag, et cinq tests hors ligne qui verrouillent la dérive entre le manifeste et la réalité, dont l'interdiction qu'un hostname `*.hf.space` s'y glisse.

**Aucun changement du code serveur.** La surface MCP, les outils et leurs annotations sont identiques à ce qui tourne déjà en production.

## Note sur le rebuild

Le test ajouté vit sous `packages/mcp-core/`, qui fait partie des chemins surveillés par `sync-hf-space.yml`. Le Space prod va donc se reconstruire intégralement, atlas de 5,6 Go compris, pour un fichier de test. C'est le symptôme de l'ordre des couches du Dockerfile, déjà identifié : les `COPY vendor/` sont au-dessus du fetch d'atlas, donc toute modification de `mcp-core` invalide tout ce qui suit. À corriger, c'est quelques lignes et ça rendrait les rebuilds quasi instantanés.

## Pas de tag pour l'instant

Taguer `v1.0.0` déclencherait le workflow, qui tenterait de republier une version que le registre possède déjà et refuse. Le premier tag utile sera celui de la prochaine version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)