### PR TITLE
perf(web): cache le vent du corridor point par point

### DIFF
--- a/packages/web/src/api/openmeteo.test.ts
+++ b/packages/web/src/api/openmeteo.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { sanitizeHourly, fetchWindCorridor } from "./openmeteo";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { clearWindCorridorCache, sanitizeHourly, fetchWindCorridor } from "./openmeteo";
 import type { HourlyData } from "../types";
 
 function makeHourly(
@@ -102,6 +102,8 @@ describe("sanitizeHourly", () => {
 });
 
 describe("fetchWindCorridor", () => {
+  // The point cache lives at module scope, so each test starts from cold.
+  beforeEach(() => clearWindCorridorCache());
   afterEach(() => vi.restoreAllMocks());
 
   function elementWithHourly(speed: number): { hourly: HourlyData } {
@@ -151,5 +153,83 @@ describe("fetchWindCorridor", () => {
     expect(await fetchWindCorridor([], ["AROME"])).toEqual([]);
     expect(await fetchWindCorridor([{ lat: 1, lon: 2 }], [])).toEqual([[]]);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("serves a fully cached corridor without a single request", async () => {
+    const coords = [
+      { lat: 43.3, lon: 5.35 },
+      { lat: 43.0, lon: 6.2 },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => [elementWithHourly(10), elementWithHourly(12)],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await fetchWindCorridor(coords, ["AROME"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const second = await fetchWindCorridor(coords, ["AROME"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no second request
+    expect(second[0][0].hourly.wind_speed_10m).toEqual([10, 10]);
+    expect(second[1][0].hourly.wind_speed_10m).toEqual([12, 12]);
+    expect(second).toEqual(first);
+  });
+
+  it("requests only the points it is missing, and maps them back in order", async () => {
+    const a = { lat: 43.3, lon: 5.35 };
+    const b = { lat: 43.0, lon: 6.2 };
+    const c = { lat: 42.8, lon: 6.9 };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ json: async () => [elementWithHourly(10), elementWithHourly(12)] })
+      .mockResolvedValueOnce({ json: async () => [elementWithHourly(14)] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWindCorridor([a, b], ["AROME"]);
+    const out = await fetchWindCorridor([a, b, c], ["AROME"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second request carries the missing point only.
+    const secondUrl = String(fetchMock.mock.calls[1][0]);
+    expect(secondUrl).toContain("latitude=42.8&longitude=6.9");
+    // ...and its single element lands on index 2, not index 0.
+    expect(out[0][0].hourly.wind_speed_10m).toEqual([10, 10]);
+    expect(out[1][0].hourly.wind_speed_10m).toEqual([12, 12]);
+    expect(out[2][0].hourly.wind_speed_10m).toEqual([14, 14]);
+  });
+
+  it("keys the cache on the model chain, not on the coordinates alone", async () => {
+    const coords = [{ lat: 43.3, lon: 5.35 }];
+    const fetchMock = vi.fn().mockResolvedValue({ json: async () => [elementWithHourly(9)] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWindCorridor(coords, ["AROME"]);
+    await fetchWindCorridor(coords, ["AROME", "ICON"]);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 for AROME, then 2 for the pair
+  });
+
+  it("does not cache a batch whose request threw", async () => {
+    const coords = [{ lat: 43.3, lon: 5.35 }];
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({ json: async () => [elementWithHourly(8)] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchWindCorridor(coords, ["AROME"])).toEqual([[]]);
+    const retry = await fetchWindCorridor(coords, ["AROME"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // retried, not served from cache
+    expect(retry[0][0].hourly.wind_speed_10m).toEqual([8, 8]);
+  });
+
+  it("caches an empty answer: a point outside every grid is a real answer", async () => {
+    const coords = [{ lat: 55.7, lon: 12.6 }]; // Danish coast, outside AROME
+    const fetchMock = vi.fn().mockResolvedValue({ json: async () => [{}] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchWindCorridor(coords, ["AROME"])).toEqual([[]]);
+    expect(await fetchWindCorridor(coords, ["AROME"])).toEqual([[]]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/api/openmeteo.ts
+++ b/packages/web/src/api/openmeteo.ts
@@ -178,6 +178,43 @@ export async function fetchAllModels(
   return models;
 }
 
+// Per-point cache for corridor wind, mirroring the 30 min TTL of
+// `fetchAllModels`. Without it, every recompute of a plan (boat change,
+// departure tweak, switch to arrival-time mode) refetched the whole corridor:
+// up to 4 requests and ~1.1 MB uncompressed for a 200 NM route whose points
+// had not moved. Keyed per point rather than per corridor so two plans that
+// only differ by a waypoint still reuse everything they have in common.
+const corridorCache = new Map<string, { models: ModelForecast[]; fetchedAt: number }>();
+
+// ~600 points is about ten long corridors kept warm. Beyond that we drop the
+// oldest insertions first; the Map preserves insertion order, so its own key
+// iteration is the eviction queue.
+const CORRIDOR_CACHE_MAX = 600;
+
+// 4 decimals is ~11 m, well under the finest model grid (AROME, 1.5 km), so
+// two keys that differ below that resolution would have returned the same
+// forecast anyway. The model list is part of the key because an entry holds
+// exactly the chain that was asked for.
+function corridorKey(coord: { lat: number; lon: number }, models: ModelName[]): string {
+  return `${coord.lat.toFixed(4)},${coord.lon.toFixed(4)}|${models.join(",")}`;
+}
+
+function storeCorridorPoint(key: string, models: ModelForecast[], fetchedAt: number): void {
+  // Delete first so a refresh moves the key back to the tail of the queue.
+  corridorCache.delete(key);
+  corridorCache.set(key, { models, fetchedAt });
+  while (corridorCache.size > CORRIDOR_CACHE_MAX) {
+    const oldest = corridorCache.keys().next();
+    if (oldest.done) break;
+    corridorCache.delete(oldest.value);
+  }
+}
+
+/** Test seam: drop every cached corridor point. Not used by the app. */
+export function clearWindCorridorCache(): void {
+  corridorCache.clear();
+}
+
 // Fetch wind for a whole route corridor in one request PER MODEL, using
 // Open-Meteo's multi-coordinate support (comma-separated latitude/longitude →
 // a JSON array, one element per coordinate, order preserved). This collapses
@@ -198,8 +235,23 @@ export async function fetchWindCorridor(
   const out: ModelForecast[][] = coords.map(() => []);
   if (coords.length === 0 || models.length === 0) return out;
 
-  const lats = coords.map((c) => c.lat).join(",");
-  const lons = coords.map((c) => c.lon).join(",");
+  // Split the corridor into what the cache already holds and what is missing.
+  // Two successive plans over the same route share most of their points, so a
+  // boat change or a departure tweak usually finds everything here.
+  const now = Date.now();
+  const missing: number[] = [];
+  for (let i = 0; i < coords.length; i++) {
+    const hit = corridorCache.get(corridorKey(coords[i], models));
+    if (hit && now - hit.fetchedAt < CACHE_TTL) {
+      out[i] = hit.models;
+    } else {
+      missing.push(i);
+    }
+  }
+  if (missing.length === 0) return out;
+
+  const lats = missing.map((i) => coords[i].lat).join(",");
+  const lons = missing.map((i) => coords[i].lon).join(",");
   const base = `?latitude=${lats}&longitude=${lons}&${PARAMS}`;
 
   const perModel = await Promise.all(
@@ -209,21 +261,35 @@ export async function fetchWindCorridor(
         const resp = await fetch(`${endpoint.endpoint}${base}${endpoint.extraParams || ""}`);
         const data = await resp.json();
         // Multi-coordinate → array; a 1-coord request may come back as a bare
-        // object, so normalize to an array aligned to `coords`.
+        // object, so normalize to an array aligned to `missing`.
         const arr: unknown[] = Array.isArray(data) ? data : [data];
-        return { name, arr };
+        return { name, arr, ok: true };
       } catch {
-        return { name, arr: [] as unknown[] };
+        return { name, arr: [] as unknown[], ok: false };
       }
     }),
   );
 
+  // The response array is aligned to `missing`, not to `coords`: map back
+  // through the index list before writing into `out`.
+  const fetched: ModelForecast[][] = missing.map(() => []);
   for (const { name, arr } of perModel) {
-    for (let i = 0; i < coords.length; i++) {
-      const el = arr[i] as { hourly?: HourlyData } | undefined;
+    for (let k = 0; k < missing.length; k++) {
+      const el = arr[k] as { hourly?: HourlyData } | undefined;
       if (el && el.hourly) {
-        out[i].push({ modelName: name, hourly: sanitizeHourly(el.hourly) });
+        fetched[k].push({ modelName: name, hourly: sanitizeHourly(el.hourly) });
       }
+    }
+  }
+
+  // An empty list is a legitimate answer (point outside every grid), so it is
+  // worth caching. A request that threw is not: caching it would pin a network
+  // blip for half an hour, so a failed batch is served but not stored.
+  const cacheable = perModel.every((m) => m.ok);
+  for (let k = 0; k < missing.length; k++) {
+    out[missing[k]] = fetched[k];
+    if (cacheable) {
+      storeCorridorPoint(corridorKey(coords[missing[k]], models), fetched[k], now);
     }
   }
   return out;


### PR DESCRIPTION
## Quoi

`fetchWindCorridor` (`src/api/openmeteo.ts`) ne touchait pas la `Map` à 30 minutes utilisée par `fetchAllModels`. Ajout d'un cache mémoire **par point**, même TTL, clé `lat,lon|modèles` avec les coordonnées arrondies à 4 décimales.

À l'appel, le corridor est séparé en points déjà connus et points manquants. Seuls les manquants partent, toujours en **une seule requête multi-coordonnées par modèle**, et le tableau de réponse est réaligné sur les indices d'origine avant d'être écrit. Corridor entièrement en cache : zéro requête.

## Pourquoi

Constat 4 de l'annexe A de l'audit (`plan/audit-2026-09`), PR 0.4 du lot 0.

Tout recalcul d'un plan (changement de bateau, ajustement du départ, bascule en mode heure d'arrivée) refaisait la totalité des requêtes de corridor alors que les points n'avaient pas bougé. La clé est par point et non par corridor pour que deux plans qui ne diffèrent que d'un waypoint réutilisent tout le reste.

## Mesure

Corridor synthétique de 41 points le long d'une route de 200 NM, mesuré en direct sur Open-Meteo (une requête AROME, `--compressed`) :

| | Sur le fil | JSON brut |
|---|---|---|
| 1 modèle, 41 points | 19,3 Ko | 294 Ko |
| 4 modèles (le défaut) | ~77 Ko | ~1,18 Mo |

| Requêtes vent du corridor | Avant | Après |
|---|---|---|
| Premier calcul | 4 | 4 |
| Recalcul dans les 30 min, mêmes points | 4 | **0** |
| Recalcul après ajout d'un waypoint, 40 points communs sur 41 | 4 | 4 requêtes pour 1 point, soit ~0,5 Ko compressés |

Cohérent avec les 17 à 32 Ko compressés par modèle relevés par l'annexe A.

## Détails de conception

- 4 décimales, c'est environ 11 m, largement sous la maille la plus fine (AROME, 1,5 km) : deux clés qui diffèrent en dessous auraient de toute façon renvoyé la même prévision.
- Le chaînage de modèles fait partie de la clé, une entrée portant exactement la chaîne demandée.
- Un lot dont une requête a levé est servi mais **pas** mémorisé : cacher un échec figerait une coupure réseau pendant une demi-heure. Une liste vide, elle, est une vraie réponse (point hors de toutes les grilles) et se cache.
- Cache borné à 600 points, environ dix longs corridors, éviction par ordre d'insertion (la `Map` conserve cet ordre, elle est sa propre file).

## Tests

`src/api/openmeteo.test.ts`, `fetch` bouchonné via `vi.stubGlobal`, cache vidé avant chaque test : deuxième appel identique sans aucune requête, coordonnées partiellement recouvrantes ne demandant que le sous-ensemble manquant avec vérification de l'URL et du réalignement des indices, clé sensible au chaînage de modèles, lot en échec rejoué, réponse vide mise en cache. Les 3 tests existants passent inchangés.

`npm run typecheck`, `lint:budget` (11 erreurs, budget 11, inchangé), `test` (270 tests) et `build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)