### PR TITLE
fix(web): vouvoiement de l'aide au réordonnancement des modèles

### DIFF
--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -235,7 +235,7 @@ export function ConfigPage() {
         <h1 className="text-3xl font-bold mb-2">Modèles météo</h1>
         <p className="text-sm opacity-80 mb-8 leading-relaxed">
           Les {ACTIVE_LIMIT} premiers modèles sont affichés dans la table de
-          prévision, dans cet ordre. Glisse-dépose pour réordonner (sur
+          prévision, dans cet ordre. Glissez-déposez pour réordonner (sur
           mobile, appui maintenu sur une ligne, ou directement la poignée
           ⋮⋮). Cette configuration ne touche pas les plans de passage.
         </p>


### PR DESCRIPTION
« Glisse-dépose pour réordonner », dans l'aide de /config → Modèles météo, était le dernier tutoiement de la copy utilisateur. Il passe à « Glissez-déposez », comme « Glissez un point de la courbe » dans l'éditeur de polaire.

Trouvé en relisant /config après la passe QA. Le sweep automatique de la QA portait sur les pronoms (`tu`, `ton`, `ta`, `tes`) et ne pouvait pas détecter un impératif à la deuxième personne du singulier, qui ne contient aucun de ces mots.

Sweep élargi passé sur tout `packages/web/src` et `packages/web/public` (impératifs singuliers et pluriels des verbes d'interface) : c'était la seule occurrence. Les 22 autres impératifs de la copy sont déjà au pluriel de politesse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)