### PR TITLE
fix(ci): pushes interactifs app-authentifiés, traces d'échec archivées, échec signalé

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -57,6 +57,7 @@ jobs:
       # workflow — c'est pour ça que ci.yml écoute aussi les push sur fix/**
       # (les pushes, eux, viennent de l'app Claude et déclenchent bien).
       - uses: anthropics/claude-code-action@v1
+        id: claude
         env:
           GH_TOKEN: ${{ github.token }}
         with:
@@ -72,6 +73,16 @@ jobs:
                minimal qui résout l'issue. En cas d'ambiguïté, choisis
                l'interprétation la plus conservatrice et note l'hypothèse dans
                le corps de la PR.
+
+            Va droit au but : ouvre directement les fichiers cités par
+            l'issue (ou trouve-les par UN Grep ciblé), écris le fix, teste,
+            pousse. Pas d'inventaire général du repo, pas de lecture hors
+            périmètre. Tu ne peux PAS créer ni modifier de fichiers binaires
+            (images, icônes, polices) : si le fix en exige, commente le
+            blocage sur l'issue immédiatement et termine — c'est une fin de
+            run valide. De même, si tu n'identifies pas la cause après une
+            exploration courte, ne t'enfonce pas : commente l'issue avec ton
+            diagnostic partiel et ce qui te manque, puis termine.
             3. Respecte CLAUDE.md : conventions du repo, domaine voile (nœuds,
                caps vrais…), conventional commits. Exception runner CI :
                ignore la consigne worktree, travaille dans le checkout.
@@ -101,3 +112,25 @@ jobs:
           claude_args: |
             --max-turns 50
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(cd:*),Bash(ls:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git switch:*),Bash(git push:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(npm:*),Bash(uv:*),Bash(uvx:*)"
+
+      # L'agent coupé (max-turns, timeout, crash) ne peut rien poster : c'est
+      # le workflow qui signale l'échec sur l'issue, de façon déterministe.
+      - name: Signaler l'échec sur l'issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "⚠️ L'agent a tenté un fix mais n'a pas abouti (limite de tours, timeout ou erreur). Détails : ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — la trace complète est dans les artifacts du run. Précisez l'issue (fichiers concernés, comportement attendu) puis réarmez \`agent:fix\` pour relancer."
+
+      # Trace complète de la conversation, archivée uniquement en cas d'échec
+      # pour diagnostiquer les max-turns (repo public : artifacts publics).
+      - name: Archiver la trace d'exécution
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-trace-${{ github.run_id }}
+          path: ${{ steps.claude.outputs.execution_file }}
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -50,6 +50,7 @@ jobs:
       # Le GITHUB_TOKEN passé ici est borné par le bloc permissions ci-dessus :
       # c'est lui le vrai garde-fou, pas la confiance dans le prompt.
       - uses: anthropics/claude-code-action@v1
+        id: claude
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -92,3 +93,14 @@ jobs:
           claude_args: |
             --max-turns 25
             --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh label list),Bash(gh search:*),Read,Glob,Grep"
+
+      # Trace complète de la conversation, archivée uniquement en cas d'échec
+      # pour diagnostiquer les max-turns (repo public : artifacts publics).
+      - name: Archiver la trace d'exécution
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-trace-${{ github.run_id }}
+          path: ${{ steps.claude.outputs.execution_file }}
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,15 +40,20 @@ jobs:
       id-token: write
       actions: read # lire les résultats CI sur les PRs
     steps:
+      # persist-credentials: false — sinon le GITHUB_TOKEN par défaut reste
+      # dans la config git et les pushes de l'agent partent avec lui : aucun
+      # workflow ne se déclenche dessus (constaté au run 31742540466 : commit
+      # poussé sur la PR sans aucun check CI). Le seul credential restant est
+      # celui de l'app Claude, dont les pushes déclenchent bien ci.yml.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       # Pas d'input github_token : l'action s'authentifie comme la Claude
-      # GitHub App. C'est indispensable — les commits poussés avec le
-      # GITHUB_TOKEN par défaut ne déclencheraient jamais ci.yml sur la PR,
-      # et le gate CI serait mort-né.
+      # GitHub App (cf. checkout ci-dessus).
       - uses: anthropics/claude-code-action@v1
+        id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: dev
@@ -56,3 +61,15 @@ jobs:
             --max-turns 50
             --allowedTools "Bash(cd:*),Bash(ls:*),Bash(npm:*),Bash(uv:*),Bash(uvx:*)"
             --append-system-prompt "Tu tournes dans un runner GitHub Actions : ignore la consigne worktree de CLAUDE.md et travaille directement dans le checkout. Toute branche part de dev et toute PR cible dev, jamais main. La promotion dev vers main est toujours manuelle. Commandes Bash simples uniquement, sans pipe ni enchaînement : elles seraient refusées par l'allowlist."
+
+      # Trace complète de la conversation, archivée uniquement en cas d'échec
+      # pour diagnostiquer les max-turns sans exposer le transcript en
+      # permanence (repo public : les artifacts sont téléchargeables).
+      - name: Archiver la trace d'exécution
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-trace-${{ github.run_id }}
+          path: ${{ steps.claude.outputs.execution_file }}
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
Trois améliorations issues des derniers tests live :

- **claude.yml, persist-credentials: false** : le push de l'itération @claude sur PR #239 est parti avec le GITHUB_TOKEN par défaut → commit sans aucun check CI (run 31742540466). Même correctif que claude-fix.yml.
- **Échec signalé sur l'issue** : un agent coupé (max-turns, timeout) ne peut rien poster. claude-fix.yml a maintenant un step `if: failure()` qui commente l'issue avec le lien du run, de façon déterministe.
- **Traces exploitables** : les 3 workflows archivent la trace complète de la conversation (`outputs.execution_file`) en artifact (7 jours) en cas d'échec — fini le diagnostic à l'aveugle sur les max-turns. Prompt fix durci en « droit au but » + interdiction explicite des fichiers binaires (leçon du run 51 tours sur le PNG de #228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)