### PR TITLE
perf(web): échantillonne le corridor aux milieux de segments serveur

### DIFF
--- a/packages/web/src/api/forecastCache.test.ts
+++ b/packages/web/src/api/forecastCache.test.ts
@@ -5,10 +5,15 @@ import { describe, it, expect } from "vitest";
 import {
   assembleForecastCache,
   interpolateCorridor,
+  planCorridor,
+  routeLengthNm,
+  serverAlignedCorridor,
+  serverSegmentLengthNm,
   CACHE_MODEL_SLUGS,
   type SampledPoint,
 } from "./forecastCache";
 import { parisIsoToUtcMs } from "./marine";
+import { haversineNm, interpolateGreatCircle, type GeoPoint } from "../plan/geo";
 import type { ModelForecast, MarineHourly } from "../types";
 
 const MARSEILLE: [number, number] = [43.3, 5.35];
@@ -64,6 +69,194 @@ describe("interpolateCorridor", () => {
 
   it("throws on fewer than 2 waypoints", () => {
     expect(() => interpolateCorridor([MARSEILLE], 10)).toThrow();
+  });
+});
+
+// ── server segmentation, ported ──────────────────────────────────────────────
+// A deliberate second implementation of the server rule, transcribed from
+// packages/data-adapters/src/openwind_data/routing/passage.py
+// (`_resolve_segment_length`, MAX_SAMPLED_SEGMENTS = 10, band [10, 30] NM) and
+// routing/geometry.py (`segment_route`, `midpoint`). If the client mirror in
+// forecastCache.ts drifts from the server, these tests go red.
+
+const SERVER_MAX_SAMPLED_SEGMENTS = 10;
+const SERVER_MIN_SEG_NM = 10;
+const SERVER_MAX_SEG_NM = 30;
+
+function serverEffectiveSegmentNm(waypoints: [number, number][], requestedNm = 10): number {
+  const total = routeLengthNm(waypoints);
+  const target = total / SERVER_MAX_SAMPLED_SEGMENTS;
+  if (target <= requestedNm) return requestedNm;
+  const effective = Math.min(SERVER_MAX_SEG_NM, Math.max(SERVER_MIN_SEG_NM, target));
+  return effective <= requestedNm ? requestedNm : effective;
+}
+
+// Transcription of segment_route + [midpoint(s.start, s.end) for s in segments]:
+// interpolate the sub-segment ends first, then take their great-circle middle,
+// exactly as the server does rather than shortcutting to fraction (i+0.5)/n.
+function serverSegmentMidpoints(waypoints: [number, number][], requestedNm = 10): GeoPoint[] {
+  const segmentNm = serverEffectiveSegmentNm(waypoints, requestedNm);
+  const mids: GeoPoint[] = [];
+  for (let leg = 0; leg < waypoints.length - 1; leg++) {
+    const a: GeoPoint = { lat: waypoints[leg][0], lon: waypoints[leg][1] };
+    const b: GeoPoint = { lat: waypoints[leg + 1][0], lon: waypoints[leg + 1][1] };
+    const n = Math.max(1, Math.ceil(haversineNm(a, b) / segmentNm));
+    for (let i = 0; i < n; i++) {
+      const start = i === 0 ? a : interpolateGreatCircle(a, b, i / n);
+      const end = i === n - 1 ? b : interpolateGreatCircle(a, b, (i + 1) / n);
+      mids.push(interpolateGreatCircle(start, end, 0.5));
+    }
+  }
+  return mids;
+}
+
+function nearestNm(target: GeoPoint, candidates: GeoPoint[]): number {
+  return Math.min(...candidates.map((c) => haversineNm(target, c)));
+}
+
+// Rhumb-ish forward step, good enough to lay out test routes of a given length.
+function pointAt(from: [number, number], bearingDeg: number, distNm: number): [number, number] {
+  const brg = (bearingDeg * Math.PI) / 180;
+  const lat = from[0] + (distNm * Math.cos(brg)) / 60;
+  const lon = from[1] + (distNm * Math.sin(brg)) / (60 * Math.cos((from[0] * Math.PI) / 180));
+  return [lat, lon];
+}
+
+// Routes of roughly the requested length, from 2 to 5 waypoints, laid out with
+// a heading change at each waypoint so no leg is a continuation of the last.
+function routeOf(totalNm: number, waypointCount: number): [number, number][] {
+  const legs = waypointCount - 1;
+  const legNm = totalNm / legs;
+  const wpts: [number, number][] = [[43.3, 5.35]];
+  for (let i = 0; i < legs; i++) {
+    wpts.push(pointAt(wpts[i], 100 + i * 25, legNm));
+  }
+  return wpts;
+}
+
+const ROUTE_CASES: [number, number][] = [
+  [30, 2], [30, 3],
+  [63, 2], [63, 3], [63, 4],
+  [120, 2], [120, 3], [120, 5],
+  [200, 2], [200, 4], [200, 5],
+  [400, 2], [400, 3], [400, 5],
+];
+
+describe("serverSegmentLengthNm", () => {
+  it("keeps the requested 10 NM on a short route", () => {
+    expect(serverSegmentLengthNm(routeOf(30, 2))).toBe(10);
+    expect(serverSegmentLengthNm(routeOf(63, 2))).toBe(10);
+  });
+
+  it("stretches to a tenth of the route in the middle band", () => {
+    const route = routeOf(200, 2);
+    expect(serverSegmentLengthNm(route)).toBeCloseTo(routeLengthNm(route) / 10, 6);
+  });
+
+  it("caps at 30 NM on a long route", () => {
+    expect(serverSegmentLengthNm(routeOf(400, 2))).toBe(30);
+    expect(serverSegmentLengthNm(routeOf(900, 2))).toBe(30);
+  });
+
+  it("agrees with the ported server rule on every case", () => {
+    for (const [nm, count] of ROUTE_CASES) {
+      const route = routeOf(nm, count);
+      expect(serverSegmentLengthNm(route)).toBeCloseTo(serverEffectiveSegmentNm(route), 9);
+    }
+  });
+});
+
+describe("planCorridor", () => {
+  it("puts a sample on every server segment midpoint, well within 1 NM", () => {
+    for (const [nm, count] of ROUTE_CASES) {
+      const route = routeOf(nm, count);
+      const corridor = planCorridor(route);
+      for (const mid of serverSegmentMidpoints(route)) {
+        expect(nearestNm(mid, corridor)).toBeLessThan(1);
+      }
+    }
+  });
+
+  it("lands exactly on the midpoints, not merely near them", () => {
+    // The whole point of splitting each leg into 2n rather than halving a
+    // spacing: the nearest-neighbour lookup has no distance error to argue
+    // about. A metre of slack absorbs floating-point noise only.
+    for (const [nm, count] of ROUTE_CASES) {
+      const route = routeOf(nm, count);
+      const corridor = planCorridor(route);
+      for (const mid of serverSegmentMidpoints(route)) {
+        expect(nearestNm(mid, corridor)).toBeLessThan(0.001);
+      }
+    }
+  });
+
+  it("also carries every segment boundary, so a shifted segmentation still hits", () => {
+    const route = routeOf(200, 3);
+    const corridor = planCorridor(route);
+    const segmentNm = serverSegmentLengthNm(route);
+    for (let leg = 0; leg < route.length - 1; leg++) {
+      const a: GeoPoint = { lat: route[leg][0], lon: route[leg][1] };
+      const b: GeoPoint = { lat: route[leg + 1][0], lon: route[leg + 1][1] };
+      const n = Math.max(1, Math.ceil(haversineNm(a, b) / segmentNm));
+      for (let i = 0; i <= n; i++) {
+        expect(nearestNm(interpolateGreatCircle(a, b, i / n), corridor)).toBeLessThan(0.001);
+      }
+    }
+  });
+
+  it("samples far fewer points than the old fixed 5 NM spacing", () => {
+    const before = (route: [number, number][]) =>
+      interpolateCorridor(route, Math.max(5, routeLengthNm(route) / 60)).length;
+    for (const nm of [120, 200, 400]) {
+      const route = routeOf(nm, 2);
+      expect(planCorridor(route).length).toBeLessThan(before(route));
+    }
+    // A 200 NM passage is the audit's reference case: 41 points, now 21.
+    expect(planCorridor(routeOf(200, 2)).length).toBe(21);
+  });
+
+  it("stays under the point guard even on a route no one will sail", () => {
+    // MAX_CORRIDOR_POINTS has always bounded the number of intervals, so the
+    // stretched fallback lands on 61 samples. Unchanged here, and only that
+    // path loses the exact alignment: a 3000 NM route is out of reach anyway
+    // with a 7-day forecast horizon.
+    expect(planCorridor(routeOf(3000, 2)).length).toBeLessThanOrEqual(61);
+    // 600 NM over 4 legs still fits the aligned rule (30 NM segments), so it
+    // keeps the exact alignment asserted above.
+    const manyLegs = routeOf(600, 5);
+    expect(planCorridor(manyLegs).length).toBeLessThanOrEqual(60);
+    for (const mid of serverSegmentMidpoints(manyLegs)) {
+      expect(nearestNm(mid, planCorridor(manyLegs))).toBeLessThan(0.001);
+    }
+  });
+
+  it("starts and ends on the waypoints", () => {
+    const route = routeOf(120, 3);
+    const corridor = planCorridor(route);
+    expect(corridor[0].lat).toBeCloseTo(route[0][0], 6);
+    expect(corridor[0].lon).toBeCloseTo(route[0][1], 6);
+    expect(corridor[corridor.length - 1].lat).toBeCloseTo(route[route.length - 1][0], 6);
+    expect(corridor[corridor.length - 1].lon).toBeCloseTo(route[route.length - 1][1], 6);
+  });
+});
+
+describe("serverAlignedCorridor", () => {
+  it("splits each leg into twice the server's sub-segment count", () => {
+    const route = routeOf(63, 2);
+    // 63 NM at 10 NM per sub-segment -> 7 server segments -> 14 intervals.
+    expect(serverAlignedCorridor(route, 10).length).toBe(15);
+  });
+
+  it("does not duplicate the shared waypoint between legs", () => {
+    const route = routeOf(120, 3);
+    const oneLeg = serverAlignedCorridor([route[0], route[1]], 12).length;
+    const secondLegOnly = serverAlignedCorridor([route[1], route[2]], 12).length;
+    expect(serverAlignedCorridor(route, 12).length).toBe(oneLeg + secondLegOnly - 1);
+  });
+
+  it("rejects degenerate input", () => {
+    expect(() => serverAlignedCorridor([[43.3, 5.35]], 10)).toThrow();
+    expect(() => serverAlignedCorridor(routeOf(30, 2), 0)).toThrow();
   });
 });
 

--- a/packages/web/src/api/forecastCache.ts
+++ b/packages/web/src/api/forecastCache.ts
@@ -31,12 +31,25 @@ export const CACHE_MODEL_SLUGS: Partial<Record<ModelName, string>> = {
 };
 const GFS_SLUG = "gfs_seamless";
 
-// Generous cap on corridor sample points. The browser has its own Open-Meteo
-// quota (~600/min per IP), so we sample far denser than the server's ~10-segment
-// budget; this only guards pathologically long routes from issuing hundreds of
-// requests. Beyond it, spacing stretches.
+// Guard on corridor sample points, not the working rule: the corridor is now
+// derived from the server's own segmentation (see serverSegmentLengthNm). It
+// only catches routes where that rule cannot fit under the cap, typically a
+// very long passage or so many waypoints that one point per leg already
+// overflows. Beyond it, spacing stretches.
 const MAX_CORRIDOR_POINTS = 60;
 const DEFAULT_SPACING_NM = 5;
+
+// Mirror of the server's sampling rule, `_resolve_segment_length` in
+// packages/data-adapters/src/openwind_data/routing/passage.py. Keep these three
+// in step with MAX_SAMPLED_SEGMENTS / MIN_SEG_LENGTH_NM / MAX_SEG_LENGTH_NM
+// there; the test asserts the resulting geometry, not the constants.
+const MAX_SAMPLED_SEGMENTS = 10;
+const MIN_SEG_LENGTH_NM = 10;
+const MAX_SEG_LENGTH_NM = 30;
+
+// Default `segment_length_nm` of `estimate_passage`. The web never overrides
+// it, so this is what the server will resolve against.
+const SERVER_REQUESTED_SEGMENT_NM = 10;
 
 export interface CacheWindSeries {
   speed_kn: (number | null)[];
@@ -88,10 +101,11 @@ function roundOrNull(v: number | null | undefined, dp: number): number | null {
   return Number(v.toFixed(dp));
 }
 
-// Interpolate sample points along the waypoint polyline at ~spacingNm, denser
-// than the server's segmentation so every server segment midpoint has a near
-// corridor sample. Mirrors segment_route: n = max(1, ceil(d/spacing)) per leg,
-// endpoints hit the waypoints, shared waypoints between legs are not duplicated.
+// Interpolate sample points along the waypoint polyline at ~spacingNm. Mirrors
+// segment_route: n = max(1, ceil(d/spacing)) per leg, endpoints hit the
+// waypoints, shared waypoints between legs are not duplicated. Kept as the
+// fallback path and for callers that pass an explicit spacing; the corridor a
+// plan actually samples comes from planCorridor below.
 export function interpolateCorridor(
   waypoints: [number, number][],
   spacingNm: number = DEFAULT_SPACING_NM,
@@ -122,6 +136,65 @@ export function routeLengthNm(waypoints: [number, number][]): number {
     );
   }
   return total;
+}
+
+// Effective sub-segment length the server will use for this route, in NM.
+//
+// Mirrors `_resolve_segment_length`: the requested length is stretched so the
+// route yields at most MAX_SAMPLED_SEGMENTS samples, clamped to
+// [MIN_SEG_LENGTH_NM, MAX_SEG_LENGTH_NM], and never shortened below what was
+// asked. In practice: 10 NM up to a 100 NM route, total/10 from there to 300
+// NM, 30 NM beyond.
+export function serverSegmentLengthNm(
+  waypoints: [number, number][],
+  requestedNm: number = SERVER_REQUESTED_SEGMENT_NM,
+): number {
+  const total = routeLengthNm(waypoints);
+  const target = total / MAX_SAMPLED_SEGMENTS;
+  if (target <= requestedNm) return requestedNm;
+  const effective = Math.min(MAX_SEG_LENGTH_NM, Math.max(MIN_SEG_LENGTH_NM, target));
+  return effective <= requestedNm ? requestedNm : effective;
+}
+
+// Corridor sampled so that every point the server will read sits exactly on a
+// sample, rather than merely near one.
+//
+// The server splits each leg into n = max(1, ceil(d / L)) sub-segments of equal
+// length (`segment_route`) and fetches at each sub-segment's midpoint, which
+// the cache adapter resolves by nearest neighbour. Splitting the same leg into
+// 2n instead of n therefore lands a corridor point on every sub-segment
+// boundary AND on every midpoint: the nearest-neighbour lookup is exact, with
+// no distance error to argue about. Halving a spacing and rounding up would
+// not do it, since ceil(d / (L/2)) is not always 2 * ceil(d / L).
+export function serverAlignedCorridor(
+  waypoints: [number, number][],
+  segmentNm: number,
+): GeoPoint[] {
+  if (waypoints.length < 2) throw new Error("need at least 2 waypoints");
+  if (segmentNm <= 0) throw new Error("segmentNm must be > 0");
+  const out: GeoPoint[] = [];
+  for (let leg = 0; leg < waypoints.length - 1; leg++) {
+    const a: GeoPoint = { lat: waypoints[leg][0], lon: waypoints[leg][1] };
+    const b: GeoPoint = { lat: waypoints[leg + 1][0], lon: waypoints[leg + 1][1] };
+    const n = Math.max(1, Math.ceil(haversineNm(a, b) / segmentNm)) * 2;
+    for (let i = 0; i <= n; i++) {
+      // Skip every leg's start except the first: it is the previous leg's end.
+      if (i === 0 && leg > 0) continue;
+      out.push(interpolateGreatCircle(a, b, i / n));
+    }
+  }
+  return out;
+}
+
+// The corridor `buildForecastCache` actually samples. Server-aligned by
+// default; falls back to plain spacing when the aligned corridor cannot fit
+// under MAX_CORRIDOR_POINTS, which needs either a passage well past 800 NM or
+// a route with dozens of legs.
+export function planCorridor(waypoints: [number, number][]): GeoPoint[] {
+  const aligned = serverAlignedCorridor(waypoints, serverSegmentLengthNm(waypoints));
+  if (aligned.length <= MAX_CORRIDOR_POINTS) return aligned;
+  const spacing = Math.max(DEFAULT_SPACING_NM, routeLengthNm(waypoints) / MAX_CORRIDOR_POINTS);
+  return interpolateCorridor(waypoints, spacing);
 }
 
 // Coverage contract (mirrors the server): each segment fetch asks for
@@ -278,9 +351,15 @@ export async function buildForecastCache(
   waypoints: [number, number][],
   opts: { spacingNm?: number; window?: CacheWindow } = {},
 ): Promise<ForecastCache> {
-  const totalNm = routeLengthNm(waypoints);
-  const spacing = Math.max(opts.spacingNm ?? DEFAULT_SPACING_NM, totalNm / MAX_CORRIDOR_POINTS);
-  const corridor = interpolateCorridor(waypoints, spacing);
+  // An explicit spacing still wins (nothing in the app passes one today); the
+  // default is the server-aligned corridor.
+  const corridor =
+    opts.spacingNm === undefined
+      ? planCorridor(waypoints)
+      : interpolateCorridor(
+          waypoints,
+          Math.max(opts.spacingNm, routeLengthNm(waypoints) / MAX_CORRIDOR_POINTS),
+        );
   const models = mappableActiveModels();
   // Wind: ONE request per model for the whole corridor (multi-coordinate).
   // Marine: kept per-point because fetchMarine merges the per-location MARC/SHOM


### PR DESCRIPTION
> **En attente du GO 1 de l'audit avant merge.** Cette PR aligne l'échantillonnage client sur la segmentation serveur ; l'audit veut trancher la décision avant de la livrer.

## Quoi

Le corridor était échantillonné tous les 5 NM, bien plus dense que ce que le serveur lit. Le serveur découpe chaque tronçon en `n = max(1, ceil(d / L))` sous-tronçons (`segment_route`) et ne va chercher la météo qu'au **milieu** de chacun (`seg_mid_points`), résolu en plus proche voisin par `CacheBackedAdapter._nearest`. Tout le reste des points du corridor était fetché, assemblé et posté pour rien.

La règle serveur est reproduite côté client dans deux fonctions pures :

- `serverSegmentLengthNm` reprend `_resolve_segment_length` (`passage.py`) : au plus `MAX_SAMPLED_SEGMENTS = 10` échantillons, longueur bornée à `[10, 30]` NM, jamais raccourcie sous ce qui est demandé. En pratique 10 NM jusqu'à 100 NM de route, total/10 jusqu'à 300, 30 NM au-delà.
- `serverAlignedCorridor` découpe chaque tronçon en **2n** au lieu de n. Un point de corridor tombe donc exactement sur chaque frontière **et** sur chaque milieu de sous-tronçon.

Diviser un espacement par deux n'aurait pas suffi : `ceil(d / (L/2))` ne vaut pas toujours `2 * ceil(d / L)`. Sur un tronçon de 25 NM avec L = 10, la version par espacement rate un milieu de 2,5 NM. Le découpage en 2n, lui, est exact au flottant près.

Le plafond de 60 points reste, en garde-fou : il ne se déclenche plus que sur une route hors de portée d'un horizon à 7 jours ou sur une route à des dizaines d'étapes.

## Pourquoi

Constat 2 de l'annexe A de l'audit (`plan/audit-2026-09`), PR 0.3 du lot 0, sous **GO 1**.

## Mesure

Cache assemblé pour de vrai (`assembleForecastCache`, 4 modèles, axe de 168 h, fenêtre simple clampée), route directe :

| Route | Points de corridor | POST clampé | POST 168 h | Requêtes Marine |
|---|---|---|---|---|
| 30 NM | 8 → 9 | 15 → 16 Ko | 103 → 115 Ko | 8 → 9 |
| 63 NM | 14 → 15 | 43 → 46 Ko | 178 → 190 Ko | 14 → 15 |
| 200 NM | 42 → 21 | 336 → **169 Ko** | 529 → 266 Ko | 42 → 21 |
| 300 NM | 62 → 23 | 720 → **268 Ko** | 780 → 291 Ko | 62 → 23 |

Le nombre de requêtes vent ne bouge pas (une par modèle, multi-coordonnées), mais chacune porte deux à trois fois moins de coordonnées. Les requêtes Marine et MARC, elles, sont par point : c'est là que la moitié des requêtes d'un calcul de 200 NM disparaît.

À noter franchement : sous 100 NM, l'alignement exact coûte **un point de plus** qu'avant, parce que la garantie porte désormais sur les frontières en plus des milieux. Au-delà, il divise par deux puis par trois. Le compromis est assumé : c'est ce qui rend la lecture serveur exacte plutôt qu'approchée, et ce qui la garde correcte si la segmentation serveur bouge un jour.

## Tests

`src/api/forecastCache.test.ts` porte une **seconde implémentation** de la règle serveur, transcrite depuis `passage.py` (`_resolve_segment_length`, `MAX_SAMPLED_SEGMENTS`, bande `[10, 30]`) et `geometry.py` (`segment_route`, `midpoint`, y compris le fait d'interpoler les extrémités avant d'en prendre le milieu plutôt que de raccourcir à la fraction `(i+0,5)/n`). Si le miroir client dérive du serveur, les tests passent au rouge.

Sur 14 routes (30, 63, 120, 200 et 400 NM, de 2 à 5 waypoints, avec changement de cap à chaque étape) :

- chaque milieu de segment serveur a un point de corridor **à moins de 1 NM** ;
- et même à moins de 1 m, l'alignement étant exact et non approché ;
- chaque frontière de segment aussi ;
- `serverSegmentLengthNm` est comparée point par point à la règle portée ;
- le corridor commence et finit sur les waypoints, ne duplique pas l'étape partagée entre deux tronçons, et reste sous le garde-fou.

Les tests existants de `interpolateCorridor` restent verts : la fonction ne change pas, elle devient le chemin de repli et celui des appels qui passent un espacement explicite.

`npm run typecheck`, `lint:budget` (11 erreurs, budget 11, inchangé), `test` (278 tests) et `build` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)