### PR TITLE
fix(web): hint du coefficient sans doublon de valeur et 100 % expliqué

### DIFF
--- a/packages/web/src/components/BoatEssentials.tsx
+++ b/packages/web/src/components/BoatEssentials.tsx
@@ -77,10 +77,15 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
           />
         </label>
       </div>
+      {/* Single source of truth for the recommended value: the slider label.
+          The hint explains the scale but never repeats a number that could
+          drift from COEFF_DEFAULT. */}
       <p className="polar-hint">
-        On atteint 100 % de la performance polaire uniquement en mode course ; en
-        plaisance, un coefficient de 75 % est souvent plus approprié.
-        {importedActive && <> Polaire issue de tes performances réelles ? Mets 100 %.</>}
+        Les 100 % correspondent à la polaire théorique, calculée bateau à vide
+        avec des voiles de course : en pratique on navigue en dessous. La valeur
+        par défaut est un bon point de départ ; baisse-la si le bateau est chargé
+        ou les voiles fatiguées.
+        {importedActive && <> Polaire mesurée sur ton propre bateau ? Là, 100 % se justifie.</>}
       </p>
 
       {/* Motor (optional) — switches segments with sail speed under the


### PR DESCRIPTION
Suite de #248 (refs #247).

- Le hint de l'onglet Bateau ne répète plus la valeur recommandée en dur : le label du slider est le seul indicateur chiffré (le doublon venait de diverger : hint à 80 % vs défaut à 75 %).
- Reformulation du 100 % : polaire théorique calculée bateau à vide avec des voiles de course, on navigue en dessous en pratique ; la mention « polaire importée » précise que 100 % se justifie seulement avec une polaire mesurée sur son propre bateau.

Vérifs : 193 tests verts, lint:budget 26/26, copy sans tiret cadratin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)