### PR TITLE
fix(web): vouvoiement systématique dans la copy utilisateur

### DIFF
--- a/packages/web/src/components/BoatAdvanced.tsx
+++ b/packages/web/src/components/BoatAdvanced.tsx
@@ -41,7 +41,7 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
     if (file.size > IMPORT_MAX_BYTES) {
       setImportNotice({
         kind: "error",
-        text: "Fichier trop volumineux : une polaire fait quelques ko, vérifie que c'est le bon fichier.",
+        text: "Fichier trop volumineux : une polaire fait quelques ko, vérifiez que c'est le bon fichier.",
       });
       return;
     }
@@ -222,7 +222,7 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
             Télécharger un fichier d'exemple (.csv)
           </a>{" "}
           : la polaire du croiseur 30 pieds, à ouvrir dans un tableur et remplacer
-          par les valeurs de ton bateau.
+          par les valeurs de votre bateau.
         </p>
       </div>
 
@@ -321,8 +321,8 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
         </div>
         {importedActive ? (
           <p className="polar-hint">
-            Polaire importée active : le réglage spi est verrouillé, ton fichier est
-            supposé refléter déjà ta garde-robe de voiles.
+            Polaire importée active : le réglage spi est verrouillé, votre fichier est
+            supposé refléter déjà votre garde-robe de voiles.
           </p>
         ) : (
           config.spi !== "off" && (
@@ -355,9 +355,9 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
           {tuningOpen && (
             <>
               <p className="polar-hint">
-                Glisse un point de la courbe sélectionnée pour fixer sa vitesse
+                Glissez un point de la courbe sélectionnée pour fixer sa vitesse
                 (valeurs brutes, avant coefficient). Les points ajustés restent
-                quand tu changes de spi.
+                quand vous changez de spi.
               </p>
               <TwsPills
                 twsKn={effective.tws_kn}

--- a/packages/web/src/components/BoatEssentials.tsx
+++ b/packages/web/src/components/BoatEssentials.tsx
@@ -83,9 +83,9 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
       <p className="polar-hint">
         Les 100 % correspondent à la polaire théorique, calculée bateau à vide
         avec des voiles de course : en pratique on navigue en dessous. La valeur
-        par défaut est un bon point de départ ; baisse-la si le bateau est chargé
+        par défaut est un bon point de départ ; baissez-la si le bateau est chargé
         ou les voiles fatiguées.
-        {importedActive && <> Polaire mesurée sur ton propre bateau ? Là, 100 % se justifie.</>}
+        {importedActive && <> Polaire mesurée sur votre propre bateau ? Là, 100 % se justifie.</>}
       </p>
 
       {/* Motor (optional) — switches segments with sail speed under the

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -319,9 +319,9 @@ export function ConfigPage() {
           <>
             <h1 className="text-3xl font-bold mb-2">Bateau</h1>
             <p className="text-sm opacity-80 mb-8 leading-relaxed">
-              Décris ton bateau : ces réglages nourrissent tous tes plans de
+              Décrivez votre bateau : ces réglages nourrissent tous vos plans de
               passage. L'essentiel suffit pour bien commencer ; la tuile
-              Avancé permet d'importer ta propre polaire et d'affiner le
+              Avancé permet d'importer votre propre polaire et d'affiner le
               comportement au près et sous spi.
             </p>
             <div className="flex flex-col gap-5">
@@ -355,10 +355,10 @@ export function ConfigPage() {
 
         <footer className="config-storage-note mt-10">
           OhMyWind ne propose volontairement pas de comptes utilisateurs :
-          aucune donnée n'est envoyée sur un serveur pour identifier qui tu es.
-          Tes préférences (modèles, polaire perso) sont stockées localement
-          dans ton navigateur. Si tu changes d'appareil, de navigateur ou si
-          tu effaces les cookies de ce site, ces ajustements seront perdus.
+          aucune donnée n'est envoyée sur un serveur pour identifier qui vous êtes.
+          Vos préférences (modèles, polaire perso) sont stockées localement
+          dans votre navigateur. Si vous changez d'appareil, de navigateur ou si
+          vous effacez les cookies de ce site, ces ajustements seront perdus.
         </footer>
       </main>
 


### PR DESCRIPTION
La copy web tutoyait par endroits (intro Bateau, note de stockage local, hints import/spi/tuning, et le hint coefficient fraîchement reformulé dans #250). Sweep complet de `packages/web/src` : tout est au vouvoiement, aligné sur le reste de la copy (Laissez, Renseignez, Cliquez).

Vérifs : plus aucune occurrence de tu/ton/ta/tes/toi ni d'impératif singulier dans la copy, 193 tests verts, lint:budget 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)