### PR TITLE
fix(web): le bouton retour Android ferme les panneaux au lieu de quitter l'app

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,12 +23,24 @@ import { LocateButton } from "./components/LocateButton";
 import { SeamarkButton } from "./components/SeamarkButton";
 import { useSeamarks } from "./hooks/useSeamarks";
 import { useGeolocation } from "./hooks/useGeolocation";
+import { useBackDismiss } from "./hooks/useBackDismiss";
 import { useMapView } from "./hooks/useMapView";
 import { parseMapView, mapViewQuery } from "./utils/mapViewParams";
 import { hasDeclinedGeolocation } from "./config/geolocPreference";
 import { loadLastSpot, saveLastSpot } from "./config/lastSpot";
 
 const DEFAULT_MAP_CENTER: { lat: number; lon: number } = { lat: 43.3, lon: 5.35 };
+
+/** A spot the user is only looking at. Named by its coordinates rather than
+    reverse-geocoded: the lookup is instant and offline, and a position is
+    meaningful information at sea. */
+function previewSpot(lat: number, lon: number): Spot {
+  return {
+    name: `${lat.toFixed(3)}, ${lon.toFixed(3)}`,
+    latitude: lat,
+    longitude: lon,
+  };
+}
 
 function EmptyState() {
   return (
@@ -95,6 +107,25 @@ function App() {
   const [loadedSpotKey, setLoadedSpotKey] = useState<string | null>(null);
   const [selectedHour, setSelectedHour] = useState<string | null>(null);
   const [view, setView] = useState<MetricView>("wind");
+  // Whether the forecast panel counts as a layer the back button should
+  // close. Only a deliberate pick does: a spot restored from the last visit
+  // (issue #301) or previewed from the first-visit fix is this session's
+  // starting point, and back must leave the app from there rather than
+  // stopping on an empty map (issue #300).
+  const [spotIsLayer, setSpotIsLayer] = useState(false);
+  const selectSpot = useCallback((next: Spot) => {
+    setSpot(next);
+    setSpotIsLayer(true);
+  }, []);
+  const clearSpot = useCallback(() => {
+    setSpot(null);
+    setSpotIsLayer(false);
+    setForecasts([]);
+    setMarine(null);
+    setLoadedSpotKey(null);
+    setSelectedHour(null);
+  }, []);
+  useBackDismiss(spotIsLayer, clearSpot);
   const activeSpotKey = spot ? `${spot.latitude},${spot.longitude}` : null;
   const isLoading = activeSpotKey != null && loadedSpotKey !== activeSpotKey;
   useEffect(() => {
@@ -134,16 +165,10 @@ function App() {
   }, [spot]);
 
   // Tap or left click on the map: show the forecast there without saving.
-  // Named by its coordinates rather than reverse-geocoded: the lookup is
-  // instant and offline, and a position is meaningful information at sea.
   // Creating a spot stays a deliberate act (long press, or right click).
   const handlePreviewSpot = useCallback((lat: number, lon: number) => {
-    setSpot({
-      name: `${lat.toFixed(3)}, ${lon.toFixed(3)}`,
-      latitude: lat,
-      longitude: lon,
-    });
-  }, []);
+    selectSpot(previewSpot(lat, lon));
+  }, [selectSpot]);
 
   // First-visit geolocation: if the user has no saved spots, ask the browser
   // for their position, fly the map there and show the wind at that point
@@ -174,7 +199,9 @@ function App() {
       // chose their focus — leave the viewport and their selection alone.
       if (fix && !spotRef.current) {
         setFlyToStamp(fix.stamp);
-        handlePreviewSpot(fix.lat, fix.lon);
+        // Not selectSpot: nobody asked for this spot, so back must not have
+        // to dismiss it before leaving the app.
+        setSpot(previewSpot(fix.lat, fix.lon));
       }
     });
   // Run once on mount; the customSpots check covers the returning-user case.
@@ -218,7 +245,7 @@ function App() {
           no position granted ranks Brest in Belarus and Brest in Croatia
           alongside the Finistère one. */}
       <Header
-        onSelectSpot={setSpot}
+        onSelectSpot={selectSpot}
         nearLat={userPosition?.lat ?? mapView?.lat ?? spot?.latitude ?? null}
         nearLon={userPosition?.lon ?? mapView?.lon ?? spot?.longitude ?? null}
         savedSpots={customSpots}
@@ -237,10 +264,10 @@ function App() {
           initialView={initialView}
           defaultCenter={DEFAULT_MAP_CENTER}
           bottomInsetRef={dataPanelRef}
-          onSelectSpot={setSpot}
+          onSelectSpot={selectSpot}
           onPreviewSpot={handlePreviewSpot}
-          onAddSpot={(s) => { addSpot(s); setSpot(s); }}
-          onRemoveSpot={(s) => { removeSpot(s); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) { setSpot(null); setForecasts([]); setLoadedSpotKey(null); setSelectedHour(null); } }}
+          onAddSpot={(s) => { addSpot(s); selectSpot(s); }}
+          onRemoveSpot={(s) => { removeSpot(s); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) clearSpot(); }}
           onRenameSpot={(s, name) => { renameSpot(s, name); if (spot?.latitude === s.latitude && spot?.longitude === s.longitude) setSpot({ ...s, name }); }}
           forecasts={forecasts}
           marine={marine}

--- a/packages/web/src/components/InfoButton.tsx
+++ b/packages/web/src/components/InfoButton.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { InfoPanel } from "./InfoPanel";
+import { useBackDismiss } from "../hooks/useBackDismiss";
 
 function InfoIcon() {
   return (
@@ -69,6 +70,10 @@ function InfoModal({ onClose }: { onClose: () => void }) {
 
 export function InfoButton() {
   const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  // Android's back button closes the modal instead of leaving the app, the
+  // same as the ✕ and Escape (issue #300).
+  useBackDismiss(open, close);
   return (
     <>
       <button
@@ -80,7 +85,7 @@ export function InfoButton() {
       >
         <InfoIcon />
       </button>
-      {open && <InfoModal onClose={() => setOpen(false)} />}
+      {open && <InfoModal onClose={close} />}
     </>
   );
 }

--- a/packages/web/src/hooks/useBackDismiss.test.ts
+++ b/packages/web/src/hooks/useBackDismiss.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect, vi } from "vitest";
+import { BackStack, isLayerEntry, type HistoryLike } from "./useBackDismiss";
+
+/** Just enough of the history API to observe what the stack does to it. A
+    real `back()` is asynchronous and fires `popstate`; here the test plays
+    that part by calling `handlePop()` itself, which is also what the real
+    listener does. */
+class FakeHistory implements HistoryLike {
+  entries: unknown[] = [null];
+  index = 0;
+
+  get state(): unknown {
+    return this.entries[this.index];
+  }
+
+  pushState(data: unknown): void {
+    this.entries.length = this.index + 1;
+    this.entries.push(data);
+    this.index += 1;
+  }
+
+  back(): void {
+    if (this.index > 0) this.index -= 1;
+  }
+}
+
+describe("isLayerEntry", () => {
+  it("recognises the entries a layer pushes", () => {
+    const history = new FakeHistory();
+    new BackStack(history).open(() => {});
+    expect(isLayerEntry(history.state)).toBe(true);
+  });
+
+  it("leaves every other entry alone", () => {
+    // null is what the router pushes for a navigation, and what a plain page
+    // load leaves behind.
+    expect(isLayerEntry(null)).toBe(false);
+    expect(isLayerEntry(undefined)).toBe(false);
+    expect(isLayerEntry({})).toBe(false);
+    expect(isLayerEntry({ scroll: 12 })).toBe(false);
+  });
+});
+
+describe("BackStack", () => {
+  it("spends one history entry per open layer", () => {
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    stack.open(() => {});
+    stack.open(() => {});
+    expect(history.entries).toHaveLength(3);
+    expect(stack.depth).toBe(2);
+  });
+
+  it("dismisses the topmost layer only, innermost first", () => {
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    const outer = vi.fn();
+    const inner = vi.fn();
+    stack.open(outer);
+    stack.open(inner);
+
+    history.back();
+    stack.handlePop();
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(outer).not.toHaveBeenCalled();
+
+    history.back();
+    stack.handlePop();
+    expect(outer).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the app once every layer is closed", () => {
+    // Nothing left to dismiss: the press belongs to the browser, which takes
+    // the user out of the app. The stack must not throw over it.
+    const stack = new BackStack(new FakeHistory());
+    expect(() => stack.handlePop()).not.toThrow();
+  });
+
+  it("drops its entry when the layer closes from inside the app", () => {
+    // Seed: closing the infos modal with its ✕ used to leave a dead entry
+    // behind, so the next back press did nothing visible.
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    const dismiss = vi.fn();
+    const token = stack.open(dismiss);
+
+    stack.close(token);
+    expect(history.index).toBe(0);
+    expect(stack.depth).toBe(0);
+
+    // The back() above fires a popstate of its own; it must not be mistaken
+    // for a user press and dismiss the next layer down.
+    stack.handlePop();
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it("keeps history intact when the layer closed is not the current entry", () => {
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    const under = stack.open(() => {});
+    stack.open(() => {});
+
+    stack.close(under);
+    expect(history.index).toBe(2);
+    expect(stack.depth).toBe(1);
+  });
+
+  it("consumes a self-pop only once", () => {
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    const closed = vi.fn();
+    const kept = vi.fn();
+    const token = stack.open(closed);
+    stack.close(token);
+    stack.handlePop();
+
+    stack.open(kept);
+    history.back();
+    stack.handlePop();
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgets the layers of a page being left", () => {
+    const history = new FakeHistory();
+    const stack = new BackStack(history);
+    const dismiss = vi.fn();
+    stack.open(dismiss);
+
+    stack.detachAll();
+    stack.handlePop();
+    expect(dismiss).not.toHaveBeenCalled();
+    expect(stack.depth).toBe(0);
+  });
+});

--- a/packages/web/src/hooks/useBackDismiss.ts
+++ b/packages/web/src/hooks/useBackDismiss.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { useEffect, useRef } from "react";
+
+/**
+ * The Android back button, mapped onto the panels the app opens over the map.
+ *
+ * In a TWA the system back button is the browser's back button: with a single
+ * history entry it leaves the app outright. So opening the forecast panel, the
+ * infos modal or a leg detail used to be undismissable by the gesture every
+ * Android user reaches for first, and pressing back threw them out of the app
+ * instead (issue #300).
+ *
+ * A layer therefore pushes a history entry of its own while it is open. Back
+ * pops that entry, the layer closes, and the app stays put. Closing the layer
+ * from inside (a close button, picking something else) pops the entry back off
+ * so a later back press still leaves the app on the first try.
+ *
+ * The entries carry no URL change: a layer is transient state, not a place one
+ * bookmarks or shares. What marks them is `history.state`, which is also how
+ * the router knows to replace such an entry rather than stack a navigation on
+ * top of it (see `router.tsx`).
+ */
+
+const LAYER_KEY = "ohmywind:layer";
+
+/** The slice of `window.history` this module needs, so the stack below can be
+    driven by a fake in tests (there is no DOM in this test environment). */
+export interface HistoryLike {
+  readonly state: unknown;
+  pushState(data: unknown, unused: string): void;
+  back(): void;
+}
+
+/** Whether a history entry is one a layer pushed for itself. */
+export function isLayerEntry(state: unknown): boolean {
+  return typeof state === "object" && state !== null && LAYER_KEY in state;
+}
+
+function entryToken(state: unknown): number | null {
+  if (!isLayerEntry(state)) return null;
+  const token = (state as Record<string, unknown>)[LAYER_KEY];
+  return typeof token === "number" ? token : null;
+}
+
+export class BackStack {
+  private readonly history: HistoryLike;
+  private layers: { token: number; dismiss: () => void }[] = [];
+  /** Pops this stack asked for itself. Their `popstate` must dismiss nothing:
+      the layer that triggered them is already closing. */
+  private selfPops = 0;
+  private nextToken = 1;
+
+  constructor(history: HistoryLike) {
+    this.history = history;
+  }
+
+  get depth(): number {
+    return this.layers.length;
+  }
+
+  /** Opens a layer: one history entry to spend on the next back press. */
+  open(dismiss: () => void): number {
+    const token = this.nextToken++;
+    this.layers.push({ token, dismiss });
+    this.history.pushState({ [LAYER_KEY]: token }, "");
+    return token;
+  }
+
+  /** A back gesture. Dismisses the topmost layer, nothing else: nested layers
+      close one press at a time, innermost first. */
+  handlePop(): void {
+    if (this.selfPops > 0) {
+      this.selfPops -= 1;
+      return;
+    }
+    this.layers.pop()?.dismiss();
+  }
+
+  /** The layer closed from inside the app. Its entry is dropped so the user
+      never has to press back on a layer that is already gone. Skipped when the
+      entry is not the current one (another layer opened over it, or a
+      navigation replaced it): rewriting history from under them would cost
+      more than the stray entry it saves. */
+  close(token: number): void {
+    const idx = this.layers.findIndex((layer) => layer.token === token);
+    if (idx === -1) return;
+    this.layers.splice(idx, 1);
+    if (entryToken(this.history.state) !== token) return;
+    this.selfPops += 1;
+    this.history.back();
+  }
+
+  /** Navigating to another page. The layers belong to the page being left and
+      are about to unmount; forgetting them keeps a later back press from
+      dismissing something nobody can see. */
+  detachAll(): void {
+    this.layers.length = 0;
+  }
+}
+
+const noopHistory: HistoryLike = {
+  state: null,
+  pushState() {},
+  back() {},
+};
+
+export const backStack = new BackStack(
+  typeof window === "undefined" ? noopHistory : window.history,
+);
+
+/** One listener for every layer: `popstate` says a press happened, the stack
+    says which layer it belongs to. Installed on the first layer and kept, the
+    way the router keeps its own. */
+let listening = false;
+function listenOnce(): void {
+  if (listening || typeof window === "undefined") return;
+  listening = true;
+  window.addEventListener("popstate", () => backStack.handlePop());
+}
+
+/**
+ * Dismiss `active` state with the back button.
+ *
+ * `onDismiss` is read through a ref, so callers can pass an inline closure
+ * without reopening a history entry on every render.
+ */
+export function useBackDismiss(active: boolean, onDismiss: () => void): void {
+  const dismissRef = useRef(onDismiss);
+  useEffect(() => {
+    dismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!active) return;
+    listenOnce();
+    const token = backStack.open(() => dismissRef.current());
+    return () => backStack.close(token);
+  }, [active]);
+}

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTheme } from "../design/useTheme";
+import { useBackDismiss } from "../hooks/useBackDismiss";
 import { validateSweep, type SweepValidation } from "./validateSweep";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "./types";
 import { aggregateLegs, buildLegSummaryCells, type AggregatedLeg } from "./aggregateLegs";
@@ -401,6 +402,10 @@ function ArchetypeSelector({
   onCustomCleared?: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  // Back closes the boat picker instead of leaving the planner (issue #300),
+  // like the click-away overlay below.
+  const close = useCallback(() => setOpen(false), []);
+  useBackDismiss(open, close);
   // Re-read the polar config every render. Cheap (localStorage parse + a few
   // boolean checks) and ensures the « Perso » entry appears immediately after
   // the user edits /config in another tab and comes back here.

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useState } from "react";
 import { checkForAppUpdate } from "./sw";
+import { backStack, isLayerEntry } from "./hooks/useBackDismiss";
 
 /**
  * Minimal client-side routing, no dependency.
@@ -64,7 +65,16 @@ export function useRouter(): { path: string; search: string } {
       e.preventDefault();
       // Re-clicking the current URL should do nothing rather than remount.
       if (href === window.location.pathname + window.location.search) return;
-      window.history.pushState(null, "", href);
+      // Leaving a page with a panel open: the entry that panel pushed is
+      // transient state of the page being left, so the navigation takes its
+      // place rather than stacking on top of it. Otherwise a back press would
+      // land on an entry whose panel is long gone and appear to do nothing.
+      if (isLayerEntry(window.history.state)) {
+        window.history.replaceState(null, "", href);
+      } else {
+        window.history.pushState(null, "", href);
+      }
+      backStack.detachAll();
       window.scrollTo(0, 0);
       sync();
     };

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -27,6 +27,7 @@ import { SeamarkButton } from "../components/SeamarkButton";
 import { useSeamarks } from "../hooks/useSeamarks";
 import { useWaypointDepths } from "../hooks/useWaypointDepths";
 import { useGeolocation } from "../hooks/useGeolocation";
+import { useBackDismiss } from "../hooks/useBackDismiss";
 import { useMapView } from "../hooks/useMapView";
 import { parseMapView, mapViewQuery } from "../utils/mapViewParams";
 import { setCookie, clearCookie } from "../utils/cookies";
@@ -507,6 +508,9 @@ export function PlanPage() {
   // its segments change so we never highlight stale ranges.
   const [selectedLegIdx, setSelectedLegIdx] = useState<number | null>(null);
   useEffect(() => { setSelectedLegIdx(null); }, [waypoints, passage]);
+  // Back collapses the open leg rather than leaving the planner (issue #300).
+  const collapseLeg = useCallback(() => setSelectedLegIdx(null), []);
+  useBackDismiss(selectedLegIdx !== null, collapseLeg);
   const [windows, setWindows] = useState<PassageWindow[] | null>(null);
   const [metaWarnings, setMetaWarnings] = useState<string[]>([]);
   // Compact "pick a mode" state on mobile: drops the sidebar to just the


### PR DESCRIPTION
Ferme #300.

## Le problème

Dans une TWA, le bouton retour du système **est** celui du navigateur. L'app n'ayant qu'une entrée d'historique sur `/`, un appui sur retour sortait de l'app quel que soit ce qui était ouvert : météo d'un spot, modale d'infos, détail d'étape. Reproduit sur l'émulateur avant correctif : sélection d'un spot puis retour, l'app se ferme.

## Le correctif

Un panneau ouvert pousse une entrée d'historique (sans changer d'URL : c'est de l'état transitoire, pas une adresse à partager). Retour la consomme et ferme le panneau, l'app reste au premier plan.

- Fermeture depuis l'app (croix, sélection d'autre chose) : l'entrée est reprise, pour qu'un retour ultérieur sorte de l'app du premier coup.
- Navigation alors qu'un panneau est ouvert : elle **remplace** l'entrée du panneau au lieu de s'empiler dessus. Sinon revenir en arrière atterrissait sur une entrée dont le panneau n'existe plus, et l'appui paraissait sans effet, exactement le reproche de l'issue.
- Un spot restauré de la visite précédente (#301) ou la position obtenue au premier lancement ne sont pas des panneaux : ce sont les états de départ, retour quitte l'app depuis là.

Panneaux couverts : météo d'un spot choisi, modale d'infos, détail d'étape et sélecteur de bateau du planificateur.

## Vérifications

- 9 tests unitaires sur la pile de retour (LIFO, reprise d'entrée, pop auto-provoqué non confondu avec un appui utilisateur), 274 au total, verts.
- Build de prod piloté au navigateur : sélection d'un spot pousse une entrée et une seule ; retour referme le panneau ; la croix de la modale ne laisse pas d'entrée morte ; aller sur `/plan` panneau ouvert puis retour ramène sur `/` sans appui perdu.
- ESLint : aucune erreur ajoutée (11 erreurs préexistantes sur `dev`, inchangées).