### PR TITLE
fix(android): déclare la vraie empreinte Play App Signing dans assetlinks

### DIFF
--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -30,7 +30,28 @@ Le contenu web, lui, se met à jour tout seul (c'est le site). Un rebuild n'est 
 
 ## assetlinks.json
 
-`packages/web/public/.well-known/assetlinks.json` doit contenir l'empreinte SHA256 du certificat de signature, sinon l'app s'ouvre avec la barre Chrome au lieu du plein écran. Il est servi sur https://ohmywind.fr/.well-known/assetlinks.json. Si le keystore change (jamais, en principe), régénérer via `bubblewrap fingerprint` et redéployer le site.
+`packages/web/public/.well-known/assetlinks.json` doit contenir l'empreinte SHA256 de **chaque** certificat susceptible de signer l'app, sinon celle-ci s'ouvre avec la barre Chrome au lieu du plein écran. Il est servi sur https://ohmywind.fr/.well-known/assetlinks.json.
+
+Il en faut deux pour `fr.ohmywind.app`, parce que les deux canaux de distribution signent différemment:
+
+- la **clé d'upload** (`android.keystore` local), pour les APK installés en direct via `bubblewrap install` / `adb install`;
+- la **clé Play App Signing**, celle avec laquelle Google re-signe le build qu'il distribue. Play Console la publie sous Test et publication → Intégrité de l'app → Clé de signature de l'app.
+
+Ne jamais faire confiance à une empreinte recopiée à la main: la vérité terrain, c'est le certificat de l'APK réellement installé. Pour la mesurer:
+
+```bash
+adb pull "$(adb shell pm path fr.ohmywind.app | grep base.apk | sed 's/package://' | tr -d '\r')" /tmp/play.apk
+keytool -printcert -jarfile /tmp/play.apk | grep SHA256
+```
+
+Sur un build issu du Play Store, le certificat porte `CN=Android, O=Google Inc.`: c'est la clé Play App Signing. Une empreinte fausse ou manquante se voit dans `adb logcat`, au lancement de l'app:
+
+```
+W chromium: [...digital_asset_links_handler.cc] Statement failure matching fingerprint.
+W cr_WebAppLaunchHandler: Target url verification has been failed.
+```
+
+Le fichier étant servi par le site, une correction ne demande aucun rebuild de l'app: il suffit de redéployer la prod, puis de relancer l'app (Chrome met en cache le résultat de la vérification, un `adb shell pm clear com.android.chrome` force une revérification).
 
 ## Variante dev
 

--- a/packages/android/twa-manifest.json
+++ b/packages/android/twa-manifest.json
@@ -42,7 +42,7 @@
   "orientation": "default",
   "fingerprints": [
     {
-      "value": "15:48:9B:CA:4F:C2:A1:13:B3:5C:6E:AC:CD:2A:79:5C:86:51:B9:C7:F8:37:97:BB:0D:3C:AB:4D:AE:91:FC:CD"
+      "value": "DF:C9:D2:19:37:69:24:65:19:47:96:EF:D7:A2:61:D3:6C:C6:3A:D6:06:6B:1C:C5:28:3A:35:CF:2D:E2:05:90"
     },
     {
       "value": "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"

--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "fr.ohmywind.app",
       "sha256_cert_fingerprints": [
-        "15:48:9B:CA:4F:C2:A1:13:B3:5C:6E:AC:CD:2A:79:5C:86:51:B9:C7:F8:37:97:BB:0D:3C:AB:4D:AE:91:FC:CD",
+        "DF:C9:D2:19:37:69:24:65:19:47:96:EF:D7:A2:61:D3:6C:C6:3A:D6:06:6B:1C:C5:28:3A:35:CF:2D:E2:05:90",
         "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
       ]
     }


### PR DESCRIPTION
## Symptôme

L'app installée depuis le Play Store s'ouvre avec la barre d'URL Chrome au lieu du plein écran, malgré les correctifs d'août.

## Reproduction

Émulateur Android 15, image `google_apis_playstore`, app installée depuis le Play Store (`installer=com.android.vending`, versionCode 3).

```
D TWALauncherActivity: Using url from Manifest: https://ohmywind.fr/
W chromium: [...digital_asset_links_handler.cc:170] Statement failure matching fingerprint.
W cr_WebAppLaunchHandler: Target url verification has been failed.
```

## Cause

Le certificat de l'APK réellement distribué par Play, mesuré sur l'APK installé:

```
Owner: CN=Android, OU=Android, O=Google Inc., L=Mountain View, ST=California, C=US
SHA256: DF:C9:D2:19:37:69:24:65:19:47:96:EF:D7:A2:61:D3:6C:C6:3A:D6:06:6B:1C:C5:28:3A:35:CF:2D:E2:05:90
```

Cette empreinte n'était pas déclarée. Celle qui l'était sous le nom "Play App Signing" (`15:48:9B:CA…`, ajoutée en dc50201) ne correspond à aucun certificat identifiable: ni la clé Play ci-dessus, ni la clé d'upload locale (`6B:F4…`), ni l'ancienne clé perdue (`91:53…`). Elle est retirée, une empreinte non identifiée déléguant quand même le statut d'origine de confiance à tout APK signé avec ce certificat sous le package `fr.ohmywind.app`.

## Changements

- `assetlinks.json`: `15:48:9B:CA…` remplacée par `DF:C9:D2:19…`. La clé d'upload `6B:F4…` reste, pour les installs `adb` directes. Entrée `.dev` inchangée.
- `twa-manifest.json`: même substitution, pour que `bubblewrap fingerprint generateAssetLinks` régénère le bon fichier.
- `README`: documente la mesure de l'empreinte depuis l'APK installé plutôt que la recopie manuelle depuis la Play Console, et la signature du problème dans logcat.

## Portée

Aucun rebuild de l'app n'est nécessaire: `assetlinks.json` est servi par le site, la vérification se refait au lancement. Le correctif ne prend effet pour l'app du Store qu'une fois `main` déployé sur ohmywind.fr. Validation end to end sur l'émulateur prévue après la promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)