### PR TITLE
feat(mcp): durcit le contrat des tools (route hors terre, quatre hints)

### DIFF
--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -639,10 +639,17 @@ def build_server(
         # would hand the tester a link to production.
         return _PLAN_WIDGET_HTML.replace("__WEB_BASE__", WEB_BASE).replace("__WEB_HOST__", WEB_HOST)
 
+    # Every tool below spells out all four hints, including the two the spec
+    # calls meaningful only when ``readOnlyHint`` is false. Redundant here by
+    # the letter of the spec, but directory validators check for four booleans
+    # rather than re-deriving the defaults, and a tool that omits them reads as
+    # unannotated to them. Eight lines is cheaper than a rejected listing.
     @server.tool(
         annotations=ToolAnnotations(
             title="Calculation method",
             readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
             openWorldHint=False,
         ),
     )
@@ -664,6 +671,8 @@ def build_server(
         annotations=ToolAnnotations(
             title="Boat archetypes",
             readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
             openWorldHint=False,
         ),
     )
@@ -679,6 +688,8 @@ def build_server(
         annotations=ToolAnnotations(
             title="Marine forecast",
             readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
             openWorldHint=True,
         ),
     )
@@ -738,6 +749,8 @@ def build_server(
         annotations=ToolAnnotations(
             title="Plan a passage",
             readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
             openWorldHint=True,
         ),
         meta={"ui": {"resourceUri": PLAN_UI_RESOURCE_URI}},

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -494,6 +494,8 @@ but the underlying complexity is unchanged.
 
 - No automatic routing optimisation (LLM + human choose).
 - No coastal acceleration zones (caller adds intermediate waypoints).
+- No land or obstacle check: the polyline is timed exactly as drawn,
+  so keeping it off the coast is the caller's job.
 - No port/starboard polar asymmetry, no spinnaker-specific curves.
 - No hull condition modelling beyond the `efficiency` knob.
 
@@ -709,6 +711,10 @@ def build_server(
             end: ISO-8601 datetime, timezone-aware.
             models: optional list of model names; defaults to AROME for the Med.
 
+        Pass a point at sea. Over land Open-Meteo still returns wind, but
+        every sea value comes back null, so the ``sea`` array is present and
+        empty of information rather than absent.
+
         Note: the first request after inactivity may incur ~5s of cold-start.
 
         """
@@ -803,6 +809,40 @@ def build_server(
         compare-windows. The widget renders one of the windows by default
         and the chat lets the user pick another.
 
+        ## Waypoints must stay in the water
+
+        This server does no land check. It samples wind and sea along the
+        polyline you pass, then reports distance, ETA and complexity for that
+        polyline, whatever it crosses. A leg drawn through a peninsula raises
+        no error: it returns a passage that is too short, too fast, and scored
+        on conditions the boat would never meet.
+
+        So the route is yours to draw. Between every consecutive pair of
+        waypoints the straight line must stay at sea. Add intermediate
+        waypoints to round anything the direct line would cut: headlands,
+        peninsulas, islands, shoals.
+
+        - Toulon to Saint-Tropez: the direct line crosses the Massif des
+          Maures. Pass south of the presqu'île de Giens, then round cap Bénat
+          and cap Camarat before turning north into the gulf.
+        - Brest to Douarnenez: the direct line crosses the presqu'île de
+          Crozon. Exit the goulet, round the cap de la Chèvre, then head east
+          into the bay.
+
+        Keep about 1 NM of clearance off headlands, more with onshore wind or
+        swell, and do not shave the inside of islands. Extra waypoints are
+        close to free: the cap is 50, and sampling cost follows
+        ``segment_length_nm`` and total distance, not the waypoint count. When
+        in doubt, add the waypoint.
+
+        A waypoint that lands ashore has a second effect. Open-Meteo returns
+        no sea state over land, so those samples carry a null wave height and
+        the complexity score silently falls back to wind only, dropping the
+        axis that would have flagged a rough passage.
+
+        Name the capes you routed around in your reply ("passage au large du
+        cap Bénat"), so the user can correct a leg you drew wrong.
+
         ## Returned payload
 
         Single mode:
@@ -861,9 +901,9 @@ def build_server(
 
         ## Args
 
-            waypoints: list of ``{"lat": ..., "lon": ...}`` dicts (>=2). Caller
-                keeps the polyline off land: add intermediate waypoints to
-                skirt capes and peninsulas.
+            waypoints: list of ``{"lat": ..., "lon": ...}`` dicts, 2 to 50.
+                Used exactly as drawn. Read "Waypoints must stay in the
+                water" above before building it.
             departure: ISO-8601 datetime, timezone-aware.
             archetype: one of ``list_boat_archetypes()`` names.
             efficiency: multiplier on polar speed. ``0.85`` racing, ``0.75``

--- a/packages/mcp-core/tests/test_tool_annotations.py
+++ b/packages/mcp-core/tests/test_tool_annotations.py
@@ -63,3 +63,36 @@ async def test_open_world_marks_the_tools_that_call_out(tools) -> None:
     assert by_name["plan_passage"] is True
     assert by_name["list_boat_archetypes"] is False
     assert by_name["read_me"] is False
+
+
+async def test_all_four_hints_are_explicit_booleans(tools) -> None:
+    """Directory validators count four booleans, they do not re-derive defaults.
+
+    ``destructiveHint`` and ``idempotentHint`` are formally meaningful only when
+    ``readOnlyHint`` is false, so omitting them on this all-read-only server
+    would be defensible by the letter of the spec, and would still get every
+    tool read as unannotated by a validator that just checks the four fields.
+    """
+    gaps = sorted(
+        f"{tool.name}.{hint}"
+        for tool in tools
+        for hint in ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
+        if not isinstance(getattr(tool.annotations, hint, None), bool)
+    )
+    assert gaps == []
+
+
+async def test_read_only_tools_are_harmless_to_repeat(tools) -> None:
+    """Guards the copy-paste failure of a new tool.
+
+    A tool that reads nothing but declares itself destructive, or a fetch that
+    claims a side effect on repetition, makes hosts prompt for confirmation on
+    something safe. Wrong in the direction that costs a click every call.
+    """
+    incoherent = sorted(
+        tool.name
+        for tool in tools
+        if tool.annotations.readOnlyHint
+        and not (tool.annotations.destructiveHint is False and tool.annotations.idempotentHint)
+    )
+    assert incoherent == []

--- a/packages/mcp-core/tests/test_tool_guidance.py
+++ b/packages/mcp-core/tests/test_tool_guidance.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""Guards on the instructions the tool descriptions carry to the client.
+
+A tool description is prompt, not documentation: it is the only thing standing
+between the model and a plausible wrong call. The land rule is the one worth
+pinning, because breaking it fails silently. Nothing on this server checks that
+a leg stays at sea, so a route drawn through a peninsula returns a normal-looking
+passage that is too short, too fast, and scored on conditions the boat would
+never meet. No exception, no warning, no way for the user to tell.
+
+These assertions match on section headings and a couple of load-bearing phrases.
+Reword them freely, but do it deliberately: a failure here means the client just
+lost a rule it cannot infer on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openwind_mcp_core import build_server
+
+
+@pytest.fixture
+async def by_name():
+    tools = await build_server(adapter=object()).list_tools()
+    return {t.name: t for t in tools}
+
+
+def test_plan_passage_makes_the_land_rule_prominent(by_name) -> None:
+    """Not buried in the Args block, where it lived until this test existed."""
+    description = by_name["plan_passage"].description
+    assert "## Waypoints must stay in the water" in description
+    assert "no land check" in description
+
+    # Ahead of the payload docs: the caller has to read it before it matters,
+    # not after it has already drawn the route.
+    heading = description.index("## Waypoints must stay in the water")
+    assert heading < description.index("## Returned payload")
+
+
+def test_plan_passage_shows_a_route_that_needs_the_rule(by_name) -> None:
+    """An abstract rule gets acknowledged and ignored; a worked example sticks.
+
+    One per basin, both first-class scope: the direct line really does cross
+    land on each.
+    """
+    description = by_name["plan_passage"].description
+    assert "Toulon to Saint-Tropez" in description
+    assert "Brest to Douarnenez" in description
+
+
+def test_marine_forecast_warns_that_land_points_lose_sea_state(by_name) -> None:
+    """Open-Meteo answers for an inland point rather than refusing it.
+
+    Wind comes back normally, every wave value comes back null. Verified
+    against the live API on a Vercors point at 1085 m.
+    """
+    description = by_name["get_marine_forecast"].description
+    assert "Pass a point at sea" in description


### PR DESCRIPTION
Deux durcissements du contrat que les tools MCP présentent au client. Le premier compte, le second est de la conformité d'annuaire.

## 1. La route doit rester dans l'eau

Le serveur ne fait aucun contrôle de terre. Il échantillonne le vent et la mer le long de la polyligne reçue, puis rend distance, ETA et complexité pour cette polyligne, quoi qu'elle traverse. Une jambe tirée à travers une presqu'île ne lève aucune erreur : elle rend une traversée trop courte, trop rapide, et notée sur des conditions que le bateau ne rencontrerait jamais. C'est la classe de bug la plus coûteuse ici, parce qu'elle ne ressemble pas à un bug côté utilisateur.

La règle existait déjà, en deux lignes dans le bloc `Args`, sous 150 lignes de docstring. Autant dire nulle part. Elle passe en section à part entière avant la doc du payload, et porte maintenant :

- le pourquoi, formulé comme une conséquence et pas comme une convention,
- la marge d'écart aux caps (environ 1 NM, plus par vent de mer ou houle),
- le fait que les waypoints intermédiaires ne coûtent rien : plafond à 50, et le coût de sampling suit `segment_length_nm` et la distance totale, pas le nombre de waypoints,
- un exemple par bassin dont la ligne directe traverse vraiment la terre : Toulon → Saint-Tropez coupe le Massif des Maures, Brest → Douarnenez coupe la presqu'île de Crozon,
- la consigne de nommer les caps contournés dans la réponse, pour que l'utilisateur puisse corriger une jambe mal tracée.

Deux effets de bord documentés au passage.

`get_marine_forecast` prévient qu'un point à terre perd l'état de mer. Open-Meteo répond pour un point intérieur au lieu de le refuser : vent normal, toutes les valeurs de vague à `null`. Vérifié en live sur un point du Vercors à 1085 m d'altitude. Conséquence concrète sur une route mal tracée : la complexité retombe silencieusement sur l'axe vent seul, donc perd l'axe qui aurait signalé une mer dure.

`read_me` liste maintenant l'absence de contrôle de terre parmi ce qui n'est pas modélisé en V1, à côté des zones d'accélération côtière. C'est le texte que le client cite à l'utilisateur quand on lui demande comment c'est calculé.

## 2. Les quatre hints d'annotation

Les 4 tools portaient `readOnlyHint` et `openWorldHint`, mais pas `destructiveHint` ni `idempotentHint`. La spec MCP dit que ces deux-là ne sont significatifs que si `readOnlyHint` est faux, donc les omettre sur un serveur 100 % lecture se défend à la lettre. Sauf que les validateurs d'annuaire comptent quatre booléens plutôt que de re-dériver les défauts, et un tool qui n'en expose que deux leur apparaît non annoté. Avec `server.json` déjà prêt pour le registre (namespace `fr.ohmywind` validé par TXT), huit lignes valent mieux qu'une soumission refusée.

Sortie réelle de `list_tools()` après le patch :

```
read_me                  readOnly=True destructive=False idempotent=True openWorld=False
list_boat_archetypes     readOnly=True destructive=False idempotent=True openWorld=False
get_marine_forecast      readOnly=True destructive=False idempotent=True openWorld=True
plan_passage             readOnly=True destructive=False idempotent=True openWorld=True
```

## Tests

Cinq tests ajoutés, tous sur des contrats qui cassent en silence.

`test_tool_annotations.py` : les quatre hints sont des booléens explicites sur chaque tool, et un tool en lecture seule ne peut pas se déclarer destructif ou non idempotent. Ce second cas est le piège du copier-coller sur un futur tool, et il coûte une confirmation utilisateur à chaque appel d'une opération sans risque.

`test_tool_guidance.py` (nouveau) : la section terre est présente, placée avant la doc du payload, et les deux exemples de route sont conservés. Les assertions épinglent l'instruction, pas sa formulation. Une description d'outil est du prompt, pas de la documentation : c'est la seule chose entre le modèle et un appel plausible mais faux, et sa disparition ne casse rien de visible.

`uv run pytest -q` sur mcp-core : 59 passed. `ruff check` + `ruff format --check` : clean.

## Portée

Aucun changement de comportement des tools : uniquement des annotations et du texte de description. `hf-space` ne lit ni les annotations ni les docstrings, pas de couplage.

## Suite possible

Le contrôle de terre pourrait être appliqué côté serveur plutôt que demandé au client. Le web app consomme déjà un DTM qui couvre la terre (`packages/web/src/api/bathymetry.test.ts` note que la presqu'île de Quiberon en ressort à +15 m), donc échantillonner la polyligne et refuser ou signaler les points à altitude positive est faisable. C'est un autre calibre de changement et une décision de design, hors périmètre ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
