### PR TITLE
chore: réaligne dev sur main après les promotions squashées (#241)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, dev]
+    # fix/** et claude/** : branches poussées par l'agent Claude. Sa PR est
+    # créée avec le GITHUB_TOKEN par défaut, dont les événements ne
+    # déclenchent aucun workflow — mais ses pushes viennent de l'app Claude
+    # et déclenchent, et les check runs posés sur le SHA de tête satisfont
+    # les required status checks de la PR.
+    branches: [main, dev, "fix/**", "claude/**"]
   workflow_call:
 
 # A branch pushed twice in a row only needs its latest state verified.

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -49,7 +49,16 @@ jobs:
       # par sa toolbox interne (Read + git add/commit + git-push.sh, sans
       # Edit/Write ni gh) — constaté au run 31736398989. En mode agent pur,
       # l'allowlist ci-dessous fait foi et le prompt pilote tout le flow.
+      #
+      # GH_TOKEN : sans lui, gh n'est pas authentifié dans le process de
+      # l'agent (constaté au run 31737271536 : l'étape 1 du prompt échouait
+      # dès le premier tour). Conséquence assumée : la PR est créée par
+      # github-actions[bot], dont les événements ne déclenchent pas de
+      # workflow — c'est pour ça que ci.yml écoute aussi les push sur fix/**
+      # (les pushes, eux, viennent de l'app Claude et déclenchent bien).
       - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: dev
@@ -66,11 +75,15 @@ jobs:
             3. Respecte CLAUDE.md : conventions du repo, domaine voile (nœuds,
                caps vrais…), conventional commits. Exception runner CI :
                ignore la consigne worktree, travaille dans le checkout.
-            4. Avant de committer, lance les tests du périmètre touché :
+            4. Si c'est rapide, lance les tests du périmètre touché avant de
+               committer (utilise `cd` seul pour changer de dossier, jamais
+               de commande composée) :
                - Python : `uv sync --extra dev` puis `uv run pytest -q` dans le
                  package modifié, et `uvx ruff check` + `uvx ruff format --check`
                - Web : `npm ci` à la racine puis `npm run typecheck` et
                  `npm run test` dans packages/web
+               Ne t'acharne pas : la CI de la PR fait le gate final. Mieux vaut
+               une PR poussée sans tests locaux qu'un run à sec sans PR.
             5. Ouvre une PR DRAFT vers dev (jamais main) :
                `gh pr create --base dev --draft`, titre en conventional commit
                référençant l'issue, corps contenant « Closes #${{ github.event.issue.number }} »,
@@ -86,5 +99,5 @@ jobs:
             redirection ni enchaînement (&&) — elles seraient refusées par
             l'allowlist et chaque refus gaspille un tour.
           claude_args: |
-            --max-turns 40
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git switch:*),Bash(git push:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(npm ci),Bash(npm run:*),Bash(uv sync:*),Bash(uv run:*),Bash(uvx ruff:*)"
+            --max-turns 50
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(cd:*),Bash(ls:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git switch:*),Bash(git push:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(npm:*),Bash(uv:*),Bash(uvx:*)"

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -77,6 +77,13 @@ jobs:
                reproduction manquantes. Si l'issue est claire et complète,
                ne commente pas.
 
+            Termine TOUJOURS par une action visible : au minimum un label
+            posé (constaté sur l'issue), ou un commentaire-question si tu ne
+            peux pas trancher. Ne termine jamais sans avoir fait l'un des
+            deux. Les images jointes aux issues te sont invisibles :
+            appuie-toi sur le texte ; s'il ne suffit pas, demande une
+            description écrite en commentaire.
+
             Tu ne modifies aucun fichier et tu n'écris pas de code.
 
             Contrainte outillage : commandes gh SIMPLES uniquement, sans pipe,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,6 +53,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: dev
           claude_args: |
-            --max-turns 25
-            --allowedTools "Bash(npm ci),Bash(npm run:*),Bash(uv sync:*),Bash(uv run:*),Bash(uvx ruff:*)"
+            --max-turns 50
+            --allowedTools "Bash(cd:*),Bash(ls:*),Bash(npm:*),Bash(uv:*),Bash(uvx:*)"
             --append-system-prompt "Tu tournes dans un runner GitHub Actions : ignore la consigne worktree de CLAUDE.md et travaille directement dans le checkout. Toute branche part de dev et toute PR cible dev, jamais main. La promotion dev vers main est toujours manuelle. Commandes Bash simples uniquement, sans pipe ni enchaînement : elles seraient refusées par l'allowlist."

--- a/packages/web/src/components/Onboarding.tsx
+++ b/packages/web/src/components/Onboarding.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
+import { STORAGE_KEY as CUSTOM_SPOTS_KEY } from "../hooks/useCustomSpots";
+import { migrateLegacyKey } from "../utils/localStorageMigration";
 
-const STORAGE_KEY = "openwind:onboarding-v1";
-const CUSTOM_SPOTS_KEY = "openwind_custom_spots";
+const STORAGE_KEY = "ohmywind:onboarding-v1";
+const LEGACY_STORAGE_KEY = "openwind:onboarding-v1";
 const LAST_SIMULATION_KEY = "ow_last_simulation_v1";
 // Time between page load and the planner hint surfacing — for first-time
 // users only. The check is a snapshot at mount; subsequent state changes
@@ -20,6 +22,7 @@ const BODY = "Pour tracer un trajet entre deux spots et estimer la durée, cliqu
 // through to false — better silently skip the hint than crash the home page.
 function isFirstTimeUser(): boolean {
   try {
+    migrateLegacyKey(LEGACY_STORAGE_KEY, STORAGE_KEY);
     if (localStorage.getItem(STORAGE_KEY) === "done") return false;
     const spotsRaw = localStorage.getItem(CUSTOM_SPOTS_KEY);
     if (spotsRaw) {

--- a/packages/web/src/hooks/useCustomSpots.ts
+++ b/packages/web/src/hooks/useCustomSpots.ts
@@ -1,9 +1,12 @@
 import { useState } from "react";
 import type { Spot } from "../types";
+import { migrateLegacyKey } from "../utils/localStorageMigration";
 
-const STORAGE_KEY = "openwind_custom_spots";
+export const STORAGE_KEY = "ohmywind_custom_spots";
+const LEGACY_STORAGE_KEY = "openwind_custom_spots";
 
 function loadSpots(): Spot[] {
+  migrateLegacyKey(LEGACY_STORAGE_KEY, STORAGE_KEY);
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     return raw ? JSON.parse(raw) : [];

--- a/packages/web/src/utils/localStorageMigration.test.ts
+++ b/packages/web/src/utils/localStorageMigration.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { migrateLegacyKey } from "./localStorageMigration";
+
+// vitest's default "node" environment has no global localStorage, so a
+// minimal in-memory stand-in is installed before each test.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+const LEGACY_KEY = "openwind_custom_spots";
+const NEW_KEY = "ohmywind_custom_spots";
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: new MemoryStorage(),
+    configurable: true,
+  });
+});
+
+describe("migrateLegacyKey", () => {
+  it("copies the value and drops the legacy key when only the legacy key exists", () => {
+    localStorage.setItem(LEGACY_KEY, "[{\"name\":\"spot\"}]");
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    expect(localStorage.getItem(NEW_KEY)).toBe("[{\"name\":\"spot\"}]");
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it("does nothing when only the new key exists", () => {
+    localStorage.setItem(NEW_KEY, "[]");
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    expect(localStorage.getItem(NEW_KEY)).toBe("[]");
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it("keeps the new value and leaves the legacy key untouched when both exist", () => {
+    localStorage.setItem(LEGACY_KEY, "[\"old\"]");
+    localStorage.setItem(NEW_KEY, "[\"new\"]");
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    expect(localStorage.getItem(NEW_KEY)).toBe("[\"new\"]");
+    expect(localStorage.getItem(LEGACY_KEY)).toBe("[\"old\"]");
+  });
+
+  it("does nothing when neither key exists", () => {
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    expect(localStorage.getItem(NEW_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it("is idempotent: calling it twice does not lose or duplicate data", () => {
+    localStorage.setItem(LEGACY_KEY, "[\"spot\"]");
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    migrateLegacyKey(LEGACY_KEY, NEW_KEY);
+    expect(localStorage.getItem(NEW_KEY)).toBe("[\"spot\"]");
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+});

--- a/packages/web/src/utils/localStorageMigration.ts
+++ b/packages/web/src/utils/localStorageMigration.ts
@@ -1,0 +1,15 @@
+// One-shot migration of a legacy localStorage key to its renamed successor.
+// Runs at most once per key pair: if the new key is already present, the old
+// value is never copied over it, so a returning user's fresher data always
+// wins. Safe to call on every load — it is a no-op once migrated.
+export function migrateLegacyKey(legacyKey: string, newKey: string): void {
+  try {
+    if (localStorage.getItem(newKey) !== null) return;
+    const legacyValue = localStorage.getItem(legacyKey);
+    if (legacyValue === null) return;
+    localStorage.setItem(newKey, legacyValue);
+    localStorage.removeItem(legacyKey);
+  } catch {
+    /* localStorage blocked (private browsing, quota) — no-op */
+  }
+}


### PR DESCRIPTION
Même opération que #231 : les promotions squashées créent des commits équivalents mais distincts sur main, dev diverge. Ce merge réaligne dev en superset de main. Contenu identique, merge trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)