### PR TITLE
feat(web): polaire perso en tête du sélecteur de bateau, % retiré de l'onglet plan

### DIFF
--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -11,6 +11,7 @@ import {
   effectivePolar,
   initialPlanBoat,
   isImportedActive,
+  isPersoActive,
   isPolarCustomized,
   loadPolarConfig,
   planEfficiency,
@@ -175,6 +176,21 @@ describe("persistence", () => {
     savePolarConfig(bad);
     expect(loadPolarConfig().imported).toBeNull();
   });
+
+  it("round-trips a parked perso (persoActive: false)", () => {
+    savePolarConfig(withImported({ persoActive: false }));
+    expect(loadPolarConfig().persoActive).toBe(false);
+  });
+
+  it("defaults persoActive to true on configs persisted before the field", () => {
+    store[STORAGE_KEY] = JSON.stringify({
+      v: 3,
+      base: DEFAULT_BASE,
+      spi: "asymmetric",
+      overrides: {},
+    });
+    expect(loadPolarConfig().persoActive).toBe(true);
+  });
 });
 
 describe("effectivePolar", () => {
@@ -330,6 +346,24 @@ describe("isPolarCustomized", () => {
   });
 });
 
+describe("isPersoActive", () => {
+  it("is false while nothing is customized, whatever the flag says", () => {
+    expect(isPersoActive(defaultPolarConfig())).toBe(false);
+    expect(isPersoActive({ ...defaultPolarConfig(), persoActive: false })).toBe(false);
+  });
+
+  it("is true for a fresh customization (flag defaults to true)", () => {
+    expect(isPersoActive({ ...defaultPolarConfig(), spi: "asymmetric" })).toBe(true);
+    expect(isPersoActive(withImported())).toBe(true);
+  });
+
+  it("is false once the perso polar is parked for a stock archetype", () => {
+    expect(
+      isPersoActive({ ...defaultPolarConfig(), spi: "asymmetric", persoActive: false }),
+    ).toBe(false);
+  });
+});
+
 describe("initialPlanBoat", () => {
   const custom50: PolarConfig = {
     ...defaultPolarConfig(),
@@ -342,6 +376,13 @@ describe("initialPlanBoat", () => {
     // carrying the 30ft slug from an earlier session.
     expect(initialPlanBoat(custom50, "cruiser_30ft", null)).toBe("cruiser_50ft");
     expect(initialPlanBoat(custom50, null, "cruiser_30ft")).toBe("cruiser_50ft");
+  });
+
+  it("lets the URL's boat win again once the perso polar is parked", () => {
+    const parked = { ...custom50, persoActive: false };
+    expect(initialPlanBoat(parked, "cruiser_30ft", null)).toBe("cruiser_30ft");
+    expect(initialPlanBoat(parked, null, "cruiser_25ft")).toBe("cruiser_25ft");
+    expect(initialPlanBoat(parked, null, null)).toBe("cruiser_50ft");
   });
 
   it("pins to cfg.base for an active imported polar too", () => {
@@ -399,5 +440,11 @@ describe("polarFingerprint", () => {
 
   it("is stable for identical configs", () => {
     expect(polarFingerprint(withImported())).toBe(polarFingerprint(withImported()));
+  });
+
+  it("changes when the perso polar is parked (matrix push flips off)", () => {
+    expect(polarFingerprint(withImported({ persoActive: false }))).not.toBe(
+      polarFingerprint(withImported()),
+    );
   });
 });

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -140,6 +140,12 @@ export interface PolarConfig {
   // the user can flip back without losing their hand-tuning.
   source: PolarSource;
   imported: ImportedPolar | null;
+  // Whether the perso polar is the boat selected on /plan. Only meaningful
+  // while isPolarCustomized(cfg) is true: picking a stock archetype in the
+  // plan selector sets it to false (the tuning is kept, just not planned on);
+  // re-selecting « Perso » there, or touching anything in /config's Bateau
+  // tab, sets it back to true.
+  persoActive: boolean;
 }
 
 interface PersistedConfig {
@@ -158,6 +164,7 @@ interface PersistedConfig {
   coefficient?: number;
   spiMaxTwsKn?: number;
   minUpwindDeg?: number;
+  persoActive?: boolean;
 }
 
 // Per-TWA multipliers. Values derived from sailmaker performance ranges
@@ -227,6 +234,7 @@ export function defaultPolarConfig(): PolarConfig {
     overrides: {},
     source: "archetype",
     imported: null,
+    persoActive: true,
   };
 }
 
@@ -363,6 +371,9 @@ export function loadPolarConfig(): PolarConfig {
       motorSpeedKn: sanitizeMotorField(parsed.motorSpeedKn, MOTOR_SPEED_MAX),
       source,
       imported,
+      // Absent on pre-existing configs → true: the perso polar stays the
+      // default pick until the user explicitly parks it.
+      persoActive: parsed.persoActive !== false,
     };
   } catch {
     return defaultPolarConfig();
@@ -383,6 +394,7 @@ export function savePolarConfig(cfg: PolarConfig): void {
       motorSpeedKn: cfg.motorSpeedKn,
       source: cfg.source,
       imported: cfg.imported,
+      persoActive: cfg.persoActive,
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   } catch {
@@ -481,13 +493,10 @@ export function hasOverrides(cfg: PolarConfig): boolean {
 
 // True when the polar deviates from the plain archetype default — a spi mode
 // is selected, the upwind angle is pinned, a cell is hand-tuned, the motor is
-// configured, or an imported file is active. Used to decide whether to push
-// the custom matrix to the planner; when false, the server's bundled polar
-// for the requested archetype suffices. While this is true, `cfg.base` is
-// the boat of record app-wide: the customization was built against ITS grid,
-// and the /plan selector displays it as the active boat — so /plan seeds its
-// slug from it (see initialPlanBoat) instead of trusting a URL or cached
-// slug left by an earlier session (#220). The coefficient is absent from the
+// configured, or an imported file is active. In other words: the perso polar
+// EXISTS. Whether it is also the boat currently planned on is a separate
+// question (see isPersoActive) — the /plan selector lists it first as
+// « Perso » as soon as this is true. The coefficient is absent from the
 // check: it travels as the `efficiency` request parameter and never requires
 // pushing a matrix.
 export function isPolarCustomized(cfg: PolarConfig): boolean {
@@ -499,16 +508,26 @@ export function isPolarCustomized(cfg: PolarConfig): boolean {
   );
 }
 
-// The boat slug /plan starts on. A customized polar pins the boat to
-// `cfg.base` (see isPolarCustomized); otherwise the usual precedence applies:
-// the shared/bookmarked URL's boat first, then the last-simulation cache,
-// then the /config default.
+// The perso polar is defined AND is the current pick. This is the predicate
+// that gates everything perso does at plan time: /plan seeds its slug from
+// cfg.base (the grid the customization was built against, #220) and pushes
+// the custom matrix to the planner. When false — nothing customized, or the
+// user chose a stock archetype in the plan selector — the server's bundled
+// polar for the requested archetype suffices.
+export function isPersoActive(cfg: PolarConfig): boolean {
+  return isPolarCustomized(cfg) && cfg.persoActive;
+}
+
+// The boat slug /plan starts on. An active perso polar pins the boat to
+// `cfg.base` — even against a shared link carrying another type; otherwise
+// the usual precedence applies: the shared/bookmarked URL's boat first, then
+// the last-simulation cache, then the /config default.
 export function initialPlanBoat(
   cfg: PolarConfig,
   urlSlug?: string | null,
   cachedSlug?: string | null,
 ): string {
-  if (isPolarCustomized(cfg)) return cfg.base;
+  if (isPersoActive(cfg)) return cfg.base;
   return urlSlug || cachedSlug || cfg.base;
 }
 
@@ -524,11 +543,12 @@ function hashMatrix(imp: ImportedPolar): string {
 }
 
 // Compact key capturing every input that affects effectivePolar() and the
-// plan-time efficiency. Used to invalidate the lastSimulation cache so a
-// /config tweak doesn't leave stale results on /plan.
+// plan-time efficiency — plus whether the perso polar is the active pick,
+// which decides if the matrix is pushed at all. Used to invalidate the
+// lastSimulation cache so a /config tweak doesn't leave stale results on /plan.
 export function polarFingerprint(cfg: PolarConfig): string {
   const motorKey = `${cfg.motorThresholdKn ?? ""}/${cfg.motorSpeedKn ?? ""}`;
-  const commonKey = `c${cfg.coefficient}|${cfg.spi}@${cfg.spiMaxTwsKn}|mu${effectiveMinUpwind(cfg)}|${motorKey}`;
+  const commonKey = `c${cfg.coefficient}|${cfg.spi}@${cfg.spiMaxTwsKn}|mu${effectiveMinUpwind(cfg)}|${motorKey}|p${cfg.persoActive ? 1 : 0}`;
   if (isImportedActive(cfg)) {
     const imp = cfg.imported as ImportedPolar;
     return `imported:${imp.name}:${hashMatrix(imp)}|${commonKey}`;

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -11,6 +11,7 @@ import {
   ARCHETYPE_LABELS,
   defaultPolarConfig,
   isImportedActive,
+  isPersoActive,
   isPolarCustomized,
   loadPolarConfig,
   savePolarConfig,
@@ -420,11 +421,15 @@ function ArchetypeSelector({
   currentSlug,
   archetypes,
   onChange,
+  onPersoSelect,
   onCustomCleared,
 }: {
   currentSlug: string;
   archetypes: Archetype[];
   onChange: (slug: string) => void;
+  // Select the « Perso » entry (shown first as soon as the polar deviates
+  // from the stock archetype default).
+  onPersoSelect: () => void;
   // Notify the parent that the custom polar was reset so it can re-fetch
   // (the new fingerprint won't match the cached one, and resolveOverrides
   // will stop sending the custom matrix).
@@ -432,15 +437,19 @@ function ArchetypeSelector({
 }) {
   const [open, setOpen] = useState(false);
   // Re-read the polar config every render. Cheap (localStorage parse + a few
-  // boolean checks) and ensures the "Custom" pill appears immediately after
+  // boolean checks) and ensures the « Perso » entry appears immediately after
   // the user edits /config in another tab and comes back here.
   const polarCfg = loadPolarConfig();
-  const isCustom = isPolarCustomized(polarCfg);
+  const persoDefined = isPolarCustomized(polarCfg);
+  const persoSelected = isPersoActive(polarCfg);
   const baseLabel = ARCHETYPE_LABELS[polarCfg.base] ?? polarCfg.base;
   const current = archetypes.find((a) => a.slug === currentSlug);
-  const archetypeLabel = current?.name ?? currentSlug;
-  const label = isCustom ? "Custom" : archetypeLabel;
-  const coeffPct = Math.round(polarCfg.coefficient * 100);
+  const label = persoSelected ? "Perso" : (current?.name ?? currentSlug);
+  // Detail line of the « Perso » entry, same shape as the archetype rows:
+  // provenance of the customization rather than hull specs.
+  const persoDetail = isImportedActive(polarCfg)
+    ? `${polarCfg.imported?.name ?? "polaire"} · importée`
+    : `${baseLabel} · ajustée`;
 
   function resetCustom() {
     savePolarConfig(defaultPolarConfig());
@@ -453,24 +462,10 @@ function ArchetypeSelector({
       <button
         onClick={() => setOpen((v) => !v)}
         className="flex items-center gap-1.5 text-sm transition-colors"
-        style={{ color: isCustom ? "var(--ow-accent)" : "var(--ow-fg-1)" }}
-        title={isCustom ? `Polaire personnalisée active (base : ${baseLabel})` : "Changer le type de bateau"}
+        style={{ color: persoSelected ? "var(--ow-accent)" : "var(--ow-fg-1)" }}
+        title={persoSelected ? `Polaire personnalisée active (${persoDetail})` : "Changer le type de bateau"}
       >
         {label}
-        <span
-          style={{ color: "var(--ow-fg-2)" }}
-          title="Coefficient de performance appliqué à la polaire (réglable dans l'onglet Bateau)"
-        >
-          · {coeffPct} %
-        </span>
-        {isCustom && (
-          <span
-            className="text-[9px] font-semibold uppercase tracking-wider px-1 py-0.5 rounded"
-            style={{ background: "var(--ow-accent-soft)", color: "var(--ow-accent)" }}
-          >
-            perso
-          </span>
-        )}
         <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" style={{ opacity: 0.5 }}>
           <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round"/>
         </svg>
@@ -484,37 +479,38 @@ function ArchetypeSelector({
             className="absolute left-0 top-7 z-20 min-w-[240px] rounded-xl shadow-xl border overflow-hidden"
             style={{ background: "var(--ow-bg-1)", borderColor: "var(--ow-line-2)", boxShadow: "var(--ow-shadow-pop)" }}
           >
-            {isCustom && (
-              <div
-                className="px-4 py-3 text-xs"
-                style={{
-                  background: "var(--ow-accent-soft)",
-                  color: "var(--ow-accent)",
-                  borderBottom: "1px solid var(--ow-line)",
-                }}
-              >
-                <div className="font-semibold mb-1">Polaire personnalisée active</div>
-                <div className="opacity-80 mb-2">Base : {baseLabel}</div>
-                <div className="flex gap-2">
-                  <a
-                    href="/config"
-                    onClick={rememberReturnPath}
-                    className="underline"
-                    style={{ color: "var(--ow-accent)" }}
-                  >
+            {persoDefined && (
+              <>
+                <button
+                  onClick={() => { onPersoSelect(); setOpen(false); }}
+                  className="w-full text-left px-4 py-3 text-sm transition-colors"
+                  style={{
+                    background: persoSelected ? "var(--ow-accent-soft)" : "transparent",
+                    color: persoSelected ? "var(--ow-accent)" : "var(--ow-fg-0)",
+                  }}
+                >
+                  <div className="font-semibold">Perso</div>
+                  <div className="text-[11px] mt-0.5" style={{ color: "var(--ow-fg-2)" }}>
+                    {persoDetail}
+                  </div>
+                </button>
+                <div
+                  className="flex gap-2 px-4 pb-2.5 text-[11px]"
+                  style={{
+                    background: persoSelected ? "var(--ow-accent-soft)" : "transparent",
+                    color: "var(--ow-accent)",
+                    borderBottom: "1px solid var(--ow-line)",
+                  }}
+                >
+                  <a href="/config" onClick={rememberReturnPath} className="underline">
                     éditer
                   </a>
                   <span style={{ opacity: 0.4 }}>·</span>
-                  <button
-                    type="button"
-                    onClick={resetCustom}
-                    className="underline"
-                    style={{ color: "var(--ow-accent)" }}
-                  >
+                  <button type="button" onClick={resetCustom} className="underline">
                     réinitialiser
                   </button>
                 </div>
-              </div>
+              </>
             )}
             {archetypes.map((a) => (
               <button
@@ -522,8 +518,8 @@ function ArchetypeSelector({
                 onClick={() => { onChange(a.slug); setOpen(false); }}
                 className="w-full text-left px-4 py-3 text-sm transition-colors"
                 style={{
-                  background: !isCustom && a.slug === currentSlug ? "var(--ow-accent-soft)" : "transparent",
-                  color: !isCustom && a.slug === currentSlug ? "var(--ow-accent)" : "var(--ow-fg-0)",
+                  background: !persoSelected && a.slug === currentSlug ? "var(--ow-accent-soft)" : "transparent",
+                  color: !persoSelected && a.slug === currentSlug ? "var(--ow-accent)" : "var(--ow-fg-0)",
                   borderBottom: "1px solid var(--ow-line)",
                 }}
               >
@@ -783,6 +779,8 @@ interface PlanSidebarProps {
   archetypes: Archetype[];
   currentArchetypeSlug: string;
   onArchetypeChange: (slug: string) => void;
+  /** Select the perso polar (first entry of the boat list when defined). */
+  onPersoSelect: () => void;
   departure: string;
   onDepartureChange: (iso: string) => void;
   isStale: boolean;
@@ -874,6 +872,7 @@ export function PlanSidebar({
   archetypes,
   currentArchetypeSlug,
   onArchetypeChange,
+  onPersoSelect,
   departure,
   onDepartureChange,
   isStale,
@@ -977,26 +976,21 @@ export function PlanSidebar({
   }
 
   const archetype = archetypes.find((a) => a.slug === currentArchetypeSlug);
-  // Recap-strip boat label: the French display label rather than the raw API
-  // slug, and the polar's provenance when it isn't the stock one — the file
-  // name suffixed « importée », or the boat suffixed « ajustée » when the
-  // archetype was hand-tuned. The « ajustée » branch names cfg.base, the hull
+  // Recap-strip boat label. Perso active: the polar's provenance — the file
+  // name suffixed « importée », or cfg.base suffixed « ajustée » (the hull
   // the tuning was built on and the one the ArchetypeSelector announces —
   // never the page slug, which could still carry another boat from a stale
-  // URL/cache (#220). Re-read the config at render, same rationale as
-  // ArchetypeSelector.
+  // URL/cache, #220). Otherwise the French display label of the selected
+  // stock archetype. Re-read the config at render, same rationale as
+  // ArchetypeSelector. The performance coefficient is deliberately not
+  // repeated here: /config's Bateau tab stays its single indicator.
   const recapPolarCfg = loadPolarConfig();
   const importedName = recapPolarCfg.imported?.name ?? "polaire";
-  // The performance coefficient rides along with the boat label so the plan
-  // always states which fraction of the polar the ETA was computed with.
-  const recapCoeffPct = `${Math.round(recapPolarCfg.coefficient * 100)} %`;
-  const archetypeLabel = `${
-    isImportedActive(recapPolarCfg)
+  const archetypeLabel = isPersoActive(recapPolarCfg)
+    ? isImportedActive(recapPolarCfg)
       ? `${importedName.length > 20 ? `${importedName.slice(0, 19)}…` : importedName} (importée)`
-      : isPolarCustomized(recapPolarCfg)
-        ? `${ARCHETYPE_LABELS[recapPolarCfg.base] ?? recapPolarCfg.base} (ajustée)`
-        : ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug
-  } · ${recapCoeffPct}`;
+      : `${ARCHETYPE_LABELS[recapPolarCfg.base] ?? recapPolarCfg.base} (ajustée)`
+    : ARCHETYPE_LABELS[currentArchetypeSlug] ?? archetype?.name ?? currentArchetypeSlug;
 
   // ── Filled compare view: results loaded, inputs collapsed into a recap ────
   if (mode === "compare" && windows && windows.length > 0) {
@@ -1051,6 +1045,7 @@ export function PlanSidebar({
               currentSlug={currentArchetypeSlug}
               archetypes={archetypes}
               onChange={onArchetypeChange}
+              onPersoSelect={onPersoSelect}
               onCustomCleared={onRefetch}
             />
           </div>
@@ -1132,6 +1127,7 @@ export function PlanSidebar({
             currentSlug={currentArchetypeSlug}
             archetypes={archetypes}
             onChange={onArchetypeChange}
+            onPersoSelect={onPersoSelect}
             onCustomCleared={onRefetch}
           />
 
@@ -1208,6 +1204,7 @@ export function PlanSidebar({
             currentSlug={currentArchetypeSlug}
             archetypes={archetypes}
             onChange={onArchetypeChange}
+            onPersoSelect={onPersoSelect}
             onCustomCleared={onRefetch}
           />
         </div>

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -39,8 +39,11 @@ export function ConfigPage() {
   const [polarCfg, setPolarCfg] = useState<PolarConfig>(() => loadPolarConfig());
 
   function updatePolar(next: PolarConfig) {
-    setPolarCfg(next);
-    savePolarConfig(next);
+    // Any touch in the Bateau tab re-selects the perso polar on /plan (its
+    // selector may have parked it in favour of a stock archetype).
+    const activated = { ...next, persoActive: true };
+    setPolarCfg(activated);
+    savePolarConfig(activated);
     setSavedOnce(true);
   }
   // Resolved at mount so the back link is stable across re-renders. Consuming

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -18,7 +18,7 @@ import {
 import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
-import { effectivePolar, initialPlanBoat, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
+import { effectivePolar, initialPlanBoat, isPersoActive, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
 import { LocateButton } from "../components/LocateButton";
 import { useGeolocation } from "../hooks/useGeolocation";
 import { useMapView } from "../hooks/useMapView";
@@ -36,12 +36,14 @@ function resolveOverrides(): PlanOverrides {
   const models = activeModels(modelCfg);
   if (models.length > 0) overrides.models = models;
   const polarCfg = loadPolarConfig();
-  if (isPolarCustomized(polarCfg)) {
+  if (isPersoActive(polarCfg)) {
     // The custom matrix is always built on cfg.base's grid — the boat of
-    // record while a customization is active (#220). The page's slug matches
-    // it (seeded via initialPlanBoat, kept in sync by the selector's
-    // write-through), so passing it here would be redundant at best and, in a
-    // cross-tab /config edit, would resurrect the mismatch.
+    // record while the perso polar is the active pick (#220). The page's slug
+    // matches it (seeded via initialPlanBoat, re-pinned by handlePersoSelect),
+    // so passing it here would be redundant at best and, in a cross-tab
+    // /config edit, would resurrect the mismatch. When perso is parked in
+    // favour of a stock archetype, no matrix travels: the server's bundled
+    // polar for the requested slug wins.
     overrides.polar = effectivePolar(polarCfg);
   }
   return overrides;
@@ -594,10 +596,25 @@ export function PlanPage() {
 
   function handleArchetypeChange(slug: string) {
     setArchetype(slug);
-    // Write through to /config: one boat for the whole app. Picking an
-    // archetype while an imported polar is active means "plan on THIS boat",
-    // so the source flips back; the file itself is kept for later.
-    savePolarConfig({ ...loadPolarConfig(), base: slug, source: "archetype" });
+    const cfg = loadPolarConfig();
+    if (isPolarCustomized(cfg)) {
+      // Perso stays defined: picking a stock hull just parks it for planning
+      // (no matrix push, the server's bundled polar wins). The tuning is kept
+      // untouched so the « Perso » entry of the selector brings it back.
+      savePolarConfig({ ...cfg, persoActive: false });
+    } else {
+      // Write through to /config: one boat for the whole app.
+      savePolarConfig({ ...cfg, base: slug, source: "archetype" });
+    }
+    setIsStale(true);
+  }
+
+  // Selecting the « Perso » entry of the boat list: reactivate the
+  // customization and re-pin the page's slug to the grid it was built on.
+  function handlePersoSelect() {
+    const cfg = loadPolarConfig();
+    savePolarConfig({ ...cfg, persoActive: true });
+    setArchetype(cfg.base);
     setIsStale(true);
   }
 
@@ -803,6 +820,7 @@ export function PlanPage() {
     archetypes,
     currentArchetypeSlug: archetype,
     onArchetypeChange: handleArchetypeChange,
+    onPersoSelect: handlePersoSelect,
     departure,
     onDepartureChange: handleDepartureChange,
     isStale,


### PR DESCRIPTION
## Quoi

- Dès qu'un seul réglage de la polaire est touché dans /config (spi, cellule éditée, angle de près, moteur, polaire importée), une entrée **« Perso »** apparaît en **première position** du sélecteur de bateau de l'onglet plan, avec sa provenance en sous-titre (« Croiseur 40 pieds · ajustée » ou « mon-fichier · importée »).
- La perso est **sélectionnée par défaut**, y compris quand on ouvre un **lien partagé portant un autre type de bateau** (généralisation du comportement #220 via `isPersoActive`).
- Choisir un archétype du catalogue **gare la perso sans la perdre** (champ persisté `persoActive`) : aucune matrice n'est poussée à `plan_passage`, la polaire embarquée serveur reprend la main, et l'entrée « Perso » permet de revenir. Toute retouche dans /config resélectionne la perso.
- Le **% du coefficient n'est plus affiché dans l'onglet plan** (trigger du sélecteur + récap) : l'onglet Bateau de /config reste son unique indicateur (règle « un seul indicateur chiffré par réglage », cf. #247).

## Détails techniques

- `persoActive` rejoint le payload v3 persisté ; absent (configs existantes) → `true`, donc la perso reste le choix par défaut.
- `polarFingerprint` intègre le flag : garer/resélectionner la perso invalide le cache `lastSimulation`.
- Sélection d'un archétype quand rien n'est personnalisé : write-through vers /config inchangé (un seul bateau pour toute l'app).

## Tests

- 211 tests vitest verts (dont 8 nouveaux : `isPersoActive`, précédence URL/cache une fois la perso garée, round-trip de persistance, legacy sans champ, fingerprint).
- `tsc -b` + build de prod OK. ESLint : 5 erreurs préexistantes identiques à la baseline dev, aucune nouvelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)