### PR TITLE
fix(web): bloque la sélection de texte hors champs et pages de texte

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -19,11 +19,28 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Prevent text selection and context menu on long press (mobile) */
-.leaflet-container {
+/* Prevent text selection and context menu on long press (mobile). Applied to
+   the whole shell, not just the map: in the Android app, a long press on a
+   forecast cell raised Chrome's selection toolbar and its "tap to see search
+   results" panel, which navigates to Google and drops the user out of the app. */
+body {
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+}
+
+/* Selection stays where copying is the point: form fields and long-form pages. */
+input,
+textarea,
+select,
+[contenteditable="true"],
+.prose-conf,
+.prose-methodo {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.leaflet-container {
   touch-action: manipulation;
 }
 


### PR DESCRIPTION
Retour de testeurs: on sort trop facilement de l'app Android.

Un appui long sur une valeur du tableau de prévisions déclenche la barre de sélection de Chrome (Traduire / Copier / Partager) et, en dessous, le panneau "appuyer pour afficher les résultats de recherche". Un tap dessus navigue vers Google, donc hors du scope vérifié: l'utilisateur se retrouve dehors.

`user-select: none` couvrait seulement `.leaflet-container`. Il passe sur tout le shell. La sélection reste active là où copier a un sens: champs de formulaire, page de confidentialité, page de méthodologie.

Vérifié sur le bundle de prod plutôt que sur le dev server, l'ordre d'émission CSS différant entre les deux: `leaflet.css` sort après `index.css` mais ne réactive la sélection nulle part.

```
body{...;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none}
input,textarea,select,[contenteditable=true],.prose-conf,.prose-methodo{-webkit-user-select:text;user-select:text}
```

À noter: l'autre voie de sortie facile, le bouton X de la barre d'URL, disparaît avec #223 une fois la vérification Digital Asset Links réparée.