### PR TITLE
feat: budget de simulation sur les sweeps, et le dataset des atlas reste privé

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ Full report, per-atlas breakdown and method:
 
 ## Credits
 
+Tidal currents on the French Atlantic coast: SHOM Atlas C2D and MARC PREVIMER
+(Ifremer). The prebuilt atlases live in a **private** HF dataset, and stay
+private: the raw MARC NetCDF is used under a no-redistribution commitment, so
+the Space pulls them with a read token rather than shipping them here. Building
+without that token is supported and falls back to the global current model.
+
 Wind & sea: [Open-Meteo](https://open-meteo.com/) (CC BY 4.0). Hosting:
 [Hugging Face Spaces](https://huggingface.co/spaces). Map tiles on
 [ohmywind.fr](https://ohmywind.fr): [CARTO](https://carto.com/) /

--- a/packages/data-adapters/src/openwind_data/routing/__init__.py
+++ b/packages/data-adapters/src/openwind_data/routing/__init__.py
@@ -34,6 +34,7 @@ from openwind_data.routing.passage import (
     estimate_passage,
     estimate_passage_for_arrival,
     estimate_passage_windows,
+    resolve_sweep_interval,
 )
 
 __all__ = [
@@ -60,6 +61,7 @@ __all__ = [
     "lookup_polar",
     "midpoint",
     "normalize_twa",
+    "resolve_sweep_interval",
     "score_complexity",
     "segment_route",
     "validate_point",

--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -76,6 +76,23 @@ LIGHT_WIND_THRESHOLD_KN = 3.0  # under this min boat speed, surface "vent faible
 PREWARM_MIN_SPEED_KN = 2.0  # conservative floor to upper-bound passage duration for cache prewarm
 MAX_SWEEP_WINDOWS = 336  # 14 days x 24h hard cap
 
+# A sweep costs windows x segments simulations, and until now only the two
+# factors were bounded (MAX_SWEEP_WINDOWS here, MAX_WAYPOINTS in geometry),
+# never their product. Asking for both maxima at once is what a hostile caller
+# does, and it is reachable without a key: /mcp is deliberately exempt from the
+# REST rate limiter so a legitimate MCP session is never throttled.
+#
+# Measured on a 2026-08 laptop, network stubbed, real cache and slicing:
+#   96 sims (5 wpt, 3 d)      12 ms
+#   1848 sims (12 wpt, 7 d)  146 ms
+#   11760 sims (50 wpt, 10 d) 906 ms
+# so the budget below is roughly 650 ms of CPU, several times that on the
+# Space's shared vCPU. It sits well above any route a human draws (336 windows
+# still allow a 23-segment route) which is why exceeding it widens the
+# interval instead of failing: the same "degrade and warn" contract as
+# _resolve_segment_length, not a refusal the caller cannot act on.
+MAX_SWEEP_SIMULATIONS = 8000
+
 # Sample-cap heuristic: long passages would otherwise issue 20+ Open-Meteo
 # fetches per window. Auto-stretch segment_length_nm so we sample at most
 # MAX_SAMPLED_SEGMENTS points per route, but keep a [MIN, MAX] band so we
@@ -111,6 +128,31 @@ def _resolve_segment_length(
     if effective <= requested_nm:
         return requested_nm, None
     return effective, total
+
+
+def resolve_sweep_interval(
+    span_hours: float, requested_interval_h: int, n_segments: int
+) -> tuple[int, int]:
+    """Return (effective_interval_h, n_windows) fitting MAX_SWEEP_SIMULATIONS.
+
+    Widens the requested interval by whole hours until ``n_windows *
+    n_segments`` fits the budget. Pure function of its inputs, so it can be
+    called before any work is done and asserted on directly in tests.
+
+    Public because the REST and MCP shells have to report the interval they
+    actually got. They re-derive it from the same three inputs rather than
+    diffing the returned departure times, which would read a skipped window as
+    a wider interval.
+    """
+
+    def windows_for(interval_h: int) -> int:
+        return int(span_hours / interval_h) + 1
+
+    interval = max(1, requested_interval_h)
+    budget_windows = max(1, MAX_SWEEP_SIMULATIONS // max(1, n_segments))
+    while windows_for(interval) > budget_windows and windows_for(interval) > 1:
+        interval += 1
+    return interval, windows_for(interval)
 
 
 def wave_derate(hs_m: float, twa_deg: float) -> float:
@@ -1023,6 +1065,14 @@ async def estimate_passage_windows(
     returning one ``PassageReport`` per window. All simulations after the first
     are cache hits API cost is identical to a single ``estimate_passage`` call.
 
+    ``sweep_interval_hours`` is a request, not a guarantee: it is widened by
+    whole hours when the resulting sweep would exceed ``MAX_SWEEP_SIMULATIONS``
+    (windows x segments). Read the effective interval back from the departure
+    times of the returned reports. Exceeding ``MAX_SWEEP_WINDOWS`` still raises
+    instead, on purpose: that cap says the request runs past the useful weather
+    horizon, which is a caller mistake to fix, while the simulation budget is a
+    resource limit a coarser sweep still answers honestly.
+
     Args:
         waypoints: ordered route waypoints (>=2 points).
         earliest_departure: start of sweep window (timezone-aware).
@@ -1065,6 +1115,15 @@ async def estimate_passage_windows(
     segments = segment_route(waypoints, effective_length_nm)
     seg_mid_points = [midpoint(s.start, s.end) for s in segments]
     route_nm = sum(s.distance_nm for s in segments)
+
+    # Fit the simulation budget before doing any work. MAX_SWEEP_WINDOWS above
+    # caps one factor and MAX_WAYPOINTS the other; this caps their product,
+    # which is what the sweep actually costs. Callers read the effective
+    # interval back from the departure times of the returned reports.
+    span_hours = (latest_utc - earliest_utc).total_seconds() / 3600
+    sweep_interval_hours, _ = resolve_sweep_interval(
+        span_hours, sweep_interval_hours, len(segments)
+    )
 
     own_adapter = adapter is None
     fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
@@ -1156,6 +1215,12 @@ async def estimate_passage_windows(
                 # decision as ForecastHorizonError above: skip the window
                 # rather than failing the whole sweep.
                 pass
+            # Every window after the first is a cache hit, and a coroutine that
+            # never awaits anything real never yields: without this the whole
+            # sweep runs as one uninterruptible block and the process serves
+            # nothing else meanwhile, landing page and rate-limited REST
+            # included. Yielding per window costs nothing measurable.
+            await asyncio.sleep(0)
             current += timedelta(hours=sweep_interval_hours)
     finally:
         if own_adapter and hasattr(fetch_adapter, "aclose"):

--- a/packages/data-adapters/tests/test_passage.py
+++ b/packages/data-adapters/tests/test_passage.py
@@ -22,11 +22,13 @@ from openwind_data.routing.archetypes import BoatPolar, get_polar, lookup_polar
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import (
     LIGHT_WIND_THRESHOLD_KN,
+    MAX_SWEEP_SIMULATIONS,
     MAX_SWEEP_WINDOWS,
     best_vmg_upwind,
     estimate_passage,
     estimate_passage_for_arrival,
     estimate_passage_windows,
+    resolve_sweep_interval,
     wave_derate,
 )
 
@@ -1711,3 +1713,57 @@ class TestBoatAwareLayout:
         assert earliest_fetch_start > target - timedelta(hours=4)
         assert plan.report.max_sampling_drift_h is not None
         assert plan.report.max_sampling_drift_h < 0.1
+
+
+class TestSweepSimulationBudget:
+    """A sweep costs windows x segments. Both factors were capped, their
+    product was not, and the product is what runs on the CPU. Reachable
+    without a key through /mcp, which is exempt from the REST rate limiter.
+    """
+
+    def test_leaves_a_request_within_budget_untouched(self) -> None:
+        # 24 h at 1 h on a 4-segment route: 25 x 4 = 100 sims, nowhere near.
+        interval, windows = resolve_sweep_interval(24, 1, 4)
+        assert interval == 1
+        assert windows == 25
+
+    def test_widens_the_interval_until_the_product_fits(self) -> None:
+        # 14 d at 1 h on a 49-segment route: 337 x 49 = 16513 sims.
+        interval, windows = resolve_sweep_interval(336, 1, 49)
+        assert interval > 1
+        assert windows * 49 <= MAX_SWEEP_SIMULATIONS
+
+    def test_never_narrows_what_the_caller_asked_for(self) -> None:
+        """A caller asking for a coarse sweep keeps it, budget or no budget."""
+        interval, _ = resolve_sweep_interval(336, 6, 4)
+        assert interval == 6
+
+    def test_a_single_window_is_always_allowed(self) -> None:
+        """Degrading must bottom out at one window rather than loop forever
+        on a route so long that even one simulation exceeds the budget."""
+        interval, windows = resolve_sweep_interval(336, 1, MAX_SWEEP_SIMULATIONS * 2)
+        assert windows == 1
+        assert interval >= 1
+
+    async def test_sweep_honours_the_budget_end_to_end(self) -> None:
+        """The public entry point returns fewer, wider-spaced windows rather
+        than refusing, and the departure times carry the effective interval."""
+        adapter = StubAdapter(tws_kn=10.0, twd_deg=0.0)
+        earliest = datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+        # 50 waypoints ~8 nm apart: 49 segments, no sub-segmentation.
+        route = [Point(43.0 + i * 0.10, 5.0 + i * 0.10) for i in range(50)]
+        reports = await estimate_passage_windows(
+            route,
+            earliest,
+            earliest + timedelta(days=13),
+            "cruiser_40ft",
+            sweep_interval_hours=1,
+            adapter=adapter,
+        )
+        n_segments = len(reports[0].segments)
+        assert len(reports) * n_segments <= MAX_SWEEP_SIMULATIONS
+        # Spacing actually widened, and uniformly.
+        spacing = reports[1].departure_time - reports[0].departure_time
+        assert spacing > timedelta(hours=1)
+        for a, b in pairwise(reports):
+            assert b.departure_time - a.departure_time == spacing

--- a/packages/hf-space/Dockerfile
+++ b/packages/hf-space/Dockerfile
@@ -16,7 +16,12 @@ RUN pip install /app/data-adapters /app/mcp-core "uvicorn[standard]>=0.30" \
     "huggingface_hub[hf_xet]>=0.24"
 
 # Pull the tidal atlas dataset at build time (MARC PREVIMER + SHOM Atlas C2D).
-# The dataset is private so we need an HF token with read access. On HF
+# The dataset is private so we need an HF token with read access.
+#
+# It has to STAY private. It holds raw MARC PREVIMER NetCDF, which we are
+# allowed to use under a no-redistribution commitment, and flipping the
+# dataset to public would break that commitment in one click. fetch_atlases.py
+# prints a loud warning at build time when the visibility has changed. On HF
 # Spaces, define the secret in Settings -> Variables and secrets -> Secrets:
 #   HF_TOKEN  (User Access Token with read scope on Qdonnars/openwind-tidal-atlas)
 # Runtime reads MARC subdirs via MARC_ATLAS_DIR and the SHOM Parquet+JSON via

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -43,6 +43,7 @@ from openwind_data.routing.passage import (
     estimate_passage,
     estimate_passage_for_arrival,
     estimate_passage_windows,
+    resolve_sweep_interval,
 )
 from openwind_mcp_core import build_server
 from starlette.applications import Starlette
@@ -674,8 +675,17 @@ async def _api_passage(request: Request) -> JSONResponse:
         # Sweep is partial-tolerant: estimate_passage_windows skips windows
         # that hit ForecastHorizonError. Compute the expected count to surface
         # a meta-warning if some were dropped.
-        expected_windows = (
-            int((latest_departure - departure).total_seconds() / 3600 / sweep_interval) + 1
+        #
+        # Count against the interval the engine actually used, not the one
+        # requested: it widens the spacing when windows x segments would blow
+        # the simulation budget, and counting against the request would report
+        # the windows we never intended to run as lost to a short forecast
+        # horizon.
+        span_hours = (latest_departure - departure).total_seconds() / 3600
+        effective_interval, expected_windows = (
+            resolve_sweep_interval(span_hours, sweep_interval, len(reports[0].segments))
+            if reports
+            else (sweep_interval, int(span_hours / sweep_interval) + 1)
         )
         skipped_count = max(0, expected_windows - len(reports))
 
@@ -706,6 +716,13 @@ async def _api_passage(request: Request) -> JSONResponse:
             )
 
         meta_warnings: list[str] = []
+        if effective_interval != sweep_interval:
+            meta_warnings.append(
+                f"pas d'échantillonnage élargi à {effective_interval} h "
+                f"(au lieu de {sweep_interval} h) : la route compte "
+                f"{len(reports[0].segments)} tronçons, trop pour simuler "
+                f"autant de créneaux."
+            )
         if skipped_count > 0:
             meta_warnings.append(
                 f"{skipped_count} fenêtre(s) ignorée(s) faute de couverture météo "
@@ -733,7 +750,7 @@ async def _api_passage(request: Request) -> JSONResponse:
                 "sweep": {
                     "earliest": departure.isoformat(),
                     "latest": latest_departure.isoformat(),
-                    "interval_hours": sweep_interval,
+                    "interval_hours": effective_interval,
                     "window_count": len(windows),
                 },
                 "windows": windows,

--- a/packages/hf-space/fetch_atlases.py
+++ b/packages/hf-space/fetch_atlases.py
@@ -5,7 +5,8 @@
 
 Reads ``HF_TOKEN`` (mounted as a build secret) and ``HF_DATASET_ID`` from
 the environment, snapshots the dataset under ``ATLAS_DATA_DIR`` (default
-``/app/data/atlas``), and reports what was fetched. Falls back gracefully
+``/app/data/atlas``), and reports what was fetched. The dataset is private by
+obligation, not by convenience, and this script warns when it is not. Falls back gracefully
 (empty dir, runtime uses Open-Meteo SMOC only) when the token is absent
 so contributors can build the image without an HF account.
 
@@ -42,7 +43,23 @@ def main() -> None:
         os.makedirs(target, exist_ok=True)
         return
 
-    from huggingface_hub import snapshot_download
+    from huggingface_hub import HfApi, snapshot_download
+
+    # The dataset must stay private: redistributing the raw MARC PREVIMER
+    # NetCDF is something we committed not to do, and dataset visibility is a
+    # single toggle in the HF settings. Warn loudly rather than fail: breaking
+    # the production build would punish the deployment for a settings mistake
+    # made elsewhere, and the build is not where that gets fixed.
+    try:
+        if HfApi(token=token).dataset_info(dataset_id).private is False:
+            print("=" * 72)
+            print(f"WARNING: dataset {dataset_id} is PUBLIC.")
+            print("It holds raw MARC PREVIMER NetCDF, redistributed under a")
+            print("no-redistribution commitment. Set it back to private in the")
+            print("HF dataset settings.")
+            print("=" * 72)
+    except Exception as exc:
+        print(f"NOTE: could not check dataset visibility ({exc})")
 
     print(f"Fetching {dataset_id} -> {target}")
     snapshot_download(dataset_id, repo_type="dataset", local_dir=target, token=token)

--- a/packages/hf-space/tests/test_api_sweep.py
+++ b/packages/hf-space/tests/test_api_sweep.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import pathlib
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
@@ -99,3 +100,77 @@ async def test_skipped_windows_surface_a_meta_warning(monkeypatch) -> None:
     resp = await app._api_passage(_FakeRequest(_sweep_body()))
     warnings = _payload(resp)["meta_warnings"]
     assert any("ignorée" in w for w in warnings)
+
+
+@pytest.fixture
+def widened_sweep(monkeypatch):
+    """Engine returns a sweep it deliberately ran coarser than requested.
+
+    29 segments over 13 days at 1 h would be ~9100 simulations, past the
+    budget, so the engine widens to 2 h and returns half as many windows. The
+    shell must read that back instead of counting against the request.
+    """
+    n_segments, interval_h = 29, 2
+    span_h = 13 * 24
+    reports = [
+        SimpleNamespace(
+            departure_time=DEPARTURE + timedelta(hours=i * interval_h),
+            arrival_time=DEPARTURE + timedelta(hours=i * interval_h + 8),
+            duration_h=8.0,
+            distance_nm=41.4,
+            warnings=[],
+            segments=[object()] * n_segments,
+        )
+        for i in range(int(span_h / interval_h) + 1)
+    ]
+
+    async def _stub(*args, **kwargs):
+        return reports
+
+    monkeypatch.setattr(app, "estimate_passage_windows", _stub)
+    monkeypatch.setattr(
+        app,
+        "score_complexity",
+        lambda r, **k: SimpleNamespace(
+            level=2, label="modéré", tws_max_kn=14.0, rationale="stub", warnings=[]
+        ),
+    )
+    monkeypatch.setattr(app, "build_conditions_summary", lambda r: {})
+    monkeypatch.setattr(app, "_to_json", lambda o: {})
+    return reports
+
+
+@pytest.mark.asyncio
+async def test_widened_sweep_advertises_the_interval_it_ran(widened_sweep) -> None:
+    body = _payload(
+        await app._api_passage(
+            _FakeRequest(
+                _sweep_body(
+                    latest_departure=(DEPARTURE + timedelta(days=13)).isoformat(),
+                    sweep_interval_hours=1,
+                )
+            )
+        )
+    )
+    assert body["sweep"]["interval_hours"] == 2
+    assert any("élargi" in w for w in body["meta_warnings"])
+
+
+@pytest.mark.asyncio
+async def test_widened_sweep_does_not_report_phantom_dropped_windows(widened_sweep) -> None:
+    """The windows never run are not windows lost to a short forecast horizon.
+
+    Counting the expected total against the requested 1 h interval would
+    invent 156 of them and tell the user the forecast ran out.
+    """
+    body = _payload(
+        await app._api_passage(
+            _FakeRequest(
+                _sweep_body(
+                    latest_departure=(DEPARTURE + timedelta(days=13)).isoformat(),
+                    sweep_interval_hours=1,
+                )
+            )
+        )
+    )
+    assert not any("ignorée" in w for w in body["meta_warnings"])

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -52,6 +52,7 @@ from openwind_data.routing import (
     build_conditions_summary,
     get_polar,
     list_archetypes,
+    resolve_sweep_interval,
     validate_point,
     validate_waypoints,
 )
@@ -1040,6 +1041,23 @@ def build_server(
             ]
 
             meta_warnings: list[str] = []
+            # The engine widens the interval when windows x segments would blow
+            # the simulation budget, so report what the sweep actually did
+            # rather than what was asked for.
+            effective_interval = sweep_interval_hours
+            if reports:
+                effective_interval, _ = resolve_sweep_interval(
+                    (latest_dep.astimezone(UTC) - dep.astimezone(UTC)).total_seconds() / 3600,
+                    sweep_interval_hours,
+                    len(reports[0].segments),
+                )
+                if effective_interval != sweep_interval_hours:
+                    meta_warnings.append(
+                        f"pas d'échantillonnage élargi à {effective_interval} h "
+                        f"(au lieu de {sweep_interval_hours} h) : la route compte "
+                        f"{len(reports[0].segments)} tronçons, trop pour simuler "
+                        f"autant de créneaux."
+                    )
             if target_eta is not None:
                 target_utc = datetime.fromisoformat(target_eta).astimezone(UTC)
                 tolerance = timedelta(hours=2)
@@ -1062,7 +1080,7 @@ def build_server(
                 "sweep": {
                     "earliest": dep.isoformat(),
                     "latest": latest_dep.isoformat(),
-                    "interval_hours": sweep_interval_hours,
+                    "interval_hours": effective_interval,
                     "window_count": len(windows),
                 },
                 "windows": windows,

--- a/packages/mcp-core/tests/test_server.py
+++ b/packages/mcp-core/tests/test_server.py
@@ -359,3 +359,58 @@ class TestDisclaimer:
         assert "official marine forecast" in text
         assert "charts" in text
         assert "responsible" in text
+
+
+class TestSweepBudget:
+    """The engine widens the sweep interval when windows x segments would blow
+    the simulation budget. What the payload advertises has to match what ran,
+    or the client reads a spacing the departure times contradict.
+    """
+
+    async def test_reports_the_interval_actually_used(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        # 30 waypoints -> 29 segments; 13 d at 1 h would be ~9100 simulations.
+        route = [{"lat": 43.0 + i * 0.10, "lon": 5.0 + i * 0.10} for i in range(30)]
+        dep = datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+        out = await _call(
+            server,
+            "plan_passage",
+            {
+                "waypoints": route,
+                "departure": dep.isoformat(),
+                "latest_departure": (dep + timedelta(days=13)).isoformat(),
+                "sweep_interval_hours": 1,
+                "archetype": "cruiser_40ft",
+            },
+        )
+        advertised = out["sweep"]["interval_hours"]
+        assert advertised > 1, "expected the budget to widen the 1 h request"
+
+        # The advertised spacing is the one between consecutive departures.
+        first = datetime.fromisoformat(out["windows"][0]["departure"])
+        second = datetime.fromisoformat(out["windows"][1]["departure"])
+        assert (second - first) == timedelta(hours=advertised)
+
+    async def test_says_so_in_meta_warnings(self) -> None:
+        """A silently coarser sweep is a silently different answer."""
+        server = build_server(adapter=StubAdapter())
+        route = [{"lat": 43.0 + i * 0.10, "lon": 5.0 + i * 0.10} for i in range(30)]
+        dep = datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+        out = await _call(
+            server,
+            "plan_passage",
+            {
+                "waypoints": route,
+                "departure": dep.isoformat(),
+                "latest_departure": (dep + timedelta(days=13)).isoformat(),
+                "sweep_interval_hours": 1,
+                "archetype": "cruiser_40ft",
+            },
+        )
+        assert any("élargi" in w for w in out["meta_warnings"])
+
+    async def test_leaves_an_ordinary_sweep_alone(self) -> None:
+        server = build_server(adapter=StubAdapter())
+        out = await _call(server, "plan_passage", _SWEEP_ARGS)
+        assert out["sweep"]["interval_hours"] == _SWEEP_ARGS["sweep_interval_hours"]
+        assert not any("élargi" in w for w in out["meta_warnings"])


### PR DESCRIPTION
Points 1 et 2 de l'asymétrie `/mcp` relevée sur les Spaces, volets A et C. Le volet B (plafond de concurrence) attend l'instrumentation de la tâche 8 pour être calibré sur des mesures plutôt qu'au jugé.

## Le problème, mesuré

Un sweep coûte `fenêtres x tronçons`. `MAX_SWEEP_WINDOWS = 336` borne un facteur, `MAX_WAYPOINTS = 50` borne l'autre, **rien ne bornait leur produit**, alors que c'est lui qui tourne sur le CPU. Et c'est atteignable sans clé : `/mcp` est volontairement exempté du rate limiter REST, pour de bonnes raisons écrites dans `security.py`.

Réseau bouchonné, vrai cache, vrai `_slice_bundle` :

| Cas | Simulations | Avant | Après |
|---|---:|---:|---:|
| Nominal (2 wpt, 1 j) | 24 | 12 ms | 12 ms |
| Réaliste (5 wpt, 3 j) | 96 | 11 ms | 11 ms |
| Lourd (12 wpt, 7 j) | 1 848 | 146 ms | 138 ms |
| Pire cas (50 wpt, 10 j) | 11 760 → 5 880 | 906 ms | **468 ms** |

Entre l'usage légitime et le pire cas, il y avait un facteur 100 en CPU.

## A. Le budget

`MAX_SWEEP_SIMULATIONS = 8000`, appliqué avant tout travail. Il **élargit le pas d'échantillonnage** au lieu de refuser, exactement comme `_resolve_segment_length` étire déjà la longueur de tronçon sur les routes longues : c'est le contrat maison, et un rejet sec aurait cassé un usage légitime de l'app (14 jours au pas horaire y est proposé).

Le dépassement de `MAX_SWEEP_WINDOWS` continue de lever, et c'est délibéré : ce plafond dit que la demande sort de l'horizon météo utile, donc une erreur d'appelant à corriger, là où le budget est une limite de ressource à laquelle un sweep plus grossier répond honnêtement.

Les deux coquilles annoncent le pas réellement utilisé, via `resolve_sweep_interval` rendu public, et le disent en `meta_warning`. **Piège évité :** côté REST, `expected_windows` servait à détecter les fenêtres perdues faute de couverture météo. Compté contre le pas demandé, il aurait inventé 156 fenêtres perdues sur un sweep élargi. Deux tests verrouillent ça, dont un vérifié par mutation.

## C. Rendre la main à l'event loop

Toutes les fenêtres sauf la première sont des cache hits, et une coroutine qui n'attend rien de réel ne cède jamais la main. Le sweep monopolisait donc le processus de bout en bout, landing page et REST pourtant plafonné compris. Un `await asyncio.sleep(0)` par fenêtre.

## Dataset des atlas

`Qdonnars/openwind-tidal-atlas` contient du NetCDF MARC PREVIMER brut sous engagement de non-redistribution, et sa visibilité est un bouton. Note dans le Dockerfile, dans les Credits du README, et un contrôle au build qui **avertit sans bloquer** (faire échouer le build punirait le déploiement pour un réglage changé ailleurs).

Reste à faire à la main : le même avertissement en tête de la carte du dataset sur huggingface.co.

## Tests

470 tests Python verts (data-adapters 279 + 3 skip, mcp-core 66, hf-space 125), dont 10 nouveaux. Ruff clean sur les trois paquets. Smoke live contre la vraie Open-Meteo sur le chemin nominal : pas annoncé conforme, aucun `meta_warning` parasite, disclaimer présent.

La dégradation elle-même n'est couverte que par les tests, pas par le smoke live : la déclencher demande une route à 25+ waypoints sur 14 jours, ce qui martèle une API keyless gratuite. Une tentative a d'ailleurs renvoyé un 503 d'Open-Meteo.

## Trouvé en chemin

Le premier smoke est mort en `ConnectTimeout` sur 28 waypoints : chaque point ouvre son propre `AsyncClient`, donc ~50 handshakes TLS simultanés. C'est **la tâche 6 reproduite en conditions réelles**, et ce n'est plus théorique. Passer un client partagé a suffi à débloquer le smoke.