### PR TITLE
chore(license): passe le projet sous AGPL-3.0-or-later et met en place le DCO

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Description
+
+<!-- Ce que change cette PR, et pourquoi. -->
+
+## Checklist
+
+- [ ] Les tests passent (`uv run pytest` côté Python, `npm run test` côté web)
+- [ ] Lint OK (`uv run ruff check .` côté Python, `npm run lint` côté web)
+- [ ] Mes commits sont signés avec `git commit -s` (DCO, voir [CONTRIBUTING.md](../CONTRIBUTING.md))

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,72 @@
+# Vérifie la présence du Signed-off-by (DCO) sur chaque commit d'une PR.
+# Non bloquant pour l'instant : le job signale les commits non signés en
+# commentaire de PR et sort toujours en succès. À durcir si le volume de
+# contributions externes le justifie.
+#
+# pull_request_target plutôt que pull_request : les PR de forks n'ont qu'un
+# GITHUB_TOKEN en lecture seule sur pull_request, insuffisant pour commenter.
+# Sûr ici : le job n'exécute jamais le code de la PR (aucun checkout), il ne
+# fait qu'interroger l'API GitHub.
+name: DCO
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  signoff:
+    name: Signed-off-by présent (informatif)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "<!-- dco-check -->";
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner, repo, pull_number: number, per_page: 100,
+            });
+            const missing = commits
+              .filter((c) => c.parents.length < 2) // les commits de merge sont exemptés
+              .filter((c) => !/^Signed-off-by: .+ <.+@.+>/m.test(c.commit.message))
+              .map((c) => `- \`${c.sha.slice(0, 7)}\` ${c.commit.message.split("\n")[0]}`);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (missing.length === 0) {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id,
+                  body: `${marker}\n✅ DCO : tous les commits de cette PR sont signés. Merci !`,
+                });
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              "⚠️ **DCO : commits non signés.** Ce contrôle est informatif, il ne bloque pas la PR.",
+              "",
+              "Les commits suivants n'ont pas de ligne `Signed-off-by` :",
+              "",
+              ...missing,
+              "",
+              "Pour signer vos prochains commits : `git commit -s`. Pour reprendre",
+              "toute la branche : `git rebase --signoff origin/dev` puis",
+              "`git push --force-with-lease`. Détails dans",
+              `[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/dev/CONTRIBUTING.md).`,
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contribuer à OhMyWind
+
+Merci de votre intérêt. Les contributions sont bienvenues, en particulier sur
+les polaires de nouveaux archétypes, l'extension de la couverture MARC, les
+corrections et la documentation.
+
+## Avant de commencer
+
+- Les issues et les PR se passent sur GitHub, en français ou en anglais.
+- Le dépôt suit les conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, `test:`).
+- Les tests doivent passer avant tout commit : `uv run pytest` côté Python
+  (`packages/data-adapters`, `packages/mcp-core`, `packages/hf-space`),
+  `npm run test` côté web.
+- Lint : `uv run ruff check .` côté Python, `npm run lint` côté web.
+
+## Signer vos commits (DCO)
+
+Toute contribution doit être signée avec :
+
+```
+git commit -s
+```
+
+Cette option ajoute une ligne `Signed-off-by: Votre Nom <email>` à la fin du
+message de commit. Elle atteste que vous acceptez le
+[Developer Certificate of Origin](DCO.txt) (DCO 1.1, le texte standard du
+projet Linux).
+
+En signant, vous certifiez trois choses :
+
+1. vous avez écrit cette contribution, ou vous avez le droit de la soumettre
+   sous la licence du projet ;
+2. si elle reprend du code existant, ce code est sous une licence open source
+   compatible et vous en respectez les conditions ;
+3. vous comprenez que la contribution est publique et sera conservée avec
+   votre signature.
+
+Si vous avez oublié de signer, `git commit --amend -s` corrige le dernier
+commit, et `git rebase --signoff origin/dev` reprend toute la branche.
+
+## Vos droits d'auteur restent les vôtres
+
+Le DCO n'est pas un CLA : vous ne cédez rien. Vous restez titulaire du droit
+d'auteur sur chaque ligne que vous écrivez. Votre signature certifie
+uniquement l'origine de la contribution et autorise sa diffusion sous la
+licence du projet.
+
+## Licence des contributions
+
+Toute contribution est diffusée sous [AGPL-3.0-or-later](LICENSE), comme le
+reste du projet.
+
+## Si vous êtes salarié
+
+Certains contrats de travail attribuent à l'employeur les droits sur le code
+écrit par le salarié, parfois même en dehors du temps de travail. Avant de
+contribuer, vérifiez que votre contrat ou votre clause de propriété
+intellectuelle vous le permet, ou demandez l'accord écrit de votre employeur.

--- a/COPYING.MIT
+++ b/COPYING.MIT
@@ -1,0 +1,23 @@
+Historical licence: this MIT licence covers OhMyWind as published up to and including commit f276c3c5763ecf382ed40de3ea2fbf54f1809a17, the last MIT-licensed commit; every later version is distributed under the GNU AGPL-3.0-or-later (see LICENSE).
+
+MIT License
+
+Copyright (c) 2026 Quentin Donnars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 OhMyWind Contributors
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > global current model for the SHOM Atlas C2D and MARC PREVIMER atlases.
 > Free, keyless, open source.
 
-[**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://mcp.ohmywind.fr/mcp) · [MIT](LICENSE) + [trademark](TRADEMARK.md)
+[**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://mcp.ohmywind.fr/mcp) · [AGPL-3.0](LICENSE) + [trademark](TRADEMARK.md)
 
 ![OhMyWind passage plan rendered in the web app](docs/screenshots/plan.png)
 
@@ -88,7 +88,7 @@ Three prompts, each exercising a different tool:
 | 🗓️ **Window-aware**           | One call sweeps a 14-day departure range and lets your LLM pick the calmest weekend slot, no math by hand. |
 | 🔌 **Client-agnostic**        | One HTTP MCP endpoint. Works in Claude Desktop, Le Chat, Cursor, Goose, Zed, Continue, …     |
 | 🖼️ **Rich on supporting hosts** | On Claude / ChatGPT / VS Code Copilot / Goose, an interactive widget renders inline via [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix). Other hosts fall back to a clean text summary + deep-link. |
-| 🛠️ **Open source, MIT**       | Self-host on Fly, Modal, or your own VPS: `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. Fork it under your own name and icons, see [TRADEMARK.md](TRADEMARK.md). |
+| 🛠️ **Open source, AGPL**      | Self-host on Fly, Modal, or your own VPS: `mcp-core` is deployment-agnostic. The HF Space is one wrapper among many. Fork it under your own name and icons, see [TRADEMARK.md](TRADEMARK.md). |
 
 ## What the LLM sees
 
@@ -197,10 +197,14 @@ Wind & sea: [Open-Meteo](https://open-meteo.com/) (CC BY 4.0). Hosting:
 
 ## License and trademark
 
-Code: [MIT](LICENSE). That covers everything under `packages/`, the web app, the
-MCP server and the data adapters alike.
+Code: [AGPL-3.0-or-later](LICENSE). That covers everything under `packages/`,
+the web app, the MCP server and the data adapters alike. Forking and
+redistribution stay free; if you serve a modified instance over the network
+(your own MCP endpoint, a derived web app), you must publish its source.
+Versions up to commit `f276c3c` were MIT-licensed and remain so: see
+[COPYING.MIT](COPYING.MIT).
 
-Two things the MIT licence does **not** cover:
+Two things the AGPL licence does **not** cover:
 
 - **The name "OhMyWind"**, filed as a trademark at the INPI, the French
   industrial property office.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,6 +1,7 @@
 # Politique de marque
 
-Le code d'OhMyWind est distribué sous licence MIT (voir [LICENSE](LICENSE)).
+Le code d'OhMyWind est distribué sous licence AGPL-3.0-or-later (voir
+[LICENSE](LICENSE)).
 Cette licence ne confère aucun droit sur le nom « OhMyWind », qui fait l'objet
 d'un dépôt de marque à l'INPI, en cours d'examen.
 
@@ -20,7 +21,7 @@ d'un dépôt de marque à l'INPI, en cours d'examen.
 ## Éléments graphiques
 
 Les éléments graphiques (logo, icônes) sont protégés par le droit d'auteur et
-ne sont pas couverts par la licence MIT. Un fork doit utiliser sa propre
+ne sont pas couverts par la licence AGPL. Un fork doit utiliser sa propre
 identité visuelle.
 
 Sont concernés les fichiers d'identité de marque du dépôt :
@@ -33,7 +34,7 @@ Sont concernés les fichiers d'identité de marque du dépôt :
 - `packages/web/public/wind-icon.png`
 
 Les autres visuels du dépôt sont des figures techniques et restent sous licence
-MIT : diagrammes de la page méthodologie, courbes polaires des archétypes,
+AGPL : diagrammes de la page méthodologie, courbes polaires des archétypes,
 carte de couverture des atlas.
 
 ## Contact
@@ -44,8 +45,8 @@ contact@ohmywind.fr
 
 # Trademark policy
 
-The OhMyWind source code is distributed under the MIT licence (see
-[LICENSE](LICENSE)). That licence grants no rights over the name "OhMyWind",
+The OhMyWind source code is distributed under the AGPL-3.0-or-later licence
+(see [LICENSE](LICENSE)). That licence grants no rights over the name "OhMyWind",
 which is the subject of a pending trademark application at the INPI, the French
 industrial property office.
 
@@ -65,9 +66,9 @@ industrial property office.
 ## Visual assets
 
 The visual assets (logo, icons) are protected by copyright and are not covered
-by the MIT licence. A fork must use its own visual identity. The brand identity
+by the AGPL licence. A fork must use its own visual identity. The brand identity
 files are listed in the French section above. Every other visual in the
-repository is a technical figure and stays under the MIT licence.
+repository is a technical figure and stays under the AGPL licence.
 
 ## Contact
 

--- a/docs/methodologie.md
+++ b/docs/methodologie.md
@@ -9,7 +9,7 @@
 
 ### Vent (multi-modèle)
 
-Les prévisions vent proviennent d'**Open-Meteo Forecast API** (keyless, MIT-friendly) avec une cascade de modèles à horizon croissant :
+Les prévisions vent proviennent d'**Open-Meteo Forecast API** (keyless, données sous CC BY 4.0) avec une cascade de modèles à horizon croissant :
 
 - **AROME** (Météo-France, 1.3 km) : modèle haute résolution sur l'Atlantique
   français + Méditerranée, ~48 h. Capture les thermiques et les vents locaux.
@@ -124,7 +124,7 @@ les zones MARC.
 | SHOM Atlas C2D | Licence Ouverte Etalab 2.0 | SHOM, via data.gouv.fr |
 | Atlas MARC PREVIMER | Engagement non-redistribution NetCDF brut, Parquet dérivé OK | Pineau-Guillou (2013), URL ci-dessus |
 | Marégraphes REFMAR (validation) | Libre, source obligatoire | "REFMAR. http://dx.doi.org/10.17183/REFMAR#RONIM" |
-| Code OhMyWind | MIT, hors nom « OhMyWind » et identité visuelle | [LICENSE](../LICENSE), [TRADEMARK.md](../TRADEMARK.md) |
+| Code OhMyWind | AGPL-3.0-or-later, hors nom « OhMyWind » et identité visuelle | [LICENSE](../LICENSE), [TRADEMARK.md](../TRADEMARK.md) |
 
 ## Documentation technique
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-wind-monorepo",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "description": "Monorepo root. Each package is self-contained: see packages/web (npm), packages/data-adapters, packages/mcp-core, packages/hf-space (Python via uv).",
   "workspaces": ["packages/web"]
 }

--- a/packages/data-adapters/pyproject.toml
+++ b/packages/data-adapters/pyproject.toml
@@ -2,7 +2,7 @@
 name = "openwind-data"
 version = "0.1.0"
 description = "Marine data adapters, polars, routing, and complexity scoring for OhMyWind"
-license = "MIT"
+license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.27",

--- a/packages/data-adapters/src/openwind_data/__init__.py
+++ b/packages/data-adapters/src/openwind_data/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """OhMyWind domain logic — marine adapters, polars, routing, complexity."""
 
 from openwind_data.adapters.base import (

--- a/packages/data-adapters/src/openwind_data/adapters/__init__.py
+++ b/packages/data-adapters/src/openwind_data/adapters/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars

--- a/packages/data-adapters/src/openwind_data/adapters/base.py
+++ b/packages/data-adapters/src/openwind_data/adapters/base.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Marine forecast types and adapter Protocol.
 
 Direction conventions (mixed by physical phenomenon — mirrors meteorological and

--- a/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
+++ b/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Adapter backed by a client-supplied forecast cache.
 
 Instead of calling Open-Meteo, this adapter reads wind (multi-model) and sea

--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import asyncio

--- a/packages/data-adapters/src/openwind_data/currents/__init__.py
+++ b/packages/data-adapters/src/openwind_data/currents/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tidal currents and heights subpackage.
 
 Provides:

--- a/packages/data-adapters/src/openwind_data/currents/harmonic.py
+++ b/packages/data-adapters/src/openwind_data/currents/harmonic.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tidal harmonic predictor.
 
 Schureman + Cartwright 1985 astronomical longitudes. Standard convention used

--- a/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
+++ b/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """MARC PREVIMER atlas runtime loader and predictor.
 
 Reads tiled Parquet datasets produced by ``scripts/build_marc_atlas.py`` (one

--- a/packages/data-adapters/src/openwind_data/currents/narrow_pass.py
+++ b/packages/data-adapters/src/openwind_data/currents/narrow_pass.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Per-point confidence labelling for current values.
 
 The qualitative tag (``"high"`` / ``"medium"`` / ``"low"`` / ``None``) sits

--- a/packages/data-adapters/src/openwind_data/currents/router.py
+++ b/packages/data-adapters/src/openwind_data/currents/router.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Composite marine adapter — SHOM > MARC > Open-Meteo cascade.
 
 Wraps an upstream ``MarineDataAdapter`` (typically ``OpenMeteoAdapter``)

--- a/packages/data-adapters/src/openwind_data/currents/shom_c2d.py
+++ b/packages/data-adapters/src/openwind_data/currents/shom_c2d.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Parser for the SHOM "Courants de marée 2D" ASCII atlas (Édition 2005).
 
 This module loads the public-domain dataset distributed by SHOM under

--- a/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
+++ b/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Runtime SHOM Atlas C2D registry: spatial index + tide-relative predictor.
 
 Loads the Parquet + JSON artefacts produced by ``scripts/build_shom_c2d.py``

--- a/packages/data-adapters/src/openwind_data/routing/__init__.py
+++ b/packages/data-adapters/src/openwind_data/routing/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Routing — geometry, polars, and passage time estimation."""
 
 from openwind_data.routing.archetypes import (

--- a/packages/data-adapters/src/openwind_data/routing/archetypes.py
+++ b/packages/data-adapters/src/openwind_data/routing/archetypes.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Boat archetype registry — loads ORC-style polars from `polars/*.json`.
 
 V1 ships 7 archetypes (5 monohull cruisers from 20 to 50 ft, 1 catamaran, 1

--- a/packages/data-adapters/src/openwind_data/routing/complexity.py
+++ b/packages/data-adapters/src/openwind_data/routing/complexity.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Complexity scoring for a passage.
 
 V1 design choices:

--- a/packages/data-adapters/src/openwind_data/routing/geometry.py
+++ b/packages/data-adapters/src/openwind_data/routing/geometry.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Spherical geometry helpers — all distances in nautical miles, angles in degrees.
 
 Earth radius is taken as 3440.065 NM (mean radius 6371.0088 km / 1.852).

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Passage time + complexity estimation along a polyline of waypoints.
 
 V1 design choices:

--- a/packages/data-adapters/src/openwind_data/routing/polars/__init__.py
+++ b/packages/data-adapters/src/openwind_data/routing/polars/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars

--- a/packages/data-adapters/tests/__init__.py
+++ b/packages/data-adapters/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars

--- a/packages/data-adapters/tests/conftest.py
+++ b/packages/data-adapters/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import json

--- a/packages/data-adapters/tests/currents/__init__.py
+++ b/packages/data-adapters/tests/currents/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars

--- a/packages/data-adapters/tests/currents/test_harmonic.py
+++ b/packages/data-adapters/tests/currents/test_harmonic.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for the Schureman harmonic predictor.
 
 Validation against:

--- a/packages/data-adapters/tests/currents/test_marc_atlas.py
+++ b/packages/data-adapters/tests/currents/test_marc_atlas.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for the MARC atlas runtime loader.
 
 The fixture is a minimal in-memory atlas with one cell, M2-only constants.

--- a/packages/data-adapters/tests/currents/test_narrow_pass.py
+++ b/packages/data-adapters/tests/currents/test_narrow_pass.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for source-based current confidence labelling."""
 
 from __future__ import annotations

--- a/packages/data-adapters/tests/currents/test_router.py
+++ b/packages/data-adapters/tests/currents/test_router.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for the MARC ↔ Open-Meteo composite adapter."""
 
 from __future__ import annotations

--- a/packages/data-adapters/tests/currents/test_shom_c2d.py
+++ b/packages/data-adapters/tests/currents/test_shom_c2d.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for the SHOM Atlas C2D ASCII parser.
 
 The real C2D distribution is large (~6 MB extracted) and held outside the

--- a/packages/data-adapters/tests/currents/test_shom_c2d_registry.py
+++ b/packages/data-adapters/tests/currents/test_shom_c2d_registry.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for the runtime SHOM Atlas C2D registry.
 
 Builds a small synthetic registry on disk (one zone, a few points, one

--- a/packages/data-adapters/tests/test_archetypes.py
+++ b/packages/data-adapters/tests/test_archetypes.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import dataclasses

--- a/packages/data-adapters/tests/test_cache_backed.py
+++ b/packages/data-adapters/tests/test_cache_backed.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta

--- a/packages/data-adapters/tests/test_complexity.py
+++ b/packages/data-adapters/tests/test_complexity.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import dataclasses

--- a/packages/data-adapters/tests/test_geometry.py
+++ b/packages/data-adapters/tests/test_geometry.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import math

--- a/packages/data-adapters/tests/test_geometry_validation.py
+++ b/packages/data-adapters/tests/test_geometry_validation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Boundary validation for waypoints and single points.
 
 These guards run at the public boundary (REST handlers + MCP tools), so their

--- a/packages/data-adapters/tests/test_openmeteo.py
+++ b/packages/data-adapters/tests/test_openmeteo.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta

--- a/packages/data-adapters/tests/test_openmeteo_batch.py
+++ b/packages/data-adapters/tests/test_openmeteo_batch.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Tests for OpenMeteoAdapter.prewarm_batch (multi-coordinate batching).
 
 The win: a passage samples one point per segment, so the per-segment fetch path

--- a/packages/data-adapters/tests/test_openmeteo_rate_limit.py
+++ b/packages/data-adapters/tests/test_openmeteo_rate_limit.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Upstream 429 handling.
 
 Before this, a 429 from Open-Meteo reached callers as a raw ``HTTPStatusError``

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 import math

--- a/packages/edge-proxy/src/index.js
+++ b/packages/edge-proxy/src/index.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 /**
  * Reverse proxy putting our own domain in front of the MCP Spaces.
  *

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -6,7 +6,7 @@ colorTo: indigo
 sdk: docker
 app_port: 7860
 pinned: false
-license: mit
+license: agpl-3.0
 short_description: Sailing passage planner for any coast, via MCP.
 ---
 
@@ -76,7 +76,7 @@ asks you for credentials is guessing rather than reading the server.
 - **Boat-aware.** 7 archetypes from 20 to 50 ft, real polars, an `efficiency` parameter for trim and crew level.
 - **Window-aware.** One call sweeps up to 14 days of hourly departures so the LLM can pick the calmest slot.
 - **Client-agnostic.** One HTTP MCP endpoint, no vendor lock-in. Rich [MCP Apps](https://modelcontextprotocol.io/extensions/client-matrix) widget on supporting hosts; clean deep-link fallback on the rest.
-- **Open source, MIT.** Self-host on Fly, Modal, or your own VPS in minutes, under your own name and icons.
+- **Open source, AGPL.** Self-host on Fly, Modal, or your own VPS in minutes, under your own name and icons.
 
 ## Four tools
 
@@ -112,7 +112,9 @@ sleep takes ~5 s to wake. Acceptable for V1.
 
 ## License and trademark
 
-Code: MIT. The name "OhMyWind" is filed as a trademark at the INPI, and the
-visual identity (logo, icons) stays under copyright. Neither is covered by the
-MIT licence, so a fork ships under its own name and icons. Full policy:
+Code: AGPL-3.0-or-later. Forking and self-hosting stay free; a modified
+instance served over the network must publish its source. The name "OhMyWind"
+is filed as a trademark at the INPI, and the visual identity (logo, icons)
+stays under copyright. Neither is covered by the AGPL licence, so a fork ships
+under its own name and icons. Full policy:
 [TRADEMARK.md](https://github.com/qdonnars/ohmywind/blob/main/TRADEMARK.md).

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """HF Space entry point — serves the OhMyWind FastMCP server over HTTP.
 
 This wrapper is intentionally thin. All tools live in ``openwind_mcp_core``

--- a/packages/hf-space/fetch_atlases.py
+++ b/packages/hf-space/fetch_atlases.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Pull tidal atlases from the HF Dataset at Docker build time.
 
 Reads ``HF_TOKEN`` (mounted as a build secret) and ``HF_DATASET_ID`` from

--- a/packages/hf-space/pyproject.toml
+++ b/packages/hf-space/pyproject.toml
@@ -2,6 +2,7 @@
 name = "openwind-hf-space"
 version = "0.1.0"
 description = "Hugging Face Spaces wrapper serving the OhMyWind MCP server and its REST API."
+license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"
 
 # Until now these versions lived only in the Dockerfile's pip install line,

--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Deployment-side hardening for the public Space: CORS allowlist, per-IP
 rate limiting, security headers.
 

--- a/packages/hf-space/tests/conftest.py
+++ b/packages/hf-space/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Put the hf-space package dir on sys.path for the whole test session.
 
 ``app.py`` imports its sibling ``security`` module by bare name, which is how

--- a/packages/hf-space/tests/test_api_by_eta.py
+++ b/packages/hf-space/tests/test_api_by_eta.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Characterisation of ``POST /api/v1/passage-by-eta``.
 
 This endpoint arrived after the April plan and had never been tested: the

--- a/packages/hf-space/tests/test_api_marc_overlay.py
+++ b/packages/hf-space/tests/test_api_marc_overlay.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Characterisation of ``GET /api/v1/marine/marc`` and of the landing page.
 
 The overlay endpoint had no test. It is unusual enough to deserve one: it

--- a/packages/hf-space/tests/test_api_passage_cache.py
+++ b/packages/hf-space/tests/test_api_passage_cache.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Endpoint tests for the client-supplied forecast_cache wiring in app.py.
 
 hf-space has no pyproject (it ships via Docker), so we load app.py by path and

--- a/packages/hf-space/tests/test_api_sweep.py
+++ b/packages/hf-space/tests/test_api_sweep.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Coverage for the sweep response assembly in ``_api_passage``.
 
 Written because the ``target_eta`` filtering branch had no test at all: a stray

--- a/packages/hf-space/tests/test_api_validation.py
+++ b/packages/hf-space/tests/test_api_validation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Input-bounds tests for the REST handlers.
 
 Same contract as ``mcp-core/tests/test_server_validation.py``: identical

--- a/packages/hf-space/tests/test_dependency_parity.py
+++ b/packages/hf-space/tests/test_dependency_parity.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """The Dockerfile and pyproject.toml must agree on what the Space needs.
 
 The Space builds from the Dockerfile, not from ``pyproject.toml``: its

--- a/packages/hf-space/tests/test_parse_polar.py
+++ b/packages/hf-space/tests/test_parse_polar.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Unit tests for ``_parse_polar`` — the gate every custom polar from the web
 app passes through. First coverage of this function: it existed since the
 custom-polar feature with zero tests, and it is exactly where new payload

--- a/packages/hf-space/tests/test_security.py
+++ b/packages/hf-space/tests/test_security.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Unit tests for the deployment hardening in ``security.py``.
 
 Covers the three properties that matter operationally:

--- a/packages/mcp-core/pyproject.toml
+++ b/packages/mcp-core/pyproject.toml
@@ -2,7 +2,7 @@
 name = "openwind-mcp-core"
 version = "0.1.0"
 description = "Cloud-agnostic FastMCP server for OhMyWind: sailing planner tools."
-license = "MIT"
+license = "AGPL-3.0-or-later"
 requires-python = ">=3.12"
 dependencies = [
     # MCP Apps support requires:

--- a/packages/mcp-core/scripts/run_local.py
+++ b/packages/mcp-core/scripts/run_local.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Run the OhMyWind MCP server over stdio for local Claude Desktop integration.
 
 Usage (in claude_desktop_config.json):

--- a/packages/mcp-core/src/openwind_mcp_core/__init__.py
+++ b/packages/mcp-core/src/openwind_mcp_core/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """OhMyWind MCP server — cloud-agnostic FastMCP definition."""
 
 from openwind_mcp_core.server import build_server

--- a/packages/mcp-core/src/openwind_mcp_core/feedback.py
+++ b/packages/mcp-core/src/openwind_mcp_core/feedback.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Feedback tool: lets a calling LLM log a structured note about a tool
 interaction (an unclear parameter, missing data, a wrong-feeling result,
 a feature request).

--- a/packages/mcp-core/src/openwind_mcp_core/render.py
+++ b/packages/mcp-core/src/openwind_mcp_core/render.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Deep-link helper used by ``plan_passage``.
 
 Historically this module also generated a ~5 KB self-contained HTML widget

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -510,8 +510,10 @@ but the underlying complexity is unchanged.
 
 ## Licence and trademark
 
-The OhMyWind source code is MIT licensed. Two things the MIT grant does
-not cover: the name "OhMyWind", filed as a trademark at the INPI (the
+The OhMyWind source code is licensed under the AGPL-3.0-or-later. Forks
+and redistribution stay free; a modified instance served over the
+network must publish its source. Two things the AGPL grant does not
+cover: the name "OhMyWind", filed as a trademark at the INPI (the
 French industrial property office), and the visual identity (logo,
 icons), which stays under copyright. Forks are welcome under their own
 name and icons. Policy:

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """FastMCP server factory.
 
 `build_server()` returns a `FastMCP` instance with all tools registered. It is

--- a/packages/mcp-core/src/openwind_mcp_core/widget.py
+++ b/packages/mcp-core/src/openwind_mcp_core/widget.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Static HTML template consumed by ``render.py`` to produce the passage widget.
 
 Kept in its own module so the visual contract is trivial to inspect / iterate

--- a/packages/mcp-core/tests/test_branding.py
+++ b/packages/mcp-core/tests/test_branding.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Guards on the brand strings clients actually see.
 
 Written after the 2026-08-01 cosmetic rebrand shipped with the server name

--- a/packages/mcp-core/tests/test_registry_manifest.py
+++ b/packages/mcp-core/tests/test_registry_manifest.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """The registry manifest must keep matching what we actually serve.
 
 ``server.json`` is what directories, clients and articles copy from. Once an

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta

--- a/packages/mcp-core/tests/test_server_validation.py
+++ b/packages/mcp-core/tests/test_server_validation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Boundary validation on the MCP surface.
 
 Mirror of the REST checks in ``hf-space/tests``: the same bad input must be

--- a/packages/mcp-core/tests/test_tool_annotations.py
+++ b/packages/mcp-core/tests/test_tool_annotations.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Every tool declares what it does to the world.
 
 Annotations drive how clients present a tool: read-only ones can be offered

--- a/packages/mcp-core/tests/test_web_base.py
+++ b/packages/mcp-core/tests/test_web_base.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 """Deep-links must point at the environment the server runs in.
 
 The dev Space handed out production links: every plan produced while testing

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openwind-web",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState, useEffect, useRef, useCallback } from "react";
 import { nowParisHourPrefix } from "./utils/format";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "./types";

--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import App from "./App";
 import { PlanPage } from "./routes/PlanPage";
 import { MethodologiePage } from "./routes/MethodologiePage";

--- a/packages/web/src/api/config.ts
+++ b/packages/web/src/api/config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Base du backend MCP / HF Space. Surchargée par environnement via VITE_API_BASE
 // (Cloudflare Pages : Production -> Space prod, Preview -> Space dev). Sans
 // override, on retombe sur la prod. Vite expose toute var d'env préfixée

--- a/packages/web/src/api/coordinates.test.ts
+++ b/packages/web/src/api/coordinates.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { parseCoordinates, formatCoordinates } from "./coordinates";
 

--- a/packages/web/src/api/coordinates.ts
+++ b/packages/web/src/api/coordinates.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 /**
  * Recognise coordinates typed straight into the search box.
  *

--- a/packages/web/src/api/forecastCache.test.ts
+++ b/packages/web/src/api/forecastCache.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import {
   assembleForecastCache,

--- a/packages/web/src/api/forecastCache.ts
+++ b/packages/web/src/api/forecastCache.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Builds the `forecast_cache` payload posted to the backend so passage planning
 // reads weather the BROWSER fetched (one Open-Meteo call per user IP) instead of
 // the HF Space's single IP. The server keeps full authority over segmentation;

--- a/packages/web/src/api/geocoding.ts
+++ b/packages/web/src/api/geocoding.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { PlaceResult } from "./places";
 import { dedupePlaces, withDistances } from "./places";
 

--- a/packages/web/src/api/marine.test.ts
+++ b/packages/web/src/api/marine.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import {
   isCurrentsRelevant,

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type {
   MarineHourly,
 } from "../types";

--- a/packages/web/src/api/openmeteo.test.ts
+++ b/packages/web/src/api/openmeteo.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { sanitizeHourly, fetchWindCorridor } from "./openmeteo";
 import type { HourlyData } from "../types";

--- a/packages/web/src/api/openmeteo.ts
+++ b/packages/web/src/api/openmeteo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { ModelForecast, HourlyData, GeocodingResult } from "../types";
 import {
   ACTIVE_LIMIT,

--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it } from "vitest";
 import { formatRetryDelay, friendlyError } from "./passage";
 

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { PassageResponse, PassageByEtaResponse, MultiWindowResponse, Archetype } from "../plan/types";
 import type { ModelName } from "../config/modelConfig";
 import type { PolarData } from "../config/polarConfig";

--- a/packages/web/src/api/places.test.ts
+++ b/packages/web/src/api/places.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import type { PlaceResult } from "./places";
 import {

--- a/packages/web/src/api/places.ts
+++ b/packages/web/src/api/places.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { Spot } from "../types";
 import { haversineNm } from "../utils/geo";
 

--- a/packages/web/src/components/BoatAdvanced.tsx
+++ b/packages/web/src/components/BoatAdvanced.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useMemo, useRef, useState } from "react";
 import {
   ARCHETYPE_LABELS,

--- a/packages/web/src/components/BoatEssentials.tsx
+++ b/packages/web/src/components/BoatEssentials.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import {
   ARCHETYPE_LABELS,
   COEFF_MAX,

--- a/packages/web/src/components/BoatResult.tsx
+++ b/packages/web/src/components/BoatResult.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useMemo, useState } from "react";
 import {
   ARCHETYPE_LABELS,

--- a/packages/web/src/components/ConfigTile.tsx
+++ b/packages/web/src/components/ConfigTile.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState, type ReactNode } from "react";
 
 // Card primitive for the /config page — extracts the recipe previously

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { Spot } from "../types";
 import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";

--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { InfoPanel } from "./InfoPanel";

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export function InfoPanel() {
   return (
     <div

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -127,9 +127,11 @@ export function InfoPanel() {
             rel="noreferrer"
             className="underline hover:opacity-80"
           >
-            licence MIT
+            licence AGPL-3.0
           </a>
-          . Vous pouvez le forker, le modifier et le redistribuer. En revanche,
+          . Vous pouvez le forker, le modifier et le redistribuer. Si vous
+          exposez une version modifiée sur le réseau, vous devez en publier
+          les sources. En revanche,
           le nom « OhMyWind » fait l'objet d'un dépôt de marque à l'INPI, et
           l'identité visuelle (logo, icônes) reste protégée par le droit
           d'auteur : un fork se publie sous son propre nom et ses propres

--- a/packages/web/src/components/LocateButton.tsx
+++ b/packages/web/src/components/LocateButton.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState } from "react";
 import type { GeolocStatus } from "../hooks/useGeolocation";
 import { geolocMessage } from "../hooks/useGeolocation";

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import type { MarineHourly, ModelForecast, MetricView } from "../types";
 import { TimelineHeader } from "./TimelineHeader";

--- a/packages/web/src/components/MetricPills.tsx
+++ b/packages/web/src/components/MetricPills.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { ReactNode } from "react";
 import type { MetricView } from "../types";
 

--- a/packages/web/src/components/Onboarding.tsx
+++ b/packages/web/src/components/Onboarding.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import { STORAGE_KEY as CUSTOM_SPOTS_KEY } from "../hooks/useCustomSpots";
 import { migrateLegacyKey } from "../utils/localStorageMigration";

--- a/packages/web/src/components/PolarDiagram.test.ts
+++ b/packages/web/src/components/PolarDiagram.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it } from "vitest";
 import { visiblePolarPoints } from "./polarPoints";
 

--- a/packages/web/src/components/PolarDiagram.tsx
+++ b/packages/web/src/components/PolarDiagram.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useMemo, useRef, useState } from "react";
 import { visiblePolarPoints } from "./polarPoints";
 

--- a/packages/web/src/components/QuickSpots.tsx
+++ b/packages/web/src/components/QuickSpots.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { Spot } from "../types";
 import { QUICK_SPOTS } from "../spots";
 

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useRef, useCallback, useState, type RefObject } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";

--- a/packages/web/src/components/SpotSearch.tsx
+++ b/packages/web/src/components/SpotSearch.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import type { Spot } from "../types";

--- a/packages/web/src/components/TideChart.tsx
+++ b/packages/web/src/components/TideChart.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import type { MarineHourly, ModelForecast } from "../types";
 import { TimelineHeader } from "./TimelineHeader";

--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { formatHour } from "../utils/format";
 import type { ModelForecast } from "../types";
 import type { TimezoneMode } from "../hooks/useTimezone";

--- a/packages/web/src/components/WindArrow.tsx
+++ b/packages/web/src/components/WindArrow.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export function WindArrow({ degrees }: { degrees: number }) {
   return (
     <svg

--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { getBeaufortLevel } from "../utils/colors";
 
 interface WindCellProps {

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import type { ModelForecast } from "../types";
 import { TimelineHeader } from "./TimelineHeader";

--- a/packages/web/src/components/polarPoints.ts
+++ b/packages/web/src/components/polarPoints.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Geometry helper for PolarDiagram, in its own module so the component file
 // only exports components (react-refresh constraint) and tests can import it
 // without touching React.

--- a/packages/web/src/config/geolocPreference.ts
+++ b/packages/web/src/config/geolocPreference.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 /**
  * Remembers that the user turned down location sharing.
  *

--- a/packages/web/src/config/modelConfig.ts
+++ b/packages/web/src/config/modelConfig.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Persisted ordering of the wind models the app fetches from Open-Meteo.
 // The top `ACTIVE_LIMIT` models in the order are the ones actually fetched
 // and shown as rows in the forecast table; the rest are kept in the catalog

--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BASE_POLARS,

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // User-customized polar diagram, persisted in localStorage.
 //
 // Two sources, one active at a time:

--- a/packages/web/src/config/polarImport.test.ts
+++ b/packages/web/src/config/polarImport.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import exampleCsv from "../../public/polars/exemple-polaire.csv?raw";
 import { describe, expect, it } from "vitest";
 import { parsePolarFile, PolarImportError } from "./polarImport";

--- a/packages/web/src/config/polarImport.ts
+++ b/packages/web/src/config/polarImport.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Parser for user-supplied polar files (qtVlm / Expedition / MaxSea layout):
 // first line lists the TWS columns (optionally prefixed by a "TWA\TWS"-style
 // label), each following line is a TWA row followed by one boat speed per TWS.

--- a/packages/web/src/config/returnPath.ts
+++ b/packages/web/src/config/returnPath.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Remember which page the user was on before opening /config so the back
 // link can land them where they came from instead of always bouncing to "/".
 // Stored in sessionStorage (not local) because the value is only meaningful

--- a/packages/web/src/content/methodologie.md
+++ b/packages/web/src/content/methodologie.md
@@ -318,7 +318,7 @@ Limites assumées des données :
 | SHOM Atlas C2D                | Licence Ouverte Etalab 2.0                           | SHOM, via data.gouv.fr                                          |
 | Atlas MARC PREVIMER           | Engagement non-redistribution NetCDF brut            | Pineau-Guillou (2013)                                           |
 | Marégraphes REFMAR            | Libre, source obligatoire                            | REFMAR, dx.doi.org/10.17183/REFMAR#RONIM                        |
-| Code OhMyWind                 | MIT, hors nom et identité visuelle                   | [TRADEMARK.md](https://github.com/qdonnars/ohmywind/blob/main/TRADEMARK.md) |
+| Code OhMyWind                 | AGPL-3.0-or-later, hors nom et identité visuelle     | [TRADEMARK.md](https://github.com/qdonnars/ohmywind/blob/main/TRADEMARK.md) |
 
 Référence académique pour MARC : Pineau-Guillou Lucia (2013). PREVIMER, Validation des atlas de composantes harmoniques de hauteurs et courants de marée. Rapport Ifremer, 89 p. [archimer.ifremer.fr/doc/00157/26801](http://archimer.ifremer.fr/doc/00157/26801/)
 
@@ -333,6 +333,6 @@ Faire vivre un planificateur météo-marine open source et sans publicité serai
 
 ## Code et contributions
 
-Le code d'OhMyWind est intégralement open source, sous licence MIT. Le code, les polaires, le prédicteur harmonique et la cascade de routage sont sur le dépôt GitHub. Les contributions sont bienvenues, en particulier sur les polaires de nouveaux archétypes et sur l'extension de la couverture MARC.
+Le code d'OhMyWind est intégralement open source, sous licence AGPL-3.0-or-later : le fork et la redistribution restent libres, et toute instance modifiée exposée sur le réseau doit publier ses sources. Le code, les polaires, le prédicteur harmonique et la cascade de routage sont sur le dépôt GitHub. Les contributions sont bienvenues, en particulier sur les polaires de nouveaux archétypes et sur l'extension de la couverture MARC.
 
-Deux choses ne sont pas couvertes par la licence MIT : le nom « OhMyWind », qui fait l'objet d'un dépôt de marque à l'INPI, et l'identité visuelle (logo, icônes), qui reste protégée par le droit d'auteur. Vous pouvez forker le projet et le republier librement, sous votre propre nom et vos propres icônes. Le détail est dans la [politique de marque](https://github.com/qdonnars/ohmywind/blob/main/TRADEMARK.md).
+Deux choses ne sont pas couvertes par la licence AGPL : le nom « OhMyWind », qui fait l'objet d'un dépôt de marque à l'INPI, et l'identité visuelle (logo, icônes), qui reste protégée par le droit d'auteur. Vous pouvez forker le projet et le republier librement, sous votre propre nom et vos propres icônes. Le détail est dans la [politique de marque](https://github.com/qdonnars/ohmywind/blob/main/TRADEMARK.md).

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { createContext, useContext, useEffect, useState } from 'react';
 
 type ThemeMode = 'light' | 'dark';

--- a/packages/web/src/hooks/useCustomSpots.ts
+++ b/packages/web/src/hooks/useCustomSpots.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState } from "react";
 import type { Spot } from "../types";
 import { migrateLegacyKey } from "../utils/localStorageMigration";

--- a/packages/web/src/hooks/useGeolocation.test.ts
+++ b/packages/web/src/hooks/useGeolocation.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { statusFromErrorCode, geolocMessage } from "./useGeolocation";
 

--- a/packages/web/src/hooks/useGeolocation.ts
+++ b/packages/web/src/hooks/useGeolocation.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useCallback, useRef, useState } from "react";
 import {
   clearGeolocationDecline,

--- a/packages/web/src/hooks/useMapView.test.ts
+++ b/packages/web/src/hooks/useMapView.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { roundView } from "./useMapView";
 

--- a/packages/web/src/hooks/useMapView.ts
+++ b/packages/web/src/hooks/useMapView.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useCallback, useState } from "react";
 import type { MapView } from "../utils/mapViewParams";
 

--- a/packages/web/src/hooks/useTimezone.ts
+++ b/packages/web/src/hooks/useTimezone.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState, useEffect } from "react";
 
 export type TimezoneMode = "local" | "utc" | "boat";

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { AggregatedLeg } from "./aggregateLegs";
 
 // "Conditions vues du bateau" — North-up compass with the boat rotated to its

--- a/packages/web/src/plan/ModeToggle.tsx
+++ b/packages/web/src/plan/ModeToggle.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export type PlanMode = "single" | "compare";
 
 // Sub-mode inside "Simuler ma route": is the picked time a departure or a

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useMemo, useState } from "react";
 import { useTheme } from "../design/theme";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "./types";

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Visual building blocks for the /plan right panel — keeps PlanSidebar.tsx
 // focused on state wiring while these components stay design-only.
 

--- a/packages/web/src/plan/WindowsTable.tsx
+++ b/packages/web/src/plan/WindowsTable.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useMemo, useState } from "react";
 import type { PassageWindow } from "./types";
 import { CX_COLORS } from "./types";

--- a/packages/web/src/plan/aggregateLegs.test.ts
+++ b/packages/web/src/plan/aggregateLegs.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it } from "vitest";
 import { aggregateLegs, buildLegSummaryCells, type AggregatedLeg } from "./aggregateLegs";
 import type { SegmentReport } from "./types";

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { SegmentReport } from "./types";
 
 export interface AggregatedLeg {

--- a/packages/web/src/plan/format.test.ts
+++ b/packages/web/src/plan/format.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it } from "vitest";
 import { fmtDuration, fmtDurationSafe, fr1 } from "./format";
 

--- a/packages/web/src/plan/format.ts
+++ b/packages/web/src/plan/format.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Shared number/duration formatters for the /plan panel. Consolidates helpers
 // that had drifted into separate copies across PlanStates.tsx and
 // WindowsTable.tsx so the "12h30" convention and French decimals stay in one

--- a/packages/web/src/plan/geo.ts
+++ b/packages/web/src/plan/geo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Spherical geometry helpers — distances in nautical miles, angles in degrees.
 // TypeScript mirror of packages/data-adapters/.../routing/geometry.py. Kept in
 // sync so the client can sample the same route polyline the server segments.

--- a/packages/web/src/plan/lastSimulation.ts
+++ b/packages/web/src/plan/lastSimulation.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type {
   PassageReport,
   ComplexityScore,

--- a/packages/web/src/plan/parseUrl.ts
+++ b/packages/web/src/plan/parseUrl.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export interface ParsedPlanParams {
   waypoints: [number, number][];
   departure: string;

--- a/packages/web/src/plan/types.ts
+++ b/packages/web/src/plan/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export interface PlanWaypoint {
   lat: number;
   lon: number;

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useState } from "react";
 import { checkForAppUpdate } from "./sw";
 

--- a/packages/web/src/routes/ConfidentialitePage.tsx
+++ b/packages/web/src/routes/ConfidentialitePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ACTIVE_LIMIT,

--- a/packages/web/src/routes/MethodologiePage.tsx
+++ b/packages/web/src/routes/MethodologiePage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { useState, useEffect, useMemo, useRef, useCallback, forwardRef, useImperativeHandle } from "react";
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";

--- a/packages/web/src/spots.ts
+++ b/packages/web/src/spots.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { Spot } from "./types";
 
 export const QUICK_SPOTS: Spot[] = [];

--- a/packages/web/src/sw.test.ts
+++ b/packages/web/src/sw.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { shouldCheckForUpdate } from "./sw";
 

--- a/packages/web/src/sw.ts
+++ b/packages/web/src/sw.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { registerSW } from "virtual:pwa-register";
 
 /**

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 export interface Spot {
   name: string;
   latitude: number;

--- a/packages/web/src/utils/accuracy.test.ts
+++ b/packages/web/src/utils/accuracy.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { shouldDrawAccuracy } from "./accuracy";
 

--- a/packages/web/src/utils/accuracy.ts
+++ b/packages/web/src/utils/accuracy.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 /** Below this the accuracy disc is smaller than the position dot itself, so
     drawing it adds nothing. */
 const MIN_ACCURACY_M = 25;

--- a/packages/web/src/utils/colors.ts
+++ b/packages/web/src/utils/colors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // 9 Beaufort steps — 0-50 kn, covers Mediterranean mistral (35-40 kn)
 const BEAUFORT_STEPS: [number, string, string][] = [
   //  kn_max, bg_color,   text_color

--- a/packages/web/src/utils/cookies.ts
+++ b/packages/web/src/utils/cookies.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Cookie helpers. Single place where the attribute string is built, so the
 // security flags cannot drift between call sites.
 

--- a/packages/web/src/utils/format.ts
+++ b/packages/web/src/utils/format.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import type { TimezoneMode } from "../hooks/useTimezone";
 
 const DAYS_EN = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];

--- a/packages/web/src/utils/geo.test.ts
+++ b/packages/web/src/utils/geo.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it } from "vitest";
 import { haversineNm, fmtNm } from "./geo";
 

--- a/packages/web/src/utils/geo.ts
+++ b/packages/web/src/utils/geo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Pure geo helpers for the plan map. Deliberately leaflet-free: leaflet
 // touches the DOM and crashes the node vitest env, and keeping these
 // functions dependency-free makes them unit-testable in isolation.

--- a/packages/web/src/utils/localStorageMigration.test.ts
+++ b/packages/web/src/utils/localStorageMigration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, expect, it, beforeEach } from "vitest";
 import { migrateLegacyKey } from "./localStorageMigration";
 

--- a/packages/web/src/utils/localStorageMigration.ts
+++ b/packages/web/src/utils/localStorageMigration.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // One-shot migration of a legacy localStorage key to its renamed successor.
 // Runs at most once per key pair: if the new key is already present, the old
 // value is never copied over it, so a returning user's fresher data always

--- a/packages/web/src/utils/mapViewParams.test.ts
+++ b/packages/web/src/utils/mapViewParams.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { parseMapView, mapViewQuery } from "./mapViewParams";
 

--- a/packages/web/src/utils/mapViewParams.ts
+++ b/packages/web/src/utils/mapViewParams.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 /**
  * The map viewport, carried across the explore <-> planner navigation.
  *

--- a/packages/web/src/utils/userPositionLayer.ts
+++ b/packages/web/src/utils/userPositionLayer.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import L from "leaflet";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { shouldDrawAccuracy } from "./accuracy";

--- a/packages/web/src/utils/visibleCenter.test.ts
+++ b/packages/web/src/utils/visibleCenter.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 import { describe, it, expect } from "vitest";
 import { centerForBottomInset, mercatorY } from "./visibleCenter";
 

--- a/packages/web/src/utils/visibleCenter.ts
+++ b/packages/web/src/utils/visibleCenter.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
 // Where must the map centre go so a point of interest lands in the middle of
 // the *visible* strip of the map, when a UI panel overlays the bottom
 // `insetPx` pixels of the container? Answer: `insetPx / 2` screen pixels


### PR DESCRIPTION
## Résumé

Bascule complète du projet de MIT vers AGPL-3.0-or-later, titulaire du copyright Quentin Donnars, avec mise en place du DCO pour les contributions externes. Chantier exclusivement documentaire et déclaratif, aucune logique métier touchée. L'historique git n'est pas réécrit : les versions publiées jusqu'à `f276c3c` restent sous MIT.

## Fichiers touchés par catégorie

**Licence**
- `LICENSE` : texte officiel et intégral de l'AGPL-3.0 (gnu.org, non modifié, 661 lignes)
- `COPYING.MIT` : texte MIT historique borné au commit `f276c3c5763ecf382ed40de3ea2fbf54f1809a17`, copyright corrigé en « Quentin Donnars »

**Métadonnées**
- `package.json` racine et `packages/web/package.json` : `AGPL-3.0-or-later`
- `pyproject.toml` de `mcp-core`, `data-adapters` et `hf-space` (champ ajouté pour hf-space, absent avant)
- Frontmatter du README du Space HF : `license: agpl-3.0`
- Aucun classifier Python de licence n'existait, rien d'autre à aligner

**En-têtes SPDX** (152 fichiers)
- Tous les `.py`, `.ts`, `.tsx` de `packages/`, tests compris, plus le worker `edge-proxy/src/index.js`
- Exclus : `vite.config.ts` (config) et `vite-env.d.ts` (stub Vite)
- Script maison idempotent plutôt que `reuse` : aucun shebang dans le dépôt, trois syntaxes de commentaire, l'outil n'apportait rien

**Documentation et copy**
- `README.md` : badges, tableau des arguments, section licence avec renvoi vers COPYING.MIT
- `TRADEMARK.md` : six occurrences FR et EN, logique du document inchangée
- `docs/methodologie.md` et `packages/web/src/content/methodologie.md` : tableau des sources et section open source
- `InfoPanel.tsx` et copy du tool `read_me` (`server.py`, trouvée au grep de recoupement) : une phrase explique la clause réseau, fork et redistribution libres, sources à publier pour toute instance modifiée exposée sur le réseau
- Les licences de données sont inchangées : CC BY 4.0 (Open-Meteo), Licence Ouverte Etalab 2.0 (SHOM), non-redistribution (MARC PREVIMER)

**DCO**
- `DCO.txt` : texte officiel du Developer Certificate of Origin 1.1, non modifié
- `CONTRIBUTING.md` : signature `git commit -s`, ce que la signature certifie en trois points, conservation des droits d'auteur (différence avec un CLA), diffusion sous AGPL, rappel aux salariés
- `.github/PULL_REQUEST_TEMPLATE.md` : checklist avec case sign-off
- `.github/workflows/dco-check.yml` : contrôle non bloquant, commentaire de PR

## Vérifications

- ruff check + format et pytest verts sur les trois paquets Python (269 + 54 + 118 tests)
- vitest 211 verts, typecheck OK, `lint:budget` 25/26 OK
- Smoke MCP live en conditions réelles (Open-Meteo, sans stub) : 4/4 PASS, `plan_passage` Marseille → Porquerolles résout AROME, `read_me` sert la copy AGPL
- Audit des dépendances : npm (MIT, ISC, Apache-2.0, BSD, BlueOak-1.0.0, MPL-2.0, CC-BY-4.0) et Python (MIT, BSD, Apache, MPL, PSF), rien d'incompatible avec une œuvre AGPL
- Grep résiduel : plus aucune occurrence MIT non intentionnelle

## Points qui méritent un arbitrage humain

1. **`npm run lint` échoue, mais à l'identique sur `dev` propre** : erreurs `react-hooks` v7 préexistantes (App.tsx, SpotMap.tsx, MarineTable.tsx), et la CI web ne lance que `lint:budget` + `test`, qui passent. Non corrigé ici, hors périmètre.
2. **`edge-proxy/src/index.js`** : en-tête SPDX ajouté bien que le périmètre annoncé soit Python/TypeScript. C'est du source première partie ; à retirer si le périmètre strict est préféré.
3. **`marketing-drafts/`** : une mention MIT laissée telle quelle (archives sous l'ancien branding openwind.fr).
4. **Workflow DCO en `pull_request_target`** : nécessaire pour pouvoir commenter les PR venant de forks (token en lecture seule sur `pull_request`). Sûr car le job ne fait que des appels API, sans checkout du code de la PR. Il sort toujours en succès.
5. **Sign-off** : les cinq commits de cette PR sont signés au nom de l'identité git configurée, `qdonnars <qdonnars@gmail.com>`. Si vous préférez `Quentin Donnars` en toutes lettres dans les Signed-off-by, il faudra ajuster `git config user.name` et reprendre la branche.
6. Le merge vers `dev` touchera `mcp-core`, `data-adapters` et `hf-space`, donc resynchronisera le Space dev (`openwind-mcp-dev`).
