### PR TITLE
fix(web): migrer la clé spots avant lecture dans isFirstTimeUser()

### DIFF
--- a/packages/web/src/components/Onboarding.tsx
+++ b/packages/web/src/components/Onboarding.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
-import { STORAGE_KEY as CUSTOM_SPOTS_KEY } from "../hooks/useCustomSpots";
+import {
+  STORAGE_KEY as CUSTOM_SPOTS_KEY,
+  LEGACY_STORAGE_KEY as CUSTOM_SPOTS_LEGACY_KEY,
+} from "../hooks/useCustomSpots";
 import { migrateLegacyKey } from "../utils/localStorageMigration";
 
 const STORAGE_KEY = "ohmywind:onboarding-v1";
@@ -24,6 +27,7 @@ function isFirstTimeUser(): boolean {
   try {
     migrateLegacyKey(LEGACY_STORAGE_KEY, STORAGE_KEY);
     if (localStorage.getItem(STORAGE_KEY) === "done") return false;
+    migrateLegacyKey(CUSTOM_SPOTS_LEGACY_KEY, CUSTOM_SPOTS_KEY);
     const spotsRaw = localStorage.getItem(CUSTOM_SPOTS_KEY);
     if (spotsRaw) {
       const parsed = JSON.parse(spotsRaw);

--- a/packages/web/src/hooks/useCustomSpots.ts
+++ b/packages/web/src/hooks/useCustomSpots.ts
@@ -3,7 +3,7 @@ import type { Spot } from "../types";
 import { migrateLegacyKey } from "../utils/localStorageMigration";
 
 export const STORAGE_KEY = "ohmywind_custom_spots";
-const LEGACY_STORAGE_KEY = "openwind_custom_spots";
+export const LEGACY_STORAGE_KEY = "openwind_custom_spots";
 
 function loadSpots(): Spot[] {
   migrateLegacyKey(LEGACY_STORAGE_KEY, STORAGE_KEY);


### PR DESCRIPTION
Corrige un bug manqué dans #239 : `isFirstTimeUser()` dans `Onboarding.tsx` lisait la nouvelle clé `ohmywind_custom_spots` sans avoir migré l'ancienne `openwind_custom_spots` au préalable. Un utilisateur existant pouvait être brièvement pris pour un first-timer si `Onboarding` s'exécutait avant le premier `loadSpots()`.

- Export de `LEGACY_STORAGE_KEY` depuis `useCustomSpots.ts`
- Appel de `migrateLegacyKey` sur la clé spots dans `isFirstTimeUser()` avant lecture

typecheck et tests (193/193) verts.

Generated with [Claude Code](https://claude.ai/code)