### PR TITLE
chore(web): vide 14 des 25 erreurs ESLint tolérées, budget 25 → 11

### DIFF
--- a/packages/web/scripts/lint-budget.mjs
+++ b/packages/web/scripts/lint-budget.mjs
@@ -2,11 +2,17 @@
 /**
  * Lint ratchet.
  *
- * `npm run lint` reports 26 pre-existing errors, all of the same few kinds:
- * refs written during render, setState called straight from an effect body,
- * a handful of `any`, empty catch blocks. Clearing them is not a lint chore,
- * it is the frontend work of phase 4 of the refacto plan, which lifts state
- * and effects out of the big components.
+ * `npm run lint` reports 11 pre-existing errors, now of only two kinds:
+ * refs written during render (SpotMap) and setState called straight from an
+ * effect body (App, PlanPage). Both are the frontend work of phase 4 of the
+ * refacto plan, which lifts state and effects out of the big components: the
+ * first changes when a Leaflet handler sees a fresh callback, the second means
+ * deriving during render instead of cascading. Neither is a lint chore.
+ *
+ * The other 14 were: `any` reaching into Leaflet internals, empty catch blocks,
+ * a raw NBSP, a dead local, a component declared inside a render, and two
+ * modules mixing components with plain exports. All cleared, none of them
+ * touching behaviour.
  *
  * Making lint blocking today would therefore mean either a red CI forever or
  * a rushed rewrite of the components. Neither is acceptable, so CI enforces a
@@ -17,7 +23,7 @@
  */
 import { ESLint } from "eslint";
 
-const BUDGET = 25;
+const BUDGET = 11;
 
 const eslint = new ESLint();
 const results = await eslint.lintFiles(["."]);

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -156,7 +156,6 @@ function MarineCell({
   // wave is going is direction + 180. For "to" (current), no offset.
   let arrowFlip = 0;
   let renderArrow = false;
-  let renderHeader = false;
   let degText: string | null = null;
 
   switch (row.kind) {
@@ -239,8 +238,8 @@ function MarineCell({
       break;
     }
   }
-  // touch unused symbol so TS doesn't drop it (silences noUnusedLocals).
-  void renderHeader;
+  // secondary is assigned per row kind above but only read by the arrow branch;
+  // touched here so noUnusedLocals stays on for the rest of the file.
   void secondary;
 
   if (value == null) {

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -6,13 +6,20 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "../types";
 import { QUICK_SPOTS } from "../spots";
-import { useTheme } from "../design/theme";
+import { useTheme } from "../design/useTheme";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { syncUserPositionLayer } from "../utils/userPositionLayer";
 import { syncSeamarkLayer } from "../utils/seamarkLayer";
 import { addBasemap, BASEMAP_MAX_ZOOM, type Basemap } from "../utils/basemapLayer";
 import { centerForBottomInset } from "../utils/visibleCenter";
 import type { MapView } from "../utils/mapViewParams";
+
+// Leaflet renders a CircleMarker into an SVG node it keeps to itself: there is
+// no public accessor, only the internal ``_path``. Hit-testing needs that node
+// to map an element back to its spot, so the field is declared here instead of
+// being reached through ``any`` — same escape hatch, but one that still type
+// checks the property and its type.
+type WithSvgPath = { _path?: Element };
 
 // Spot-map arrows are drawn into a single 300×300 SVG anchored at the spot
 // (centre = 150,150). For ``wind``, each forecast contributes one arrow + label.
@@ -564,7 +571,7 @@ export function SpotMap({
         .on("click", () => onSelectRef.current(spot))
         .addTo(map);
       if (isCustom) {
-        const svgEl = (marker as any)._path as Element | undefined;
+        const svgEl = (marker as unknown as WithSvgPath)._path;
         if (svgEl) elementToSpotRef.current.set(svgEl, spot);
       }
       markersRef.current.set(key, marker);
@@ -649,7 +656,7 @@ export function SpotMap({
     // Remove old markers
     for (const [key, marker] of markersRef.current) {
       if (!desiredKeys.has(key)) {
-        const svgEl = (marker as any)._path as Element | undefined;
+        const svgEl = (marker as unknown as WithSvgPath)._path;
         if (svgEl) elementToSpotRef.current.delete(svgEl);
         marker.remove();
         markersRef.current.delete(key);
@@ -687,7 +694,7 @@ export function SpotMap({
           .on("click", () => onSelectRef.current(s))
           .addTo(map);
         if (isCustom) {
-          const svgEl = (marker as any)._path as Element | undefined;
+          const svgEl = (marker as unknown as WithSvgPath)._path;
           if (svgEl) elementToSpotRef.current.set(svgEl, s);
         }
         markersRef.current.set(key, marker);

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -1,29 +1,32 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-type ThemeMode = 'light' | 'dark';
+import { ThemeCtx, useTheme, type ThemeMode } from './useTheme';
 
 const STORAGE_KEY = 'ow_theme';
 
+// Every access below is guarded because both APIs throw outright, rather than
+// returning null, when the browser blocks site data: Safari in private mode
+// for localStorage, and any embedder that denies matchMedia. A theme is a
+// preference, so failing to read one falls back to the default instead of
+// taking the app down.
 function getInitialMode(): ThemeMode {
   try {
     const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
     if (stored === 'light' || stored === 'dark') return stored;
-  } catch {}
+  } catch {
+    // Storage denied: fall through to the system preference.
+  }
   // No stored preference — follow system
   try {
     return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-  } catch {}
+  } catch {
+    // matchMedia denied: fall through to the default below.
+  }
   return 'dark';
 }
-
-const ThemeCtx = createContext<{
-  mode: ThemeMode;
-  resolvedTheme: ThemeMode;
-  setMode: (m: ThemeMode) => void;
-}>({ mode: 'dark', resolvedTheme: 'dark', setMode: () => {} });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [mode, setModeState] = useState<ThemeMode>(getInitialMode);
@@ -34,7 +37,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   function setMode(m: ThemeMode) {
     setModeState(m);
-    try { localStorage.setItem(STORAGE_KEY, m); } catch {}
+    try {
+      localStorage.setItem(STORAGE_KEY, m);
+    } catch {
+      // Storage denied: the theme still applies, it just will not survive a reload.
+    }
   }
 
   return (
@@ -43,8 +50,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     </ThemeCtx.Provider>
   );
 }
-
-export function useTheme() { return useContext(ThemeCtx); }
 
 function SunIcon() {
   return (

--- a/packages/web/src/design/useTheme.ts
+++ b/packages/web/src/design/useTheme.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+// The context and its hook live apart from theme.tsx so that file exports
+// components and nothing else: Fast Refresh gives up on a module that mixes
+// the two, and a theme change would then reload the whole app instead of
+// swapping the component.
+
+import { createContext, useContext } from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+export const ThemeCtx = createContext<{
+  mode: ThemeMode;
+  resolvedTheme: ThemeMode;
+  setMode: (m: ThemeMode) => void;
+}>({ mode: 'dark', resolvedTheme: 'dark', setMode: () => {} });
+
+export function useTheme() {
+  return useContext(ThemeCtx);
+}

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
-import { useTheme } from "../design/theme";
+import { useTheme } from "../design/useTheme";
 import type { SegmentReport } from "./types";
 import { cxLevel, CX_COLORS } from "./types";
 import { haversineNm, fmtNm } from "../utils/geo";

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { useMemo, useState } from "react";
-import { useTheme } from "../design/theme";
+import { useTheme } from "../design/useTheme";
+import { validateSweep, type SweepValidation } from "./validateSweep";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "./types";
 import { aggregateLegs, buildLegSummaryCells, type AggregatedLeg } from "./aggregateLegs";
 import { cxLevel, CX_COLORS } from "./types";
@@ -291,46 +292,6 @@ const SWEEP_INTERVALS: { value: number; label: string }[] = [
   { value: 3, label: "Toutes les 3h" },
   { value: 6, label: "Toutes les 6h" },
 ];
-
-// Match the single-mode slider cap: Open-Meteo forecast tops out at ~today+15;
-// we keep 14 d to leave 1 d of margin for clock skew / TZ crossings.
-const SWEEP_HORIZON_DAYS = 14;
-// Backend safety cap: 14 d × 24 h = 336 windows. Mirror it here so we can
-// surface a friendly hint before sending an oversize request.
-const MAX_SWEEP_WINDOWS = 336;
-
-export interface SweepValidation {
-  ok: boolean;
-  message?: string;
-}
-
-export function validateSweep(earliest: string, latest: string, intervalHours: number): SweepValidation {
-  if (!earliest || !latest) return { ok: false, message: "Renseignez une fenêtre de départ." };
-  const e = new Date(earliest);
-  const l = new Date(latest);
-  if (Number.isNaN(e.getTime()) || Number.isNaN(l.getTime())) {
-    return { ok: false, message: "Dates invalides." };
-  }
-  if (l.getTime() <= e.getTime()) {
-    return { ok: false, message: "Le « plus tard » doit être après le « plus tôt »." };
-  }
-  const horizonMs = SWEEP_HORIZON_DAYS * 86_400_000;
-  const now = new Date();
-  if (l.getTime() - now.getTime() > horizonMs) {
-    return {
-      ok: false,
-      message: `La météo n'est fiable que sur ${SWEEP_HORIZON_DAYS} jours. Choisissez une date plus tôt.`,
-    };
-  }
-  const windows = Math.floor((l.getTime() - e.getTime()) / 3_600_000 / intervalHours) + 1;
-  if (windows > MAX_SWEEP_WINDOWS) {
-    return {
-      ok: false,
-      message: `Trop de créneaux à comparer (${windows}). Réduisez la fenêtre ou augmentez le pas.`,
-    };
-  }
-  return { ok: true };
-}
 
 // Minimal "YYYY-MM-DDTHH:MM" formatter from a Date (local time).
 function toLocalIsoMin(d: Date): string {

--- a/packages/web/src/plan/WindowsTable.tsx
+++ b/packages/web/src/plan/WindowsTable.tsx
@@ -7,6 +7,7 @@ import { CX_COLORS } from "./types";
 import { fmtDurationSafe } from "./format";
 
 type SortKey = "departure" | "duration" | "complexity";
+type SortDir = "asc" | "desc";
 
 const SAIL_LABELS: Record<string, string> = {
   pres: "Près",
@@ -55,7 +56,7 @@ export interface WindowsTableProps {
 
 export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>("departure");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const sorted = useMemo(() => {
     const list = [...windows];
@@ -82,24 +83,6 @@ export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
     }
   }
 
-  function SortHeader({ k, label, align = "left" }: { k: SortKey; label: string; align?: "left" | "right" | "center" }) {
-    const active = sortKey === k;
-    const arrow = active ? (sortDir === "asc" ? "▲" : "▼") : "";
-    return (
-      <button
-        onClick={() => toggleSort(k)}
-        className="flex items-center gap-1 transition-colors w-full"
-        style={{
-          color: active ? "var(--ow-fg-0)" : "var(--ow-fg-3)",
-          justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start",
-          fontWeight: 600,
-        }}
-      >
-        {label} <span className="text-[8px] opacity-60">{arrow || "↕"}</span>
-      </button>
-    );
-  }
-
   return (
     <div>
       <div
@@ -110,13 +93,13 @@ export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
           color: "var(--ow-fg-3)",
         }}
       >
-        <SortHeader k="departure" label="Départ" />
-        <SortHeader k="duration" label="Durée" />
+        <SortHeader k="departure" label="Départ" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
+        <SortHeader k="duration" label="Durée" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
         <span className="text-left">ETA</span>
         <span className="text-left">Allure</span>
         <span className="text-left">Vent (kn)</span>
         <span className="text-left">Mer</span>
-        <SortHeader k="complexity" label="⚡" align="center" />
+        <SortHeader k="complexity" label="⚡" align="center" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} />
       </div>
 
       <div>
@@ -170,5 +153,41 @@ export function WindowsTable({ windows, onSelect }: WindowsTableProps) {
         })}
       </div>
     </div>
+  );
+}
+
+// Declared at module scope, not inside WindowsTable: a component created during
+// render is a new type on every render, so React unmounts the old one and
+// remounts a fresh instance, losing its state and its DOM node. Harmless for a
+// stateless header today, a real bug the day one of them holds a popover.
+function SortHeader({
+  k,
+  label,
+  align = "left",
+  sortKey,
+  sortDir,
+  onToggle,
+}: {
+  k: SortKey;
+  label: string;
+  align?: "left" | "right" | "center";
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onToggle: (key: SortKey) => void;
+}) {
+  const active = sortKey === k;
+  const arrow = active ? (sortDir === "asc" ? "▲" : "▼") : "";
+  return (
+    <button
+      onClick={() => onToggle(k)}
+      className="flex items-center gap-1 transition-colors w-full"
+      style={{
+        color: active ? "var(--ow-fg-0)" : "var(--ow-fg-3)",
+        justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start",
+        fontWeight: 600,
+      }}
+    >
+      {label} <span className="text-[8px] opacity-60">{arrow || "↕"}</span>
+    </button>
   );
 }

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -123,8 +123,10 @@ export function buildLegSummaryCells(leg: AggregatedLeg): LegSummaryCells {
   const tMax = Math.round(leg.tws_max);
   // NBSP between the number and "kn" so the wind chip stays on one line when
   // SummaryCell renders with width:min-content. Multi-word labels (Mer Formée,
-  // Vent Contre Courant) still break at their normal spaces.
-  const wind = tMin === tMax ? `${tMin} kn` : `${tMin}–${tMax} kn`;
+  // Vent Contre Courant) still break at their normal spaces. Spelled as an
+  // escape: a raw NBSP is invisible in review and reads as a stray space, so
+  // no-irregular-whitespace rejects it.
+  const wind = tMin === tMax ? `${tMin}\u00a0kn` : `${tMin}–${tMax}\u00a0kn`;
 
   const chopIndex =
     leg.hs_avg_m != null && leg.tp_avg_s != null && leg.tp_avg_s > 0

--- a/packages/web/src/plan/validateSweep.test.ts
+++ b/packages/web/src/plan/validateSweep.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { validateSweep } from "./validateSweep";
+
+// The horizon rule is relative to now, so the clock is pinned. Everything else
+// is pure, but a floating clock would make the horizon cases pass or fail
+// depending on the day the suite runs.
+const NOW = new Date("2026-06-01T08:00:00Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Local-time strings, the format the datetime-local inputs produce.
+function plusHours(h: number): string {
+  const d = new Date(NOW.getTime() + h * 3_600_000);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+describe("validateSweep", () => {
+  it("accepts a plain window inside the horizon", () => {
+    expect(validateSweep(plusHours(2), plusHours(26), 3)).toEqual({ ok: true });
+  });
+
+  it("asks for a window when either bound is empty", () => {
+    expect(validateSweep("", plusHours(26), 3).ok).toBe(false);
+    expect(validateSweep(plusHours(2), "", 3).ok).toBe(false);
+  });
+
+  it("rejects unparseable dates", () => {
+    expect(validateSweep("pas-une-date", plusHours(26), 3).message).toBe("Dates invalides.");
+  });
+
+  it("rejects a window that ends before it starts, and one of zero length", () => {
+    expect(validateSweep(plusHours(26), plusHours(2), 3).ok).toBe(false);
+    expect(validateSweep(plusHours(2), plusHours(2), 3).ok).toBe(false);
+  });
+
+  it("refuses a departure past the forecast horizon", () => {
+    // 14 d is the cap mirrored from the backend; 15 d is beyond it.
+    expect(validateSweep(plusHours(2), plusHours(15 * 24), 6).message).toContain("14 jours");
+  });
+
+  it("refuses more windows than the backend accepts, and names the count", () => {
+    // 336 h at a 1 h step is 337 windows, one over the cap.
+    const result = validateSweep(plusHours(0), plusHours(336), 1);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("337");
+  });
+
+  it("accepts the same span once the step thins it back under the cap", () => {
+    expect(validateSweep(plusHours(0), plusHours(336), 2)).toEqual({ ok: true });
+  });
+});

--- a/packages/web/src/plan/validateSweep.ts
+++ b/packages/web/src/plan/validateSweep.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+// Pulled out of PlanSidebar.tsx so that file exports components only: Fast
+// Refresh bails on a module that mixes components with plain functions, which
+// cost a full reload on every edit of the sidebar.
+
+// Match the single-mode slider cap: Open-Meteo forecast tops out at ~today+15;
+// we keep 14 d to leave 1 d of margin for clock skew / TZ crossings.
+const SWEEP_HORIZON_DAYS = 14;
+// Backend safety cap: 14 d × 24 h = 336 windows. Mirror it here so we can
+// surface a friendly hint before sending an oversize request.
+const MAX_SWEEP_WINDOWS = 336;
+
+export interface SweepValidation {
+  ok: boolean;
+  message?: string;
+}
+
+export function validateSweep(earliest: string, latest: string, intervalHours: number): SweepValidation {
+  if (!earliest || !latest) return { ok: false, message: "Renseignez une fenêtre de départ." };
+  const e = new Date(earliest);
+  const l = new Date(latest);
+  if (Number.isNaN(e.getTime()) || Number.isNaN(l.getTime())) {
+    return { ok: false, message: "Dates invalides." };
+  }
+  if (l.getTime() <= e.getTime()) {
+    return { ok: false, message: "Le « plus tard » doit être après le « plus tôt »." };
+  }
+  const horizonMs = SWEEP_HORIZON_DAYS * 86_400_000;
+  const now = new Date();
+  if (l.getTime() - now.getTime() > horizonMs) {
+    return {
+      ok: false,
+      message: `La météo n'est fiable que sur ${SWEEP_HORIZON_DAYS} jours. Choisissez une date plus tôt.`,
+    };
+  }
+  const windows = Math.floor((l.getTime() - e.getTime()) / 3_600_000 / intervalHours) + 1;
+  if (windows > MAX_SWEEP_WINDOWS) {
+    return {
+      ok: false,
+      message: `Trop de créneaux à comparer (${windows}). Réduisez la fenêtre ou augmentez le pas.`,
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Le ratchet plafonnait à 25 erreurs préexistantes en les décrivant toutes comme la phase 4 du refacto. C'est faux pour plus de la moitié : quatorze d'entre elles ne demandaient aucun lifting d'état, juste d'être faites.

## Ce qui est vidé

| Règle | Où | Le fix |
|---|---|---|
| `no-irregular-whitespace` ×2 | `aggregateLegs.ts` | Les NBSP sont **voulues**, elles empêchent le chip de vent de couper entre le chiffre et « kn ». Écrites en ` `, elles disent la même chose et se voient en relecture, là où le caractère brut passe pour une espace de trop. |
| `no-explicit-any` ×3 | `SpotMap.tsx` | `(marker as any)._path` tape dans l'interne de Leaflet, qui n'expose pas le nœud SVG d'un `CircleMarker`. Un type local garde l'échappatoire mais type la propriété. |
| `no-empty` ×3 | `theme.tsx` | Les trois `catch {}` entourent `localStorage` et `matchMedia`, qui **lèvent** au lieu de rendre `null` quand le navigateur bloque les données de site. Commentés : un thème est une préférence, ne pas la lire ne doit pas coûter l'app. |
| `static-components` ×3 | `WindowsTable.tsx` | `SortHeader` était déclaré dans le render, donc recréé en tant que type à chaque rendu, remonté et vidé de son état par React. Sans effet visible aujourd'hui, l'en-tête étant sans état ; à réparer avant que l'un d'eux porte un popover. |
| `only-export-components` ×2 | `theme.tsx`, `PlanSidebar.tsx` | Les deux mélangeaient composants et exports simples, ce qui fait renoncer Fast Refresh sur tout le module. `useTheme` et `validateSweep` partent chacun dans leur fichier. |
| `prefer-const` ×1 | `MarineTable.tsx` | `renderHeader` n'était ni assigné ni lu, seulement maintenu en vie par un `void`. Supprimé. |

## Ce qui reste, et pourquoi

Onze erreurs, de deux familles seulement, toutes deux vraiment phase 4 :

- **`react-hooks/refs` ×6** (`SpotMap`) : le pattern « latest ref » écrit en render. Le passer en `useEffect` décale le moment où la ref est à jour, dans un composant carte qui a un historique de bugs tactiles. Demande une repasse QA, pas une PR de lint.
- **`set-state-in-effect` ×5** (`App`, `PlanPage`, dont l'hydratation depuis le cache) : il faut dériver au render au lieu de cascader. Ça touche le chemin de calcul de passage.

Le commentaire du ratchet est mis à jour : il ne promet plus que le reste est du même acabit, et il dit lesquelles ont été vidées.

## Bonus

`validateSweep` sort de `PlanSidebar` avec sa première suite : sept cas, dont le plafond de 336 créneaux et l'horizon à 14 jours, **tous deux vérifiés par mutation** (remonter le plafond à 400 ou l'horizon à 20 j fait bien échouer le test concerné). La fonction était intestable tant qu'elle vivait dans un fichier de composants.

## Vérification

Aucun changement de comportement. 258 tests verts (7 nouveaux), typecheck et build de prod inchangés, budget abaissé de 25 à 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)