### PR TITLE
fix(web): poignée du tiroir de plan attrapable au doigt

### DIFF
--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -306,6 +306,15 @@ const ResizableMobileDrawer = forwardRef<DrawerHandle, {
         transition: isAnimating ? "height 280ms cubic-bezier(0.4, 0, 0.2, 1)" : undefined,
       }}
     >
+      {/* Grab handle. 28 px of full-width strip rather than the 14 px this
+          shipped with: at 14 px the target was under half a fingertip and
+          users reported missing it outright. The handle sits flush against
+          the map, so the hit area cannot be widened with a negative margin
+          (the drawer is overflow-y-auto and would clip it) — the strip itself
+          has to carry the height. It stays under the 44 px touch guideline on
+          purpose: at DRAWER_MIN_VH the drawer is a peek, and a 44 px handle
+          would eat most of it. `chromePx` in the fit-to-results effect reads
+          the height from the DOM, so nothing else needs updating. */}
       <div
         role="separator"
         aria-orientation="horizontal"
@@ -315,11 +324,11 @@ const ResizableMobileDrawer = forwardRef<DrawerHandle, {
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
         className="shrink-0 flex items-center justify-center cursor-row-resize touch-none"
-        style={{ height: 14, background: "var(--ow-bg-1)" }}
+        style={{ height: 28, background: "var(--ow-bg-1)" }}
       >
         <span
           className="block rounded-full"
-          style={{ width: 36, height: 4, background: "var(--ow-line-2)" }}
+          style={{ width: 44, height: 5, background: "var(--ow-line-2)" }}
         />
       </div>
       <div ref={contentRef} className="flex-1 min-h-0 overflow-y-auto">{children}</div>


### PR DESCRIPTION
Retour utilisateur : sur mobile, en mode plan, la poignée de redimensionnement du panneau ne s'attrape pas.

La zone tactile faisait **14 px de haut** pour une pilule de 36×5, soit moins de la moitié d'un bout de doigt.

## Ce que fait cette PR

- bande de préhension : **14 px → 28 px**, sur toute la largeur du tiroir ;
- pilule visible : **36×4 → 44×5**, pour que la cible se voie autant qu'elle se touche.

## Pourquoi pas 44 px

- À `DRAWER_MIN_VH` (12 vh) le tiroir n'est qu'un liseré : une poignée de 44 px en mangerait l'essentiel.
- Élargir la zone sans prendre de hauteur n'était pas possible : la poignée est collée à la carte et le tiroir est en `overflow-y-auto`, qui rognerait toute marge négative.

28 px double la cible tout en gardant le tiroir utilisable à sa hauteur minimale.

## Rien d'autre à ajuster

`chromePx`, dans l'effet d'ajustement à la hauteur des résultats, lit la hauteur de la poignée depuis le DOM (`outer.offsetHeight - container.clientHeight`) : aucune constante à synchroniser.

## Tests

Suite web 245 tests, typecheck, lint budget et build verts. Vérification tactile sur l'émulateur Android dev avant promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)