### PR TITLE
fix(web): le louvoyage se déduit de l'angle de remontée du bateau (#277)

### DIFF
--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -19,6 +19,7 @@ import {
   isPolarCustomized,
   loadPolarConfig,
   planEfficiency,
+  planMinUpwind,
   polarFingerprint,
   savePolarConfig,
   spiBoostAt,
@@ -337,6 +338,34 @@ describe("min upwind derivation", () => {
   it("follows the archetype passed as override", () => {
     expect(effectiveMinUpwind(defaultPolarConfig(), "catamaran_40ft")).toBe(
       BASE_POLARS.catamaran_40ft.min_upwind_twa_deg,
+    );
+  });
+});
+
+describe("planMinUpwind", () => {
+  it("follows the planned stock archetype, not the parked config", () => {
+    // A pinned angle sitting in /config while perso is parked must not leak:
+    // the server planned on its bundled catamaran polar.
+    const parked: PolarConfig = { ...defaultPolarConfig(), minUpwindDeg: 38, persoActive: false };
+    expect(planMinUpwind(parked, "catamaran_40ft")).toBe(
+      BASE_POLARS.catamaran_40ft.min_upwind_twa_deg,
+    );
+    expect(planMinUpwind(defaultPolarConfig(), "racer_cruiser")).toBe(
+      BASE_POLARS.racer_cruiser.min_upwind_twa_deg,
+    );
+  });
+
+  it("uses the perso polar's angle when perso is the boat of record", () => {
+    // Perso active: the custom matrix travels, so its angle is what the
+    // server swept from — the page slug is irrelevant.
+    const perso: PolarConfig = { ...defaultPolarConfig(), minUpwindDeg: 38, persoActive: true };
+    expect(planMinUpwind(perso, "catamaran_40ft")).toBe(38);
+    expect(planMinUpwind(withImported({ persoActive: true }), "cruiser_20ft")).toBe(45);
+  });
+
+  it("falls back to the default archetype on an unknown slug", () => {
+    expect(planMinUpwind(defaultPolarConfig(), "sloop_of_theseus")).toBe(
+      BASE_POLARS[DEFAULT_BASE].min_upwind_twa_deg,
     );
   });
 });

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -445,6 +445,18 @@ export function effectiveMinUpwind(cfg: PolarConfig, archetype?: string): number
   return base.min_upwind_twa_deg ?? derivedMinUpwind(base);
 }
 
+// The minimum upwind angle the *planned* boat actually sails at, mirroring
+// which polar the server used (see resolveOverrides in PlanPage): with an
+// active perso polar the custom matrix travels, so the config's effective
+// angle applies; otherwise the server planned on its bundled polar for the
+// requested slug, and a pinned angle sitting unused in /config must not leak
+// into the display.
+export function planMinUpwind(cfg: PolarConfig, archetypeSlug: string): number {
+  if (isPersoActive(cfg)) return effectiveMinUpwind(cfg);
+  const base = BASE_POLARS[archetypeSlug] ?? BASE_POLARS[DEFAULT_BASE];
+  return base.min_upwind_twa_deg ?? derivedMinUpwind(base);
+}
+
 // Compute the effective polar payload. Imported source: the uploaded file
 // wins wholesale — spi and overrides are archetype-editor concepts, an
 // imported polar is presumed to already reflect the boat's sail inventory

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -17,6 +17,7 @@ import {
   isPersoActive,
   isPolarCustomized,
   loadPolarConfig,
+  planMinUpwind,
   savePolarConfig,
 } from "../config/polarConfig";
 import { rememberReturnPath } from "../config/returnPath";
@@ -1255,7 +1256,16 @@ export function PlanSidebar({
         </div>
       ) : (
         (() => {
-          const legs = aggregateLegs(passage.segments, waypoints, passage.efficiency);
+          // Min upwind angle of the boat this plan was computed for, so a
+          // leg whose direct course sits in the no-go zone reads
+          // "Près (louvoyage)" instead of a close-hauled label the boat
+          // cannot hold (#277).
+          const legs = aggregateLegs(
+            passage.segments,
+            waypoints,
+            passage.efficiency,
+            planMinUpwind(recapPolarCfg, currentArchetypeSlug),
+          );
           return (
             <LegList
               legs={legs}

--- a/packages/web/src/plan/aggregateLegs.test.ts
+++ b/packages/web/src/plan/aggregateLegs.test.ts
@@ -83,6 +83,56 @@ describe("aggregateLegs", () => {
   });
 });
 
+describe("aggregateLegs point of sail", () => {
+  // A one-leg route whose direct course sits at `twa` deg off the wind.
+  function legAt(twa: number, minUpwindDeg?: number) {
+    const segments = [seg({ twa_deg: twa })];
+    const waypoints: [number, number][] = [[43.0, 5.0], [43.1, 5.1]];
+    return aggregateLegs(segments, waypoints, 0.75, minUpwindDeg)[0];
+  }
+
+  // #277: a leg whose direct course is inside the no-go zone is billed at the
+  // tacking speed server-side, so calling it plain "Près" told the sailor to
+  // steer an angle the boat cannot hold.
+  it("qualifies the label when the course is below the boat's upwind angle", () => {
+    expect(legAt(30, 45).point_of_sail).toBe("Près (louvoyage)");
+    expect(legAt(44.9, 45).point_of_sail).toBe("Près (louvoyage)");
+  });
+
+  it("stays a bare Près between the upwind angle and the close-hauled bucket", () => {
+    expect(legAt(45, 45).point_of_sail).toBe("Près");
+    expect(legAt(49, 45).point_of_sail).toBe("Près");
+  });
+
+  // A stiffer boat (catamaran, 50 deg) tacks over a wider band than a
+  // racer-cruiser (42 deg) on the very same route.
+  it("moves the boundary with the boat", () => {
+    expect(legAt(47, 50).point_of_sail).toBe("Près (louvoyage)");
+    expect(legAt(47, 42).point_of_sail).toBe("Près");
+  });
+
+  it("leaves the other buckets untouched", () => {
+    expect(legAt(60, 45).point_of_sail).toBe("Travers");
+    expect(legAt(120, 45).point_of_sail).toBe("Largue");
+    expect(legAt(170, 45).point_of_sail).toBe("Arrière");
+    // Signed TWA normalises to the same buckets.
+    expect(legAt(-30, 45).point_of_sail).toBe("Près (louvoyage)");
+    expect(legAt(-120, 45).point_of_sail).toBe("Largue");
+  });
+
+  it("omits the qualifier when no upwind angle is supplied", () => {
+    expect(legAt(30).point_of_sail).toBe("Près");
+  });
+
+  // Under power the allure is irrelevant: the motor label wins whatever the
+  // angle, including inside the no-go zone.
+  it("keeps Moteur over the qualifier when the leg is motored", () => {
+    const segments = [seg({ twa_deg: 20, motor_used: true })];
+    const waypoints: [number, number][] = [[43.0, 5.0], [43.1, 5.1]];
+    expect(aggregateLegs(segments, waypoints, 0.75, 45)[0].point_of_sail).toBe("Moteur");
+  });
+});
+
 function makeLeg(overrides: Partial<AggregatedLeg> = {}): AggregatedLeg {
   return {
     distance_nm: 5,

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -58,10 +58,19 @@ function circularMeanDeg(angles: number[]): number {
   return (((Math.atan2(s, c) * 180) / Math.PI) + 360) % 360;
 }
 
-function twaToPointOfSail(twa: number): string {
+// `minUpwindDeg` is the boat's minimum sailable TWA — below it the direct
+// course is in the no-go zone and the planner already bills the leg at the
+// tacking speed (`best_vmg_upwind` in passage.py), so the label says so
+// instead of a bare "Près" the sailor cannot actually steer. Above the angle
+// the boat is genuinely close-hauled. The server tacks from its optimal-VMG
+// angle, which sits at or above `minUpwindDeg`, so the qualifier is
+// conservative: it never claims tacking where the boat could hold the course.
+// Pass 0 to disable the qualifier entirely.
+function twaToPointOfSail(twa: number, minUpwindDeg: number): string {
   // twa_deg is signed (-180..180) or unsigned (0..360), normalise to 0-180
   const a = Math.abs(twa) > 180 ? 360 - Math.abs(twa) : Math.abs(twa);
-  if (a < 50) return "Louvoyage";
+  if (a < minUpwindDeg) return "Près (louvoyage)";
+  if (a < 50) return "Près";
   if (a < 90) return "Travers";
   if (a < 135) return "Largue";
   return "Arrière";
@@ -138,8 +147,11 @@ export function buildLegSummaryCells(leg: AggregatedLeg): LegSummaryCells {
 
   return {
     duration: legDurationLabel(leg),
-    // Bare one-word allure ("Louvoyage" / "Travers" / "Largue" / "Arrière") to
-    // keep the cell narrow enough for the grid.
+    // Short allure ("Près" / "Travers" / "Largue" / "Arrière", or the
+    // "Près (louvoyage)" qualifier) — SummaryCell renders at width:min-content
+    // and breaks on spaces, so the two-word form wraps inside the column
+    // rather than widening it, like "Mer Formée" already does. The one-word
+    // forms match the WindowsTable ALLURE column copy.
     allure: leg.point_of_sail,
     wind,
     flag,
@@ -188,6 +200,7 @@ export function aggregateLegs(
   segments: SegmentReport[],
   waypoints: [number, number][],
   efficiency = 0.75,
+  minUpwindDeg = 0,
 ): AggregatedLeg[] {
   if (waypoints.length < 2 || segments.length === 0) return [];
 
@@ -280,7 +293,7 @@ export function aggregateLegs(
       twd_avg_deg,
       bearing_avg_deg,
       gust_max_kn,
-      point_of_sail: motor_used ? "Moteur" : twaToPointOfSail(twa_avg_deg),
+      point_of_sail: motor_used ? "Moteur" : twaToPointOfSail(twa_avg_deg, minUpwindDeg),
       polar_after_eff_kn,
       wave_delta_kn,
       current_delta_kn,


### PR DESCRIPTION
Suite de #280, qui renommait « Près » en « Louvoyage » pour toute allure sous 50° de TWA.

L'issue #277 demande le louvoyage **quand on est sous l'angle de remontée du bateau**, pas en dessous d'un seuil fixe. Un bateau qui tient 45° au près n'est pas en train de louvoyer à 47°. Et la #280 laissait `SAIL_LABELS` du tableau des fenêtres sur « Près » pour la même allure, les deux vues se contredisaient.

## Ce que fait cette PR

Le label devient conditionnel :

- sous l'angle de remontée minimal du bateau, le cap direct est dans le no-go. Le serveur facture déjà l'étape à la vitesse de louvoyage (`best_vmg_upwind` dans `passage.py`), l'étape affiche donc **« Près (louvoyage) »** ;
- au-dessus, le bateau est réellement au près et garde **« Près »**, cohérent avec la colonne ALLURE du tableau des fenêtres.

## Détails

- `twaToPointOfSail(twa, minUpwindDeg)` : `0` désactive le qualificatif.
- `planMinUpwind(cfg, slug)` reflète la polaire réellement utilisée par le serveur (même règle que `resolveOverrides` dans `PlanPage`) : polaire perso active, son angle ; sinon celui de l'archétype demandé. Un angle épinglé dans /config mais mis de côté ne fuite donc pas dans l'affichage.
- Le qualificatif est conservateur : le serveur louvoie depuis son angle de VMG optimal, situé au-dessus de l'angle minimal, donc on ne l'annonce jamais là où le bateau peut tenir le cap.
- « Près (louvoyage) » passe à la ligne dans la cellule comme « Mer Formée » le fait déjà (`SummaryCell` est en `width:min-content`), la grille ne s'élargit pas.
- Le moteur reste prioritaire sur l'allure.

Angles de remontée embarqués, pour situer la bascule : racer-cruiser 42°, croiseur 40/50 pieds 44°, croiseur 25/30 pieds 45°, croiseur 20 pieds 46°, catamaran 50°.

## Tests

9 nouveaux : bornes du qualificatif, TWA signé, frontière qui suit le bateau, moteur prioritaire, résolution de la polaire de plan. Suite web 245 tests, typecheck, lint budget et build verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)