### PR TITLE
Dev: repositionnement mondial de la description, version 1.0.1

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -82,7 +82,7 @@ jobs:
             -e 's/^title: OhMyWind MCP$/title: OhMyWind MCP (dev)/' \
             -e 's/^colorFrom: blue$/colorFrom: gray/' \
             -e 's/^colorTo: indigo$/colorTo: yellow/' \
-            -e 's/^short_description: .*/short_description: (dev) French Atlantic + Med sailing planner via MCP./' \
+            -e 's/^short_description: .*/short_description: (dev) Sailing passage planner for any coast, via MCP./' \
             -e 's/^# OhMyWind MCP ⛵$/# OhMyWind MCP (dev) ⛵/' \
             -e 's#mcp\.ohmywind\.fr#mcp-dev.ohmywind.fr#g' \
             -e 's/on `main`/on `dev`/g' \

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 > **Talk to your LLM. Cast off with confidence.**
 >
 > OhMyWind turns any MCP-capable assistant (Claude, Le Chat, Cursor, Goose,
-> Zed, Continue) into a sailing planner for the French Atlantic and
-> Mediterranean coasts. Ask in plain language. Get a per-leg ETA, a 1‑5
-> complexity score, high-precision tidal currents on the Atlantic
-> (SHOM Atlas C2D and MARC PREVIMER), and a deep-link to the full plan.
+> Zed, Continue) into a sailing planner. Ask in plain language, anywhere in
+> the world: get a per-leg ETA, a 1‑5 complexity score, and a deep-link to
+> the full plan. On the French Atlantic coast it goes further, swapping the
+> global current model for the SHOM Atlas C2D and MARC PREVIMER atlases.
 > Free, keyless, open source.
 
 [**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://mcp.ohmywind.fr/mcp) · MIT
@@ -83,7 +83,7 @@ Three prompts, each exercising a different tool:
 |                              |                                                                                              |
 |------------------------------|----------------------------------------------------------------------------------------------|
 | 🆓 **Free, keyless**         | Wind & sea via [Open-Meteo](https://open-meteo.com) (CC BY 4.0). No account, no API key.     |
-| 🌊 **Mediterranean-tuned**   | Defaults to AROME 1.3 km, catches thermals, mistral, tramontane. Falls back to ICON-EU → ECMWF → GFS as the horizon stretches out. |
+| 🌍 **Works anywhere**        | Global models (ECMWF, GFS) cover any coast. Over France, AROME 1.3 km takes over and catches thermals, mistral, tramontane. |
 | ⛵ **Boat-aware**             | Seven archetypes from 20 ft trailer-cruisers to bluewater 50-footers, real polars, an `efficiency` parameter for trim and crew level. |
 | 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot, no math by hand. |
 | 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
@@ -113,8 +113,8 @@ silently get the structured payload + the `openwind_url` deep-link.
 packages/
 ├── data-adapters/   # pure domain logic (forecast adapters, polars, routing, complexity)
 ├── mcp-core/        # FastMCP server (cloud-agnostic, no Gradio, no HF deps)
-├── hf-space/        # ~20-line Docker wrapper for Hugging Face Spaces
-└── web/             # React 19 + Vite app deployed to GitHub Pages (ohmywind.fr)
+├── hf-space/        # Docker wrapper for Hugging Face Spaces (Starlette + uvicorn)
+└── web/             # React 19 + Vite app deployed to Cloudflare Pages (ohmywind.fr)
 ```
 
 `mcp-core` stays deployment-agnostic. Re-deploying on Fly, Modal, or a VPS is

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -7,15 +7,16 @@ sdk: docker
 app_port: 7860
 pinned: false
 license: mit
-short_description: French Atlantic + Mediterranean sailing planner via MCP.
+short_description: Sailing passage planner for any coast, via MCP.
 ---
 
 # OhMyWind MCP ⛵
 
 > **Talk to your LLM. Cast off with confidence.**
 >
-> Turns any MCP-capable assistant into a sailing planner for the French
-> Atlantic and Mediterranean coasts. Free, keyless, open source.
+> Turns any MCP-capable assistant into a sailing planner, anywhere in the
+> world. Extra precision on the French Atlantic coast, where SHOM and MARC
+> tidal atlases replace the global model. Free, keyless, open source.
 
 ![OhMyWind passage plan rendered in the web app](https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png)
 

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -93,7 +93,7 @@ LANDING_HTML = """<!doctype html>
   <link rel="icon" type="image/png" sizes="192x192" href="https://ohmywind.fr/icon-192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="https://ohmywind.fr/icon-512.png">
   <link rel="apple-touch-icon" href="https://ohmywind.fr/icon-192.png">
-  <meta name="description" content="OhMyWind MCP — free, keyless sailing planner for the French Atlantic and Mediterranean coasts.">
+  <meta name="description" content="OhMyWind MCP. Free, keyless sailing passage planner for any coast, with high-precision tides on the French Atlantic.">
   <meta property="og:title" content="OhMyWind MCP">
   <meta property="og:description" content="Talk to your LLM. Cast off with confidence. Free, keyless sailing planner via MCP.">
   <meta property="og:image" content="https://ohmywind.fr/icon-512.png">
@@ -186,9 +186,9 @@ LANDING_HTML = """<!doctype html>
 <body>
   <h1>OhMyWind MCP <span class="badge">running</span></h1>
   <p class="lede">Talk to your LLM. Cast off with confidence.<br>
-    A free, keyless, open-source sailing planner for the French Atlantic and
-    Mediterranean coasts. Exposed as an MCP server so any compatible
-    assistant can use it.</p>
+    A free, keyless, open-source sailing planner for any coast, with
+    high-precision tidal currents on the French Atlantic. Exposed as an MCP
+    server so any compatible assistant can use it.</p>
 
   <img class="hero" src="https://raw.githubusercontent.com/qdonnars/ohmywind/main/docs/screenshots/plan.png"
        alt="OhMyWind passage plan: 5 waypoints, 48.6 nm, ETA 21:24, complexity 3 of 5.">

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "OhMyWind",
   "short_name": "OhMyWind",
-  "description": "French Atlantic and Mediterranean sailing planner. Wind forecasts, passage estimates and SHOM-grade tidal currents.",
+  "description": "Sailing planner for any coast. Wind forecasts, passage estimates, and SHOM-grade tidal currents on the French Atlantic.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#030712",

--- a/packages/web/src/content/methodologie.md
+++ b/packages/web/src/content/methodologie.md
@@ -1,6 +1,6 @@
 # Méthodologie
 
-OhMyWind est un planificateur de navigation à la voile open source pour les côtes françaises. Cette page explique d'où viennent les données, comment on estime un passage, et ce que l'outil ne sait volontairement pas faire.
+OhMyWind est un planificateur de navigation à la voile open source, utilisable partout dans le monde, avec une précision renforcée sur les côtes atlantiques françaises. Cette page explique d'où viennent les données, comment on estime un passage, et ce que l'outil ne sait volontairement pas faire.
 
 ## Sommaire
 

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "fr.ohmywind/sailing-planner",
   "title": "OhMyWind",
-  "description": "Sailing passage planner for the French Atlantic and Mediterranean. Free, no API key.",
-  "version": "1.0.0",
+  "description": "Sailing passage planner for any coast, with high-precision tides on the French Atlantic.",
+  "version": "1.0.1",
   "websiteUrl": "https://ohmywind.fr",
   "repository": {
     "url": "https://github.com/qdonnars/ohmywind",
@@ -13,7 +13,9 @@
     {
       "src": "https://ohmywind.fr/icon-512.png",
       "mimeType": "image/png",
-      "sizes": ["512x512"]
+      "sizes": [
+        "512x512"
+      ]
     }
   ],
   "remotes": [


### PR DESCRIPTION
Aligne toute la copie publique sur ce que le code fait réellement, et prépare la republication au registre.

## Le changement

« for the French Atlantic and Mediterranean coasts » annonçait une restriction inexistante : la chaîne de repli va jusqu'à ECMWF et GFS, mondiaux tous les deux, et l'API marine d'Open-Meteo l'est aussi. La nouvelle formulation met la couverture mondiale d'abord et la précision française ensuite, comme un avantage plutôt que comme un périmètre.

Sept surfaces alignées, dont le `sed` du workflow qui aurait sinon réinjecté l'ancienne formulation sur la carte du Space dev.

Contraintes de longueur vérifiées : 88 caractères sur 100 pour le registre, 47 sur 60 pour la carte HF.

## Version 1.0.1

`1.0.0` est déjà publié au registre avec l'ancienne description, et le registre refuse de republier une version existante. Après ce merge, le tag `v1.0.1` déclenchera le workflow qui republiera la nouvelle.

## Corrections de doc

Le README affirmait que `hf-space` fait « ~20 lignes » (plus de mille, et il porte toute l'API REST) et que le web est sur GitHub Pages (Cloudflare Pages).

## Tests

mcp-core 52, hf-space 96, ruff propre, `server.json` revalidé par le registre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)