### PR TITLE
fix(android-dev): icônes bubblewrap tirées de dev.ohmywind.fr

### DIFF
--- a/packages/android-dev/twa-manifest.json
+++ b/packages/android-dev/twa-manifest.json
@@ -13,8 +13,8 @@
   "backgroundColor": "#030712",
   "enableNotifications": false,
   "startUrl": "/",
-  "iconUrl": "https://ohmywind.fr/icon-512.png",
-  "maskableIconUrl": "https://ohmywind.fr/icon-maskable-512.png",
+  "iconUrl": "https://dev.ohmywind.fr/icon-512.png",
+  "maskableIconUrl": "https://dev.ohmywind.fr/icon-maskable-512.png",
   "splashScreenFadeOutDuration": 300,
   "signingKey": {
     "path": "../android/android.keystore",


### PR DESCRIPTION
La flavor Android dev pointe sur dev.ohmywind.fr mais téléchargeait ses icônes depuis la prod au moment du `bubblewrap update`. Conséquence : impossible d'embarquer un changement d'icône (comme #228 / #249) dans l'app dev avant la promotion en prod.

Alignement de `iconUrl` / `maskableIconUrl` sur l'environnement de la flavor. Suite de #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)