### PR TITLE
fix(web): plus de zéro parasite dans le seuil d'affalage du spi (#270)

### DIFF
--- a/packages/web/src/components/BoatAdvanced.tsx
+++ b/packages/web/src/components/BoatAdvanced.tsx
@@ -8,10 +8,12 @@ import {
   MIN_UPWIND_MIN,
   SPI_MAX_TWS_MAX,
   SPI_MAX_TWS_MIN,
+  commitSpiMaxTwsDraft,
   effectiveMinUpwind,
   effectivePolar,
   hasOverrides,
   isImportedActive,
+  parseSpiMaxTwsDraft,
   type PolarConfig,
   type PolarSource,
   type SpiKind,
@@ -37,6 +39,7 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
   );
   const [tuningOpen, setTuningOpen] = useState(false);
   const [selectedTwsIdx, setSelectedTwsIdx] = useState(0);
+  const [spiMaxTwsDraft, setSpiMaxTwsDraft] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importedActive = isImportedActive(config);
 
@@ -117,20 +120,23 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
     onChange({ ...config, spi });
   }
 
+  // While the field is focused the raw text is what gets rendered, so an
+  // empty field stays empty and a typed digit stays the digit that was typed
+  // (see parseSpiMaxTwsDraft for why driving the input straight off the
+  // config paints a zero the user never entered). null = not editing.
   function setSpiMaxTws(raw: string) {
-    const num = Number(raw);
-    if (!Number.isFinite(num)) return;
-    // Only clamp the upper bound while typing. Clamping the lower bound too
-    // would round e.g. a typed "1" (first digit of "18") up to the MIN
-    // (8) immediately, so the next keystroke appends to "8" instead of "1"
-    // and the value gets stuck oscillating between MIN and MAX. The floor is
-    // enforced on blur instead, once the user is done typing.
-    onChange({ ...config, spiMaxTwsKn: Math.round(Math.min(SPI_MAX_TWS_MAX, num)) });
+    setSpiMaxTwsDraft(raw);
+    const next = parseSpiMaxTwsDraft(raw);
+    if (next !== null && next !== config.spiMaxTwsKn) {
+      onChange({ ...config, spiMaxTwsKn: next });
+    }
   }
 
-  function clampSpiMaxTwsOnBlur() {
-    if (config.spiMaxTwsKn < SPI_MAX_TWS_MIN) {
-      onChange({ ...config, spiMaxTwsKn: SPI_MAX_TWS_MIN });
+  function commitSpiMaxTws() {
+    const next = commitSpiMaxTwsDraft(spiMaxTwsDraft ?? "");
+    setSpiMaxTwsDraft(null);
+    if (next !== null && next !== config.spiMaxTwsKn) {
+      onChange({ ...config, spiMaxTwsKn: next });
     }
   }
 
@@ -322,9 +328,9 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
                 step="1"
                 min={SPI_MAX_TWS_MIN}
                 max={SPI_MAX_TWS_MAX}
-                value={config.spiMaxTwsKn}
+                value={spiMaxTwsDraft ?? config.spiMaxTwsKn}
                 onChange={(e) => setSpiMaxTws(e.target.value)}
-                onBlur={clampSpiMaxTwsOnBlur}
+                onBlur={commitSpiMaxTws}
                 className="polar-motor-input w-20"
               />
               kn

--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -9,6 +9,9 @@ import {
   MOTOR_MAX_KN,
   SERVER_DEFAULT_EFFICIENCY,
   SPI_MAX_TWS_DEFAULT,
+  SPI_MAX_TWS_MAX,
+  SPI_MAX_TWS_MIN,
+  commitSpiMaxTwsDraft,
   defaultPolarConfig,
   derivedMinUpwind,
   effectiveMinUpwind,
@@ -18,6 +21,7 @@ import {
   isPersoActive,
   isPolarCustomized,
   loadPolarConfig,
+  parseSpiMaxTwsDraft,
   planEfficiency,
   planMinUpwind,
   polarFingerprint,
@@ -339,6 +343,44 @@ describe("min upwind derivation", () => {
     expect(effectiveMinUpwind(defaultPolarConfig(), "catamaran_40ft")).toBe(
       BASE_POLARS.catamaran_40ft.min_upwind_twa_deg,
     );
+  });
+});
+
+describe("spi drop-threshold draft parsing", () => {
+  // #270 regression found in QA on 2026-08-20: clearing the field wrote
+  // Number("") = 0 into the config, so a "0" appeared under the caret and the
+  // next keystrokes appended to it ("18" typed, "018" displayed).
+  it("commits nothing while the field is empty", () => {
+    expect(parseSpiMaxTwsDraft("")).toBeNull();
+    expect(parseSpiMaxTwsDraft("   ")).toBeNull();
+  });
+
+  it("lets a first digit below the floor stand while typing", () => {
+    // The "1" of "18" must survive: clamping it up to the floor here is what
+    // #270 was opened about.
+    expect(parseSpiMaxTwsDraft("1")).toBe(1);
+    expect(parseSpiMaxTwsDraft("18")).toBe(18);
+  });
+
+  it("still enforces the ceiling while typing", () => {
+    expect(parseSpiMaxTwsDraft("45")).toBe(SPI_MAX_TWS_MAX);
+  });
+
+  it("rejects what is not a usable number", () => {
+    expect(parseSpiMaxTwsDraft("abc")).toBeNull();
+    expect(parseSpiMaxTwsDraft("-5")).toBeNull();
+  });
+
+  it("applies the floor on blur", () => {
+    expect(commitSpiMaxTwsDraft("3")).toBe(SPI_MAX_TWS_MIN);
+    expect(commitSpiMaxTwsDraft("18")).toBe(18);
+    expect(commitSpiMaxTwsDraft("45")).toBe(SPI_MAX_TWS_MAX);
+  });
+
+  it("commits nothing on blur from an empty or unparsable field", () => {
+    // The caller keeps the last good config value rather than inventing one.
+    expect(commitSpiMaxTwsDraft("")).toBeNull();
+    expect(commitSpiMaxTwsDraft("abc")).toBeNull();
   });
 });
 

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -312,6 +312,39 @@ function clampSpiMaxTws(raw: unknown): number {
   return Math.min(SPI_MAX_TWS_MAX, Math.max(SPI_MAX_TWS_MIN, Math.round(raw)));
 }
 
+// ── Spi drop-threshold field parsing ────────────────────────────────────────
+// Kept here rather than in the component so it can be tested: vitest runs
+// without a DOM, so the input itself is untestable.
+//
+// The field is a controlled number input, which makes an empty value a
+// problem: `Number("")` is 0, and writing that 0 back into the config paints
+// a "0" the user never typed, right under the caret. Worse, React compares a
+// number input's value loosely, so once the DOM holds "018" it reads back as
+// 18 and React never corrects it — the field stays visually wrong while the
+// stored value is right (#270 regression, found in QA on 2026-08-20).
+//
+// `null` means "not a committable value": the caller leaves the config alone
+// and keeps rendering the raw text the user typed.
+
+// While typing. The upper bound is enforced, the floor is NOT: clamping up
+// mid-typing would turn the "1" of "18" into the floor and swallow the next
+// keystroke, which is the bug #270 set out to fix in the first place.
+export function parseSpiMaxTwsDraft(raw: string): number | null {
+  const val = raw.trim();
+  if (val === "") return null;
+  const num = Number(val);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return Math.round(Math.min(SPI_MAX_TWS_MAX, num));
+}
+
+// On blur, once the user is done typing: the floor applies. An empty or
+// unparsable draft commits nothing, so the field falls back to the last good
+// config value instead of inventing one.
+export function commitSpiMaxTwsDraft(raw: string): number | null {
+  const parsed = parseSpiMaxTwsDraft(raw);
+  return parsed === null ? null : Math.max(SPI_MAX_TWS_MIN, parsed);
+}
+
 function sanitizeOverrides(raw: unknown, base: PolarData): Record<string, number> {
   if (raw == null || typeof raw !== "object") return {};
   const out: Record<string, number> = {};


### PR DESCRIPTION
Trouvé en QA le 2026-08-20, sur la passe de validation de la promotion.

## Le défaut

Dans /config → Bateau → Avancé, avec un spi sélectionné, vider le champ « Affaler au-dessus de » au clavier y réinsérait aussitôt un `0`. La frappe suivante s'y ajoutait : taper `1` puis `8` affichait `01` puis `018`.

Deux causes empilées :

1. `Number("")` vaut `0`, et cette valeur repartait dans la config, donc dans le champ, sous le curseur.
2. Le champ est un `input type="number"` contrôlé. React compare la valeur du DOM en **égalité faible** : `"018" != 18` est faux, donc il ne corrige jamais l'affichage. La valeur stockée restait juste (18, la légende du diagramme polaire le confirmait), seul le champ mentait.

C'est une variante du bug que #270 corrigeait : le ticket avait retiré le clamp bas pendant la frappe, mais laissé la chaîne vide se transformer en 0.

## Le correctif

Le texte saisi devient la source de vérité tant que le champ est en cours d'édition (`spiMaxTwsDraft`). Un champ vide reste vide, un chiffre tapé reste le chiffre tapé, et la config ne reçoit que des valeurs committables.

- `parseSpiMaxTwsDraft` (à la frappe) : plafond appliqué, plancher **non**, pour que le « 1 » de « 18 » survive, ce que #270 corrigeait déjà et qui reste acquis.
- `commitSpiMaxTwsDraft` (au blur) : plancher appliqué. Un champ vide ou illisible ne committe rien, le champ retombe donc sur la dernière valeur valide au lieu d'en inventer une.

Les deux vivent dans `polarConfig` plutôt que dans le composant : vitest tourne sans DOM sur ce paquet, l'input lui-même n'est pas testable. C'est aussi ce qui rend le correctif vérifiable en CI plutôt qu'à l'œil.

## Tests

6 nouveaux (champ vide, chiffre sous le plancher préservé à la frappe, plafond appliqué, saisie illisible rejetée, plancher au blur, blur depuis un champ vide). Suite web 251 tests, typecheck, lint budget et build verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)