### PR TITLE
fix(web): stabilize mobile viewport (dvh, page zoom, pull-to-refresh)

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>OhMyWind</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#030712" />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -173,7 +173,7 @@ function App() {
 
   return (
     <div
-      className="h-screen flex flex-col overflow-hidden"
+      className="h-dvh flex flex-col overflow-hidden"
       style={{ background: 'var(--ow-bg-0)', color: 'var(--ow-fg-0)' }}
     >
       {/* Search proximity reference: the granted position first, else where

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -7,6 +7,12 @@
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
 }
 
+html,
+body {
+  /* Block pull-to-refresh and scroll chaining on mobile (map pans, page must not) */
+  overscroll-behavior: none;
+}
+
 body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -745,7 +745,7 @@ export function PlanPage() {
   if (!isParsedOk(initialParsed)) {
     return (
       <div
-        className="h-screen flex flex-col items-center justify-center px-6"
+        className="h-dvh flex flex-col items-center justify-center px-6"
         style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
       >
         <div className="max-w-sm text-center space-y-4">
@@ -803,7 +803,7 @@ export function PlanPage() {
 
   return (
     <div
-      className="h-screen flex flex-col overflow-hidden"
+      className="h-dvh flex flex-col overflow-hidden"
       style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-0)" }}
     >
       {/* On the planner the route being drawn is the strongest statement of


### PR DESCRIPTION
Tester feedback on mobile Chrome showed three issues:
- bottom UI cut off: h-screen (100vh) includes the area behind the collapsible URL bar, and the page never scrolls so the bar never retracts -> switch app shells to h-dvh
- pinch outside the map zoomed the whole page and wrecked the layout -> lock page zoom via viewport meta (map pinch-zoom unaffected, handled by Leaflet)
- accidental pull-to-refresh reloaded the app mid-use -> overscroll-behavior: none on html/body