### PR TITLE
docs+feat: P0 vitrine — avertissement d'usage, badge CI, lien mort, bench des courants

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@
 > global current model for the SHOM Atlas C2D and MARC PREVIMER atlases.
 > Free, keyless, open source.
 
+[![CI](https://github.com/qdonnars/ohmywind/actions/workflows/ci.yml/badge.svg)](https://github.com/qdonnars/ohmywind/actions/workflows/ci.yml)
+
 [**ohmywind.fr**](https://ohmywind.fr) · [MCP endpoint](https://mcp.ohmywind.fr/mcp) · [AGPL-3.0](LICENSE) + [trademark](TRADEMARK.md)
+
+> [!WARNING]
+> **Decision-support tool, not a navigation instrument.** OhMyWind does not
+> replace the official marine forecast from your national weather service,
+> up-to-date charts, or the skipper's judgement. Forecast models are sometimes
+> wrong: you remain responsible for your passage.
 
 ![OhMyWind passage plan rendered in the web app](docs/screenshots/plan.png)
 
@@ -145,8 +153,8 @@ npm run build          # outputs packages/web/dist
 
 Wind, sea (`Hs` max), per-leg ETA, 1–5 complexity. Tides and currents ignored
 on the Med (negligible). No automatic routing optimisation: the LLM and the
-human stay in the loop. Roadmap and scope decisions live in
-[`plan/`](plan/) (local).
+human stay in the loop. Roadmap and scope decisions live in a `plan/` directory kept
+local to the working copy, not published here.
 
 ## Calculation method
 
@@ -174,6 +182,36 @@ Implementation: [`packages/data-adapters/src/openwind_data/routing/passage.py`](
 ### Compare-windows mode
 
 `plan_passage` accepts an optional `latest_departure` that turns the call into a window comparison: it walks N hourly departures over the same route and returns one entry per window. Weather is fetched once (cache prewarm), simulations are in-memory. Hard cap: 14 d × 24 h = 336 windows. The LLM (not the server) picks the best option qualitatively.
+
+### Currents: why SHOM and MARC, not just the global model
+
+Open-Meteo's SMOC current field is global and 8 km wide. On the French Atlantic
+coast that is not enough: the passes where a current decides the passage are
+narrower than one grid cell. The adapter therefore stacks two coastal sources on
+top of it, the SHOM Atlas C2D and the MARC PREVIMER atlases, and falls back to
+SMOC outside their coverage.
+
+The gap is measured, not assumed. Over 120 SHOM-covered points and 24 hourly
+snapshots each (2880 pairs, seed 42), pairwise speed disagreement in knots:
+
+| Pair | mean | median | p95 | max |
+|---|---:|---:|---:|---:|
+| SHOM vs MARC | 0.293 | 0.177 | 0.951 | 2.879 |
+| SHOM vs SMOC | 0.549 | 0.385 | 1.606 | 3.907 |
+| MARC vs SMOC | 0.490 | 0.347 | 1.460 | 4.068 |
+
+Read the first row against the second. The MARC harmonic engine tracks the SHOM
+reference about twice as closely as the global model does, and direction tells
+the same story (7.3° median between SHOM and MARC, 23.6° between SHOM and SMOC).
+A p95 spread of 1.6 kn against a 5 kn boat is the difference between carrying a
+pass and fighting it. Note what this is not: SMOC adds wind-driven and Stokes
+components that SHOM's harmonic atlas leaves out, so the second row mixes
+predictor skill with a genuine physical difference and is not a pure error
+metric. The third row is the one that decided the 5 GB payload was worth
+shipping.
+
+Full report, per-atlas breakdown and method:
+[`docs/bench/currents_3way_2026-05-10_1818.md`](docs/bench/currents_3way_2026-05-10_1818.md).
 
 ### Mediterranean defaults
 

--- a/docs/bench/currents_3way_2026-05-10_1818.md
+++ b/docs/bench/currents_3way_2026-05-10_1818.md
@@ -1,4 +1,4 @@
-# OpenWind currents bench: SHOM vs MARC vs SMOC
+# OhMyWind currents bench: SHOM vs MARC vs SMOC
 
 - Sample: 120 SHOM-covered points, 24 hourly snapshots each
 - Date window: 2026-05-15T00:00:00+00:00 + 24 h

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -83,6 +83,22 @@ PLAN_UI_MIME = "text/html;profile=mcp-app"
 # value still on the old brand, because the sweep that renamed everything else
 # matched "OpenWind" and "openwind.fr" and this one is lowercase and bare.
 SERVER_NAME = "ohmywind"
+
+# Usage warning attached to every plan_passage payload, single mode and
+# compare-windows alike. The tool hands back an ETA and a 1-5 complexity score
+# that a skipper may act on to decide whether to put to sea, so the caveat
+# travels with the numbers instead of living in the docs only.
+#
+# English on purpose: it is read by the model, not by the user, and the model
+# relays it in whatever language the conversation runs in. The French wording
+# shown in the web app lives in packages/web/src/plan/SafetyNotice.tsx and the
+# English one in the README. All three say the same thing; keep them in sync.
+PASSAGE_DISCLAIMER = (
+    "Decision-support tool, not a navigation instrument. OhMyWind does not "
+    "replace the official marine forecast from the national weather service, "
+    "up-to-date charts, or the skipper's judgement. Forecast models are "
+    "sometimes wrong: the skipper remains responsible for the passage."
+)
 # unpkg serves the official @modelcontextprotocol/ext-apps SDK bundle that
 # implements the ui/initialize -> ui/notifications/initialized handshake and
 # the ui/notifications/tool-result listener. Same CDN as the official
@@ -853,6 +869,7 @@ def build_server(
           human-readable rationale.
         - ``openwind_url``: deep-link to ohmywind.fr/plan that renders the
           same passage in the standalone web app.
+        - ``disclaimer``: usage warning to relay (see below).
 
         Compare-windows mode (``latest_departure`` set):
 
@@ -865,6 +882,17 @@ def build_server(
           angle, hs_min/max), ``warnings``, ``passage`` (full per-segment
           report), ``complexity_full`` (full score), ``openwind_url``.
         - ``meta_warnings``: top-level notes ("3 fenêtres ignorées …").
+        - ``disclaimer``: usage warning to relay (see below).
+
+        ## ALWAYS relay the disclaimer
+
+        This tool returns an ETA and a difficulty score the user may act on to
+        decide whether to put to sea. Carry the ``disclaimer`` field into your
+        reply, once, in the user's language, phrased naturally rather than
+        quoted verbatim. Put it after the numbers, not before: it qualifies
+        them, it does not replace them. Do not drop it because the plan looks
+        easy, and do not repeat it on every follow-up turn about the same
+        passage.
 
         ## How it renders
 
@@ -1039,6 +1067,7 @@ def build_server(
                 },
                 "windows": windows,
                 "meta_warnings": meta_warnings,
+                "disclaimer": PASSAGE_DISCLAIMER,
             }
 
         # --- SINGLE MODE ---
@@ -1058,6 +1087,7 @@ def build_server(
             "passage": _passage_to_dict(report),
             "complexity": asdict(score),
             "openwind_url": build_ohmywind_url(waypoints, departure, archetype),
+            "disclaimer": PASSAGE_DISCLAIMER,
         }
 
     return server

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -14,6 +14,7 @@ from openwind_data.adapters.base import (
 )
 
 from openwind_mcp_core import build_server
+from openwind_mcp_core.server import PASSAGE_DISCLAIMER
 
 
 class StubAdapter:
@@ -328,3 +329,33 @@ class TestGetMarineForecast:
         assert "wind" in out
         assert "meteofrance_arome_france" in out["wind"]
         assert isinstance(out["wind"]["meteofrance_arome_france"][0]["time"], str)
+
+
+class TestDisclaimer:
+    """The usage warning ships with the numbers, in both modes.
+
+    plan_passage hands back an ETA and a difficulty score a skipper may act on
+    to decide whether to put to sea. The warning is part of the payload rather
+    than documentation so it cannot be lost between the docs and the reply.
+    """
+
+    async def test_single_mode_carries_the_disclaimer(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _BASE_PLAN_ARGS)
+        assert out["disclaimer"] == PASSAGE_DISCLAIMER
+
+    async def test_sweep_mode_carries_the_disclaimer(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        assert out["disclaimer"] == PASSAGE_DISCLAIMER
+
+    def test_disclaimer_says_the_three_things_that_matter(self) -> None:
+        """Reword it freely, but keep what it is actually for: naming the tool
+        as decision support, pointing at the official forecast and the charts
+        it does not replace, and leaving responsibility with the skipper."""
+        text = PASSAGE_DISCLAIMER.lower()
+        assert "decision-support" in text
+        assert "not a navigation instrument" in text
+        assert "official marine forecast" in text
+        assert "charts" in text
+        assert "responsible" in text

--- a/packages/mcp-core/tests/test_tool_guidance.py
+++ b/packages/mcp-core/tests/test_tool_guidance.py
@@ -59,3 +59,20 @@ def test_marine_forecast_warns_that_land_points_lose_sea_state(by_name) -> None:
     """
     description = by_name["get_marine_forecast"].description
     assert "Pass a point at sea" in description
+
+
+def test_plan_passage_tells_the_model_to_relay_the_disclaimer(by_name) -> None:
+    """A payload field the model is not told to use is a field it drops.
+
+    The warning only reaches the user if the reply carries it, so the
+    instruction is as load-bearing as the field itself.
+    """
+    description = by_name["plan_passage"].description
+    assert "## ALWAYS relay the disclaimer" in description
+    assert "``disclaimer``" in description
+
+    # After the numbers, not instead of them: the instruction says so, and the
+    # section sits past the payload docs so the model reads it in that order.
+    assert description.index("## Returned payload") < description.index(
+        "## ALWAYS relay the disclaimer"
+    )

--- a/packages/web/src/plan/SafetyNotice.tsx
+++ b/packages/web/src/plan/SafetyNotice.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+// ── SafetyNotice ─────────────────────────────────────────────────────────────
+// Persistent usage warning on the plan view. Deliberately not dismissible and
+// not a toast: it qualifies the ETA and the complexity score the user is about
+// to act on, so it has to survive as long as those numbers are on screen.
+// Rendered at the bottom of both sidebar containers (desktop column, mobile
+// drawer), which is where the figures it qualifies are read. Sticky rather
+// than merely last, so it stays on screen without scrolling to the end of a
+// long leg list. The warn background is mixed against --ow-bg-1 (the shared
+// background of both containers) instead of using --ow-warn-soft directly:
+// that token is 12 % alpha and content would scroll through it.
+//
+// The same text lives in three places, on purpose: here, in the README, and in
+// the `disclaimer` field of every `plan_passage` payload. Keep them in sync.
+export function SafetyNotice() {
+  return (
+    <div
+      className="sticky bottom-0 z-10 px-4 py-3 text-[11px] leading-relaxed"
+      style={{
+        background: "color-mix(in srgb, var(--ow-warn) 12%, var(--ow-bg-1))",
+        borderTop: "1px solid var(--ow-warn-line)",
+        color: "var(--ow-fg-1)",
+      }}
+    >
+      <span className="inline-flex items-center gap-1.5 font-semibold">
+        <svg
+          width="11"
+          height="11"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="var(--ow-warn)"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="shrink-0"
+          aria-hidden="true"
+        >
+          <path d="M8 2 14 13H2z" />
+          <path d="M8 7v3" />
+          <circle cx="8" cy="12" r="0.5" fill="var(--ow-warn)" />
+        </svg>
+        Aide à la décision, pas un instrument de navigation.
+      </span>{" "}
+      OhMyWind ne remplace ni le bulletin météo marine officiel, ni des cartes à
+      jour, ni votre jugement de chef de bord. Les modèles se trompent parfois :
+      vous restez responsable de votre navigation.
+    </div>
+  );
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo, useRef, useCallback, forwardRef, useImper
 import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
+import { SafetyNotice } from "../plan/SafetyNotice";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError, type PlanOverrides } from "../api/passage";
 import { buildForecastCacheSafe, singleWindowMs, sweepWindowMs, etaWindowMs } from "../api/forecastCache";
 import { Header } from "../components/Header";
@@ -1058,6 +1059,7 @@ export function PlanPage() {
         {/* Desktop sidebar — user-resizable via the handle on the left edge. */}
         <ResizableDesktopSidebar defaultPx={384}>
           <PlanSidebar {...sidebarProps} />
+          <SafetyNotice />
         </ResizableDesktopSidebar>
       </div>
 
@@ -1079,6 +1081,7 @@ export function PlanPage() {
         resultsFitKey={resultsFitKey}
       >
         <PlanSidebar {...sidebarProps} />
+        <SafetyNotice />
       </ResizableMobileDrawer>
     </div>
   );


### PR DESCRIPTION
Tâches 1 à 4 du backlog de revue (P0 vitrine). La tâche 1 est hors code, déjà appliquée sur le dépôt.

## 1. Description, website et topics (fait, hors PR)

`gh repo edit` passé : la description parlait encore d'une « React app that disply wind in your current location ». Elle a été ajustée par rapport au texte proposé par la revue, qui laissait entendre que les atlas SHOM/MARC couvrent tout le périmètre alors qu'ils s'arrêtent à la façade Atlantique. Les 9 topics et la homepage sont posés.

## 2. Avertissement d'usage, trois surfaces

Le constat de la revue était incomplet mais sa conclusion tenait : un second avertissement existait déjà côté web (`InfoPanel`), sauf qu'il porte sur la couche amers OpenSeaMap, qu'il est en français, et qu'il vit derrière un bouton. Rien ne qualifiait les ETA ni l'indice de complexité.

- **README** : bloc `[!WARNING]` sous le titre.
- **Web** : bandeau non fermable en bas des deux conteneurs de la vue plan (colonne desktop, tiroir mobile), `sticky` pour rester lisible sans dérouler la liste des tronçons. Vérifié sur le build de prod en clair, en sombre et en 390 px.
- **MCP** : champ `disclaimer` dans le payload de `plan_passage`, mode simple et mode comparaison de fenêtres, plus une section `## ALWAYS relay the disclaimer` dans la description du tool. Un champ que rien n'ordonne d'utiliser est un champ que le modèle laisse tomber.

4 tests couvrent la présence du champ dans les deux modes, le fond du texte, et l'instruction de relais.

## 3. Badge CI et lien mort

Badge ajouté. Le lien `[plan/](plan/)` rendait un 404 sur GitHub, ce répertoire étant local et gitignoré : remplacé par du texte. Critère d'acceptation vérifié, les 9 liens relatifs du README résolvent.

## 4. Bench des courants remonté

Nouvelle sous-section « Currents: why SHOM and MARC, not just the global model » dans *Calculation method*, avec le tableau de désaccord des vitesses et un lien vers le rapport complet. La lecture précise que SHOM vs SMOC n'est pas une métrique d'erreur pure, SMOC ajoutant des composantes vent et Stokes que l'atlas harmonique laisse de côté. Titre interne du bench aligné sur OhMyWind.

## Tests

| Suite | Résultat |
|---|---|
| mcp-core | 63 passed |
| data-adapters | 274 passed, 3 skipped |
| hf-space | 123 passed |
| web (vitest) | 251 passed |
| web typecheck / lint budget | OK / 25 sur 26 |

Ruff clean sur les trois paquets Python.