### PR TITLE
chore(dco): signe les commits automatiquement au lieu de compter sur la mémoire

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Ajoute la ligne Signed-off-by (DCO) si elle manque.
+#
+# Le contrôle DCO de CI signalait 46 commits non signés sur les 60 derniers :
+# `git commit -s` marche très bien tant qu'on y pense, et on n'y pense pas.
+# Le hook retire la question de la mémoire de qui commite, session Claude
+# comprise.
+#
+# Activé par `core.hooksPath`, que `make hooks` positionne (voir CONTRIBUTING).
+#
+# $1 = fichier du message, $2 = origine (message|template|merge|squash|commit).
+
+msg_file="$1"
+source="$2"
+
+# Les commits de merge et de squash sont exemptés par le contrôle CI, qui ne
+# regarde que les commits à un seul parent. Les signer n'ajouterait qu'un
+# trailer sur un message que personne n'a rédigé.
+case "$source" in
+  merge | squash) exit 0 ;;
+esac
+
+# L'identité du committer, pas celle de l'auteur : c'est elle que `git commit
+# -s` utilise, et c'est le committer qui atteste du DCO. `git var` applique la
+# même résolution que git (env, config locale, globale).
+ident=$(git var GIT_COMMITTER_IDENT) || exit 0
+name=${ident%% <*}
+rest=${ident#*<}
+email=${rest%%>*}
+
+[ -n "$name" ] && [ -n "$email" ] || exit 0
+
+# --if-exists addIfDifferent : `git commit -s` a déjà posé le trailer avant que
+# ce hook tourne, et un amend relit un message qui le porte déjà. Dans les deux
+# cas on ne veut pas d'un doublon, mais on veut quand même pouvoir ajouter sa
+# propre signature à côté de celle d'un autre committer.
+git interpret-trailers \
+  --in-place \
+  --where end \
+  --if-exists addIfDifferent \
+  --trailer "Signed-off-by: $name <$email>" \
+  "$msg_file"

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -43,6 +43,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # core.hooksPath est une config LOCALE : elle ne voyage pas avec le
+      # clone, donc le runner repart sans hook et l'agent produit des commits
+      # non signés, exactement ce que le contrôle DCO signale ensuite sur sa
+      # propre PR. Une ligne ici couvre la seule source de commits qui échappe
+      # au `make hooks` des postes de travail.
+      - name: Activer les hooks du dépôt (signature DCO)
+        run: git config core.hooksPath .githooks
+
       # L'agent ne peut pas ouvrir les pièces jointes (pas de curl/WebFetch
       # dans son allowlist, et c'est voulu) : les images sont téléchargées
       # ICI, avant son lancement, de façon déterministe et bornée. En cas de

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,22 @@ En signant, vous certifiez trois choses :
 Si vous avez oublié de signer, `git commit --amend -s` corrige le dernier
 commit, et `git rebase --signoff origin/dev` reprend toute la branche.
 
+### Ne plus y penser
+
+`git commit -s` fonctionne tant qu'on s'en souvient, et le dépôt a accumulé
+46 commits non signés sur 60. Le hook `.githooks/prepare-commit-msg` ajoute la
+ligne à votre place, sans doublon si vous avez déjà passé `-s`, et sans rien
+poser sur les commits de merge, que le contrôle exempte. Activez-le une fois
+par clone :
+
+```
+make hooks
+```
+
+`make install` le fait déjà, donc une installation normale suffit. Le hook
+utilise l'identité que git résoudrait de toute façon (`user.name` et
+`user.email`) : signer reste votre acte, il n'est plus votre corvée.
+
 ## Vos droits d'auteur restent les vôtres
 
 Le DCO n'est pas un CLA : vous ne cédez rien. Vous restez titulaire du droit

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,17 @@ help: ## Show this help
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: install
-install: ## Install every package's dependencies
+install: hooks ## Install every package's dependencies
 	@for p in $(PY_PACKAGES); do echo "→ $$p"; (cd $$p && uv sync --extra dev); done
 	npm ci
+
+# core.hooksPath est une config locale, donc absente d'un clone frais : sans
+# cette cible, chaque nouveau clone recommence à produire des commits non
+# signés. Accrochée à `install` pour qu'on n'ait jamais à y penser.
+.PHONY: hooks
+hooks: ## Activer les hooks du dépôt (signature DCO automatique)
+	git config core.hooksPath .githooks
+	@echo "hooks actifs : .githooks (Signed-off-by ajouté automatiquement)"
 
 .PHONY: test
 test: test-py test-web ## Run every test suite


### PR DESCRIPTION
Le contrôle DCO signale les commits sans `Signed-off-by`. Il a raison, et souvent : **46 des 60 derniers commits** hors merges n'en portaient pas, dont celui qui a déclenché ce chantier sur la PR de promotion #303.

La consigne `git commit -s` de CONTRIBUTING n'est pas fausse, elle demande simplement de penser à chaque fois à quelque chose qu'aucun humain, ni aucune session d'agent, ne pense à chaque fois. Tant que la signature dépend de la mémoire, le compteur remonte.

## Le hook

`.githooks/prepare-commit-msg` pose la ligne à partir de l'identité que git résout de toute façon pour le committer (`git var GIT_COMMITTER_IDENT`, donc env puis config locale puis globale, exactement comme `-s`).

Il passe par `git interpret-trailers --if-exists addIfDifferent` plutôt que par un `echo` : un `-s` déjà donné ne produit pas de doublon, un amend non plus, et la ligne se place correctement après un `Co-Authored-By` au lieu de casser le bloc de trailers.

Les merges et les squashes sont ignorés. Le contrôle CI les exempte déjà (`c.parents.length < 2`), et signer un message que personne n'a rédigé n'atteste de rien.

## Vérification

Dépôt jetable, six scénarios :

| Scénario | Attendu | Obtenu |
|---|---|---|
| commit simple, sans `-s` | 1 signature | 1 |
| commit avec `-s` | pas de doublon | 1 |
| `--amend` d'un commit signé | pas de doublon | 1 |
| message à corps multiple | signature en fin de bloc | 1 |
| commit de merge | aucune signature | 0 |
| commit portant un `Co-Authored-By` | co-auteur préservé, signature après | conforme |

Et le commit de cette PR n'a **pas** été signé à la main : sa ligne `Signed-off-by` vient du hook.

## Les deux points d'activation

`core.hooksPath` est une config locale, elle ne voyage pas avec le clone. Un hook committé mais jamais activé ne sert à rien, donc l'activation est câblée aux deux seuls endroits d'où partent des commits :

- **`make hooks`**, accroché en dépendance de `make install`. Sans ça, chaque nouveau clone recommence à produire des commits non signés.
- **une étape dans `claude-fix.yml`**, pour l'agent GHA. C'est la seule source de commits qui n'a pas de `make install` derrière elle, et elle ouvrait des PR que le contrôle DCO épinglait ensuite.

`sync-hf-space.yml` commite aussi, mais dans le miroir du Space, hors périmètre du DCO du dépôt.

## Ce que ça ne fait pas

Les commits déjà poussés restent non signés. Les rattraper demanderait de réécrire l'historique de `dev` et de forcer le push, ce qui casserait la PR de promotion en cours pour un contrôle explicitement non bloquant. Le compteur s'arrête ici plutôt qu'il ne se remet à zéro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)