### PR TITLE
perf(web): mémoïse les conversions d'heure de Paris

### DIFF
--- a/packages/web/src/api/marine.test.ts
+++ b/packages/web/src/api/marine.test.ts
@@ -109,6 +109,66 @@ describe("parisIsoToUtcMs", () => {
     const ms = parisIsoToUtcMs("2026-07-01T12:00");
     expect(new Date(ms).toISOString()).toBe("2026-07-01T10:00:00.000Z");
   });
+
+  it("is memoized: repeated calls return the very same value", () => {
+    // The result is cached per input string, so a second call must not drift
+    // (and, incidentally, must not depend on the formatter being rebuilt).
+    const first = parisIsoToUtcMs("2026-05-08T07:00");
+    for (let i = 0; i < 5; i++) {
+      expect(parisIsoToUtcMs("2026-05-08T07:00")).toBe(first);
+    }
+    // Interleaving other keys must not evict or corrupt the first one.
+    parisIsoToUtcMs("2026-05-08T08:00");
+    parisIsoToUtcMs("2026-01-15T00:00");
+    expect(parisIsoToUtcMs("2026-05-08T07:00")).toBe(first);
+  });
+
+  it("stays cold-path identical across the spring-forward boundary", () => {
+    // 2026-03-29: Paris jumps 02:00 CET to 03:00 CEST. These expectations lock
+    // in the existing single-pass behaviour (the hour right at the switch is
+    // ambiguous by construction), so the memo cannot silently change it.
+    const cases: [string, string][] = [
+      ["2026-03-29T00:00", "2026-03-28T23:00:00.000Z"],
+      ["2026-03-29T01:00", "2026-03-28T23:00:00.000Z"],
+      ["2026-03-29T02:00", "2026-03-29T00:00:00.000Z"],
+      ["2026-03-29T03:00", "2026-03-29T01:00:00.000Z"],
+      ["2026-03-29T04:00", "2026-03-29T02:00:00.000Z"],
+    ];
+    for (const [iso, expected] of cases) {
+      expect(new Date(parisIsoToUtcMs(iso)).toISOString()).toBe(expected);
+      // second read comes from the memo and must match byte for byte
+      expect(new Date(parisIsoToUtcMs(iso)).toISOString()).toBe(expected);
+    }
+  });
+
+  it("stays cold-path identical across the fall-back boundary", () => {
+    // 2026-10-25: Paris falls back from 03:00 CEST to 02:00 CET.
+    const cases: [string, string][] = [
+      ["2026-10-25T00:00", "2026-10-24T22:00:00.000Z"],
+      ["2026-10-25T01:00", "2026-10-25T00:00:00.000Z"],
+      ["2026-10-25T02:00", "2026-10-25T01:00:00.000Z"],
+      ["2026-10-25T03:00", "2026-10-25T02:00:00.000Z"],
+      ["2026-10-25T04:00", "2026-10-25T03:00:00.000Z"],
+    ];
+    for (const [iso, expected] of cases) {
+      expect(new Date(parisIsoToUtcMs(iso)).toISOString()).toBe(expected);
+      expect(new Date(parisIsoToUtcMs(iso)).toISOString()).toBe(expected);
+    }
+  });
+
+  it("keeps returning correct values past the memo cap", () => {
+    // The map is cleared wholesale when it fills up; a value read after the
+    // reset must be recomputed identically rather than lost.
+    const probe = "2026-07-01T00:00";
+    const before = parisIsoToUtcMs(probe);
+    for (let i = 0; i < 4200; i++) {
+      const day = String((i % 28) + 1).padStart(2, "0");
+      const hour = String(i % 24).padStart(2, "0");
+      const minute = String(i % 60).padStart(2, "0");
+      parisIsoToUtcMs(`2027-02-${day}T${hour}:${minute}`);
+    }
+    expect(parisIsoToUtcMs(probe)).toBe(before);
+  });
 });
 
 function brestMarine(): MarineHourly {

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -71,16 +71,32 @@ function pad(arr: (number | null)[] | undefined, n: number): (number | null)[] {
 // The trick: parse the naive string as if it were UTC, then ask Intl what
 // Paris wall-clock would be at that absolute instant. The diff is the Paris
 // offset for that day (handles DST without a tz library).
+//
+// Hoisted out of the function body: constructing an Intl.DateTimeFormat costs
+// ~70 us, and assembling a 200 NM forecast cache calls this ~76k times (41
+// corridor points x 5 series x 168 hours x 2 passes). Building it once and
+// memoizing per input string takes that from ~5 s of main thread to a few ms.
+const PARIS_PARTS_DTF = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Europe/Paris",
+  year: "numeric", month: "2-digit", day: "2-digit",
+  hour: "2-digit", minute: "2-digit", second: "2-digit",
+  hour12: false,
+});
+
+// A single passage touches at most a few hundred distinct timestamps, so the
+// map stays tiny in practice. The cap only guards a long-lived tab that keeps
+// planning: past it we drop everything rather than evict one by one, since a
+// full reset costs one cold pass and the entries are cheap to recompute.
+const PARIS_MS_MEMO_MAX = 4096;
+const parisMsMemo = new Map<string, number>();
+
 export function parisIsoToUtcMs(parisIso: string): number {
+  const hit = parisMsMemo.get(parisIso);
+  if (hit !== undefined) return hit;
+
   const asUtc = new Date(parisIso + ":00Z");
-  const dtf = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Europe/Paris",
-    year: "numeric", month: "2-digit", day: "2-digit",
-    hour: "2-digit", minute: "2-digit", second: "2-digit",
-    hour12: false,
-  });
   const parts: Record<string, string> = {};
-  for (const p of dtf.formatToParts(asUtc)) {
+  for (const p of PARIS_PARTS_DTF.formatToParts(asUtc)) {
     if (p.type !== "literal") parts[p.type] = p.value;
   }
   // Some engines emit "24" at the midnight rollover; coerce to 00.
@@ -94,7 +110,11 @@ export function parisIsoToUtcMs(parisIso: string): number {
     Number(parts.second),
   );
   const offsetMs = parisAsIfUtc - asUtc.getTime();
-  return asUtc.getTime() - offsetMs;
+  const ms = asUtc.getTime() - offsetMs;
+
+  if (parisMsMemo.size >= PARIS_MS_MEMO_MAX) parisMsMemo.clear();
+  parisMsMemo.set(parisIso, ms);
+  return ms;
 }
 
 async function fetchMarcOverlay(

--- a/packages/web/src/utils/format.test.ts
+++ b/packages/web/src/utils/format.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it } from "vitest";
+import { formatDayHeader, formatHour } from "./format";
+
+// `parisTzOffsetMin` is module-private; "utc" mode is the only path that
+// exercises it without depending on the machine timezone, so the tests below
+// go through formatHour(iso, "utc") on purpose.
+describe("formatHour, utc mode", () => {
+  it("subtracts the CEST offset in summer", () => {
+    expect(formatHour("2026-07-01T12:00", "utc")).toBe("10");
+  });
+
+  it("subtracts the CET offset in winter", () => {
+    expect(formatHour("2026-01-15T12:00", "utc")).toBe("11");
+  });
+
+  it("is stable across repeated calls (memoized offset)", () => {
+    const first = formatHour("2026-07-01T12:00", "utc");
+    for (let i = 0; i < 5; i++) {
+      expect(formatHour("2026-07-01T12:00", "utc")).toBe(first);
+    }
+    // Other keys in between must not disturb the cached one.
+    formatHour("2026-01-15T12:00", "utc");
+    formatHour("2026-03-29T04:00", "utc");
+    expect(formatHour("2026-07-01T12:00", "utc")).toBe(first);
+  });
+
+  it("switches offset on the day Paris springs forward", () => {
+    // 2026-03-29: CET (+01:00) before 01:00 UTC, CEST (+02:00) after.
+    expect(formatHour("2026-03-29T00:00", "utc")).toBe("23");
+    expect(formatHour("2026-03-29T04:00", "utc")).toBe("2");
+    expect(formatHour("2026-03-30T04:00", "utc")).toBe("2");
+  });
+
+  it("switches offset on the day Paris falls back", () => {
+    // 2026-10-25: CEST (+02:00) before 01:00 UTC, CET (+01:00) after.
+    expect(formatHour("2026-10-25T00:00", "utc")).toBe("22");
+    expect(formatHour("2026-10-25T04:00", "utc")).toBe("3");
+    expect(formatHour("2026-10-26T04:00", "utc")).toBe("3");
+  });
+});
+
+describe("formatDayHeader, boat mode", () => {
+  it("reads the day straight off the Paris date part", () => {
+    expect(formatDayHeader("2026-07-01T12:00", "boat")).toBe("WED 1");
+    expect(formatDayHeader("2026-03-29T02:00", "boat")).toBe("SUN 29");
+  });
+});

--- a/packages/web/src/utils/format.ts
+++ b/packages/web/src/utils/format.ts
@@ -11,24 +11,40 @@ const DAYS_EN = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 // UTC mode: append the Paris UTC offset so Date can convert to UTC.
 // Local mode: interpret as-is via Date (current browser local time).
 
+// Hoisted out of parisTzOffsetMin: building an Intl.DateTimeFormat costs
+// ~70 us and the timeline header formats 168 cells per render, so a per-call
+// constructor showed up as 50 to 100 ms of jank per render on mobile.
+const PARIS_HHMM_DTF = new Intl.DateTimeFormat("en-US", {
+  timeZone: "Europe/Paris",
+  hour: "numeric",
+  minute: "numeric",
+  hour12: false,
+});
+
+// One entry per distinct timestamp rendered. A 7-day timeline is 168 keys, so
+// the cap is only there to bound a tab left open across many spots; past it we
+// drop everything rather than evict one by one, the entries being cheap.
+const PARIS_OFFSET_MEMO_MAX = 4096;
+const parisOffsetMemo = new Map<string, number>();
+
 /** UTC offset in minutes for Europe/Paris at the given ISO date-time string */
 function parisTzOffsetMin(iso: string): number {
+  const hit = parisOffsetMemo.get(iso);
+  if (hit !== undefined) return hit;
   // Append a fake UTC marker to get a Date object, then compute the offset
   // by comparing Paris wall-clock to UTC wall-clock.
   const utcMs = new Date(iso + "Z").getTime();
   // Format the UTC timestamp in Europe/Paris to read the displayed hour/minute
-  const parisFormatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: "Europe/Paris",
-    hour: "numeric",
-    minute: "numeric",
-    hour12: false,
-  });
-  const parts = parisFormatter.formatToParts(new Date(utcMs));
+  const parts = PARIS_HHMM_DTF.formatToParts(new Date(utcMs));
   const parisHour = Number(parts.find((p) => p.type === "hour")?.value ?? 0);
   const parisMin = Number(parts.find((p) => p.type === "minute")?.value ?? 0);
   const utcHour = new Date(utcMs).getUTCHours();
   const utcMin = new Date(utcMs).getUTCMinutes();
-  return (parisHour * 60 + parisMin) - (utcHour * 60 + utcMin);
+  const offset = (parisHour * 60 + parisMin) - (utcHour * 60 + utcMin);
+
+  if (parisOffsetMemo.size >= PARIS_OFFSET_MEMO_MAX) parisOffsetMemo.clear();
+  parisOffsetMemo.set(iso, offset);
+  return offset;
 }
 
 /**


### PR DESCRIPTION
## Quoi

`parisIsoToUtcMs` (`src/api/marine.ts`) construisait un `Intl.DateTimeFormat` neuf à chaque appel. Idem pour `parisTzOffsetMin` (`src/utils/format.ts`). Le formateur est maintenant construit une seule fois au niveau module, et le résultat est mémoïsé par chaîne d'entrée dans une `Map` bornée à 4096 clés (vidée en bloc au-delà : les entrées sont peu coûteuses à recalculer et une passe froide suffit à les reconstruire).

## Pourquoi

Constat 1 de l'annexe A de l'audit (`plan/audit-2026-09`), PR 0.1 du lot 0.

Assembler un cache de prévisions de 200 NM appelle `parisIsoToUtcMs` environ 76 000 fois : 41 points de corridor x (4 modèles + mer) x 168 heures x 2 passes, plus `mergeMarcOverlay`. `parisTzOffsetMin` est appelé 168 fois par rendu de l'en-tête de timeline, soit à chaque tap sur une heure.

## Mesure

Micro-bench Node 22 (`process.hrtime`), 100 000 appels sur 168 timestamps distincts, soit un horizon horaire de 7 jours :

| Variante | µs par appel | Total 100 k |
|---|---|---|
| Avant : `Intl.DateTimeFormat` par appel | 34 à 35 µs | 3 380 ms |
| Formateur hissé seul | 3,3 µs | 332 ms |
| Formateur hissé + mémo (livré) | 0,013 à 0,036 µs | 1 à 4 ms |

Rapporté aux ~76 000 appels d'un calcul 200 NM : environ 2,6 s de thread principal ramenées à quelques millisecondes sur poste, davantage encore sur un Android moyen.

## Comportement

Inchangé, y compris la coercition de l'heure `"24"` au passage de minuit émise par certains moteurs.

## Tests

- `src/api/marine.test.ts` : les 3 tests existants passent ; ajout de la stabilité des appels répétés, des bornes de changement d'heure (2026-03-29 et 2026-10-25, chacune avec ses voisines) et d'un test qui franchit le plafond de la Map pour vérifier qu'une valeur relue après purge est recalculée à l'identique.
- `src/utils/format.test.ts` (nouveau) : `formatHour` en mode `utc`, seul chemin qui exerce `parisTzOffsetMin` sans dépendre du fuseau de la machine, sur été, hiver et les deux bascules.

`npm run typecheck`, `lint:budget` (11 erreurs, budget 11, inchangé), `test` (275 tests) et `build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)