### PR TITLE
fix(web): coefficient par défaut à 0.75 et affiché sur la page plan

### DIFF
--- a/packages/web/src/components/BoatEssentials.tsx
+++ b/packages/web/src/components/BoatEssentials.tsx
@@ -79,7 +79,7 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
       </div>
       <p className="polar-hint">
         On atteint 100 % de la performance polaire uniquement en mode course ; en
-        plaisance, un coefficient de 80 % est souvent plus approprié.
+        plaisance, un coefficient de 75 % est souvent plus approprié.
         {importedActive && <> Polaire issue de tes performances réelles ? Mets 100 %.</>}
       </p>
 

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -68,11 +68,12 @@ export const DEFAULT_BASE = "cruiser_30ft";
 
 // Performance coefficient applied at plan time (the server's `efficiency`
 // parameter). 100% = a race crew sailing the polar; cruising realistically
-// loses ~20% (sail trim, comfort margins, helm attention).
+// loses ~25% (sail trim, comfort margins, helm attention). The default
+// matches the server-side plan_passage default so web and MCP plans agree.
 export const COEFF_MIN = 0.5;
 export const COEFF_MAX = 1.0;
 export const COEFF_STEP = 0.01;
-export const COEFF_DEFAULT = 0.8;
+export const COEFF_DEFAULT = 0.75;
 
 // Historical plan_passage default efficiency — what pre-v3 configs implicitly
 // planned with when they didn't pin 1.0. Consumed by the v1/v2 migration so
@@ -111,7 +112,7 @@ export interface PolarConfig {
   // Archetype the user started from. Determines the (tws_kn, twa_deg) grid.
   base: string;
   // Performance coefficient sent to plan_passage as `efficiency`. 1.0 = race
-  // trim (sail the polar), 0.8 = typical cruising. Applies to imported polars
+  // trim (sail the polar), 0.75 = typical cruising. Applies to imported polars
   // too: a file built from real logged performance should sit at 1.0.
   coefficient: number;
   // Spinnaker selection: asymmetric (reaching) or symmetric (running). Applies

--- a/packages/web/src/content/methodologie.md
+++ b/packages/web/src/content/methodologie.md
@@ -181,7 +181,7 @@ $$
 
 avec :
 
-- **`η` (efficacité)** : facteur multiplicatif qui ramène le polaire ORC théorique à la voile réelle. **OhMyWind utilise actuellement la valeur 0.75 par défaut, et cette valeur n'est pas modifiable depuis l'interface web.** Le paramètre existe côté serveur (un client expert peut le surcharger) mais aucun champ utilisateur ne l'expose pour l'instant. Valeurs de référence si on devait l'ajuster :
+- **`η` (efficacité)** : facteur multiplicatif qui ramène le polaire ORC théorique à la voile réelle. **OhMyWind utilise la valeur 0.75 par défaut**, côté serveur comme dans l'interface web : c'est le « coefficient de performance » réglable de 50 à 100 % dans l'onglet Bateau, et le plan affiche la valeur utilisée à côté du nom du bateau. Valeurs de référence pour l'ajuster :
   - `0.85` régate (carène propre, voiles fraîches, équipage attentif)
   - `0.75` croisière (réglages standards, marges de confort, défaut OhMyWind)
   - `0.65` croisière chargée en famille (eau, gasoil, équipement, carène salie)

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -440,6 +440,7 @@ function ArchetypeSelector({
   const current = archetypes.find((a) => a.slug === currentSlug);
   const archetypeLabel = current?.name ?? currentSlug;
   const label = isCustom ? "Custom" : archetypeLabel;
+  const coeffPct = Math.round(polarCfg.coefficient * 100);
 
   function resetCustom() {
     savePolarConfig(defaultPolarConfig());
@@ -456,6 +457,12 @@ function ArchetypeSelector({
         title={isCustom ? `Polaire personnalisée active (base : ${baseLabel})` : "Changer le type de bateau"}
       >
         {label}
+        <span
+          style={{ color: "var(--ow-fg-2)" }}
+          title="Coefficient de performance appliqué à la polaire (réglable dans l'onglet Bateau)"
+        >
+          · {coeffPct} %
+        </span>
         {isCustom && (
           <span
             className="text-[9px] font-semibold uppercase tracking-wider px-1 py-0.5 rounded"
@@ -977,11 +984,16 @@ export function PlanSidebar({
   // as ArchetypeSelector.
   const recapPolarCfg = loadPolarConfig();
   const importedName = recapPolarCfg.imported?.name ?? "polaire";
-  const archetypeLabel = isImportedActive(recapPolarCfg)
-    ? `${importedName.length > 20 ? `${importedName.slice(0, 19)}…` : importedName} (importée)`
-    : `${ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug}${
-        isPolarCustomized(recapPolarCfg) ? " (ajustée)" : ""
-      }`;
+  // The performance coefficient rides along with the boat label so the plan
+  // always states which fraction of the polar the ETA was computed with.
+  const recapCoeffPct = `${Math.round(recapPolarCfg.coefficient * 100)} %`;
+  const archetypeLabel = `${
+    isImportedActive(recapPolarCfg)
+      ? `${importedName.length > 20 ? `${importedName.slice(0, 19)}…` : importedName} (importée)`
+      : `${ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug}${
+          isPolarCustomized(recapPolarCfg) ? " (ajustée)" : ""
+        }`
+  } · ${recapCoeffPct}`;
 
   // ── Filled compare view: results loaded, inputs collapsed into a recap ────
   if (mode === "compare" && windows && windows.length > 0) {

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -46,7 +46,7 @@ function resolveOverrides(archetype: string): PlanOverrides {
 }
 
 // Plan-time efficiency — the /config performance coefficient, always explicit
-// since config v3 (1.0 = race trim, 0.8 = typical cruising).
+// since config v3 (1.0 = race trim, 0.75 = typical cruising).
 function resolveEfficiency(): number {
   return planEfficiency(loadPolarConfig());
 }


### PR DESCRIPTION
Closes #247

## Quoi

- `COEFF_DEFAULT` passe de 0.8 à **0.75** dans `polarConfig.ts` : le défaut web s'aligne sur le défaut serveur de `plan_passage` (déjà 0.75 partout : mcp-core, hf-space, data-adapters). Un plan web et un plan MCP donnent désormais la même ETA à config égale.
- Le coefficient est **affiché sur la page plan** :
  - dans le récap compact (« Croiseur 30 pieds · 75 % »), y compris en mode comparaison et pour les polaires importées ;
  - dans le sélecteur de bateau, avec un tooltip qui pointe vers l'onglet Bateau.
- Copy mise à jour : le hint de l'onglet Bateau recommande 75 % (au lieu de 80 %), et la méthodologie ne prétend plus que le coefficient n'est pas réglable depuis l'interface web (faux depuis la config v3).

## Comportement de migration

Les configs v3 déjà persistées gardent la valeur enregistrée par l'utilisateur (pas de migration forcée : impossible de distinguer un 0.8 choisi d'un 0.8 par défaut). Seules les nouvelles installations et les resets partent à 75 %. Les migrations v1/v2 tombaient déjà sur 0.75.

## Vérifs

- 193 tests web verts (`vitest run`)
- `lint:budget` au budget (26/26, aucune nouvelle erreur)
- `npm run build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)