### PR TITLE
fix(ci): suit les mp4 en LFS avant de pousser sur le Space

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -110,6 +110,13 @@ jobs:
           find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
           cp -R "$BUILD_DIR/." ./
           git lfs install --local || true
+          # The Hub's pre-receive hook rejects binary blobs that aren't in
+          # Xet/LFS storage, whatever their size, and the wholesale copy above
+          # takes the Space's default .gitattributes down with it. Re-declare
+          # tracking for the binaries we actually ship (the landing demo), or
+          # the push dies with "your push was rejected because it contains
+          # binary files". Written before `git add` so the filter runs.
+          printf '%s\n' '*.mp4 filter=lfs diff=lfs merge=lfs -text' > .gitattributes
           git config user.name  "$GIT_USER_NAME"
           git config user.email "$GIT_USER_EMAIL"
           git add -A


### PR DESCRIPTION
Le sync du Space dev déclenché par #288 a échoué :

```
remote: Your push was rejected because it contains binary files.
remote: Please use https://huggingface.co/docs/hub/xet to store binary files.
remote: Offending files:
remote:   - static/demo.mp4 (ref: refs/heads/main)
```

La règle du Hub ne dépend pas de la taille (le fichier fait 1,67 Mo), tout binaire doit passer par le stockage Xet/LFS. Le `.jpg` du poster passe, le `.mp4` non.

L'étape « Push to HF Space » remplace le contenu du Space en bloc (`find . -mindepth 1 ! -name .git -exec rm -rf`), ce qui emporte le `.gitattributes` livré par défaut avec un dépôt HF, et donc ses règles de suivi LFS. `git lfs install --local` était déjà là mais n'avait plus aucune règle à appliquer.

On redéclare donc le suivi pour les binaires qu'on expédie réellement, écrit avant le `git add -A` pour que le filtre s'applique à l'ajout.

À surveiller après déploiement : que le build Docker du Space matérialise bien le fichier LFS et n'en copie pas le pointeur. Le smoke post-déploiement vérifie le `Content-Length` de `/static/demo.mp4` (~1,67 Mo attendu, un pointeur ferait ~130 octets).