### PR TITLE
fix(web): le bateau d'une polaire custom prime sur le slug URL/cache du plan

### DIFF
--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -9,6 +9,7 @@ import {
   derivedMinUpwind,
   effectiveMinUpwind,
   effectivePolar,
+  initialPlanBoat,
   isImportedActive,
   isPolarCustomized,
   loadPolarConfig,
@@ -321,11 +322,43 @@ describe("isPolarCustomized", () => {
     expect(isPolarCustomized(defaultPolarConfig())).toBe(false);
   });
 
-  it("applies spi/overrides onto the URL's boat grid via the archetype override", () => {
+  it("applies spi/overrides onto an explicitly requested boat grid", () => {
     const cfg: PolarConfig = { ...defaultPolarConfig(), spi: "asymmetric" };
     const eff = effectivePolar(cfg, "cruiser_50ft");
     expect(eff.name).toBe("cruiser_50ft");
     expect(eff.min_upwind_twa_deg).toBe(BASE_POLARS.cruiser_50ft.min_upwind_twa_deg);
+  });
+});
+
+describe("initialPlanBoat", () => {
+  const custom50: PolarConfig = {
+    ...defaultPolarConfig(),
+    base: "cruiser_50ft",
+    spi: "asymmetric",
+  };
+
+  it("pins the boat to cfg.base when a customization is active (#220)", () => {
+    // The reported repro: custom polar built on a 50-footer, URL/cache still
+    // carrying the 30ft slug from an earlier session.
+    expect(initialPlanBoat(custom50, "cruiser_30ft", null)).toBe("cruiser_50ft");
+    expect(initialPlanBoat(custom50, null, "cruiser_30ft")).toBe("cruiser_50ft");
+  });
+
+  it("pins to cfg.base for an active imported polar too", () => {
+    expect(initialPlanBoat(withImported({ base: "cruiser_40ft" }), "cruiser_30ft", null)).toBe(
+      "cruiser_40ft",
+    );
+  });
+
+  it("lets the URL's boat win when nothing is customized", () => {
+    expect(initialPlanBoat(defaultPolarConfig(), "cruiser_50ft", "cruiser_25ft")).toBe(
+      "cruiser_50ft",
+    );
+  });
+
+  it("falls back to the cached slug, then cfg.base", () => {
+    expect(initialPlanBoat(defaultPolarConfig(), null, "cruiser_25ft")).toBe("cruiser_25ft");
+    expect(initialPlanBoat(defaultPolarConfig(), null, null)).toBe(DEFAULT_BASE);
   });
 });
 

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -483,12 +483,13 @@ export function hasOverrides(cfg: PolarConfig): boolean {
 // is selected, the upwind angle is pinned, a cell is hand-tuned, the motor is
 // configured, or an imported file is active. Used to decide whether to push
 // the custom matrix to the planner; when false, the server's bundled polar
-// for the requested archetype suffices. The check is archetype-independent:
-// since the /plan selector writes through to `cfg.base`, a base/archetype
-// mismatch only happens via a shared URL, where the link's boat should win —
-// deliberately NOT a customization trigger (the caller passes its slug to
-// `effectivePolar` instead). The coefficient is also absent: it travels as
-// the `efficiency` request parameter and never requires pushing a matrix.
+// for the requested archetype suffices. While this is true, `cfg.base` is
+// the boat of record app-wide: the customization was built against ITS grid,
+// and the /plan selector displays it as the active boat — so /plan seeds its
+// slug from it (see initialPlanBoat) instead of trusting a URL or cached
+// slug left by an earlier session (#220). The coefficient is absent from the
+// check: it travels as the `efficiency` request parameter and never requires
+// pushing a matrix.
 export function isPolarCustomized(cfg: PolarConfig): boolean {
   if (isImportedActive(cfg)) return true;
   const motorActive =
@@ -496,6 +497,19 @@ export function isPolarCustomized(cfg: PolarConfig): boolean {
   return (
     cfg.spi !== "off" || cfg.minUpwindDeg !== undefined || hasOverrides(cfg) || motorActive
   );
+}
+
+// The boat slug /plan starts on. A customized polar pins the boat to
+// `cfg.base` (see isPolarCustomized); otherwise the usual precedence applies:
+// the shared/bookmarked URL's boat first, then the last-simulation cache,
+// then the /config default.
+export function initialPlanBoat(
+  cfg: PolarConfig,
+  urlSlug?: string | null,
+  cachedSlug?: string | null,
+): string {
+  if (isPolarCustomized(cfg)) return cfg.base;
+  return urlSlug || cachedSlug || cfg.base;
 }
 
 // Cheap content hash (djb2) so two different files with the same name and

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -980,8 +980,11 @@ export function PlanSidebar({
   // Recap-strip boat label: the French display label rather than the raw API
   // slug, and the polar's provenance when it isn't the stock one — the file
   // name suffixed « importée », or the boat suffixed « ajustée » when the
-  // archetype was hand-tuned. Re-read the config at render, same rationale
-  // as ArchetypeSelector.
+  // archetype was hand-tuned. The « ajustée » branch names cfg.base, the hull
+  // the tuning was built on and the one the ArchetypeSelector announces —
+  // never the page slug, which could still carry another boat from a stale
+  // URL/cache (#220). Re-read the config at render, same rationale as
+  // ArchetypeSelector.
   const recapPolarCfg = loadPolarConfig();
   const importedName = recapPolarCfg.imported?.name ?? "polaire";
   // The performance coefficient rides along with the boat label so the plan
@@ -990,9 +993,9 @@ export function PlanSidebar({
   const archetypeLabel = `${
     isImportedActive(recapPolarCfg)
       ? `${importedName.length > 20 ? `${importedName.slice(0, 19)}…` : importedName} (importée)`
-      : `${ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug}${
-          isPolarCustomized(recapPolarCfg) ? " (ajustée)" : ""
-        }`
+      : isPolarCustomized(recapPolarCfg)
+        ? `${ARCHETYPE_LABELS[recapPolarCfg.base] ?? recapPolarCfg.base} (ajustée)`
+        : ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug
   } · ${recapCoeffPct}`;
 
   // ── Filled compare view: results loaded, inputs collapsed into a recap ────

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -18,7 +18,7 @@ import {
 import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
-import { effectivePolar, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
+import { effectivePolar, initialPlanBoat, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
 import { LocateButton } from "../components/LocateButton";
 import { useGeolocation } from "../hooks/useGeolocation";
 import { useMapView } from "../hooks/useMapView";
@@ -30,17 +30,19 @@ import { setCookie, clearCookie } from "../utils/cookies";
 // next refetch without a page reload. Polar matrix is only attached when the
 // editor deviates from the default for the active archetype — otherwise the
 // server's bundled polar wins, saving ~kB per request.
-function resolveOverrides(archetype: string): PlanOverrides {
+function resolveOverrides(): PlanOverrides {
   const overrides: PlanOverrides = {};
   const modelCfg = loadModelConfig();
   const models = activeModels(modelCfg);
   if (models.length > 0) overrides.models = models;
   const polarCfg = loadPolarConfig();
   if (isPolarCustomized(polarCfg)) {
-    // The current slug wins over cfg.base: a shared URL can carry a different
-    // boat than the one configured locally, and the link's boat is the one
-    // being planned — spi/overrides apply on top of ITS grid.
-    overrides.polar = effectivePolar(polarCfg, archetype);
+    // The custom matrix is always built on cfg.base's grid — the boat of
+    // record while a customization is active (#220). The page's slug matches
+    // it (seeded via initialPlanBoat, kept in sync by the selector's
+    // write-through), so passing it here would be redundant at best and, in a
+    // cross-tab /config edit, would resurrect the mismatch.
+    overrides.polar = effectivePolar(polarCfg);
   }
   return overrides;
 }
@@ -361,12 +363,17 @@ export function PlanPage() {
     if (useCachedRoute) return cachedAtMount!.waypoints;
     return [];
   });
-  const [archetype, setArchetype] = useState(() => {
-    if (isParsedOk(initialParsed) && initialParsed.archetype) return initialParsed.archetype;
-    if (useCachedRoute) return cachedAtMount!.archetype;
-    // The boat configured on /config is the app-wide default.
-    return loadPolarConfig().base;
-  });
+  const [archetype, setArchetype] = useState(() =>
+    // A customized polar pins the boat to cfg.base — the hull the tuning was
+    // built on and the one the selector displays — so a stale URL/cache slug
+    // from an earlier session can't silently re-board the plan on another
+    // boat (#220). Otherwise: URL, then cache, then the /config default.
+    initialPlanBoat(
+      loadPolarConfig(),
+      isParsedOk(initialParsed) ? initialParsed.archetype : null,
+      useCachedRoute ? cachedAtMount!.archetype : null,
+    ),
+  );
   const [departure, setDeparture] = useState(() => {
     const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";
     if (raw && new Date(raw) >= new Date()) return raw;
@@ -432,7 +439,7 @@ export function PlanPage() {
   function doFetch(wpts: [number, number][], arch: string, dep: string, anchor: TimeAnchor = "departure") {
     setIsLoading(true);
     setApiError(null);
-    const overrides = resolveOverrides(arch);
+    const overrides = resolveOverrides();
     const depIso = toTzAware(dep);
     const anchorMs = Date.parse(depIso);
     // Sample the route corridor in the browser and attach it so the server
@@ -488,13 +495,16 @@ export function PlanPage() {
 
   useEffect(() => {
     // Path A — URL has waypoints: respect the URL, restore from cache if it
-    // matches the same route + archetype, otherwise fetch fresh.
+    // matches the same route + boat, otherwise fetch fresh. The boat is the
+    // seeded `archetype` state, not the raw URL slug: a customized polar
+    // overrides the URL's boat (see initialPlanBoat), and the results shown
+    // must be the ones computed on the boat the recap displays (#220).
     if (urlHasWaypoints) {
       const cached: LastSimulation | null = loadLastSimulation();
       const cacheMatches =
         cached &&
         waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
-        cached.archetype === initialParsed.archetype &&
+        cached.archetype === archetype &&
         // Reject the cache if the user tweaked /config since the simulation
         // ran — the persisted result is stale relative to the active
         // preferences. Treat missing fingerprint as "pre-config-era" cache.
@@ -516,7 +526,7 @@ export function PlanPage() {
         }
         if (cached.single || cached.compare) return;
       }
-      doFetch(initialParsed.waypoints, initialParsed.archetype, departure);
+      doFetch(initialParsed.waypoints, archetype, departure);
       return;
     }
 
@@ -524,13 +534,18 @@ export function PlanPage() {
     // useState initializers above. Hydrate the simulation results, sync the
     // URL so reload/share works, and skip any network call.
     if (useCachedRoute && cachedAtMount) {
-      const url = buildPlanUrl(cachedAtMount.waypoints, departure, cachedAtMount.archetype);
+      const url = buildPlanUrl(cachedAtMount.waypoints, departure, archetype);
       window.history.replaceState(null, "", url);
-      // /config changed since the cache was written — discard the persisted
-      // results and refetch so the plan reflects the user's current
-      // preferences. Route + archetype + departure remain seeded.
-      if (cachedAtMount.configFingerprint !== currentConfigFingerprint()) {
-        doFetch(cachedAtMount.waypoints, cachedAtMount.archetype, departure);
+      // Discard the persisted results and refetch when /config changed since
+      // the cache was written, or when the cached simulation ran on another
+      // boat than the seeded one (a customized polar re-pins the boat to its
+      // base — the cached run may predate the fix for #220). Route + boat +
+      // departure remain seeded.
+      if (
+        cachedAtMount.configFingerprint !== currentConfigFingerprint() ||
+        cachedAtMount.archetype !== archetype
+      ) {
+        doFetch(cachedAtMount.waypoints, archetype, departure);
         return;
       }
       if (cachedAtMount.single) {
@@ -620,7 +635,7 @@ export function PlanPage() {
           archetype,
           intervalHours: sweepInterval,
           efficiency: resolveEfficiency(),
-          overrides: resolveOverrides(archetype),
+          overrides: resolveOverrides(),
           forecastCache,
         }),
       )


### PR DESCRIPTION
## Problème (#220)

Polaire personnalisée basée sur un Croiseur 50 pieds, mais le récap du plan affiche « Croiseur 30 pieds (ajustée) ». Ce n'est pas qu'un bug d'affichage : la simulation tournait réellement sur la grille 30 pieds, avec les réglages custom appliqués dessus.

## Cause

`/plan` seede son slug bateau depuis l'URL puis le cache de dernière simulation avant de retomber sur `cfg.base`. Un slug périmé d'une session antérieure (d'avant la configuration de la polaire custom) gagnait donc sur le bateau réellement configuré, alors que le sélecteur affichait déjà « Custom · Base : Croiseur 50 pieds ».

## Fix

- `initialPlanBoat()` (polarConfig) : quand une customisation est active, `cfg.base` est le bateau de référence et prime sur URL/cache ; sinon précédence inchangée (URL > cache > défaut /config).
- `resolveOverrides()` construit toujours la matrice custom sur la grille de `cfg.base` (fin du cas « réglages du 50 pieds appliqués sur la grille d'un autre bateau »).
- Le récap nomme `cfg.base` dans la branche « (ajustée) », aligné sur le sélecteur.
- L'hydratation du cache au mount exige que la simulation persistée ait tourné sur le bateau seedé, sinon refetch — auto-guérit les caches écrits avant ce fix.

Effet de bord assumé : une URL partagée portant un autre bateau ne prime plus quand le destinataire a une polaire custom active (son bateau configuré gagne, comme l'affiche le sélecteur).

## Vérifs

- `typecheck` ✓, `vitest` 197/197 ✓ (dont 4 nouveaux tests `initialPlanBoat`), build prod ✓
- `eslint` : échecs identiques avant/après (26 erreurs préexistantes sur dev, non liées)

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)