### PR TITLE
fix(web): décalage horaire de la date prévue, pas d'aujourd'hui

### DIFF
--- a/packages/web/src/plan/departureTz.test.ts
+++ b/packages/web/src/plan/departureTz.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it } from "vitest";
+import { localOffsetFor, toTzAware, tzSuffixFor } from "./departureTz";
+
+describe("tzSuffixFor", () => {
+  it("formats a positive offset", () => {
+    expect(tzSuffixFor(120)).toBe("+02:00");
+    expect(tzSuffixFor(60)).toBe("+01:00");
+  });
+
+  it("formats UTC as a positive zero", () => {
+    expect(tzSuffixFor(0)).toBe("+00:00");
+  });
+
+  it("formats a negative offset", () => {
+    expect(tzSuffixFor(-300)).toBe("-05:00");
+  });
+
+  it("formats a non-whole-hour offset", () => {
+    expect(tzSuffixFor(330)).toBe("+05:30");
+    expect(tzSuffixFor(-210)).toBe("-03:30");
+  });
+});
+
+// The offset is injected so the assertions hold whatever the machine's
+// timezone is. `localOffsetFor` gets its own coverage below.
+describe("toTzAware", () => {
+  it("appends the summer offset to a naive picker value", () => {
+    expect(toTzAware("2026-07-04T09:30", 120)).toBe("2026-07-04T09:30:00+02:00");
+  });
+
+  it("appends the winter offset to a naive picker value", () => {
+    expect(toTzAware("2026-11-04T09:30", 60)).toBe("2026-11-04T09:30:00+01:00");
+  });
+
+  it("appends a negative offset", () => {
+    expect(toTzAware("2026-07-04T09:30", -300)).toBe("2026-07-04T09:30:00-05:00");
+  });
+
+  it("leaves an already offset-bearing string untouched", () => {
+    expect(toTzAware("2026-07-04T09:30:00+02:00")).toBe("2026-07-04T09:30:00+02:00");
+    expect(toTzAware("2026-07-04T07:30:00Z")).toBe("2026-07-04T07:30:00Z");
+  });
+});
+
+describe("localOffsetFor", () => {
+  it("reads the offset of the target date, not of today", () => {
+    // The bug this replaces: a single offset, taken today, stamped onto a date
+    // up to 14 days away. Whatever the machine's timezone, a date that sits on
+    // the other side of a daylight-saving change must not inherit today's
+    // offset. Compared against the platform's own answer for each instant.
+    const summer = "2026-07-04T09:30";
+    const winter = "2026-11-04T09:30";
+    expect(localOffsetFor(summer)).toBe(-new Date(summer).getTimezoneOffset());
+    expect(localOffsetFor(winter)).toBe(-new Date(winter).getTimezoneOffset());
+  });
+
+  it("distinguishes the two sides of a daylight-saving change where there is one", () => {
+    // Skipped on a machine with no seasonal change (UTC, most of Asia), where
+    // there is nothing to distinguish.
+    const before = -new Date("2026-03-01T12:00").getTimezoneOffset();
+    const after = -new Date("2026-07-01T12:00").getTimezoneOffset();
+    if (before === after) return;
+    expect(localOffsetFor("2026-03-01T12:00")).toBe(before);
+    expect(localOffsetFor("2026-07-01T12:00")).toBe(after);
+    expect(toTzAware("2026-03-01T12:00")).not.toBe(
+      toTzAware("2026-07-01T12:00").replace("2026-07-01", "2026-03-01"),
+    );
+  });
+
+  it("falls back to the current offset on an unparsable string", () => {
+    expect(localOffsetFor("pas une date")).toBe(-new Date().getTimezoneOffset());
+  });
+});

--- a/packages/web/src/plan/departureTz.ts
+++ b/packages/web/src/plan/departureTz.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+// Turning the departure picker's naive "YYYY-MM-DDTHH:MM" into a
+// timezone-aware timestamp for the server.
+//
+// Split out of PlanPage so the rule can be tested without a DOM, and so the
+// test can pin an offset instead of depending on the machine's timezone.
+
+const TZ_AWARE = /Z$|[+-]\d{2}:\d{2}$/;
+
+/** "+02:00" / "-05:30" for an offset expressed in minutes east of UTC. */
+export function tzSuffixFor(offsetMinutes: number): string {
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMinutes);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
+  return `${sign}${hh}:${mm}`;
+}
+
+/**
+ * Local UTC offset, in minutes east of UTC, at the instant `iso` denotes.
+ *
+ * `new Date("YYYY-MM-DDTHH:MM")` parses a date-time form with no offset as
+ * local time, so the resulting Date carries the offset in force on that day,
+ * not today's. That distinction is the whole point: the slider reaches 14 days
+ * out, which straddles a daylight-saving change twice a year.
+ *
+ * An unparsable string falls back to the current offset, which is what the
+ * previous implementation always used.
+ */
+export function localOffsetFor(iso: string): number {
+  const at = new Date(iso);
+  const minutes = at.getTimezoneOffset();
+  if (Number.isNaN(minutes)) return -new Date().getTimezoneOffset();
+  return -minutes;
+}
+
+/**
+ * Append the local timezone offset to a naive "YYYY-MM-DDTHH:MM" string.
+ * Already timezone-aware input (trailing Z or ±HH:MM) is returned untouched.
+ *
+ * The offset is the one in force on the target date, not today's. Using
+ * today's shifted the departure sent to the server by one hour whenever the
+ * planned date sat on the other side of a daylight-saving change, and the
+ * server-resolved departure then rewrote the slider and the URL: the hour
+ * changed under the user right after "Calculer".
+ *
+ * The hour skipped by the spring-forward jump does not exist locally; the
+ * runtime resolves it to the following hour, so the suffix is the post-change
+ * offset. There is no right answer for a time that never happens, and the
+ * picker cannot produce one on a whole hour anyway.
+ */
+export function toTzAware(iso: string, offsetMinutes: number = localOffsetFor(iso)): string {
+  if (TZ_AWARE.test(iso)) return iso;
+  return `${iso}:00${tzSuffixFor(offsetMinutes)}`;
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "../plan/lastSimulation";
 import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
+import { toTzAware } from "../plan/departureTz";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
 import { effectivePolar, initialPlanBoat, isPersoActive, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
 import { LocateButton } from "../components/LocateButton";
@@ -88,18 +89,6 @@ function tomorrowRoundedLocal(): string {
   d.setMinutes(0, 0, 0);
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-// Append local timezone offset to a naive "YYYY-MM-DDTHH:MM" string.
-// If already timezone-aware (ends with Z or ±HH:MM), return as-is.
-function toTzAware(iso: string): string {
-  if (/Z$|[+-]\d{2}:\d{2}$/.test(iso)) return iso;
-  const off = -new Date().getTimezoneOffset();
-  const sign = off >= 0 ? "+" : "-";
-  const abs = Math.abs(off);
-  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
-  const mm = String(abs % 60).padStart(2, "0");
-  return `${iso}:00${sign}${hh}:${mm}`;
 }
 
 function fmtTime(iso: string) {


### PR DESCRIPTION
## Quoi

`toTzAware` collait l'offset local **d'aujourd'hui** à une date naïve `YYYY-MM-DDTHH:MM`. Il prend maintenant l'offset en vigueur à l'instant que la chaîne désigne : `new Date("YYYY-MM-DDTHH:MM")` parse une forme date-heure sans suffixe comme heure locale, donc la `Date` obtenue porte l'offset du jour visé.

## Pourquoi

Constat 12 de l'annexe A de l'audit (`plan/audit-2026-09`), PR 0.2 du lot 0.

Le curseur de départ va jusqu'à 14 jours en avant. Dès que la date visée passait de l'autre côté d'un changement d'heure, le départ envoyé au serveur était décalé d'une heure. Pire, la réponse du serveur repasse par `isoToLocal(res.passage.departure_time)` qui réécrit le curseur et l'URL : l'heure changeait toute seule sous les yeux de l'utilisateur juste après « Calculer ». Les deux bornes du balayage avaient le même défaut.

## Mesure

En planifiant le 20 octobre 2026 une sortie le 27, fuseau Europe/Paris :

| | Envoyé au serveur | Instant réel |
|---|---|---|
| Avant | `2026-10-27T09:30:00+02:00` | 08:30 locales, une heure trop tôt |
| Après | `2026-10-27T09:30:00+01:00` | 09:30 locales, l'heure demandée |

## Comment c'est testé

La règle sort de `PlanPage.tsx` vers `src/plan/departureTz.ts` : `tzSuffixFor(offsetMinutes)`, `localOffsetFor(iso)` et `toTzAware(iso, offsetMinutes = localOffsetFor(iso))`. Trois fonctions pures, testables sans DOM, avec l'offset injectable pour que les assertions ne dépendent pas du fuseau de la machine de CI. `PlanPage.tsx` ne change que d'un import et de la suppression du helper local.

`src/plan/departureTz.test.ts` couvre `+02:00` contre `+01:00`, les offsets négatifs (`-05:00`), les offsets à la demi-heure (`+05:30`, `-03:30`), UTC, l'entrée déjà porteuse d'un offset laissée intacte, la comparaison à la réponse de la plateforme pour deux dates de part et d'autre d'un changement d'heure, et le repli sur l'offset courant si la chaîne est inparsable. Suite verte sous `Europe/Paris`, `UTC`, `America/New_York`, `Australia/Sydney` et `Asia/Kolkata`.

L'heure sautée par le passage à l'heure d'été n'existe pas localement ; le runtime la résout à l'heure suivante, donc le suffixe est celui d'après bascule. Il n'y a pas de bonne réponse pour une heure qui n'a pas eu lieu, et le sélecteur ne peut de toute façon pas la produire sur une heure ronde. C'est écrit dans le commentaire de la fonction.

`npm run typecheck`, `lint:budget` (11 erreurs, budget 11, inchangé), `test` (276 tests) et `build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)