### PR TITLE
fix(web): remplace le fond de carte CARTO par OpenFreeMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "open-wind-monorepo",
+      "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/web"
       ]
@@ -1799,6 +1800,103 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-leaflet": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-leaflet/-/maplibre-gl-leaflet-0.1.4.tgz",
+      "integrity": "sha512-k57wcndZIvq3m08g2je4pjUPGr43ffNW3j+gXbymt8Vi2l1lUERUi1UmdTZcTPN8LuDDYOMWRNBaSLwpAu02ew==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@types/leaflet": "^1.9.0",
+        "leaflet": "^1.9.3",
+        "maplibre-gl": "^2.4.0 || ^3.3.1 || ^4.3.2 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.0.tgz",
+      "integrity": "sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "dev": true,
@@ -2465,7 +2563,6 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -2490,7 +2587,6 @@
     },
     "node_modules/@types/leaflet": {
       "version": "1.9.21",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -3647,6 +3743,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -4408,6 +4510,12 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -5538,6 +5646,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "dev": true,
@@ -5587,6 +5701,12 @@
       "bin": {
         "katex": "cli.js"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5745,6 +5865,38 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.6.0.tgz",
+      "integrity": "sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.3.0",
+        "@maplibre/mlt": "^1.2.0",
+        "@maplibre/vt-pbf": "^4.3.2",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.2.3",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^5.1.2",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -6661,6 +6813,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -6673,6 +6834,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6935,6 +7102,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -6988,6 +7167,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -7019,6 +7204,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -7026,6 +7217,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -7344,6 +7541,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rolldown": {
@@ -8043,6 +8249,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
@@ -9190,9 +9402,12 @@
     "packages/web": {
       "name": "openwind-web",
       "version": "0.0.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@maplibre/maplibre-gl-leaflet": "^0.1.4",
         "katex": "^0.16.45",
         "leaflet": "^1.9.4",
+        "maplibre-gl": "^6.6.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -9220,6 +9435,9 @@
         "vite": "^8.0.1",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,8 +14,10 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@maplibre/maplibre-gl-leaflet": "^0.1.4",
     "katex": "^0.16.45",
     "leaflet": "^1.9.4",
+    "maplibre-gl": "^6.6.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/packages/web/scripts/lint-budget.mjs
+++ b/packages/web/scripts/lint-budget.mjs
@@ -17,7 +17,7 @@
  */
 import { ESLint } from "eslint";
 
-const BUDGET = 26;
+const BUDGET = 25;
 
 const eslint = new ESLint();
 const results = await eslint.lintFiles(["."]);

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -85,12 +85,21 @@ export function InfoPanel() {
           </a>{" "}
           (données sous licence ODbL), tuiles{" "}
           <a
-            href="https://carto.com/attributions"
+            href="https://openfreemap.org"
             target="_blank"
             rel="noreferrer"
             className="underline hover:opacity-80"
           >
-            &copy; CARTO
+            OpenFreeMap
+          </a>{" "}
+          sur le schéma{" "}
+          <a
+            href="https://openmaptiles.org"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:opacity-80"
+          >
+            &copy; OpenMapTiles
           </a>
           . Amers (bouées, balises, phares, feux) :{" "}
           <a

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "../design/theme";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { syncUserPositionLayer } from "../utils/userPositionLayer";
 import { syncSeamarkLayer } from "../utils/seamarkLayer";
+import { addBasemap, BASEMAP_MAX_ZOOM, type Basemap } from "../utils/basemapLayer";
 import { centerForBottomInset } from "../utils/visibleCenter";
 import type { MapView } from "../utils/mapViewParams";
 
@@ -272,19 +273,14 @@ export function SpotMap({
   const cancelPressRef = useRef<() => void>(() => {});
   // Maps each marker's SVG element → its spot (for native long-press detection)
   const elementToSpotRef = useRef<Map<Element, Spot>>(new Map());
-  const tileLayerRef = useRef<L.TileLayer | null>(null);
+  const basemapRef = useRef<Basemap | null>(null);
   const seamarkLayerRef = useRef<L.TileLayer | null>(null);
 
   const { resolvedTheme } = useTheme();
 
-  // Switch Carto tiles when theme changes
+  // Switch the basemap style when the theme changes
   useEffect(() => {
-    if (!mapRef.current) return;
-    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
-    const url = `https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`;
-    if (tileLayerRef.current) {
-      tileLayerRef.current.setUrl(url);
-    }
+    basemapRef.current?.setTheme(resolvedTheme);
   }, [resolvedTheme]);
 
   // A previewed point is not in customSpots, so the saved-spot markers never
@@ -403,9 +399,12 @@ export function SpotMap({
         : defaultCenter
           ? [defaultCenter.lat, defaultCenter.lon]
           : [43.3, 5.35];
+    // maxZoom is declared here rather than inherited from the basemap: the
+    // GL layer is not a grid layer, so it hands the map no zoom bound.
     const map = L.map(containerRef.current, {
       zoomControl: false,
       attributionControl: false,
+      maxZoom: BASEMAP_MAX_ZOOM,
     }).setView(initialCenter, initialZoom);
     // A point-centred initial view is an auto-centre like any other: seed
     // the intent so the panel settling (skeleton → loaded table) re-aims it.
@@ -419,11 +418,7 @@ export function SpotMap({
       };
     }
 
-    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
-    const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
-      maxZoom: 19,
-    }).addTo(map);
-    tileLayerRef.current = tile;
+    basemapRef.current = addBasemap(map, resolvedTheme);
 
     // Map credits live in the info panel rather than in the corner. The OSM
     // Foundation allows this as long as they stay findable through an info

--- a/packages/web/src/content/confidentialite.md
+++ b/packages/web/src/content/confidentialite.md
@@ -50,7 +50,7 @@ indique les données applicatives transmises en plus.
 | Backend OhMyWind, hébergé par [Hugging Face](https://huggingface.co/privacy) | Coordonnées et points de passage | Calcul du plan de passage |
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Coordonnées géographiques | Géocodage inverse (nom du lieu affiché) |
 | [Photon (Komoot)](https://photon.komoot.io) | Texte de vos recherches de lieu | Recherche de lieux |
-| [CARTO](https://carto.com/privacy) | Zone de carte affichée | Fonds de carte (tuiles) |
+| [OpenFreeMap](https://openfreemap.org/privacy/) | Zone de carte affichée | Fonds de carte (tuiles) |
 | [Google Fonts](https://policies.google.com/privacy) | Adresse IP | Chargement des polices de caractères |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Rien, sauf si vous cliquez volontairement sur le lien de soutien | Dons |
 

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -12,6 +12,7 @@ import { fmtDepthM } from "./format";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { syncUserPositionLayer } from "../utils/userPositionLayer";
 import { syncSeamarkLayer } from "../utils/seamarkLayer";
+import { addBasemap, BASEMAP_MAX_ZOOM, type Basemap } from "../utils/basemapLayer";
 import type { MapView } from "../utils/mapViewParams";
 
 /** Hide a segment label when the leg is shorter than this on screen (px).
@@ -83,7 +84,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
-  const tileLayerRef = useRef<L.TileLayer | null>(null);
+  const basemapRef = useRef<Basemap | null>(null);
   const seamarkLayerRef = useRef<L.TileLayer | null>(null);
   const polylinesRef = useRef<L.Polyline[]>([]);
   const highlightLineRef = useRef<L.Polyline | null>(null);
@@ -162,23 +163,22 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
   // Switch tiles on theme change
   useEffect(() => {
-    if (!tileLayerRef.current) return;
-    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
-    tileLayerRef.current.setUrl(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`);
+    basemapRef.current?.setTheme(resolvedTheme);
   }, [resolvedTheme]);
 
   // Init map once
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
-    const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
+    // maxZoom is declared here rather than inherited from the basemap: the
+    // GL layer is not a grid layer, so it hands the map no zoom bound.
+    const map = L.map(containerRef.current, {
+      zoomControl: false,
+      attributionControl: false,
+      maxZoom: BASEMAP_MAX_ZOOM,
+    });
 
-
-    const variant = resolvedTheme === "light" ? "light_all" : "dark_all";
-    const tile = L.tileLayer(`https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`, {
-      maxZoom: 19,
-    }).addTo(map);
-    tileLayerRef.current = tile;
+    basemapRef.current = addBasemap(map, resolvedTheme);
 
     // Map credits live in the info panel rather than in the corner. The OSM
     // Foundation allows this as long as they stay findable through an info

--- a/packages/web/src/utils/basemapLayer.ts
+++ b/packages/web/src/utils/basemapLayer.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The basemap, i.e. the coastline both maps are drawn on.
+ *
+ * Served by OpenFreeMap: vector tiles of the OpenStreetMap planet, no API
+ * key, no account, no quota. We came here from CARTO, which used to serve
+ * the same Positron look as plain raster and then started stamping
+ * "API KEY REQUIRED" across every tile. Trading one keyless third party for
+ * another would only reschedule that outage, so the criterion for the
+ * replacement was that nothing about it can be revoked: OpenFreeMap's tiles
+ * are public, its styles are open, and the whole stack is self-hostable the
+ * day we need it to be.
+ *
+ * Vector rather than raster is the cost of that move. It buys crisp labels
+ * at any pixel ratio and a real dark style, and it charges MapLibre GL in
+ * the bundle plus a WebGL2 context per map. MapLibre renders inside Leaflet
+ * through ``maplibre-gl-leaflet`` rather than replacing it: the layer lands
+ * in ``tilePane`` (z-index 200), so the seamark overlay, the route and every
+ * marker keep their panes and their code untouched.
+ */
+import L from "leaflet";
+import { setWorkerUrl, type Map as MaplibreMap } from "maplibre-gl";
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
+import "maplibre-gl/dist/maplibre-gl.css";
+import "@maplibre/maplibre-gl-leaflet";
+
+// MapLibre 6 parses tiles in a worker it loads from a sibling file, resolved
+// at runtime off ``import.meta.url``. No bundler can see through that, so
+// nothing emitted the worker and its request fell through to the SPA
+// fallback: the worker was handed index.html, died without a word, and the
+// map painted its background colour and not one tile. ``?worker&url`` has
+// Vite bundle the worker (it pulls in a shared chunk of its own, so copying
+// the single file is not enough) and hand back the URL to point MapLibre at.
+setWorkerUrl(maplibreWorkerUrl);
+
+export type BasemapTheme = "light" | "dark";
+
+/** Positron is the style CARTO's ``light_all`` was itself derived from, so
+    the light map is the one users already know. ``dark`` is OpenFreeMap's
+    own, and reads darker than ``dark_all`` did. */
+const STYLE_URLS: Record<BasemapTheme, string> = {
+  light: "https://tiles.openfreemap.org/styles/positron",
+  dark: "https://tiles.openfreemap.org/styles/dark",
+};
+
+/**
+ * The sea, in dark mode.
+ *
+ * OpenFreeMap's dark style paints water rgb(27,27,29) over rgb(12,12,12)
+ * land: fifteen values apart, on a map whose entire job is to show a sailor
+ * where the water stops. Vector styling is what makes this fixable at all,
+ * so we spend it here. The tone is lifted from the app's own dark palette
+ * (between ``--ow-bg-0`` and ``--ow-bg-2``), which reads as sea because it
+ * is blue rather than because it is bright.
+ */
+const DARK_SEA = "#13212f";
+
+/** Keyless raster, used only when WebGL2 is missing (see ``addBasemap``).
+    Volume there is a rounding error, which is what keeps this within the
+    OSMF tile usage policy. */
+const FALLBACK_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+
+/** Deepest zoom either map allows. Used to be inherited from the raster tile
+    layer's ``maxZoom``; a GL layer is not a grid layer and contributes no
+    zoom bound, so both maps now have to declare it themselves. */
+export const BASEMAP_MAX_ZOOM = 19;
+
+export interface Basemap {
+  /** Swap light/dark in place. Replaces the old ``setUrl`` on the raster
+      layer. */
+  setTheme(theme: BasemapTheme): void;
+}
+
+/** MapLibre needs WebGL2, so a context that isn't WebGL2 is no context at
+    all. Asking is cheap and the answer decides whether the user gets a map
+    or an empty rectangle. */
+function hasWebGL2(): boolean {
+  try {
+    return !!document.createElement("canvas").getContext("webgl2");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attach the basemap to `map` and hand back the handle used to follow the
+ * theme. The layer is removed with the map itself: ``map.remove()`` triggers
+ * ``onRemove``, which disposes the GL map and frees its WebGL context.
+ */
+export function addBasemap(map: L.Map, theme: BasemapTheme): Basemap {
+  let current = theme;
+
+  if (!hasWebGL2()) {
+    // No usable GL context: a blank map would leave the markers and the
+    // route floating over nothing. Raster OSM is the ugly duckling but it
+    // draws a coastline on anything with a canvas, and both themes get the
+    // same one, hence the no-op setTheme.
+    L.tileLayer(FALLBACK_URL, { maxZoom: BASEMAP_MAX_ZOOM }).addTo(map);
+    return { setTheme: () => {} };
+  }
+
+  let glMap: MaplibreMap | null = null;
+
+  // Deferred until the map has a view. Leaflet defers ``onAdd`` the same way,
+  // and the GL layer reads the centre and zoom the moment it is added, so on
+  // /plan (which builds its map first and aims it after) the layer was still
+  // unbuilt when we asked it for its MapLibre map, and the page died on a
+  // blank screen. ``whenReady`` runs inline when the view is already set, so
+  // the explore map is unaffected.
+  map.whenReady(() => {
+    glMap = L.maplibreGL({ style: STYLE_URLS[current] }).addTo(map).getMaplibreMap();
+    // Re-applied on every style load rather than once: switching theme swaps
+    // the whole style document, which drops any paint property set on the
+    // one before it.
+    glMap.on("style.load", () => {
+      if (current !== "dark" || !glMap) return;
+      if (glMap.getLayer("water")) glMap.setPaintProperty("water", "fill-color", DARK_SEA);
+      if (glMap.getLayer("waterway")) glMap.setPaintProperty("waterway", "line-color", DARK_SEA);
+    });
+  });
+
+  return {
+    setTheme: (next) => {
+      // Also read by the deferred build above, so a theme switched before the
+      // map had a view still lands on the right style.
+      current = next;
+      glMap?.setStyle(STYLE_URLS[next]);
+    },
+  };
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -5,6 +5,21 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
   base: '/',
+  build: {
+    rollupOptions: {
+      output: {
+        // MapLibre GL (the basemap renderer) is bigger than the rest of the
+        // app put together, and it changes only when we bump the dependency.
+        // Left in the entry chunk it blew past workbox's 2 MiB per-file
+        // precache limit and, worse, made every app deploy re-download it.
+        // Its own chunk keeps the hash stable across our releases, so a
+        // returning user pays for it once.
+        advancedChunks: {
+          groups: [{ name: 'maplibre', test: /node_modules[\\/]maplibre-gl[\\/]/ }],
+        },
+      },
+    },
+  },
   plugins: [
     react(),
     tailwindcss(),
@@ -28,8 +43,9 @@ export default defineConfig({
         skipWaiting: true,
         clientsClaim: true,
         // Precache the built app shell. These globs cover the hashed JS/CSS/HTML
-        // plus icons and fonts emitted into dist/.
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        // plus icons and fonts emitted into dist/. ``mjs`` is there for
+        // MapLibre's tile worker, which ships as its own module file.
+        globPatterns: ['**/*.{js,mjs,css,html,ico,png,svg,woff2}'],
         // Drop stale precaches when a new SW activates.
         cleanupOutdatedCaches: true,
         // SPA fallback so deep links (/plan, /config, ...) resolve offline.


### PR DESCRIPTION
## Le problème

CARTO a fermé l'usage anonyme de ses fonds de carte. Les tuiles répondent toujours 200, mais arrivent barrées d'un filigrane « API KEY REQUIRED », sur les deux cartes et dans les deux thèmes.

## Le remplaçant

OpenFreeMap, styles `positron` et `dark`, tuiles vectorielles OpenStreetMap. Ni clé, ni compte, ni quota, et auto-hébergeable le jour où il le faudra. Prendre une autre offre gratuite sur clé (Stadia, MapTiler) aurait juste reprogrammé la même panne à deux ans.

`positron` est le style dont le `light_all` de CARTO était lui-même dérivé : la carte claire reste celle que les utilisateurs connaissent.

## Ce que ça change dans le code

Le rendu passe en vectoriel, via `maplibre-gl-leaflet`. La couche GL se pose dans le `tilePane` de Leaflet (z-index 200) : les amers, la route, les marqueurs et les tooltips gardent leurs panes et leur code. Les quatre URLs CARTO et les deux `setUrl` de thème sont remplacés par `src/utils/basemapLayer.ts`, sur le modèle de `seamarkLayer.ts`.

Trois pièges rencontrés, tous documentés dans le fichier :

- **Le worker.** MapLibre 6 charge son worker de tuiles depuis un fichier voisin résolu à l'exécution sur `import.meta.url`. Aucun bundler ne voit à travers : le worker recevait `index.html` par le fallback SPA et mourait sans un mot, carte vide, zéro erreur en console. L'import `?worker&url` le fait empaqueter par Vite.
- **`/plan`.** La carte y est créée avant d'être visée, et Leaflet diffère `onAdd` jusqu'à ce qu'une vue existe. La couche GL était donc encore non construite quand on lui demandait sa map MapLibre. Construction déplacée dans `map.whenReady`.
- **`maxZoom`.** Une couche GL n'est pas une grid layer et n'impose aucune borne de zoom : elle passe sur les options des deux cartes.

## Lisibilité en thème sombre

Le style `dark` d'OpenFreeMap peint la mer `rgb(27,27,29)` sur une terre `rgb(12,12,12)`. Quinze valeurs d'écart, sur une carte dont le seul travail est de montrer où l'eau s'arrête. La mer reprend donc un ton de la palette sombre de l'app (`#13212f`), en une constante. C'est le seul écart de goût de la PR, facile à annuler ou à retoucher.

## Poids

| Fichier | gz |
| --- | --- |
| `index` (app, inchangé) | 353 ko |
| `maplibre` | 237 ko |
| `maplibre-gl-worker` | 128 ko |
| `maplibre.css` | 10 ko |

MapLibre part dans son propre chunk : ces 237 ko ne changent qu'au bump de dépendance, donc un déploiement de l'app ne les fait pas retélécharger. Le worker est précaché avec le reste (`mjs` ajouté aux globs workbox).

## Vérifié

Sur le build de prod (`vite preview`), pas sur le serveur de dev :

- Carte exploration et `/plan`, thèmes clair et sombre, bascule de thème à chaud.
- Calage : les amers OpenSeaMap (raster, projeté par Leaflet) tombent pile sur les jetées de Marseille et sur les marques du Frioul.
- Pose de trois waypoints au clic, route et labels de distance corrects.
- Viewport mobile 390x844.
- Aucune erreur console. Reste un avertissement amont sur `wood-pattern`, une image absente du sprite d'OpenFreeMap ; cosmétique, pas de notre fait.
- `npm run typecheck`, `npm test` (251), `npm run lint:budget` (budget descendu 26 → 25).

À tester à la main après déploiement sur `dev.ohmywind.fr` : la fluidité du zoom sur un vrai GPU mobile, que l'environnement headless d'ici ne mesure pas.

## Sur les crédits

Le crédit `© CARTO` de l'InfoPanel et la ligne CARTO de la page de confidentialité pointaient vers un fournisseur qu'on n'utilise plus. Remplacés par OpenFreeMap et OpenMapTiles, comme l'exige la TileJSON amont. Au passage, la politique d'OpenFreeMap est meilleure que celle qu'elle remplace : pas de log d'IP par défaut, société hongroise, donc UE.
