### PR TITLE
fix(android): déclare l'empreinte du keystore actuel dans assetlinks

### DIFF
--- a/packages/android-dev/twa-manifest.json
+++ b/packages/android-dev/twa-manifest.json
@@ -42,6 +42,9 @@
   "fingerprints": [
     {
       "value": "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
+    },
+    {
+      "value": "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
     }
   ],
   "additionalTrustedOrigins": [],

--- a/packages/android/twa-manifest.json
+++ b/packages/android/twa-manifest.json
@@ -46,6 +46,9 @@
     },
     {
       "value": "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
+    },
+    {
+      "value": "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
     }
   ],
   "additionalTrustedOrigins": [],

--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -6,7 +6,8 @@
       "package_name": "fr.ohmywind.app",
       "sha256_cert_fingerprints": [
         "DF:C9:D2:19:37:69:24:65:19:47:96:EF:D7:A2:61:D3:6C:C6:3A:D6:06:6B:1C:C5:28:3A:35:CF:2D:E2:05:90",
-        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
+        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82",
+        "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
       ]
     }
   },
@@ -15,7 +16,10 @@
     "target": {
       "namespace": "android_app",
       "package_name": "fr.ohmywind.app.dev",
-      "sha256_cert_fingerprints": ["6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"]
+      "sha256_cert_fingerprints": [
+        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82",
+        "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
+      ]
     }
   }
 ]


### PR DESCRIPTION
Découvert en testant le build de #249/#251 sur l'émulateur : l'app dev s'ouvrait avec la barre Chrome (échec de vérification TWA).

Cause : le keystore d'upload régénéré le 2026-08-01 a l'empreinte `32:45:AD:CB:…`, mais `assetlinks.json` ne déclarait que l'ancienne `6B:F4:…` (l'ancien keystore, qui signait la v1 dev installée jusqu'ici). Tout APK signé avec le keystore actuel échouait donc la vérification `handle_all_urls`.

Fix, conformément au README android (empreinte mesurée sur l'APK réellement signé, jamais recopiée) :
- `assetlinks.json` : ajout **additif** de `32:45:…` pour `fr.ohmywind.app` et `fr.ohmywind.app.dev`, sans retirer `6B:F4:…` ni l'empreinte Play App Signing `DF:C9:…`
- `twa-manifest.json` prod + dev : même ajout dans `fingerprints`

⚠️ Question ouverte côté Play Console (hors scope de cette PR) : vérifier que la clé d'upload enregistrée chez Google correspond bien au keystore actuel avant l'upload de la 1.0.1, sinon demander un reset de clé d'upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)