### PR TITLE
fix(web): le service worker prend la main au lieu d'attendre en 'waiting'

### DIFF
--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -1,8 +1,14 @@
 # Le service worker doit etre revalide a chaque lancement, sinon le
 # navigateur peut resservir l'ancien pendant des heures et les PWA/TWA
 # installees ne voient pas les deploiements (widget iOS, apps Android).
+#
+# no-store et pas no-cache : avec no-cache, la reponse reste cachable par
+# l'edge (cf-cache-status: REVALIDATED) et le Browser Cache TTL de la zone
+# Cloudflare, a 4 h, reecrit l'en-tete en "max-age=14400" avant de le servir
+# au navigateur. Verifie en prod le 2026-08-26. no-store sort la reponse du
+# cache edge, donc plus rien ne la reecrit.
 /sw.js
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 https://dev.ohmywind.fr/*
   X-Robots-Tag: noindex, nofollow

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -24,6 +24,7 @@ createRoot(document.getElementById("root")!).render(
 );
 
 // Register the service worker so the app shell is installable and offline-
-// resilient. Silent by design: `registerType: 'autoUpdate'` swaps in the new
-// SW on the next load, and we intentionally render no update-toast today.
+// resilient. Silent by design: `registerType: 'autoUpdate'` plus `skipWaiting`
+// swap in the new SW as soon as it is found, and we intentionally render no
+// update-toast today.
 registerServiceWorker();

--- a/packages/web/src/sw.ts
+++ b/packages/web/src/sw.ts
@@ -38,8 +38,10 @@ export function registerServiceWorker(): void {
  * Ask the browser whether a newer worker exists.
  *
  * Safe to call on every navigation: throttled, and failures are swallowed.
- * An update found here is applied on the next load, per the `autoUpdate`
- * registration, so nothing is swapped under the running page.
+ * A worker found here activates straight away (`skipWaiting` in the Workbox
+ * config) and the registration then reloads the page. Pages read their state
+ * from the URL at mount, so the reload lands the reader back where they were,
+ * on the new build.
  */
 export function checkForAppUpdate(): void {
   if (!registration) return;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
       // keeps a single source of truth for install metadata.
       manifest: false,
       workbox: {
+        // Take over without waiting for every tab to close. `autoUpdate` alone
+        // is not enough here: vite-plugin-pwa only forces these two when
+        // `injectRegister` is 'auto' or left out, and we register the worker
+        // ourselves. Without them a freshly deployed worker installs, then
+        // sits in 'waiting' for as long as one tab controlled by the old one
+        // survives, which on a phone is forever: the app stayed pinned to the
+        // previously precached shell, refresh after refresh.
+        skipWaiting: true,
+        clientsClaim: true,
         // Precache the built app shell. These globs cover the hashed JS/CSS/HTML
         // plus icons and fonts emitted into dist/.
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],


### PR DESCRIPTION
## Symptôme

Un téléphone qui rafraîchit ohmywind.fr reste sur le build précaché d'un déploiement précédent, indéfiniment. Refresh après refresh, même page.

## Cause 1 : `skipWaiting` jamais activé

vite-plugin-pwa ne force `skipWaiting`/`clientsClaim` que si `injectRegister` vaut `'auto'` ou n'est pas renseigné :

```js
// node_modules/vite-plugin-pwa/dist/index.js:874
if ((injectRegister === "auto" || injectRegister == null) && registerType === "autoUpdate") {
  workbox.skipWaiting = true;
  workbox.clientsClaim = true;
}
```

Comme le worker est enregistré à la main depuis `src/sw.ts`, la condition est fausse. Le `sw.js` servi en prod ne contenait donc aucun `self.skipWaiting()`, seulement l'écouteur de message qui n'est jamais sollicité en mode `autoUpdate` :

```js
self.addEventListener("message", e => { e.data && "SKIP_WAITING" === e.data.type && self.skipWaiting() })
```

Le worker d'un nouveau déploiement s'installait puis restait en `waiting` tant qu'un onglet contrôlé par l'ancien vivait encore. Sur mobile, cet onglet ne se ferme jamais.

Les deux options sont maintenant posées explicitement. Le correctif est auto-réparateur : c'est le **nouveau** worker qui appelle `skipWaiting()`, donc les clients déjà coincés se débloquent seuls à leur prochain chargement, sans manipulation.

## Cause 2 : le `no-cache` sur /sw.js réécrit par Cloudflare

Le `_headers` demandait `Cache-Control: no-cache` sur `/sw.js`, mais la prod répondait :

```
cache-control: max-age=14400
cf-cache-status: REVALIDATED
```

La règle est bien lue (le `X-Robots-Tag` du même fichier s'applique), mais la réponse restant cachable par l'edge, le Browser Cache TTL de la zone Cloudflare (4 h) réécrit l'en-tête avant de le servir. `no-store` sort la réponse du cache edge, donc plus rien ne la réécrit.

## Vérifications

- `npm run test` : 251 tests, 21 fichiers, vert
- `npm run typecheck` : vert
- `npm run lint:budget` : 25 erreurs / budget 26, inchangé
- `npm run build` puis inspection de `dist/sw.js` : `self.skipWaiting()` et `clientsClaim()` présents
- Bundle client : `autoUpdate` résolu à `true`, la branche qui recharge la page sur `activated` est bien celle prise

## À vérifier après déploiement sur dev

`curl -I https://dev.ohmywind.fr/sw.js` doit renvoyer `cache-control: no-store` (et non `max-age=14400`).