### PR TITLE
perf(web): charge les pages de documentation à la demande

### DIFF
--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -1,12 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
+import { Suspense, lazy } from "react";
+
 import App from "./App";
 import { PlanPage } from "./routes/PlanPage";
-import { MethodologiePage } from "./routes/MethodologiePage";
 import { ConfigPage } from "./routes/ConfigPage";
-import { ConfidentialitePage } from "./routes/ConfidentialitePage";
 import { useRouter } from "./router";
+
+// Les deux pages de documentation tirent react-markdown, remark/rehype, KaTeX
+// et sa feuille de style : environ 470 KB bruts pour des pages rarement
+// consultees, jusqu'ici embarquees dans le chunk d'entree servi a la racine.
+// Chargees a la demande, elles sortent du chemin critique du premier rendu.
+// Les autres routes restent statiques : /plan est la destination principale,
+// la retarder d'un aller-retour reseau ne servirait rien.
+const MethodologiePage = lazy(() =>
+  import("./routes/MethodologiePage").then((m) => ({ default: m.MethodologiePage })),
+);
+const ConfidentialitePage = lazy(() =>
+  import("./routes/ConfidentialitePage").then((m) => ({ default: m.ConfidentialitePage })),
+);
+
+// Les deux pages imposent un fond "papier blanc" quel que soit le theme.
+// L'attente reprend ce fond pour eviter un clignotement sombre puis clair
+// pendant le telechargement du chunk.
+const docFallback = (
+  <div className="min-h-screen" style={{ background: "#ffffff", color: "#6b7280" }}>
+    <p className="max-w-3xl mx-auto px-6 py-10 text-sm">Chargement…</p>
+  </div>
+);
 
 /**
  * Path to page, resolved client-side.
@@ -25,8 +47,18 @@ export function Routes() {
   const key = path + search;
 
   if (path === "/plan") return <PlanPage key={key} />;
-  if (path === "/methodologie") return <MethodologiePage key={key} />;
+  if (path === "/methodologie")
+    return (
+      <Suspense fallback={docFallback}>
+        <MethodologiePage key={key} />
+      </Suspense>
+    );
   if (path === "/config") return <ConfigPage key={key} />;
-  if (path === "/confidentialite") return <ConfidentialitePage key={key} />;
+  if (path === "/confidentialite")
+    return (
+      <Suspense fallback={docFallback}>
+        <ConfidentialitePage key={key} />
+      </Suspense>
+    );
   return <App key={key} />;
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -46,6 +46,13 @@ export default defineConfig({
         // plus icons and fonts emitted into dist/. ``mjs`` is there for
         // MapLibre's tile worker, which ships as its own module file.
         globPatterns: ['**/*.{js,mjs,css,html,ico,png,svg,woff2}'],
+        // Ce qui n'appartient qu'aux pages de documentation reste en ligne:
+        // les polices KaTeX, la carte de couverture et les diagrammes de
+        // polaires ne servent qu'a /methodologie, chargee a la demande. Les
+        // precacher coutait ~330 KB de reseau a la premiere visite et autant
+        // de stockage, pour des pages que la plupart des visiteurs n'ouvrent
+        // jamais et qui n'ont pas besoin de fonctionner hors ligne.
+        globIgnores: ['**/KaTeX_*', 'methodologie/**', 'polars/**'],
         // Drop stale precaches when a new SW activates.
         cleanupOutdatedCaches: true,
         // SPA fallback so deep links (/plan, /config, ...) resolve offline.


### PR DESCRIPTION
Lot 0, PR 0.6 du plan de rework. Les pages Méthodologie et Confidentialité embarquaient react-markdown, remark/rehype, KaTeX et `katex/dist/katex.min.css` dans le chunk d'entrée servi à la racine. `React.lazy` + `Suspense` les déplacent dans leurs propres chunks. Les autres routes restent statiques : `/plan` est la destination principale, la retarder d'un aller-retour réseau ne servirait à rien.

## Avant / après

Build de production, tailles brutes en octets.

| | Avant | Après | Delta |
|---|---|---|---|
| Chunk d'entrée JS | 1 213 639 (`index-DHMZs5bb.js`) | **570 580** (`index-KExOy_1X.js`) | -643 059 (-53 %) |
| Chunk d'entrée JS, gzip | 365,64 ko | 169,20 ko | -54 % |
| Feuille de style d'entrée | 92 626 | 63 785 | -28 841 (-31 %) |
| Feuille de style d'entrée, gzip | 24,00 ko | 16,17 ko | -33 % |
| Précache SW, entrées | 44 | **21** | -23 |
| Précache SW, octets | 3 302 820 (3 225 Kio) | **2 890 185** (2 822 Kio) | -412 635 |

Cible du plan : chunk d'entrée sous 750 Ko bruts. Mesuré à 557 Kio.

Nouveaux chunks, chargés seulement à l'ouverture de la page concernée :

```
MethodologiePage-CZCG55DQ.js    481 704  (gzip 149,95 ko)
MethodologiePage-CSceNpVM.css    28 842  (gzip   7,92 ko)  <- katex.min.css
ConfidentialitePage-C69IH8Y7.js   6 870  (gzip   2,77 ko)
lib-HROvQaZW.js                 153 907  (gzip  45,89 ko)  <- remark/rehype partagé par les deux
```

Vérifié dans le `dist/index.html` généré : ni `lib-*.js` ni les chunks de pages ne sont en `modulepreload`, ils n'apparaissent que dans la carte de dépendances des imports dynamiques.

## globIgnores

`globIgnores: ['**/KaTeX_*', 'methodologie/**', 'polars/**']` sort du précache ce qui n'appartient qu'à ces pages : 19 polices KaTeX, la carte de couverture des atlas et les 7 diagrammes de polaires. Ces deux pages restent donc consultables en ligne uniquement, ce qui est le bon arbitrage : le shell de navigation, lui, reste entièrement hors ligne.

Note pour la relecture : les chunks `MethodologiePage-*` et `ConfidentialitePage-*` restent, eux, dans le précache (ils vivent dans `assets/` et matchent `**/*.js`). Ils y étaient déjà avant, fondus dans `index.js`, donc le réseau de première visite ne régresse pas. Les exclure aussi ferait gagner 517 Ko de plus, au prix d'un glob sur des noms de chunks hashés : à trancher séparément.

## Vérification

Sur le build de production (`npm run build && npm run preview`), pas sur le serveur de dev.

- `/methodologie` : 55 nœuds `.katex` dont 9 en display, `font-family` calculée `KaTeX_Main`, `MethodologiePage-CSceNpVM.css` bien chargée comme feuille de style séparée, `coverage_map.png` et les 7 SVG de polaires servis. Formules relues en capture, rendu identique.
- `/confidentialite` : titre et contenu rendus.
- `/` : carte et barre de recherche normales.
- `/plan` : panneau de tracé rendu, aucune erreur console (seulement les avertissements préexistants `apple-mobile-web-app-capable` et WebGL logiciel de l'environnement de test).

`npm run typecheck`, `npm run lint:budget` (11 erreurs, budget 11, inchangé), `npm run test` (265 tests) et `npm run build` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
