### PR TITLE
feat(web): la polaire affichée s'étend jusqu'au vent arrière (180°)

### DIFF
--- a/packages/web/src/components/PolarDiagram.test.ts
+++ b/packages/web/src/components/PolarDiagram.test.ts
@@ -4,6 +4,8 @@ import { visiblePolarPoints } from "./polarPoints";
 // The no-go fix: curves must not be drawn through the dead zone. A qtVlm file
 // carrying a 0° row of zeros used to drag every curve into a spike between
 // the center and the first grid angle.
+// The downwind edge mirrors the server's clamped lookup: every drawn curve
+// ends on a synthetic 180° point at the last grid angle's speed.
 
 describe("visiblePolarPoints", () => {
   const TWA = [0, 40, 50, 90];
@@ -11,7 +13,7 @@ describe("visiblePolarPoints", () => {
 
   it("drops every point below the minimum upwind angle", () => {
     const pts = visiblePolarPoints(TWA, SPEEDS, 40);
-    expect(pts.map((p) => p.twa)).toEqual([40, 50, 90]);
+    expect(pts.map((p) => p.twa)).toEqual([40, 50, 90, 180]);
     // In particular the (0°, 0 kn) point never reaches the path.
     expect(pts.some((p) => p.speed === 0)).toBe(false);
   });
@@ -19,12 +21,12 @@ describe("visiblePolarPoints", () => {
   it("interpolates the entry point exactly onto the boundary", () => {
     const pts = visiblePolarPoints(TWA, SPEEDS, 45);
     expect(pts[0]).toEqual({ twa: 45, speed: 4.5 });
-    expect(pts.map((p) => p.twa)).toEqual([45, 50, 90]);
+    expect(pts.map((p) => p.twa)).toEqual([45, 50, 90, 180]);
   });
 
   it("returns the full curve when the grid already starts at the boundary", () => {
     const pts = visiblePolarPoints([40, 50, 90], [4, 5, 6], 40);
-    expect(pts).toHaveLength(3);
+    expect(pts.map((p) => p.twa)).toEqual([40, 50, 90, 180]);
     expect(pts[0]).toEqual({ twa: 40, speed: 4 });
   });
 
@@ -43,7 +45,7 @@ describe("visiblePolarPoints", () => {
     // zeros: no interpolation toward the dead point (the old center spike),
     // the entry tapers from the 40° speed by cos(40°)/cos(28°).
     const pts = visiblePolarPoints([0, 40, 50], [0, 4.0, 5.0], 28);
-    expect(pts.map((p) => p.twa)).toEqual([28, 40, 50]);
+    expect(pts.map((p) => p.twa)).toEqual([28, 40, 50, 180]);
     const expected = (4.0 * Math.cos((40 * Math.PI) / 180)) / Math.cos((28 * Math.PI) / 180);
     expect(pts[0].speed).toBeCloseTo(expected, 2);
     expect(pts[0].speed).toBeLessThan(4.0);
@@ -51,8 +53,21 @@ describe("visiblePolarPoints", () => {
 
   it("extends along the equal-VMG arc when the boundary sits below the whole grid", () => {
     const pts = visiblePolarPoints([40, 50, 90], [4.0, 5.0, 6.0], 35);
-    expect(pts.map((p) => p.twa)).toEqual([35, 40, 50, 90]);
+    expect(pts.map((p) => p.twa)).toEqual([35, 40, 50, 90, 180]);
     expect(pts[0].speed).toBeLessThan(4.0);
     expect(pts[0].speed).toBeGreaterThan(3.0);
+  });
+
+  it("extends flat to a 180° dead run at the last grid angle's speed", () => {
+    // Archetype-shaped grid ending at 165°: the planner's lookup clamps past
+    // the last angle, so the drawn dead-run speed is the 165° one.
+    const pts = visiblePolarPoints([40, 90, 165], [4.0, 6.0, 5.0], 40);
+    expect(pts[pts.length - 1]).toEqual({ twa: 180, speed: 5.0 });
+  });
+
+  it("does not duplicate the dead-run point when the grid reaches 180°", () => {
+    const pts = visiblePolarPoints([40, 90, 180], [4.0, 6.0, 5.0], 40);
+    expect(pts.filter((p) => p.twa === 180)).toHaveLength(1);
+    expect(pts[pts.length - 1]).toEqual({ twa: 180, speed: 5.0 });
   });
 });

--- a/packages/web/src/components/PolarDiagram.tsx
+++ b/packages/web/src/components/PolarDiagram.tsx
@@ -202,8 +202,10 @@ export function PolarDiagram({
         <line x1={CX} y1={CY - R_MAX - 10} x2={CX} y2={CY + R_MAX + 10} className="polar-axis" />
         <line x1={CX} y1={CY} x2={CX + R_MAX + 10} y2={CY} className="polar-axis" />
 
-        {/* Angular ticks and labels (right side, every twa point) */}
-        {twaDeg.map((twa) => {
+        {/* Angular ticks and labels (right side, every twa point). A dead-run
+            tick is appended when the grid stops short of 180°: the drawn curve
+            is clamp-extended there (see polarPoints), the scale must follow. */}
+        {(twaDeg[twaDeg.length - 1] < 180 ? [...twaDeg, 180] : twaDeg).map((twa) => {
           const inner = polarToCartesian(twa, R_MAX);
           const outer = polarToCartesian(twa, R_MAX + 10);
           const label = polarToCartesian(twa, R_MAX + 22);

--- a/packages/web/src/components/polarPoints.ts
+++ b/packages/web/src/components/polarPoints.ts
@@ -10,6 +10,18 @@
 // is extended along the equal-VMG arc instead: pinching below the data can't
 // beat the polar's VMG, so speed tapers by cos(θ0)/cos(θ). This mirrors the
 // server, whose VMG sweep never searches below the grid's real data.
+//
+// The downwind edge gets the mirror treatment: grids usually stop short of a
+// dead run (165° on the bundled archetypes) while the planner's polar lookup
+// clamps flat past the last angle — a 180° leg sails at the last column's
+// speed. The drawn curve is extended the same way so the diagram shows what
+// the planner will actually use.
+
+function withDeadRun(pts: { twa: number; speed: number }[]): { twa: number; speed: number }[] {
+  const last = pts[pts.length - 1];
+  return last.twa >= 180 ? pts : [...pts, { twa: 180, speed: last.speed }];
+}
+
 export function visiblePolarPoints(
   twaDeg: number[],
   speeds: number[],
@@ -19,10 +31,10 @@ export function visiblePolarPoints(
   const first = pts.findIndex((p) => p.twa >= minUpwindDeg);
   if (first === -1) return [];
   const kept = pts.slice(first);
-  if (kept[0].twa === minUpwindDeg) return kept;
+  if (kept[0].twa === minUpwindDeg) return withDeadRun(kept);
   // Past 90° an equal-VMG extension is meaningless (cos ≤ 0) and such a grid
   // has no upwind data anyway — draw what exists.
-  if (kept[0].twa >= 90) return kept;
+  if (kept[0].twa >= 90) return withDeadRun(kept);
   const below = first > 0 ? pts[first - 1] : null;
   let speed: number;
   if (below && below.speed > 0.1) {
@@ -32,5 +44,5 @@ export function visiblePolarPoints(
     const rad = (deg: number) => (deg * Math.PI) / 180;
     speed = (kept[0].speed * Math.cos(rad(kept[0].twa))) / Math.cos(rad(minUpwindDeg));
   }
-  return [{ twa: minUpwindDeg, speed: Math.round(speed * 100) / 100 }, ...kept];
+  return withDeadRun([{ twa: minUpwindDeg, speed: Math.round(speed * 100) / 100 }, ...kept]);
 }


### PR DESCRIPTION
Les grilles d'archétypes s'arrêtent à 165° et la courbe du diagramme s'arrêtait avec elles, alors que le lookup du planificateur clampe à plat au-delà du dernier angle : un bord à 180° navigue à la vitesse du 165°. Le diagramme promet « ce que le planificateur utilisera », il doit donc montrer ce segment.

- `visiblePolarPoints` ajoute un point synthétique à 180° à la vitesse du dernier angle de la grille (display-only, symétrique de l'extension au près existante ; le planner n'est pas touché).
- Tick « 180° » ajouté à l'échelle angulaire quand la grille s'arrête avant.
- Pas de doublon si une polaire importée va déjà jusqu'à 180° ; pas de point ajouté aux poignées de tuning (le 180° est dérivé, pas éditable).

Vérifs : 195 tests verts (2 nouveaux cas vent arrière + attentes existantes mises à jour), lint:budget 26/26, label 180° dans le viewBox (y=462/500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)