### PR TITLE
fix(web): retire les limites maritimes tracées en pleine mer sur le fond sombre

### DIFF
--- a/packages/web/src/utils/basemapLayer.ts
+++ b/packages/web/src/utils/basemapLayer.ts
@@ -21,7 +21,7 @@
  * marker keep their panes and their code untouched.
  */
 import L from "leaflet";
-import { setWorkerUrl, type Map as MaplibreMap } from "maplibre-gl";
+import { setWorkerUrl, type FilterSpecification, type Map as MaplibreMap } from "maplibre-gl";
 import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "@maplibre/maplibre-gl-leaflet";
@@ -89,6 +89,35 @@ function hasWebGL2(): boolean {
  * theme. The layer is removed with the map itself: ``map.remove()`` triggers
  * ``onRemove``, which disposes the GL map and frees its WebGL context.
  */
+/**
+ * Drop the administrative boundaries drawn out over the sea.
+ *
+ * OpenStreetMap continues a country's or a region's boundary across the
+ * water, tagged ``maritime=1``: territorial waters, and the offshore
+ * extension of the French régions. Positron filters those out of all three
+ * of its boundary layers; the dark style filters none of them, so switching
+ * to dark drew a line running parallel to the coast a dozen miles out. On a
+ * chart, a line on the water reads as something a boat should care about,
+ * and this one is a jurisdiction, not a hazard.
+ *
+ * Applied to every layer reading the ``boundary`` source rather than to the
+ * three ids the dark style ships today, so a restyle upstream cannot quietly
+ * bring the line back. Boundaries on land are left alone: they cost nothing
+ * and they place a coastline.
+ */
+function hideMaritimeBoundaries(glMap: MaplibreMap): void {
+  const style = glMap.getStyle();
+  for (const layer of style?.layers ?? []) {
+    if (!("source-layer" in layer) || layer["source-layer"] !== "boundary") continue;
+    const notMaritime = ["!=", ["get", "maritime"], 1];
+    const existing = "filter" in layer ? layer.filter : undefined;
+    glMap.setFilter(
+      layer.id,
+      (existing ? ["all", notMaritime, existing] : notMaritime) as FilterSpecification,
+    );
+  }
+}
+
 export function addBasemap(map: L.Map, theme: BasemapTheme): Basemap {
   let current = theme;
 
@@ -115,7 +144,9 @@ export function addBasemap(map: L.Map, theme: BasemapTheme): Basemap {
     // the whole style document, which drops any paint property set on the
     // one before it.
     glMap.on("style.load", () => {
-      if (current !== "dark" || !glMap) return;
+      if (!glMap) return;
+      hideMaritimeBoundaries(glMap);
+      if (current !== "dark") return;
       if (glMap.getLayer("water")) glMap.setPaintProperty("water", "fill-color", DARK_SEA);
       if (glMap.getLayer("waterway")) glMap.setPaintProperty("waterway", "line-color", DARK_SEA);
     });


### PR DESCRIPTION
Depuis le passage aux tuiles vectorielles (#295), le fond sombre trace un trait qui longe la côte à une douzaine de milles au large.

C'est la limite des eaux territoriales : OpenStreetMap prolonge en mer les frontières administratives, marquées `maritime=1`. Sur une carte de nav, un trait sur l'eau se lit comme quelque chose dont le bateau doit tenir compte. Celui-ci est une juridiction, pas un danger, et il croise les routes qu'on trace par-dessus.

## Pourquoi en sombre seulement

Le défaut vient du style, pas de nous, et les deux styles d'OpenFreeMap ne se valent pas :

| Style | Couches `boundary` | Filtre maritime |
|---|---|---|
| `positron` (clair) | `boundary_3`, `boundary_2`, `boundary_disputed` | `["!=", ["get","maritime"], 1]` sur les trois |
| `dark` | `boundary_state`, `boundary_country_z0-4`, `boundary_country_z5-` | **aucun** |

Le thème sombre étant le défaut de l'app, le défaut est visible par défaut.

## Le correctif

Le filtre est posé sur **toute couche lisant la source `boundary`**, pas sur les trois identifiants livrés aujourd'hui : un restyle en amont ne peut donc pas ramener le trait en douce. Il est réappliqué à chaque `style.load`, comme la couleur de mer juste à côté, parce qu'un changement de thème remplace le document de style entier.

Les frontières à terre sont laissées en place : elles ne coûtent rien et elles aident à situer une côte.

## Vérification

A/B sur **build de prod servi en local**, à centre, zoom et gabarit identiques à dev (43,30 N 4,80 E, z9, 412x915) :

| | Trait en mer |
|---|---|
| `dev.ohmywind.fr` | présent |
| Build avec le correctif | absent, routes et frontières terrestres inchangées |

Thème clair inchangé, le filtre y fait doublon avec celui du style. Typecheck, 251 tests, budget lint et build de prod verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)