### PR TITLE
fix(web): points centrés dans la zone visible de la carte + vent par défaut à la géoloc (#218)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -73,13 +73,19 @@ function App() {
   }, [spot]);
   const [forecasts, setForecasts] = useState<ModelForecast[]>([]);
   const [marine, setMarine] = useState<MarineHourly | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  // Which spot the forecasts in state belong to. The loading flag is derived
+  // from it at render time rather than set in the fetch effect: deriving
+  // makes the skeleton part of the very commit that selects a spot, so the
+  // data panel already has its full height when SpotMap's camera effects
+  // measure it to centre the point in the visible strip (issue #218).
+  const [loadedSpotKey, setLoadedSpotKey] = useState<string | null>(null);
   const [selectedHour, setSelectedHour] = useState<string | null>(null);
   const [view, setView] = useState<MetricView>("wind");
+  const activeSpotKey = spot ? `${spot.latitude},${spot.longitude}` : null;
+  const isLoading = activeSpotKey != null && loadedSpotKey !== activeSpotKey;
   useEffect(() => {
     if (!spot) return;
     let cancelled = false;
-    setIsLoading(true);
     Promise.all([
       fetchAllModels(spot.latitude, spot.longitude),
       fetchMarine(spot.latitude, spot.longitude),
@@ -87,7 +93,7 @@ function App() {
       if (!cancelled) {
         setForecasts(data);
         setMarine(marineData);
-        setIsLoading(false);
+        setLoadedSpotKey(`${spot.latitude},${spot.longitude}`);
         // Preserve the previously-selected hour across spot changes so users
         // don't have to scroll the timeline back to e.g. "tomorrow 14h" every
         // time they switch favourites. Fall back to "now" only when:
@@ -113,10 +119,24 @@ function App() {
     };
   }, [spot]);
 
+  // Tap or left click on the map: show the forecast there without saving.
+  // Named by its coordinates rather than reverse-geocoded: the lookup is
+  // instant and offline, and a position is meaningful information at sea.
+  // Creating a spot stays a deliberate act (long press, or right click).
+  const handlePreviewSpot = useCallback((lat: number, lon: number) => {
+    setSpot({
+      name: `${lat.toFixed(3)}, ${lon.toFixed(3)}`,
+      latitude: lat,
+      longitude: lon,
+    });
+  }, []);
+
   // First-visit geolocation: if the user has no saved spots, ask the browser
-  // for their position and recenter the MAP — without auto-picking it as a
-  // spot. That way the canvas frames their region but stays empty (no
-  // arrows, no forecasts) until they actively drop their first spot.
+  // for their position, fly the map there and show the wind at that point
+  // right away, as a preview spot (issue #218). A first visit that lands on
+  // an empty canvas hides what the app can do; the forecast at one's own
+  // position is the fastest proof. Preview only: nothing is saved without a
+  // deliberate act (long press, or right click).
   // Denied / error → silent, the SpotMap falls back to its default center.
   // High accuracy is off here: framing a region needs a city-level fix, and
   // waking the GPS unprompted on a first visit is a poor trade.
@@ -131,23 +151,14 @@ function App() {
     if (hasDeclinedGeolocation()) return;
     locate({ enableHighAccuracy: false, maximumAge: 5 * 60 * 1000 }).then((fix) => {
       // A spot picked while the fix was in flight means the user already
-      // chose their focus — leave the viewport alone.
-      if (fix && !spotRef.current) setFlyToStamp(fix.stamp);
+      // chose their focus — leave the viewport and their selection alone.
+      if (fix && !spotRef.current) {
+        setFlyToStamp(fix.stamp);
+        handlePreviewSpot(fix.lat, fix.lon);
+      }
     });
   // Run once on mount; the customSpots check covers the returning-user case.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Tap or left click on the map: show the forecast there without saving.
-  // Named by its coordinates rather than reverse-geocoded: the lookup is
-  // instant and offline, and a position is meaningful information at sea.
-  // Creating a spot stays a deliberate act (long press, or right click).
-  const handlePreviewSpot = useCallback((lat: number, lon: number) => {
-    setSpot({
-      name: `${lat.toFixed(3)}, ${lon.toFixed(3)}`,
-      latitude: lat,
-      longitude: lon,
-    });
   }, []);
 
   // Explicit "centre sur moi": always honor it, spot selected or not.
@@ -169,6 +180,9 @@ function App() {
   }, [view, showWaves, showTides, showCurrents]);
 
   const fabRef = useRef<HTMLAnchorElement>(null);
+  // Handed to SpotMap so camera moves can centre a point in the strip of map
+  // this overlay leaves visible, instead of the full (half-covered) container.
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   return (
     <div
@@ -199,10 +213,11 @@ function App() {
           onViewChange={onViewChange}
           initialView={initialView}
           defaultCenter={DEFAULT_MAP_CENTER}
+          bottomInsetRef={overlayRef}
           onSelectSpot={setSpot}
           onPreviewSpot={handlePreviewSpot}
           onAddSpot={(s) => { addSpot(s); setSpot(s); }}
-          onRemoveSpot={(s) => { removeSpot(s); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) { setSpot(null); setForecasts([]); setSelectedHour(null); } }}
+          onRemoveSpot={(s) => { removeSpot(s); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) { setSpot(null); setForecasts([]); setLoadedSpotKey(null); setSelectedHour(null); } }}
           onRenameSpot={(s, name) => { renameSpot(s, name); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) setSpot({ ...s, name }); }}
           forecasts={forecasts}
           marine={marine}
@@ -230,7 +245,7 @@ function App() {
             ``thead.sticky top-0`` collides with the same container that
             scrolls (otherwise the hour row drifts away when the user scrolls
             down through GFS/ECMWF rows). */}
-        <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
+        <div ref={overlayRef} className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
           {/* Locate FAB — anchored to the overlay rather than to the map, so
               it rides up and down as the data panel grows and shrinks
               instead of ending up buried under it. The 16 px offset is

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useCallback, useState, type RefObject } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "../types";
@@ -6,6 +6,7 @@ import { QUICK_SPOTS } from "../spots";
 import { useTheme } from "../design/theme";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { syncUserPositionLayer } from "../utils/userPositionLayer";
+import { centerForBottomInset } from "../utils/visibleCenter";
 import type { MapView } from "../utils/mapViewParams";
 
 // Spot-map arrows are drawn into a single 300×300 SVG anchored at the spot
@@ -37,6 +38,9 @@ type ArrowItem = {
 
 const SPOT_CX = 150;
 const SPOT_CY = 150;
+// Zoom and duration of the "fly to the user" camera move.
+const FLY_ZOOM = 10;
+const FLY_MS = 1200;
 // Approximate label half-width and half-height (speed text 18px + model text 13px stacked).
 const LABEL_HW = 32;
 const LABEL_HH = 22;
@@ -151,8 +155,8 @@ interface SpotMapProps {
   customSpots: Spot[];
   // User position once the browser grants geolocation. Drawn as a dot with
   // an accuracy halo, and used as the initial center when it is already
-  // known at mount. Never auto-creates a spot: new users see their region
-  // without arrows until they drop their first pin.
+  // known at mount. Never auto-creates a spot itself: whether a fix becomes
+  // the active preview spot is the page's decision.
   userPosition?: UserPosition | null;
   // Bumped by the page when it wants the camera moved onto the user. Kept
   // separate from `userPosition` so the map draws the dot without deciding
@@ -166,6 +170,12 @@ interface SpotMapProps {
       coming back from the planner must not move the map. */
   initialView?: MapView | null;
   defaultCenter?: { lat: number; lon: number };
+  /** The data panel overlaying the bottom edge of the map (pills + tables).
+      Centring a point must aim for the middle of the strip the panel leaves
+      visible, not of the full container half-hidden behind it (issue #218).
+      A ref rather than a number: the panel grows and shrinks with its
+      content, so its height is measured at the moment the camera moves. */
+  bottomInsetRef?: RefObject<HTMLElement | null>;
   onSelectSpot: (spot: Spot) => void;
   /** Plain tap or left click on the water: show the forecast there without
       saving anything. Looking up conditions at a point should not oblige
@@ -192,6 +202,7 @@ export function SpotMap({
   onViewChange,
   initialView,
   defaultCenter,
+  bottomInsetRef,
   onSelectSpot,
   onPreviewSpot,
   onAddSpot,
@@ -293,42 +304,91 @@ export function SpotMap({
     syncUserPositionLayer(mapRef.current, userLayerRef, userPosition ?? null);
   }, [userPosition]);
 
-  // Fly to the user only when the page asks for it (first visit with no
-  // saved spot, or an explicit tap on the locate button). Keying on the
-  // stamp rather than the coordinates means a second tap still recenters
-  // after the user has panned away, even though the fix is unchanged.
-  useEffect(() => {
-    if (!mapRef.current) return;
-    if (!flyToStamp || !userPosition) return;
-    mapRef.current.flyTo([userPosition.lat, userPosition.lon], 10, { duration: 1.2 });
-    // userPosition is intentionally not a dependency: the stamp is what
-    // expresses "a move was requested", and a fresh fix alone must not
-    // steal the viewport.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [flyToStamp]);
+  // Centring a point means aiming for the middle of the strip the bottom
+  // data panel leaves visible — and the panel height at the moment a camera
+  // move starts is not final: the skeleton is swapped for tables of varying
+  // height once the forecast lands. So every auto-centre records its target
+  // here, and a ResizeObserver on the panel re-aims the camera when the
+  // height settles. A drag ends the intent: the viewport is the user's.
+  const autoCenterRef = useRef<{
+    lat: number;
+    lon: number;
+    zoom: number;
+    insetPx: number;
+    // Epoch ms when the flyTo animation lands; 0 for plain pans. A panel
+    // resize during the flight re-issues the fly with the remaining
+    // duration, so the correction reads as one continuous camera move.
+    flyEndsAt: number;
+  } | null>(null);
+
+  const visibleCenter = useCallback(
+    (lat: number, lon: number, zoom: number): [number, number] => {
+      const inset = bottomInsetRef?.current?.offsetHeight ?? 0;
+      const c = centerForBottomInset(lat, lon, zoom, inset);
+      return [c.lat, c.lon];
+    },
+    [bottomInsetRef],
+  );
+
+  const autoCenter = useCallback(
+    (lat: number, lon: number, mode: "pan" | "fly") => {
+      const map = mapRef.current;
+      if (!map) return;
+      const inset = bottomInsetRef?.current?.offsetHeight ?? 0;
+      const zoom = mode === "fly" ? FLY_ZOOM : map.getZoom();
+      const c = centerForBottomInset(lat, lon, zoom, inset);
+      autoCenterRef.current = {
+        lat,
+        lon,
+        zoom,
+        insetPx: inset,
+        flyEndsAt: mode === "fly" ? Date.now() + FLY_MS : 0,
+      };
+      if (mode === "fly") {
+        map.flyTo([c.lat, c.lon], zoom, { duration: FLY_MS / 1000 });
+      } else {
+        map.panTo([c.lat, c.lon], { animate: true });
+      }
+    },
+    [bottomInsetRef],
+  );
 
   // Init map once
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
-    const initialCenter: [number, number] = initialView
-      ? [initialView.lat, initialView.lon]
-      : current
-      ? [current.latitude, current.longitude]
-      : userPosition
-        ? [userPosition.lat, userPosition.lon]
-        : defaultCenter
-          ? [defaultCenter.lat, defaultCenter.lon]
-          : [43.3, 5.35];
     // When neither a current spot nor a granted geolocation is available
     // (typical first-visit + denied case), open wide enough to show OhMyWind's
     // full scope — Atlantic + Mediterranean French coast — so the user
     // understands the geographic reach before zooming into their region.
     const initialZoom = initialView ? initialView.zoom : current || userPosition ? 10 : 6;
+    // A camera handed over by /plan or the default region framing is a
+    // *centre* and is honoured as-is; a spot or a user fix is a *point of
+    // interest* and must land in the visible strip above the data panel.
+    const initialCenter: [number, number] = initialView
+      ? [initialView.lat, initialView.lon]
+      : current
+      ? visibleCenter(current.latitude, current.longitude, initialZoom)
+      : userPosition
+        ? visibleCenter(userPosition.lat, userPosition.lon, initialZoom)
+        : defaultCenter
+          ? [defaultCenter.lat, defaultCenter.lon]
+          : [43.3, 5.35];
     const map = L.map(containerRef.current, {
       zoomControl: false,
       attributionControl: false,
     }).setView(initialCenter, initialZoom);
+    // A point-centred initial view is an auto-centre like any other: seed
+    // the intent so the panel settling (skeleton → loaded table) re-aims it.
+    if (!initialView && (current || userPosition)) {
+      autoCenterRef.current = {
+        lat: current ? current.latitude : userPosition!.lat,
+        lon: current ? current.longitude : userPosition!.lon,
+        zoom: initialZoom,
+        insetPx: bottomInsetRef?.current?.offsetHeight ?? 0,
+        flyEndsAt: 0,
+      };
+    }
 
     const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
     const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
@@ -492,9 +552,48 @@ export function SpotMap({
     const ro = new ResizeObserver(() => map.invalidateSize());
     ro.observe(el);
 
+    // The user dragging the map ends any auto-centre intent: from then on
+    // the viewport is theirs, panel resizes must not move it. (A manual
+    // zoom keeps the intent — zooming around the centred point is still
+    // "looking at the point".)
+    map.on("dragstart", () => {
+      autoCenterRef.current = null;
+    });
+
+    // Re-aim the camera when the data panel's height settles: the height
+    // measured when an auto-centre started (often the loading skeleton) is
+    // not the height of the loaded tables, and the difference shifts the
+    // point off the visible-strip centre by half of it.
+    const overlayEl = bottomInsetRef?.current;
+    let overlayRo: ResizeObserver | null = null;
+    if (overlayEl) {
+      overlayRo = new ResizeObserver(() => {
+        const target = autoCenterRef.current;
+        if (!target || !mapRef.current) return;
+        const inset = overlayEl.offsetHeight;
+        if (inset === target.insetPx) return;
+        target.insetPx = inset;
+        const flyRemainingMs = target.flyEndsAt - Date.now();
+        // Mid-flight the interpolated getZoom() is meaningless — keep the
+        // fly's destination zoom. At rest, follow the user's current zoom.
+        const zoom = flyRemainingMs > 0 ? target.zoom : mapRef.current.getZoom();
+        target.zoom = zoom;
+        const c = centerForBottomInset(target.lat, target.lon, zoom, inset);
+        if (flyRemainingMs > 0) {
+          mapRef.current.flyTo([c.lat, c.lon], zoom, {
+            duration: Math.max(flyRemainingMs, 300) / 1000,
+          });
+        } else {
+          mapRef.current.panTo([c.lat, c.lon], { animate: true });
+        }
+      });
+      overlayRo.observe(overlayEl);
+    }
+
     return () => {
       cancelPress();
       ro.disconnect();
+      overlayRo?.disconnect();
       el.removeEventListener("pointerdown", handlePointerDown);
       el.removeEventListener("contextmenu", handleContextMenu);
       window.removeEventListener("pointermove", handlePointerMove);
@@ -572,9 +671,31 @@ export function SpotMap({
     // If the user just removed their active spot (current == null), don't
     // pan at all — preserve their viewport instead of reverting to a default.
     if (current) {
-      mapRef.current.panTo([current.latitude, current.longitude], { animate: true });
+      autoCenter(current.latitude, current.longitude, "pan");
+    } else {
+      autoCenterRef.current = null;
     }
-  }, [current, customSpots, syncMarkers]);
+  }, [current, customSpots, syncMarkers, autoCenter]);
+
+  // Fly to the user only when the page asks for it (first visit with no
+  // saved spot, or an explicit tap on the locate button). Keying on the
+  // stamp rather than the coordinates means a second tap still recenters
+  // after the user has panned away, even though the fix is unchanged.
+  //
+  // Declared AFTER the pan-to-spot effect above, and the order is load-
+  // bearing: on a first visit the page selects the fix as preview spot and
+  // requests the fly in the same commit, so both effects fire — each starts
+  // a camera move that cancels the other's, and the one declared later wins.
+  // The fly must win, or the map stays at the wide initial zoom.
+  useEffect(() => {
+    if (!mapRef.current) return;
+    if (!flyToStamp || !userPosition) return;
+    autoCenter(userPosition.lat, userPosition.lon, "fly");
+    // userPosition is intentionally not a dependency: the stamp is what
+    // expresses "a move was requested", and a fresh fix alone must not
+    // steal the viewport.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flyToStamp]);
 
   // Metric-aware arrows: wind = one per model, waves/currents = one (single
   // Open-Meteo Marine source), tides = none (scalar).

--- a/packages/web/src/utils/visibleCenter.test.ts
+++ b/packages/web/src/utils/visibleCenter.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { centerForBottomInset, mercatorY } from "./visibleCenter";
+
+describe("centerForBottomInset", () => {
+  it("returns the point itself when there is no inset", () => {
+    const c = centerForBottomInset(43.3, 5.35, 10, 0);
+    expect(c).toEqual({ lat: 43.3, lon: 5.35 });
+  });
+
+  it("never moves the longitude", () => {
+    const c = centerForBottomInset(48.38, -4.49, 12, 380);
+    expect(c.lon).toBe(-4.49);
+  });
+
+  it("moves the centre south of the point (positive inset)", () => {
+    const c = centerForBottomInset(43.3, 5.35, 10, 400);
+    expect(c.lat).toBeLessThan(43.3);
+  });
+
+  it("puts the centre exactly insetPx/2 screen pixels below the point", () => {
+    // The pixel-space contract: a panel covering the bottom `inset` pixels
+    // leaves a visible strip whose middle is inset/2 above the container
+    // centre — so the centre must project inset/2 below the point.
+    for (const [lat, zoom, inset] of [
+      [43.3, 10, 400],
+      [48.38, 6, 250],
+      [-35.0, 13, 371],
+    ]) {
+      const c = centerForBottomInset(lat, 5.35, zoom, inset);
+      const dy = mercatorY(c.lat, zoom) - mercatorY(lat, zoom);
+      expect(dy).toBeCloseTo(inset / 2, 6);
+    }
+  });
+
+  it("round-trips: shifting back by a negative inset restores the point", () => {
+    const down = centerForBottomInset(43.3, 5.35, 10, 400);
+    const back = centerForBottomInset(down.lat, down.lon, 10, -400);
+    expect(back.lat).toBeCloseTo(43.3, 9);
+  });
+});

--- a/packages/web/src/utils/visibleCenter.ts
+++ b/packages/web/src/utils/visibleCenter.ts
@@ -1,0 +1,40 @@
+// Where must the map centre go so a point of interest lands in the middle of
+// the *visible* strip of the map, when a UI panel overlays the bottom
+// `insetPx` pixels of the container? Answer: `insetPx / 2` screen pixels
+// south of the point — the map centre sits below the point, which lifts the
+// point into the centre of what the panel leaves uncovered.
+//
+// Pure Web-Mercator math, deliberately leaflet-free: leaflet touches the DOM
+// and crashes the node vitest env (same rationale as utils/geo.ts). The
+// projection matches Leaflet's default CRS (EPSG:3857, 256 px tiles), so the
+// result can be fed straight to setView / panTo / flyTo.
+
+const TILE_SIZE = 256;
+
+/** Latitude → Mercator pixel Y at the given integer zoom. Exported for the
+    tests, which verify the pixel-space contract rather than magic values. */
+export function mercatorY(lat: number, zoom: number): number {
+  const scale = TILE_SIZE * 2 ** zoom;
+  const phi = (lat * Math.PI) / 180;
+  return ((1 - Math.asinh(Math.tan(phi)) / Math.PI) / 2) * scale;
+}
+
+function latFromMercatorY(y: number, zoom: number): number {
+  const scale = TILE_SIZE * 2 ** zoom;
+  return (180 / Math.PI) * Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / scale)));
+}
+
+/**
+ * Map centre that puts (`lat`, `lon`) in the middle of the visible strip —
+ * container height minus the `insetPx` covered by the bottom panel.
+ * Longitude is untouched: the panel only eats vertical space.
+ */
+export function centerForBottomInset(
+  lat: number,
+  lon: number,
+  zoom: number,
+  insetPx: number,
+): { lat: number; lon: number } {
+  if (!insetPx) return { lat, lon };
+  return { lat: latFromMercatorY(mercatorY(lat, zoom) + insetPx / 2, zoom), lon };
+}


### PR DESCRIPTION
Traite les deux volets confirmés de #218 (partie carte météo ; /plan fonctionne déjà) :

## Centrage dans la zone visible
Le point sélectionné était centré dans le conteneur carte entier, dont le bas est masqué par le panneau de données (jusqu'à 44vh sur mobile) : il apparaissait donc trop bas, « centré sur l'écran » et non sur la carte visible.

- Nouveau helper pur `utils/visibleCenter.ts` (`centerForBottomInset`) : math Web-Mercator sans Leaflet, testé unitairement, qui décale la cible caméra de `inset/2` pour que le point atterrisse au milieu de la bande visible.
- Appliqué aux trois mouvements : `setView` initial (favori au démarrage), `panTo` (sélection/preview d'un spot), `flyTo` (géoloc).
- La hauteur du panneau au départ du mouvement n'est pas finale (squelette → tableaux de hauteur variable selon les données). Un `ResizeObserver` sur le panneau re-vise la caméra quand la hauteur se stabilise ; l'intention d'auto-centrage est annulée dès que l'utilisateur drag la carte. En plein vol, le `flyTo` est ré-émis avec la durée restante (mouvement continu).
- `isLoading` devient dérivé (spot actif ≠ dernier spot chargé) : le squelette est présent dès le commit qui sélectionne le spot, la première mesure du panneau est donc déjà proche de la bonne. Retire au passage une erreur ESLint pré-existante (`set-state-in-effect`).

## Vent par défaut dès la géoloc
Au premier lancement (aucun favori), si la géoloc est accordée, la position de l'utilisateur devient un spot *preview* (rien n'est enregistré) : vol vers la position + flèches de vent + tableau chargés d'emblée, au lieu d'une carte vide.

- Utilisateurs avec favoris : inchangé (ils arrivent déjà sur leur premier favori, vent affiché).
- Refus de géoloc mémorisé / caméra héritée de `/plan` : inchangés.
- L'ordre de déclaration des effets pan/fly est désormais porteur (commenté dans le code) : quand sélection de spot et vol partent dans le même commit, le vol doit gagner.

## Vérifications
- 198 tests vitest verts (dont 5 nouveaux sur `centerForBottomInset`), `tsc` et build de prod OK.
- Lint : 25 erreurs pré-existantes sur la base (26 avant cette branche), aucune introduite.
- Vérifié dans Chrome (viewport mobile 390×844, géoloc émulée sur Marseille, contexte isolé) : écart au centre de la bande visible mesuré à **-0,7 px** sur les trois chemins (vol géoloc premier lancement, tap preview, favori au démarrage), contre **+84 px** avant.

Reste hors scope ici : l'artefact « modèle affiché 2 fois » mentionné dans #218 (non traité, à re-qualifier si toujours reproductible).

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)