### PR TITLE
fix(pwa): sw.js en no-cache, détection immédiate des déploiements

### DIFF
--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -1,3 +1,9 @@
+# Le service worker doit etre revalide a chaque lancement, sinon le
+# navigateur peut resservir l'ancien pendant des heures et les PWA/TWA
+# installees ne voient pas les deploiements (widget iOS, apps Android).
+/sw.js
+  Cache-Control: no-cache
+
 https://dev.ohmywind.fr/*
   X-Robots-Tag: noindex, nofollow
 


### PR DESCRIPTION
Le widget iOS de l'utilisateur (PWA dev) servait l'ancienne version sans le fix de réordonnancement : `/sw.js` était mis en cache HTTP 4 h (`max-age=14400`), retardant d'autant la détection des déploiements par les PWA/TWA installées, malgré le mode autoUpdate et le check à chaque navigation (throttle 60 s) déjà en place.

Fix : règle `_headers` servant `/sw.js` en `Cache-Control: no-cache` (tous domaines). Chaîne résultante : push → build (hashes déjà régénérés) → revalidation du SW à chaque lancement/navigation → nouvelle version au chargement suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)