### PR TITLE
feat(android): patch post-bubblewrap pour la couche monochrome du launcher

### DIFF
--- a/packages/android/.gitignore
+++ b/packages/android/.gitignore
@@ -5,3 +5,4 @@
 !.gitignore
 !twa-manifest.json
 !README.md
+!patch-monochrome.sh

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -17,13 +17,18 @@ cd packages/android
 export BUBBLEWRAP_KEYSTORE_PASSWORD='<NordPass>'
 export BUBBLEWRAP_KEY_PASSWORD='<NordPass>'
 bubblewrap update   # régénère le projet Android depuis twa-manifest.json
+./patch-monochrome.sh   # injecte l'icône thémée Android 13+ (voir ci-dessous)
 bubblewrap build    # produit app-release-bundle.aab (Play) + app-release-signed.apk (device)
 ```
+
+### Icône thémée Android 13+ (patch obligatoire)
+
+Bubblewrap (1.25.0) ne lit `monochromeIconUrl` que pour l'icône de notification, jamais pour la couche `<monochrome>` de l'icône adaptative du launcher. Sans elle, l'icône reste non thémée quand l'utilisateur active les icônes thémées. `patch-monochrome.sh` corrige le projet généré: il copie `packages/web/public/icon-monochrome-512.png` dans les ressources et ajoute la couche dans `ic_launcher.xml`. À lancer **entre** `bubblewrap update` (qui écrase le projet, donc le patch) et `bubblewrap build`. Le script est idempotent et échoue fort si le template Bubblewrap change; si une future version de la CLI gère la couche launcher nativement, le supprimer.
 
 ## Publier une mise à jour
 
 1. Incrémenter `appVersionCode` (+1, entier) et `appVersion` (lisible, ex. "1.1.0") dans `twa-manifest.json`. Attention: c'est `appVersion` que Bubblewrap lit pour le versionName du bundle; si un champ `appVersionName` est aussi présent, le garder synchronisé (incident: la 1.0.1 a failli partir étiquetée 1.0.0 parce que seul `appVersionName` avait été incrémenté).
-2. `bubblewrap update --skipVersionUpgrade` puis `bubblewrap build` (sans le flag, `update` prompte interactivement pour une nouvelle version et pollue les champs en non-interactif).
+2. `bubblewrap update --skipVersionUpgrade`, puis `./patch-monochrome.sh`, puis `bubblewrap build` (sans le flag, `update` prompte interactivement pour une nouvelle version et pollue les champs en non-interactif).
 3. Uploader `app-release-bundle.aab` sur la Play Console.
 
 Le contenu web, lui, se met à jour tout seul (c'est le site). Un rebuild n'est nécessaire que pour changer le manifest Android (icône, nom, permissions, version affichée sur le Play Store).

--- a/packages/android/patch-monochrome.sh
+++ b/packages/android/patch-monochrome.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Injecte la couche <monochrome> (icône thémée Android 13+) dans le projet
+# Android généré par `bubblewrap update`. Bubblewrap 1.25.0 ne lit
+# monochromeIconUrl que pour l'icône de notification, jamais pour le
+# launcher : sans ce patch, l'icône reste non thémée sur Android 13+.
+#
+# À lancer depuis packages/android/ ou packages/android-dev/, entre
+# `bubblewrap update` et `bubblewrap build` :
+#
+#   bubblewrap update --skipVersionUpgrade
+#   ../android/patch-monochrome.sh   # ou ./patch-monochrome.sh côté prod
+#   bubblewrap build
+#
+# Idempotent : relançable sans effet de bord. Échoue fort si le template
+# Bubblewrap a changé de structure, pour ne jamais builder silencieusement
+# sans la couche monochrome.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src_png="$script_dir/../web/public/icon-monochrome-512.png"
+launcher_xml="app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
+dest_png="app/src/main/res/mipmap-xxxhdpi/ic_monochrome.png"
+
+[ -f "$src_png" ] || { echo "ERREUR: $src_png introuvable (asset web)"; exit 1; }
+[ -f "$launcher_xml" ] || { echo "ERREUR: $launcher_xml introuvable. Lancer 'bubblewrap update' d'abord."; exit 1; }
+
+cp "$src_png" "$dest_png"
+
+if grep -q "<monochrome" "$launcher_xml"; then
+  echo "Couche monochrome déjà présente dans $launcher_xml, rien à faire."
+else
+  grep -q "</adaptive-icon>" "$launcher_xml" || { echo "ERREUR: </adaptive-icon> introuvable, template Bubblewrap inattendu."; exit 1; }
+  sed -i 's|</adaptive-icon>|    <monochrome android:drawable="@mipmap/ic_monochrome" />\n</adaptive-icon>|' "$launcher_xml"
+  echo "Couche monochrome injectée dans $launcher_xml."
+fi


### PR DESCRIPTION
## Quoi

Complément indispensable de #305 : Bubblewrap 1.25.0 ne lit `monochromeIconUrl` que pour l'icône de notification, jamais pour la couche `<monochrome>` de l'icône adaptative du launcher. Le twa-manifest seul ne livrait donc pas l'icône thémée Android 13+.

- `packages/android/patch-monochrome.sh` : à lancer entre `bubblewrap update` et `bubblewrap build`, copie l'asset monochrome du site dans les ressources et injecte la couche dans `ic_launcher.xml`. Idempotent, échoue fort si le template Bubblewrap change.
- `.gitignore` : whitelist du script
- README : procédure de build et de release mise à jour

## Vérifs

Build complet de la flavor dev (dev.ohmywind.fr, qui sert déjà l'asset depuis #305) : `aapt dump xmltree` confirme `E: monochrome -> mipmap/ic_monochrome` dans l'APK signé 1.0.3 / code 3 / targetSdk 36. Reste le smoke visuel émulateur (icônes thémées ON) avant le build prod.