### PR TITLE
fix(ci): budget interactif à 50 tours, triage sans sortie muette

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -77,6 +77,13 @@ jobs:
                reproduction manquantes. Si l'issue est claire et complète,
                ne commente pas.
 
+            Termine TOUJOURS par une action visible : au minimum un label
+            posé (constaté sur l'issue), ou un commentaire-question si tu ne
+            peux pas trancher. Ne termine jamais sans avoir fait l'un des
+            deux. Les images jointes aux issues te sont invisibles :
+            appuie-toi sur le texte ; s'il ne suffit pas, demande une
+            description écrite en commentaire.
+
             Tu ne modifies aucun fichier et tu n'écris pas de code.
 
             Contrainte outillage : commandes gh SIMPLES uniquement, sans pipe,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,6 +53,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: dev
           claude_args: |
-            --max-turns 25
-            --allowedTools "Bash(npm ci),Bash(npm run:*),Bash(uv sync:*),Bash(uv run:*),Bash(uvx ruff:*)"
+            --max-turns 50
+            --allowedTools "Bash(cd:*),Bash(ls:*),Bash(npm:*),Bash(uv:*),Bash(uvx:*)"
             --append-system-prompt "Tu tournes dans un runner GitHub Actions : ignore la consigne worktree de CLAUDE.md et travaille directement dans le checkout. Toute branche part de dev et toute PR cible dev, jamais main. La promotion dev vers main est toujours manuelle. Commandes Bash simples uniquement, sans pipe ni enchaînement : elles seraient refusées par l'allowlist."


### PR DESCRIPTION
Deux derniers réglages issus des tests live :

- **Itération @claude sur PR** (run 31741415865) : Claude a terminé le fix demandé en 26 tours, et l'action a échoué le run pour dépassement du `--max-turns 25` — travail perdu avant push. `claude.yml` passe à 50 tours (même budget que claude-fix) avec `cd`/`ls`/`npm`/`uv` élargis.
- **Triage muet sur #228** (run 31741484890) : terminé sans poser ni label ni question sur une issue vierge. Prompt durci : toujours finir par une action visible (label constaté ou commentaire-question), et les images jointes sont invisibles pour l'agent — s'appuyer sur le texte, sinon demander une description écrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)