### PR TITLE
test(android): empreinte jetable temporaire pour valider la vérif TWA sur dev

### DIFF
--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -15,7 +15,10 @@
     "target": {
       "namespace": "android_app",
       "package_name": "fr.ohmywind.app.dev",
-      "sha256_cert_fingerprints": ["6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"]
+      "sha256_cert_fingerprints": [
+        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82",
+        "FF:D9:02:AB:83:74:C7:A2:B4:74:F8:FA:86:2A:43:53:E5:24:90:EF:F2:A0:40:AE:2A:1C:0B:96:2E:C1:53:F0"
+      ]
     }
   }
 ]


### PR DESCRIPTION
Temporaire, à révoquer dans la foulée.

Contrôle positif avant de promouvoir #223 en prod: observer une app TWA *passer* la vérification Digital Asset Links de bout en bout (fichier servi par Cloudflare, vérif Chrome au lancement, plein écran), sans déployer ohmywind.fr pour tester.

Le keystore d'upload n'étant pas restauré localement, le build de test de `fr.ohmywind.app.dev` est signé avec une clé jetable générée pour l'occasion (`FF:D9:02:AB…`), dont l'empreinte est ajoutée à la seule entrée `fr.ohmywind.app.dev`.

Portée: dev.ohmywind.fr (bac à sable, noindex), sur un package jamais distribué. L'entrée `fr.ohmywind.app` n'est pas touchée. Empreinte retirée dès le test passé.