### PR TITLE
fix(pwa): ne plus recharger la page sous les doigts de l'utilisateur

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -24,7 +24,7 @@ createRoot(document.getElementById("root")!).render(
 );
 
 // Register the service worker so the app shell is installable and offline-
-// resilient. Silent by design: `registerType: 'autoUpdate'` plus `skipWaiting`
-// swap in the new SW as soon as it is found, and we intentionally render no
-// update-toast today.
+// resilient. Still silent, still no update-toast: src/sw.ts takes the new
+// worker as soon as it is found, but holds it back while a route is being
+// drawn so a deploy cannot reload the page under the reader.
 registerServiceWorker();

--- a/packages/web/src/plan/draft.test.ts
+++ b/packages/web/src/plan/draft.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  clearPlanDraft,
+  hasPlanDraft,
+  loadPlanDraft,
+  parsePlanDraft,
+  savePlanDraft,
+  type PlanDraft,
+} from "./draft";
+
+/** Minimal in-memory Storage. The suite runs on the node environment, so
+    there is no sessionStorage to spy on: we install one. */
+function installStorage(store = new Map<string, string>()) {
+  vi.stubGlobal("sessionStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  });
+  return store;
+}
+
+/** Storage that throws on every access, like Safari private browsing. */
+function installBrokenStorage() {
+  const boom = () => {
+    throw new Error("storage disabled");
+  };
+  vi.stubGlobal("sessionStorage", { getItem: boom, setItem: boom, removeItem: boom });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const draft: Omit<PlanDraft, "savedAt"> = {
+  waypoints: [
+    [43.2, 5.36],
+    [43.01, 6.2],
+  ],
+  departure: "2026-09-03T09:00",
+  timeAnchor: "departure",
+  archetype: "cruiser_30ft",
+  mode: "single",
+  sweepEarliest: "2026-09-03T09:00",
+  sweepLatest: "2026-09-05T09:00",
+  sweepIntervalHours: 3,
+};
+
+describe("plan draft round-trip", () => {
+  it("restores the route being drawn", () => {
+    installStorage();
+    savePlanDraft(draft);
+    expect(loadPlanDraft()).toMatchObject(draft);
+  });
+
+  it("stamps the write so age can be judged later", () => {
+    installStorage();
+    const before = Date.now();
+    savePlanDraft(draft);
+    expect(loadPlanDraft()!.savedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("reports nothing pending on a fresh tab", () => {
+    installStorage();
+    expect(hasPlanDraft()).toBe(false);
+    expect(loadPlanDraft()).toBeNull();
+  });
+
+  it("reports a pending draft without parsing it", () => {
+    installStorage();
+    savePlanDraft(draft);
+    expect(hasPlanDraft()).toBe(true);
+  });
+
+  it("forgets the draft once the route is computed", () => {
+    installStorage();
+    savePlanDraft(draft);
+    clearPlanDraft();
+    expect(hasPlanDraft()).toBe(false);
+    expect(loadPlanDraft()).toBeNull();
+  });
+
+  it("keeps a single waypoint, the state a reload used to destroy", () => {
+    installStorage();
+    savePlanDraft({ ...draft, waypoints: [[43.2, 5.36]] });
+    expect(loadPlanDraft()!.waypoints).toEqual([[43.2, 5.36]]);
+  });
+
+  it("survives a storage that throws on every access", () => {
+    installBrokenStorage();
+    expect(() => savePlanDraft(draft)).not.toThrow();
+    expect(loadPlanDraft()).toBeNull();
+    expect(hasPlanDraft()).toBe(false);
+    expect(() => clearPlanDraft()).not.toThrow();
+  });
+});
+
+describe("parsePlanDraft", () => {
+  const now = 1_800_000_000_000;
+  const stored = JSON.stringify({ ...draft, savedAt: now });
+
+  it("accepts a well-formed payload", () => {
+    expect(parsePlanDraft(stored, now)).toMatchObject(draft);
+  });
+
+  it("rejects a payload that is not JSON", () => {
+    expect(parsePlanDraft("{oops", now)).toBeNull();
+  });
+
+  it("rejects a JSON scalar", () => {
+    expect(parsePlanDraft('"hello"', now)).toBeNull();
+    expect(parsePlanDraft("null", now)).toBeNull();
+  });
+
+  it("rejects waypoints that are not coordinate pairs", () => {
+    const bad = [
+      [["43.2", "5.36"]],
+      [[43.2]],
+      [[43.2, 5.36, 7]],
+      [[91, 5.36]],
+      [[43.2, 181]],
+      [[Number.NaN, 5.36]],
+      ["43.2,5.36"],
+    ];
+    for (const waypoints of bad) {
+      expect(parsePlanDraft(JSON.stringify({ ...draft, waypoints, savedAt: now }), now)).toBeNull();
+    }
+  });
+
+  it("rejects an unknown mode or time anchor", () => {
+    expect(
+      parsePlanDraft(JSON.stringify({ ...draft, mode: "sweep", savedAt: now }), now),
+    ).toBeNull();
+    expect(
+      parsePlanDraft(JSON.stringify({ ...draft, timeAnchor: "eta", savedAt: now }), now),
+    ).toBeNull();
+  });
+
+  it("rejects a missing departure or archetype", () => {
+    expect(parsePlanDraft(JSON.stringify({ ...draft, departure: "", savedAt: now }), now)).toBeNull();
+    expect(parsePlanDraft(JSON.stringify({ ...draft, archetype: 3, savedAt: now }), now)).toBeNull();
+  });
+
+  it("rejects a non-numeric sweep interval", () => {
+    expect(
+      parsePlanDraft(JSON.stringify({ ...draft, sweepIntervalHours: "3", savedAt: now }), now),
+    ).toBeNull();
+  });
+
+  it("rejects a draft written by a version that had no stamp", () => {
+    expect(parsePlanDraft(JSON.stringify(draft), now)).toBeNull();
+  });
+
+  it("rejects a draft older than a day, restored with the tab", () => {
+    const old = now - 25 * 3600 * 1000;
+    expect(parsePlanDraft(JSON.stringify({ ...draft, savedAt: old }), now)).toBeNull();
+    const recent = now - 23 * 3600 * 1000;
+    expect(parsePlanDraft(JSON.stringify({ ...draft, savedAt: recent }), now)).not.toBeNull();
+  });
+
+  it("accepts an empty route, the state right after a reset", () => {
+    expect(
+      parsePlanDraft(JSON.stringify({ ...draft, waypoints: [], savedAt: now }), now)?.waypoints,
+    ).toEqual([]);
+  });
+});

--- a/packages/web/src/plan/draft.ts
+++ b/packages/web/src/plan/draft.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The route being drawn, before it is computed.
+ *
+ * `ow_last_simulation_v1` and the `/plan` URL both only ever record a
+ * *successful* computation. Everything between two computations — waypoints
+ * just dropped on the map, a departure dragged on the slider, a sweep range
+ * being filled in — lived in React state alone, so any reload wiped it. A
+ * service worker taking over used to reload the page on its own, which is how
+ * a reader could lose a half-drawn passage without touching anything.
+ *
+ * This module is that missing tier: the tab's uncommitted state, in
+ * `sessionStorage` (per tab, gone when the tab closes, never shared with the
+ * next visit — a draft is not a plan). It wins over the URL and over the
+ * cached simulation at mount, because by construction it is more recent
+ * than both.
+ */
+
+/** Versioned: a shape change must not resurrect a draft written by an older
+    build, and the SW update this feature protects is exactly the moment two
+    builds meet. */
+const STORAGE_KEY = "ow_plan_draft_v1";
+
+/** Beyond this, "what I was drawing a moment ago" stops being true. Belt and
+    braces on top of sessionStorage's own tab lifetime: a tab restored by the
+    browser days later keeps its session storage. */
+const MAX_AGE_MS = 24 * 3600 * 1000;
+
+export interface PlanDraft {
+  /** Route under construction. May hold a single point, or none at all when
+      only the departure was touched. */
+  waypoints: [number, number][];
+  /** Naive local "YYYY-MM-DDTHH:MM". In ETA mode this is the target arrival,
+      as on the slider itself. */
+  departure: string;
+  /** Whether `departure` reads as a departure or as a target arrival. */
+  timeAnchor: "departure" | "arrival";
+  archetype: string;
+  mode: "single" | "compare";
+  sweepEarliest: string;
+  sweepLatest: string;
+  sweepIntervalHours: number;
+  savedAt: number;
+}
+
+function isCoordPair(v: unknown): v is [number, number] {
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    typeof v[0] === "number" &&
+    typeof v[1] === "number" &&
+    Number.isFinite(v[0]) &&
+    Number.isFinite(v[1]) &&
+    Math.abs(v[0]) <= 90 &&
+    Math.abs(v[1]) <= 180
+  );
+}
+
+/**
+ * Shape check on the way in, so a corrupted or foreign payload can never
+ * reach the page as waypoints. Exported for the tests.
+ */
+export function parsePlanDraft(raw: string, now: number): PlanDraft | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const d = parsed as Record<string, unknown>;
+  if (!Array.isArray(d.waypoints) || !d.waypoints.every(isCoordPair)) return null;
+  if (typeof d.departure !== "string" || d.departure === "") return null;
+  if (typeof d.archetype !== "string" || d.archetype === "") return null;
+  if (d.mode !== "single" && d.mode !== "compare") return null;
+  if (d.timeAnchor !== "departure" && d.timeAnchor !== "arrival") return null;
+  if (typeof d.sweepEarliest !== "string" || typeof d.sweepLatest !== "string") return null;
+  if (typeof d.sweepIntervalHours !== "number" || !Number.isFinite(d.sweepIntervalHours)) {
+    return null;
+  }
+  if (typeof d.savedAt !== "number" || !Number.isFinite(d.savedAt)) return null;
+  if (now - d.savedAt > MAX_AGE_MS) return null;
+  return {
+    waypoints: d.waypoints as [number, number][],
+    departure: d.departure,
+    timeAnchor: d.timeAnchor,
+    archetype: d.archetype,
+    mode: d.mode,
+    sweepEarliest: d.sweepEarliest,
+    sweepLatest: d.sweepLatest,
+    sweepIntervalHours: d.sweepIntervalHours,
+    savedAt: d.savedAt,
+  };
+}
+
+export function savePlanDraft(draft: Omit<PlanDraft, "savedAt">): void {
+  try {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...draft, savedAt: Date.now() } satisfies PlanDraft),
+    );
+  } catch {
+    // Storage disabled or full. The draft is a safety net, not a feature:
+    // failing to write one must never break the page.
+  }
+}
+
+export function loadPlanDraft(): PlanDraft | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? parsePlanDraft(raw, Date.now()) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Cheap probe for the service worker: is anything uncommitted in this tab? */
+export function hasPlanDraft(): boolean {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function clearPlanDraft(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { useEffect, useState } from "react";
-import { checkForAppUpdate } from "./sw";
+import { checkForAppUpdate, flushPendingUpdate } from "./sw";
 import { backStack, isLayerEntry } from "./hooks/useBackDismiss";
 
 /**
@@ -77,6 +77,11 @@ export function useRouter(): { path: string; search: string } {
       backStack.detachAll();
       window.scrollTo(0, 0);
       sync();
+      // Safest occasion to apply an update already found and held back: the
+      // reader asked to change view, so a reload here reads as that
+      // navigation. Deliberately not in `sync`, which also runs on `popstate`
+      // — a back press that only dismisses a panel must not reload the page.
+      flushPendingUpdate();
     };
 
     window.addEventListener("popstate", onPopState);

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -11,6 +11,7 @@ import { Header } from "../components/Header";
 import type { PassageReport, ComplexityScore, Archetype, PassageWindow } from "../plan/types";
 import { fmtDuration, fr1 } from "../plan/format";
 import { HeroCell } from "../plan/PlanStates";
+import { clearPlanDraft, loadPlanDraft, savePlanDraft } from "../plan/draft";
 import {
   loadLastSimulation,
   saveLastSimulation,
@@ -448,8 +449,13 @@ export function PlanPage() {
   const urlHasWaypoints = isParsedOk(initialParsed) && initialParsed.waypoints.length >= 2;
   const cachedAtMount = !urlHasWaypoints ? loadLastSimulation() : null;
   const useCachedRoute = !!(cachedAtMount && cachedAtMount.waypoints.length >= 2);
+  // Uncommitted state of THIS tab, if any. It outranks both the URL and the
+  // cache because both are written only after a successful computation, so a
+  // draft is by construction the more recent of the three. Read once at mount.
+  const [draftAtMount] = useState(loadPlanDraft);
 
   const [waypoints, setWaypoints] = useState<[number, number][]>(() => {
+    if (draftAtMount) return draftAtMount.waypoints;
     if (urlHasWaypoints) return (initialParsed as { waypoints: [number, number][] }).waypoints;
     if (useCachedRoute) return cachedAtMount!.waypoints;
     return [];
@@ -462,11 +468,15 @@ export function PlanPage() {
     // boat (#220). Otherwise: URL, then cache, then the /config default.
     initialPlanBoat(
       loadPolarConfig(),
-      isParsedOk(initialParsed) ? initialParsed.archetype : null,
+      draftAtMount?.archetype ?? (isParsedOk(initialParsed) ? initialParsed.archetype : null),
       useCachedRoute ? cachedAtMount!.archetype : null,
     ),
   );
   const [departure, setDeparture] = useState(() => {
+    // Same freshness rule as the URL below: a draft left overnight must not
+    // seed the slider with a departure that is already behind us.
+    const drafted = draftAtMount?.departure;
+    if (drafted && new Date(drafted) >= new Date()) return drafted;
     const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";
     if (raw && new Date(raw) >= new Date()) return raw;
     // Try cache: prefer the single-mode departure, then fall back to the
@@ -476,7 +486,9 @@ export function PlanPage() {
     if (cachedDep && new Date(cachedDep) >= new Date()) return cachedDep;
     return tomorrowRoundedLocal();
   });
-  const [timeAnchor, setTimeAnchor] = useState<TimeAnchor>("departure");
+  const [timeAnchor, setTimeAnchor] = useState<TimeAnchor>(
+    () => draftAtMount?.timeAnchor ?? "departure",
+  );
 
   const [passage, setPassage] = useState<PassageReport | null>(null);
   const [complexity, setComplexity] = useState<ComplexityScore | null>(null);
@@ -484,16 +496,20 @@ export function PlanPage() {
   const [apiError, setApiError] = useState<string | null>(null);
   const [archetypes, setArchetypes] = useState<Archetype[]>([]);
   const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(null);
-  const [isStale, setIsStale] = useState(false);
+  // "Edits not yet computed". A restored draft is exactly that, so it starts
+  // the page stale: the sidebar offers Recalculer instead of pretending the
+  // route on screen has results behind it.
+  const [isStale, setIsStale] = useState(() => draftAtMount != null);
 
   // Compare-windows mode (lifted from PlanSidebar in step 2)
   const [planMode, setPlanMode] = useState<"single" | "compare">(
-    () => cachedAtMount?.mode ?? "single",
+    () => draftAtMount?.mode ?? cachedAtMount?.mode ?? "single",
   );
   const [sweepEarliest, setSweepEarliest] = useState(
-    () => cachedAtMount?.compare?.sweepEarliest ?? departure,
+    () => draftAtMount?.sweepEarliest ?? cachedAtMount?.compare?.sweepEarliest ?? departure,
   );
   const [sweepLatest, setSweepLatest] = useState(() => {
+    if (draftAtMount?.sweepLatest) return draftAtMount.sweepLatest;
     if (cachedAtMount?.compare?.sweepLatest) return cachedAtMount.compare.sweepLatest;
     const d = new Date(departure);
     d.setDate(d.getDate() + 2);
@@ -501,7 +517,7 @@ export function PlanPage() {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   });
   const [sweepInterval, setSweepInterval] = useState<number>(
-    () => cachedAtMount?.compare?.sweepIntervalHours ?? 3,
+    () => draftAtMount?.sweepIntervalHours ?? cachedAtMount?.compare?.sweepIntervalHours ?? 3,
   );
   // Selected leg for the sidebar's expanded "Comment c'est calculé" — also
   // drives the highlight overlay on the map. Cleared whenever the route or
@@ -519,7 +535,7 @@ export function PlanPage() {
   // already have a route to display (cached / URL) so reload doesn't hide
   // the user's previous context.
   const [actionTaken, setActionTaken] = useState<boolean>(
-    () => urlHasWaypoints || useCachedRoute,
+    () => urlHasWaypoints || useCachedRoute || (draftAtMount?.waypoints.length ?? 0) >= 2,
   );
   // Reset to compact whenever the user drops back below 2 waypoints so the
   // next time they reach 2 they get the pick-a-mode step again.
@@ -608,7 +624,46 @@ export function PlanPage() {
       .finally(() => setIsLoading(false));
   }
 
+  // Keep this tab's uncommitted state recoverable. `isStale` is exactly the
+  // "edited since the last computation" signal, so it decides whether there is
+  // a draft at all: every success path clears it, and clearing it here erases
+  // the draft in the same beat. Cheap enough (a few hundred bytes of JSON) to
+  // run on every input change without debouncing.
   useEffect(() => {
+    if (!isStale) {
+      clearPlanDraft();
+      return;
+    }
+    savePlanDraft({
+      waypoints,
+      departure,
+      timeAnchor,
+      archetype,
+      mode: planMode,
+      sweepEarliest,
+      sweepLatest,
+      sweepIntervalHours: sweepInterval,
+    });
+  }, [
+    isStale,
+    waypoints,
+    departure,
+    timeAnchor,
+    archetype,
+    planMode,
+    sweepEarliest,
+    sweepLatest,
+    sweepInterval,
+  ]);
+
+  useEffect(() => {
+    // Path 0 — a draft was restored: it is this tab's most recent state, and
+    // by definition it has no results yet. Seeding already happened in the
+    // initializers above; hydrating the URL's or the cache's results on top
+    // would show a passage that does not match the route on screen, and
+    // fetching would spend a computation the user did not ask for.
+    if (draftAtMount) return;
+
     // Path A — URL has waypoints: respect the URL, restore from cache if it
     // matches the same route + boat, otherwise fetch fresh. The boat is the
     // seeded `archetype` state, not the raw URL slug: a customized polar

--- a/packages/web/src/sw.test.ts
+++ b/packages/web/src/sw.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { describe, it, expect } from "vitest";
-import { shouldCheckForUpdate } from "./sw";
+import { shouldApplyUpdateNow, shouldCheckForUpdate } from "./sw";
 
 describe("shouldCheckForUpdate", () => {
   it("checks on the first navigation of a session", () => {
@@ -20,5 +20,28 @@ describe("shouldCheckForUpdate", () => {
     const now = 1_000_000;
     expect(shouldCheckForUpdate(now + 60_000, now)).toBe(true);
     expect(shouldCheckForUpdate(now + 600_000, now)).toBe(true);
+  });
+});
+
+describe("shouldApplyUpdateNow", () => {
+  it("swaps straight away when nothing is being drafted", () => {
+    expect(shouldApplyUpdateNow("found", false)).toBe(true);
+  });
+
+  it("waits when a route is half drawn", () => {
+    // The whole point: a deploy must not reload the page under a reader who
+    // has placed waypoints and not computed them yet.
+    expect(shouldApplyUpdateNow("found", true)).toBe(false);
+  });
+
+  it("swaps once the tab is in the background, draft or not", () => {
+    expect(shouldApplyUpdateNow("hidden", true)).toBe(true);
+    expect(shouldApplyUpdateNow("hidden", false)).toBe(true);
+  });
+
+  it("swaps on the next in-app navigation, draft or not", () => {
+    // The reader is leaving the view anyway, and the draft is persisted.
+    expect(shouldApplyUpdateNow("navigation", true)).toBe(true);
+    expect(shouldApplyUpdateNow("navigation", false)).toBe(true);
   });
 });

--- a/packages/web/src/sw.ts
+++ b/packages/web/src/sw.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { registerSW } from "virtual:pwa-register";
+import { hasPlanDraft } from "./plan/draft";
 
 /**
  * Service worker registration, plus an update check the router can trigger.
@@ -11,10 +12,39 @@ import { registerSW } from "virtual:pwa-register";
  * that navigations stop after the first load, a long session could sit on a
  * stale worker indefinitely and never pick up a deploy. Checking on each
  * in-app navigation restores roughly the old cadence.
+ *
+ * ## Why the silent auto-update was replaced
+ *
+ * This used to run in vite-plugin-pwa's `autoUpdate` mode, with Workbox's
+ * `skipWaiting`. In that mode the plugin's own client reloads the page,
+ * unconditionally, the moment the new worker activates: its `activated`
+ * handler calls `window.location.reload()` whenever the event is an update
+ * and no `onNeedReload` was supplied. Combined with an update check on every
+ * in-app navigation, a deploy landing while someone was drawing a route
+ * reloaded the page under them, and everything not yet computed was gone:
+ * the URL and `ow_last_simulation_v1` are only written after a *successful*
+ * computation.
+ *
+ * We now register in `prompt` mode and drive the swap ourselves. The original
+ * motivation for `skipWaiting` still holds and is still met: a new worker must
+ * never sit in `waiting` forever, which on a phone that never closes its last
+ * tab means the app stays pinned to the old shell, refresh after refresh. The
+ * difference is only *when* we let it through. We call `updateSW()` ourselves,
+ * within the same session, at a moment that costs the reader nothing:
+ *
+ *   - straight away when nothing is being drafted;
+ *   - otherwise when the tab goes to the background, or on the reader's next
+ *     in-app navigation (the router calls `flushPendingUpdate`).
+ *
+ * The draft itself (see `plan/draft.ts`) is the other half of the fix: even a
+ * reload the reader did not ask for now hands their route back.
  */
 
 let registration: ServiceWorkerRegistration | undefined;
 let lastCheckedAt = 0;
+
+/** Set once a new worker is waiting: calling it swaps it in and reloads. */
+let applyUpdate: (() => void) | undefined;
 
 /** Navigations can come in bursts (back, forward, back). One network check a
     minute is plenty to catch a deploy without hammering the origin. */
@@ -25,12 +55,62 @@ export function shouldCheckForUpdate(now: number, lastAt: number): boolean {
   return now - lastAt >= MIN_INTERVAL_MS;
 }
 
+/**
+ * What woke the pending-update check.
+ *
+ * `found` is the only one that can interrupt anybody: the worker turned up on
+ * its own while the reader was looking at the page. The other two are moments
+ * the reader created, where a reload is invisible or expected anyway.
+ */
+export type UpdateTrigger = "found" | "hidden" | "navigation";
+
+/**
+ * Pure decision: may a waiting worker be swapped in right now?
+ *
+ * Kept free of `document` and `sessionStorage` so the policy can be tested on
+ * its own. The ugly part of the old behaviour was that there was no policy at
+ * all.
+ */
+export function shouldApplyUpdateNow(trigger: UpdateTrigger, hasDraft: boolean): boolean {
+  // Backgrounded tab, or a navigation the reader just made: nothing on screen
+  // is worth protecting, take the update.
+  if (trigger !== "found") return true;
+  // Found mid-session: only interrupt when there is no uncommitted route.
+  return !hasDraft;
+}
+
+function flush(trigger: UpdateTrigger): void {
+  if (!applyUpdate) return;
+  if (!shouldApplyUpdateNow(trigger, hasPlanDraft())) return;
+  const apply = applyUpdate;
+  applyUpdate = undefined;
+  apply();
+}
+
+/** Called by the router on every in-app navigation: an update that has been
+    waiting for a safe moment gets one here. */
+export function flushPendingUpdate(): void {
+  flush("navigation");
+}
+
 export function registerServiceWorker(): void {
-  registerSW({
+  const updateSW = registerSW({
     immediate: true,
     onRegisteredSW(_swScriptUrl, r) {
       registration = r;
     },
+    onNeedRefresh() {
+      // `prompt` mode names this "needs refresh"; we do not prompt. The
+      // callback only tells us a worker is waiting, and vite-plugin-pwa has
+      // already armed the `controlling` listener that reloads the page once
+      // we let the swap through.
+      applyUpdate = () => void updateSW(true);
+      flush(document.visibilityState === "hidden" ? "hidden" : "found");
+    },
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flush("hidden");
   });
 }
 
@@ -38,10 +118,10 @@ export function registerServiceWorker(): void {
  * Ask the browser whether a newer worker exists.
  *
  * Safe to call on every navigation: throttled, and failures are swallowed.
- * A worker found here activates straight away (`skipWaiting` in the Workbox
- * config) and the registration then reloads the page. Pages read their state
- * from the URL at mount, so the reload lands the reader back where they were,
- * on the new build.
+ * A worker found here installs and waits; `onNeedRefresh` then decides when it
+ * takes over. Pages read their state from the URL, and now from the session
+ * draft, at mount, so the eventual reload lands the reader back where they
+ * were, on the new build.
  */
 export function checkForAppUpdate(): void {
   if (!registration) return;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -24,8 +24,12 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      // Silent auto-update: the SW takes over on next load, no update-toast UI.
-      registerType: 'autoUpdate',
+      // The new worker is announced, not applied: 'autoUpdate' made the
+      // plugin's client call window.location.reload() by itself the instant a
+      // worker activated, which wiped any route drawn and not yet computed.
+      // Still no update-toast UI: src/sw.ts applies the update on its own, at
+      // a moment that costs the reader nothing.
+      registerType: 'prompt',
       // Registration is wired manually in src/main.tsx via 'virtual:pwa-register'.
       injectRegister: false,
       // The manifest is owned by public/manifest.json (linked from index.html).
@@ -33,14 +37,16 @@ export default defineConfig({
       // keeps a single source of truth for install metadata.
       manifest: false,
       workbox: {
-        // Take over without waiting for every tab to close. `autoUpdate` alone
-        // is not enough here: vite-plugin-pwa only forces these two when
-        // `injectRegister` is 'auto' or left out, and we register the worker
-        // ourselves. Without them a freshly deployed worker installs, then
-        // sits in 'waiting' for as long as one tab controlled by the old one
-        // survives, which on a phone is forever: the app stayed pinned to the
-        // previously precached shell, refresh after refresh.
-        skipWaiting: true,
+        // No unconditional skipWaiting in the worker: with it false, Workbox
+        // emits a SKIP_WAITING message listener instead, and src/sw.ts is the
+        // one that decides when to send it. The reason skipWaiting was here in
+        // the first place is unchanged and still honoured: a freshly deployed
+        // worker must not sit in 'waiting' for as long as one tab controlled
+        // by the old one survives, which on a phone is forever. It is now
+        // src/sw.ts that guarantees the swap happens within the session.
+        skipWaiting: false,
+        // Kept: the new worker claims the open pages as soon as it activates,
+        // so the reload lands on the new shell rather than one load later.
         clientsClaim: true,
         // Precache the built app shell. These globs cover the hashed JS/CSS/HTML
         // plus icons and fonts emitted into dist/. ``mjs`` is there for


### PR DESCRIPTION
## Le problème

`registerType: 'autoUpdate'` + `skipWaiting: true` : le client de vite-plugin-pwa recharge la page **de lui-même, sans condition**, dès qu'un worker s'active. Extrait de `node_modules/vite-plugin-pwa/dist/client/build/register.js` :

```js
if (auto) {
  wb.addEventListener("activated", (event) => {
    if (event.isUpdate || event.isExternal) {
      if (onNeedReload) onNeedReload();
      else window.location.reload();   // <- nous ne fournissions pas onNeedReload
    }
  });
}
```

Combiné au contrôle de mise à jour déclenché à chaque navigation interne (`router.tsx`), un déploiement qui atterrissait pendant qu'un utilisateur traçait une route rechargeait la page sous ses doigts. Ce qui survivait : l'URL et `ow_last_simulation_v1`, tous deux écrits **uniquement après un calcul réussi**. Ce qui était perdu : les waypoints posés, le départ réglé, les paramètres de balayage, le mode ETA. Rapport D, majeur 1 ; rapport A, finding 6.

## Ce que fait la PR

**1. Le worker ne s'installe plus tout seul.** Passage en `registerType: 'prompt'` avec `skipWaiting: false` (Workbox émet alors un écouteur de message `SKIP_WAITING` au lieu d'un `self.skipWaiting()` inconditionnel), `clientsClaim: true` conservé. C'est `src/sw.ts` qui déclenche l'échange, dans la même session, à un moment qui ne coûte rien :

- tout de suite si aucun brouillon n'est en cours ;
- sinon au passage de l'onglet en arrière-plan, ou à la prochaine navigation interne.

La motivation d'origine de `skipWaiting` (un worker bloqué en `waiting` pour toujours sur un téléphone qui ne ferme jamais son dernier onglet) reste couverte : nous appelons `updateSW()` nous-mêmes. Aucune bannière de mise à jour n'apparaît, le comportement reste silencieux.

La décision est une fonction pure et testée :

```ts
export function shouldApplyUpdateNow(trigger: UpdateTrigger, hasDraft: boolean): boolean {
  if (trigger !== "found") return true;   // onglet caché ou navigation demandée
  return !hasDraft;                        // trouvé en pleine saisie : on attend
}
```

`flushPendingUpdate()` est appelé depuis `router.tsx` dans le gestionnaire de clic seulement, pas dans `sync()` : `sync()` tourne aussi sur `popstate`, et depuis la PR #314 un retour arrière ne fait souvent que fermer un panneau. Recharger là serait pire que le problème corrigé.

**2. Le brouillon de plan.** Nouveau module `src/plan/draft.ts` : la route en cours d'édition (waypoints, départ, ancrage départ/arrivée, bateau, mode, paramètres de balayage) est persistée dans `sessionStorage` sous une clé versionnée, avec validation de forme à la lecture, TTL de 24 h et `try/catch` sur chaque accès au stockage. `PlanPage` l'écrit tant que `isStale` est vrai (le signal « édité depuis le dernier calcul » existait déjà) et l'efface dès qu'un calcul aboutit. Au montage, un brouillon l'emporte sur l'URL et sur le cache `lastSimulation` : il est par construction plus récent que les deux.

`sessionStorage` et non `localStorage` : un brouillon appartient à un onglet et à une session, ce n'est pas un plan.

## Vérification

Build de prod (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`), servi par `vite preview`, service worker actif, Chrome DevTools.

**Brouillon réhydraté.** Deux waypoints posés sur la carte sans calculer. URL restée `/plan` (vide), `ow_plan_draft_v1` écrit, `ow_last_simulation_v1` absent. Rechargement : les deux marqueurs sont toujours là, route de 901 nm affichée.

**Le calcul efface le brouillon.** Route méditerranéenne 41.90/6.28 vers 42.31/7.58, un seul calcul sur le backend dev. Après succès :

```
url:     /plan?wpts=41.90296,6.28418;42.31043,7.58057&departure=2026-09-03T08%3A00&archetype=cruiser_30ft
draft:   null
lastSim: true
```

Rechargement : plan restauré depuis l'URL et le cache (62,7 nm, 13h52, arrivée 21:51), brouillon toujours vide.

**Déploiement simulé, avant/après.** Un troisième waypoint posé (brouillon en attente), puis rebuild du bundle pour changer l'empreinte du worker, puis `registration.update()` :

| | avant (dev) | après (cette PR) |
|---|---|---|
| Nouveau worker détecté | `activated` -> `location.reload()` immédiat | `waiting: true`, page intacte |
| Waypoints non calculés | perdus | 3 marqueurs toujours affichés, brouillon intact |
| Application de la mise à jour | subie | à la navigation interne suivante |

Mesuré après la mise à jour retenue puis un clic sur « Retour à l'exploration » :

```
reloaded:     true                      (la page a bien basculé)
css:          index-G6xroGss.css        (nouveau build)
waiting:      false                     (worker échangé)
draftPending: true                      (le brouillon a survécu)
```

Retour sur `/plan` : les 3 waypoints sont là, sur le nouveau build.

## Contrôles

`npm run typecheck`, `npm run lint:budget` (11 erreurs, budget 11, inchangé), `npm run test` (295 tests, dont 17 sur `parsePlanDraft` et 4 sur `shouldApplyUpdateNow`), `npm run build`. Vérifié aussi dans le `dist/` : `sw.js` contient l'écouteur `SKIP_WAITING` et plus de `self.skipWaiting()`, et le bundle est bien compilé en mode `prompt`.

Lot 0, PR 0.8 du plan de rework. Rebasée sur `dev` après #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
