### PR TITLE
fix(web): la demande de position automatique échoue en silence

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -167,7 +167,9 @@ function App() {
     // same error bubble on every visit. The locate button still retries on
     // demand, so changing one's mind in the browser settings is enough.
     if (hasDeclinedGeolocation()) return;
-    locate({ enableHighAccuracy: false, maximumAge: 5 * 60 * 1000 }).then((fix) => {
+    // silent: an automatic request the user never made must not surface an
+    // error bubble when it fails; only the locate button reports failures.
+    locate({ enableHighAccuracy: false, maximumAge: 5 * 60 * 1000 }, { silent: true }).then((fix) => {
       // A spot picked while the fix was in flight means the user already
       // chose their focus — leave the viewport and their selection alone.
       if (fix && !spotRef.current) {

--- a/packages/web/src/hooks/useGeolocation.test.ts
+++ b/packages/web/src/hooks/useGeolocation.test.ts
@@ -2,7 +2,11 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { describe, it, expect } from "vitest";
-import { statusFromErrorCode, geolocMessage } from "./useGeolocation";
+import {
+  statusFromErrorCode,
+  statusAfterFailure,
+  geolocMessage,
+} from "./useGeolocation";
 
 describe("statusFromErrorCode", () => {
   it("maps PERMISSION_DENIED to denied", () => {
@@ -22,6 +26,24 @@ describe("statusFromErrorCode", () => {
     // "unavailable" beats crashing on an unmapped value.
     expect(statusFromErrorCode(0)).toBe("unavailable");
     expect(statusFromErrorCode(42)).toBe("unavailable");
+  });
+});
+
+describe("statusAfterFailure", () => {
+  it("swallows every failure of a silent request back to idle", () => {
+    // The app asked on its own (first-visit auto-locate); the user asked for
+    // nothing and must not be shown an error. Seed: the Android TWA's first
+    // launch fails with a technical "denied" before Chrome registers the
+    // app for permission delegation (no user ever saw a prompt).
+    for (const code of [1, 2, 3, 0]) {
+      expect(statusAfterFailure(code, true)).toBe("idle");
+    }
+  });
+
+  it("reports failures of an explicit request untouched", () => {
+    expect(statusAfterFailure(1, false)).toBe("denied");
+    expect(statusAfterFailure(2, false)).toBe("unavailable");
+    expect(statusAfterFailure(3, false)).toBe("timeout");
   });
 });
 

--- a/packages/web/src/hooks/useGeolocation.ts
+++ b/packages/web/src/hooks/useGeolocation.ts
@@ -42,6 +42,16 @@ export function statusFromErrorCode(code: number): GeolocStatus {
   }
 }
 
+/** Status to surface after a failed request. A silent request (the app asked
+    on its own, the user asked for nothing) swallows the failure and returns
+    to idle: error bubbles are reserved for explicit taps. Notably, the very
+    first launch of the Android TWA can fail with a technical "denied" before
+    Chrome has registered the app for permission delegation, and that must
+    not greet the user with an error they did nothing to cause. */
+export function statusAfterFailure(code: number, silent: boolean): GeolocStatus {
+  return silent ? "idle" : statusFromErrorCode(code);
+}
+
 /** User-facing French copy for the failure states. Returns null when there
     is nothing to say (idle, locating, ready). */
 export function geolocMessage(status: GeolocStatus): string | null {
@@ -83,16 +93,27 @@ export function useGeolocation() {
   const [attempt, setAttempt] = useState(0);
   const stampRef = useRef(0);
   const inFlightRef = useRef<Promise<UserPosition | null> | null>(null);
+  /** Whether the in-flight request may fail without surfacing an error. */
+  const silentRef = useRef(false);
 
   const locate = useCallback(
-    (options?: PositionOptions): Promise<UserPosition | null> => {
+    (
+      options?: PositionOptions,
+      { silent = false }: { silent?: boolean } = {},
+    ): Promise<UserPosition | null> => {
       if (typeof navigator === "undefined" || !navigator.geolocation) {
-        setStatus("unavailable");
+        setStatus(silent ? "idle" : "unavailable");
         return Promise.resolve(null);
       }
       // Rapid double-taps share one browser prompt rather than queueing a
       // second permission dialog behind the first.
-      if (inFlightRef.current) return inFlightRef.current;
+      if (inFlightRef.current) {
+        // A manual tap joining an in-flight silent request lifts the
+        // silence: the user now expects feedback for this very request.
+        if (!silent) silentRef.current = false;
+        return inFlightRef.current;
+      }
+      silentRef.current = silent;
 
       setStatus("locating");
       setAttempt((n) => n + 1);
@@ -114,12 +135,13 @@ export function useGeolocation() {
             resolve(next);
           },
           (err) => {
-            const failure = statusFromErrorCode(err.code);
-            setStatus(failure);
+            setStatus(statusAfterFailure(err.code, silentRef.current));
             // Only an outright refusal is remembered. A timeout or a
             // temporarily unavailable fix says nothing about consent and
             // must not silence the automatic request forever.
-            if (failure === "denied") rememberGeolocationDecline();
+            if (statusFromErrorCode(err.code) === "denied") {
+              rememberGeolocationDecline();
+            }
             resolve(null);
           },
           { ...DEFAULT_OPTIONS, ...options },


### PR DESCRIPTION
## Quoi

Le hook `useGeolocation` accepte une option `silent`, utilisée par la géolocalisation automatique de première visite : en cas d'échec le statut revient à `idle` au lieu de l'état d'erreur, donc plus de bulle « Position refusée » au premier lancement. La bulle reste réservée aux échecs du bouton localiser (un tap manuel pendant une requête silencieuse en vol lève d'ailleurs le silence). Décision extraite en fonction pure `statusAfterFailure` testée.

## Pourquoi

Constaté au smoke émulateur de la 1.0.2 : au tout premier lancement de la TWA, Chrome n'a pas encore enregistré l'app pour la délégation de permission, la demande automatique échoue en « denied » technique, et l'utilisateur était accueilli par une erreur qu'il n'a jamais causée (il n'a vu aucun prompt). Le commentaire du code promettait déjà « Denied / error → silent », c'est désormais effectif.

## Vérifs

265 tests verts (2 nouveaux sur `statusAfterFailure`), typecheck et build OK. Validation TWA sur émulateur après deploy dev (Chrome vierge, premier lancement sans bulle) à suivre dans la conversation.