### PR TITLE
fix: bornes moteur relevées à 30 kn, clamp visible au lieu du drop silencieux

### DIFF
--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -404,8 +404,11 @@ def _parse_polar(raw: Any) -> BoatPolar | None:
     # Optional motor config. Both fields must be set together; either alone
     # is dropped silently so a half-filled web form never silently changes
     # the simulation (matches the frontend / backend "both or neither" rule).
-    motor_threshold = _parse_optional_kn(raw.get("motor_threshold_kn"), max_kn=10.0)
-    motor_speed = _parse_optional_kn(raw.get("motor_speed_kn"), max_kn=12.0)
+    # The 30 kn cap mirrors the polar matrix ceiling above and the web's
+    # MOTOR_MAX_KN — keep the three aligned or the web will show a motor the
+    # simulation silently ignores.
+    motor_threshold = _parse_optional_kn(raw.get("motor_threshold_kn"), max_kn=30.0)
+    motor_speed = _parse_optional_kn(raw.get("motor_speed_kn"), max_kn=30.0)
     if motor_threshold is None or motor_speed is None:
         motor_threshold = None
         motor_speed = None

--- a/packages/hf-space/tests/test_parse_polar.py
+++ b/packages/hf-space/tests/test_parse_polar.py
@@ -100,9 +100,17 @@ class TestMotorFields:
         assert polar.motor_threshold_kn is None
         assert polar.motor_speed_kn is None
 
+    def test_fast_boat_pair_accepted(self) -> None:
+        # The 30 kn cap mirrors the polar matrix ceiling; a "motor unless the
+        # sails do better than 15 kn" config is legitimate (fast cat, RIB).
+        polar = app._parse_polar(_payload(motor_threshold_kn=15.0, motor_speed_kn=25.0))
+        assert polar.motor_threshold_kn == 15.0
+        assert polar.motor_speed_kn == 25.0
+
     def test_out_of_range_pair_dropped(self) -> None:
-        # Motor stays tolerant (silent drop), unlike min_upwind_twa_deg.
-        polar = app._parse_polar(_payload(motor_threshold_kn=15.0, motor_speed_kn=5.5))
+        # Motor stays tolerant (silent drop), unlike min_upwind_twa_deg. The
+        # web clamps at input, so anything above 30 here is a bypassing client.
+        polar = app._parse_polar(_payload(motor_threshold_kn=15.0, motor_speed_kn=50.0))
         assert polar.motor_threshold_kn is None
         assert polar.motor_speed_kn is None
 

--- a/packages/web/src/components/BoatEssentials.tsx
+++ b/packages/web/src/components/BoatEssentials.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
+import { useState } from "react";
+
 import {
   ARCHETYPE_LABELS,
   COEFF_MAX,
   COEFF_MIN,
   COEFF_STEP,
+  MOTOR_MAX_KN,
   isImportedActive,
   type PolarConfig,
 } from "../config/polarConfig";
@@ -20,6 +23,10 @@ interface BoatEssentialsProps {
 
 export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
   const importedActive = isImportedActive(config);
+  // True after a typed motor value got clamped to MOTOR_MAX_KN. Transient UI
+  // state: the stored config only ever holds valid values, so the clamp event
+  // itself has to be remembered here to be explainable to the user.
+  const [motorClamped, setMotorClamped] = useState(false);
 
   function setBase(base: string) {
     if (base === config.base) return;
@@ -36,13 +43,31 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
   function setMotorField(field: "motorThresholdKn" | "motorSpeedKn", raw: string) {
     const val = raw.trim();
     if (val === "") {
+      setMotorClamped(false);
       onChange({ ...config, [field]: undefined });
       return;
     }
     const num = Number(val);
     if (!Number.isFinite(num) || num <= 0) return;
+    if (num > MOTOR_MAX_KN) {
+      setMotorClamped(true);
+      onChange({ ...config, [field]: MOTOR_MAX_KN });
+      return;
+    }
+    setMotorClamped(false);
     onChange({ ...config, [field]: Math.round(num * 10) / 10 });
   }
+
+  const motorThreshold = config.motorThresholdKn;
+  const motorSpeed = config.motorSpeedKn;
+  const motorHalfSet = (typeof motorThreshold === "number") !== (typeof motorSpeed === "number");
+  // A threshold above the motor speed would make the engine *slow the boat
+  // down* on segments sailing between the two values — always a config
+  // mistake, worth flagging (the simulation still applies it as configured).
+  const motorInverted =
+    typeof motorThreshold === "number" &&
+    typeof motorSpeed === "number" &&
+    motorThreshold > motorSpeed;
 
   return (
     <>
@@ -104,7 +129,7 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
               inputMode="decimal"
               step="0.1"
               min="0.1"
-              max="10"
+              max={MOTOR_MAX_KN}
               placeholder="ex. 2"
               value={config.motorThresholdKn ?? ""}
               onChange={(e) => setMotorField("motorThresholdKn", e.target.value)}
@@ -118,7 +143,7 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
               inputMode="decimal"
               step="0.1"
               min="0.1"
-              max="12"
+              max={MOTOR_MAX_KN}
               placeholder="ex. 5"
               value={config.motorSpeedKn ?? ""}
               onChange={(e) => setMotorField("motorSpeedKn", e.target.value)}
@@ -127,14 +152,26 @@ export function BoatEssentials({ config, onChange }: BoatEssentialsProps) {
           </label>
         </div>
         <p className="polar-motor-hint">
-          Sous la vitesse seuil calculée par la polaire, on bascule au moteur.
-          Laissez les deux champs vides pour rester 100&nbsp;% voile (comportement par défaut).
+          Sous la vitesse seuil calculée par la polaire, on bascule au moteur
+          (jusqu'à {MOTOR_MAX_KN}&nbsp;kn). Laissez les deux champs vides pour rester
+          100&nbsp;% voile (comportement par défaut).
         </p>
-        {typeof config.motorThresholdKn === "number" !==
-          (typeof config.motorSpeedKn === "number") && (
+        {motorClamped && (
+          <p className="polar-motor-warn">
+            Valeur ramenée à {MOTOR_MAX_KN}&nbsp;kn, le plafond du simulateur : au-delà,
+            l'estimation météo par tronçon n'est plus fiable.
+          </p>
+        )}
+        {motorHalfSet && (
           <p className="polar-motor-warn">
             Renseignez les deux valeurs pour activer le moteur. Tant qu'un seul champ
             est rempli, la simulation reste 100&nbsp;% voile.
+          </p>
+        )}
+        {motorInverted && (
+          <p className="polar-motor-warn">
+            La vitesse seuil dépasse la vitesse moteur : sur les tronçons naviguant
+            entre les deux, le moteur ralentirait le bateau. Vérifiez les deux valeurs.
           </p>
         )}
       </fieldset>

--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -6,6 +6,7 @@ import {
   BASE_POLARS,
   COEFF_DEFAULT,
   DEFAULT_BASE,
+  MOTOR_MAX_KN,
   SERVER_DEFAULT_EFFICIENCY,
   SPI_MAX_TWS_DEFAULT,
   defaultPolarConfig,
@@ -158,6 +159,36 @@ describe("persistence", () => {
     expect(loaded.coefficient).toBe(1.0);
     expect(loaded.spiMaxTwsKn).toBe(30);
     expect(loaded.minUpwindDeg).toBeUndefined();
+  });
+
+  it("round-trips a motor config within the bounds", () => {
+    savePolarConfig({ ...defaultPolarConfig(), motorThresholdKn: 15, motorSpeedKn: 25 });
+    const loaded = loadPolarConfig();
+    expect(loaded.motorThresholdKn).toBe(15);
+    expect(loaded.motorSpeedKn).toBe(25);
+  });
+
+  it("clamps persisted motor values above the cap instead of dropping them", () => {
+    // A config saved by a build with laxer input validation (issue: typed 50 kn
+    // silently vanished on reload) must keep its motor, capped.
+    savePolarConfig({ ...defaultPolarConfig(), motorThresholdKn: 15, motorSpeedKn: 50 });
+    const loaded = loadPolarConfig();
+    expect(loaded.motorThresholdKn).toBe(15);
+    expect(loaded.motorSpeedKn).toBe(MOTOR_MAX_KN);
+  });
+
+  it("still drops non-positive or non-numeric motor values", () => {
+    store[STORAGE_KEY] = JSON.stringify({
+      v: 3,
+      base: DEFAULT_BASE,
+      spi: "off",
+      overrides: {},
+      motorThresholdKn: -2,
+      motorSpeedKn: "fast",
+    });
+    const loaded = loadPolarConfig();
+    expect(loaded.motorThresholdKn).toBeUndefined();
+    expect(loaded.motorSpeedKn).toBeUndefined();
   });
 
   it("drops a corrupted imported polar and snaps the source back", () => {

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -241,15 +241,20 @@ export function defaultPolarConfig(): PolarConfig {
   };
 }
 
-// Motor speed sanity bounds — keep generous enough for a fast trawler-style
-// auxiliary (8 kn) without admitting absurd values typed by accident.
-const MOTOR_SPEED_MAX = 12;
-const MOTOR_THRESHOLD_MAX = 10;
+// Motor bound, aligned on the system-wide 30 kn boat-speed ceiling (imported
+// polars and cell overrides cap there too, and so does the server's
+// `_parse_polar`). Beyond it the single-pass weather sampling assumption
+// breaks down anyway. Exported: the form's `max` attributes and copy must
+// derive from this single source.
+export const MOTOR_MAX_KN = 30;
 
-function sanitizeMotorField(raw: unknown, maxKn: number): number | undefined {
+// Clamp rather than drop out-of-range values: a persisted config from a
+// build with laxer input validation keeps its motor (at the cap) instead of
+// silently losing it. Non-numbers and non-positive values still mean "unset".
+function sanitizeMotorField(raw: unknown): number | undefined {
   if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
-  if (raw <= 0 || raw > maxKn) return undefined;
-  return Math.round(raw * 10) / 10;
+  if (raw <= 0) return undefined;
+  return Math.min(MOTOR_MAX_KN, Math.round(raw * 10) / 10);
 }
 
 function isValidBase(x: unknown): x is string {
@@ -370,8 +375,8 @@ export function loadPolarConfig(): PolarConfig {
       spiMaxTwsKn: parsed.v === 3 ? clampSpiMaxTws(parsed.spiMaxTwsKn) : SPI_MAX_TWS_DEFAULT,
       minUpwindDeg: parsed.v === 3 ? sanitizeMinUpwind(parsed.minUpwindDeg) : undefined,
       overrides: sanitizeOverrides(parsed.overrides, BASE_POLARS[base]),
-      motorThresholdKn: sanitizeMotorField(parsed.motorThresholdKn, MOTOR_THRESHOLD_MAX),
-      motorSpeedKn: sanitizeMotorField(parsed.motorSpeedKn, MOTOR_SPEED_MAX),
+      motorThresholdKn: sanitizeMotorField(parsed.motorThresholdKn),
+      motorSpeedKn: sanitizeMotorField(parsed.motorSpeedKn),
       source,
       imported,
       // Absent on pre-existing configs → true: the perso polar stays the


### PR DESCRIPTION
## Problème

Un moteur saisi au-dessus des anciennes bornes (seuil 10 kn / vitesse 12 kn) était accepté par le formulaire, affiché, persisté, puis silencieusement jeté par `sanitizeMotorField` au rechargement : la route se calculait sans moteur et les champs revenaient vides au retour dans la config. Signalé sur un couple 15/50 kn.

## Fix

- **polarConfig** : borne unique `MOTOR_MAX_KN = 30` (alignée sur le plafond 30 kn des polaires importées, des overrides et du `_parse_polar` serveur), exportée. Le sanitize clampe au plafond au lieu de dropper : une config déjà persistée hors bornes garde son moteur.
- **BoatEssentials** : clamp à la saisie avec message explicatif ; attributs `max` et copy dérivés de la constante (plus de valeur dupliquée en dur) ; nouveau warning quand le seuil dépasse la vitesse moteur (cas où le moteur ralentirait le bateau).
- **hf-space** : bornes du parse REST relevées à 30/30, contrat tolérant inchangé au-delà.

Au-delà de 30 kn, l'hypothèse single-pass de l'échantillonnage météo (heuristique 6 kn) rend la simulation mensongère ; une estimation boat-aware de cette heuristique fera l'objet d'une PR séparée.

## Validation

- 214 tests web (3 nouveaux : round-trip dans les bornes, clamp au-delà, drop des valeurs invalides), 119 tests hf-space (1 nouveau : couple 15/25 accepté), typecheck, lint budget, build, ruff : tout vert.
- Smoke live local contre la vraie API Open-Meteo (Marseille → Porquerolles, départ 2026-08-16 08:00Z) : moteur 15/25 engagé sur 5/5 segments, 40,86 nm en 1,63 h (25,0 kn de moyenne exacte) ; contre-test 50 kn droppé silencieusement, 0/5 segments moteur, 10,81 h à la voile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)