### PR TITLE
fix(api): borne le coût d'une requête sur les routes publiques

### DIFF
--- a/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
+++ b/packages/data-adapters/src/openwind_data/adapters/cache_backed.py
@@ -44,6 +44,21 @@ from openwind_data.routing.geometry import Point, haversine_distance
 # mis-parses against a newer server.
 SUPPORTED_VERSION = 1
 
+# Payload ceilings. Parsing cost is O(points x hours x series) and every
+# ``fetch`` then walks the points linearly, once per segment and per sweep
+# window, so an unbounded payload turns one HTTP request into tens of seconds
+# of CPU on a single-worker deployment. Measured during the 2026-09 audit:
+# 5000 points x 336 h is 65 MB of JSON, 768 ms to decode and 590 ms to parse,
+# before any simulation runs.
+#
+# Both ceilings sit well above what the web client sends (60 corridor points,
+# capped in ``forecastCache.ts``, over a 336 h sweep horizon at the very
+# most), so they guard against abuse and against a client bug, never against a
+# legitimate caller. Raise them together with the client caps if the corridor
+# sampling ever widens.
+MAX_CACHE_POINTS = 120
+MAX_CACHE_HOURS = 400
+
 # Sea field names carried per corridor point, index-aligned to the shared time
 # axis. Mirrors ``SeaPoint`` minus ``time``/``current_source`` (handled
 # separately) and the openmeteo ``_parse_sea`` output.
@@ -144,6 +159,12 @@ class CacheBackedAdapter:
             isinstance(times_raw, list) and len(times_raw) > 0,
             "times_ms must be a non-empty list",
         )
+        # Checked before the loop below, not after: the point of the ceiling
+        # is to refuse the work, not to do it and then complain.
+        _require(
+            len(times_raw) <= MAX_CACHE_HOURS,
+            f"times_ms has {len(times_raw)} entries, at most {MAX_CACHE_HOURS} accepted",
+        )
         times: list[datetime] = []
         for ms in times_raw:
             _require(isinstance(ms, (int, float)), "times_ms entries must be numbers")
@@ -152,6 +173,10 @@ class CacheBackedAdapter:
 
         points_raw = payload.get("points")
         _require(isinstance(points_raw, list), "points must be a list")
+        _require(
+            len(points_raw) <= MAX_CACHE_POINTS,
+            f"points has {len(points_raw)} entries, at most {MAX_CACHE_POINTS} accepted",
+        )
         points: list[_CachePoint] = []
         for i, pt in enumerate(points_raw):
             _require(isinstance(pt, dict), f"points[{i}] must be an object")

--- a/packages/data-adapters/tests/test_cache_backed.py
+++ b/packages/data-adapters/tests/test_cache_backed.py
@@ -7,7 +7,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from openwind_data.adapters.cache_backed import SUPPORTED_VERSION, CacheBackedAdapter
+from openwind_data.adapters.cache_backed import (
+    MAX_CACHE_HOURS,
+    MAX_CACHE_POINTS,
+    SUPPORTED_VERSION,
+    CacheBackedAdapter,
+)
 from openwind_data.adapters.openmeteo import AUTO_MODEL
 from openwind_data.routing.geometry import Point
 from openwind_data.routing.passage import estimate_passage
@@ -98,6 +103,57 @@ def test_from_payload_rejects_bad_shape(mutate) -> None:
 def test_non_dict_payload_rejected() -> None:
     with pytest.raises(ValueError):
         CacheBackedAdapter.from_payload([1, 2, 3])
+
+
+# ----------------------------------------------------------------- ceilings
+
+
+def _oversized_points(count):
+    """``count`` corridor points, each carrying one model on the shared axis."""
+    n = len(_TIMES_MS)
+    return [
+        _point(43.0 + i / 1000, 5.0, {"meteofrance_arome_france": _wind([10.0] * n, [180.0] * n)})
+        for i in range(count)
+    ]
+
+
+def test_accepts_a_payload_right_at_the_point_ceiling() -> None:
+    adapter = CacheBackedAdapter.from_payload(_payload(_oversized_points(MAX_CACHE_POINTS)))
+    assert isinstance(adapter, CacheBackedAdapter)
+
+
+def test_rejects_more_points_than_the_ceiling() -> None:
+    # Unbounded here means one request buys tens of seconds of CPU on a
+    # single-worker deployment: the nearest-neighbour scan is linear and runs
+    # once per segment and per sweep window.
+    with pytest.raises(ValueError) as exc:
+        CacheBackedAdapter.from_payload(_payload(_oversized_points(MAX_CACHE_POINTS + 1)))
+    assert f"at most {MAX_CACHE_POINTS} accepted" in str(exc.value)
+    assert str(MAX_CACHE_POINTS + 1) in str(exc.value)
+
+
+def test_rejects_a_longer_time_axis_than_the_ceiling() -> None:
+    payload = _payload(_oversized_points(1))
+    payload["times_ms"] = [
+        int((_T0 + timedelta(hours=h)).timestamp() * 1000) for h in range(MAX_CACHE_HOURS + 1)
+    ]
+    with pytest.raises(ValueError) as exc:
+        CacheBackedAdapter.from_payload(payload)
+    assert f"at most {MAX_CACHE_HOURS} accepted" in str(exc.value)
+
+
+def test_the_time_ceiling_is_checked_before_the_axis_is_materialised() -> None:
+    """An oversized axis must cost a length check, not N datetime conversions.
+
+    Pinned with entries that would raise a different error if they were
+    parsed: reaching the "must be numbers" message would mean the ceiling ran
+    too late to protect anything.
+    """
+    payload = _payload(_oversized_points(1))
+    payload["times_ms"] = ["not-a-number"] * (MAX_CACHE_HOURS + 1)
+    with pytest.raises(ValueError) as exc:
+        CacheBackedAdapter.from_payload(payload)
+    assert f"at most {MAX_CACHE_HOURS} accepted" in str(exc.value)
 
 
 # ---------------------------------------------------------------------- fetch

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -87,6 +87,44 @@ asks you for credentials is guessing rather than reading the server.
 | `plan_passage`            | End-to-end: per-leg timing + 1–5 complexity + ohmywind.fr deep-link, in one call. Pass `latest_departure` and it walks every hourly window up to 14 days out so the LLM can compare side-by-side. Declares an MCP Apps UI resource; supporting hosts auto-render the live plan in a sandboxed iframe. |
 | `read_me`                 | Returns OhMyWind's calculation methodology. Call it when the user asks how things are computed. |
 
+## REST API
+
+The web app talks to the same deployment over plain HTTP. Every response is
+JSON, no key and no account required.
+
+| Route | Method | Notes |
+|---|---|---|
+| `/api/v1/archetypes` | GET | The seven boat archetypes. `Cache-Control: public, max-age=86400`. |
+| `/api/v1/passage` | POST | Passage plan from a departure time. Sweeps departures when `latest_departure` is set. |
+| `/api/v1/passage-by-eta` | POST | Passage plan from a target arrival. |
+| `/api/v1/marine/marc` | GET | SHOM and MARC tidal atlas overlay for one point. Always 200, `covered` tells you whether there was anything to give. |
+| `/api/v1/_client` | GET | How this deployment sees the caller, for rate-limit diagnosis. |
+| `/mcp` | POST | The MCP endpoint. Streaming transport, never compressed. |
+
+Responses under `/api/v1` are gzipped when the client asks for it and the body
+exceeds 1 KB. `/mcp` is deliberately excluded.
+
+### Limits
+
+A single free CPU worker serves everything, MCP sessions included, so each
+route carries a ceiling. All of them are configurable by environment variable
+on the deployment.
+
+| Limit | Default | Environment variable |
+|---|---|---|
+| Requests per IP per minute on the POST planners | 30 | `OPENWIND_RATE_LIMIT_REQUESTS` |
+| Requests per IP per minute on `/api/v1/marine/marc` | 120 | `OPENWIND_MARC_RATE_LIMIT` |
+| Rate-limit window | 60 s | `OPENWIND_RATE_LIMIT_WINDOW_S` |
+| Request body on `/api/v1/*` | 4 MiB, `413` beyond | `OPENWIND_MAX_BODY_BYTES` |
+| `forecast_cache` corridor points | 120, `422` beyond | fixed in `openwind-data` |
+| `forecast_cache` time axis | 400 hours, `422` beyond | fixed in `openwind-data` |
+| Steps per `/api/v1/marine/marc` call | 800, `422` beyond | fixed in the wrapper |
+
+The overlay endpoint has its own, wider bucket because the web app calls it
+once per corridor point, up to 60 times for one computation. Its step ceiling
+allows 30 days of hourly predictions (721 steps) and refuses the shapes that
+would block the worker for seconds, such as a month at a 5-minute step.
+
 ## About this Space
 
 > ⚠️ This Space uses the **Docker SDK** (not Gradio). It does **not** carry

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -49,6 +49,7 @@ from openwind_mcp_core import build_server
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import (
     FileResponse,
@@ -58,10 +59,12 @@ from starlette.responses import (
     RedirectResponse,
 )
 from starlette.routing import Mount, Route
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from security import (
     ALLOWED_ORIGINS,
     TRUSTED_PROXY_HOPS,
+    BodySizeLimitMiddleware,
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
     bucket_id,
@@ -539,8 +542,18 @@ async def _static_asset(request: Request) -> FileResponse | PlainTextResponse:
     )
 
 
+# The archetype table is compiled into the image: it only ever changes when a
+# new build ships, and a build restarts the Space anyway. A day of edge and
+# browser caching removes one request from every /plan mount (the web app
+# re-fetches it on each mount) at no freshness cost.
+_ARCHETYPES_CACHE_CONTROL = "public, max-age=86400"
+
+
 async def _api_archetypes(_request: Request) -> JSONResponse:
-    return JSONResponse(list_archetypes_metadata())
+    return JSONResponse(
+        list_archetypes_metadata(),
+        headers={"Cache-Control": _ARCHETYPES_CACHE_CONTROL},
+    )
 
 
 async def _api_client_debug(request: Request) -> JSONResponse:
@@ -903,6 +916,10 @@ _MARC_REGISTRY = MarcAtlasRegistry.from_directory(os.environ.get("MARC_ATLAS_DIR
 # heights so the tide_height_m + z0_hydro_m fields stay on MARC regardless.
 _SHOM_REGISTRY = ShomC2dRegistry.from_directory(os.environ.get("SHOM_C2D_DIR", ""))
 
+# Hard ceiling on the number of instants a single overlay call may ask for.
+# See the comment at the check site in ``_api_marc_overlay``.
+MAX_MARC_STEPS = 800
+
 
 # ---------------------------------------------------------------------------
 async def _api_marc_overlay(request: Request) -> JSONResponse:
@@ -965,6 +982,24 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
     if span_days > 30:
         return JSONResponse({"error": "time window must be at most 30 days"}, status_code=422)
 
+    # The two ceilings above bound the window and the step separately, and
+    # their product is what actually costs: the SHOM predictor runs a Python
+    # loop per instant (~1 ms each, measured 2026-09), so 30 days at a 5-minute
+    # step is 8641 instants and ~8.8 s of blocking CPU on the single worker,
+    # MCP sessions included. 800 steps keeps the worst case under a second and
+    # still allows every shape the web app asks for: 30 days hourly is 721.
+    n_steps = int((end - start).total_seconds() // (step_minutes * 60)) + 1
+    if n_steps > MAX_MARC_STEPS:
+        return JSONResponse(
+            {
+                "error": (
+                    f"requested {n_steps} steps, at most {MAX_MARC_STEPS}: "
+                    f"shorten the window or widen step_minutes"
+                )
+            },
+            status_code=422,
+        )
+
     marc_loaded = bool(_MARC_REGISTRY.atlases)
     shom_covers = _SHOM_REGISTRY.covers(lat, lon)
     cell = _MARC_REGISTRY.cell_at(lat, lon) if marc_loaded else None
@@ -981,7 +1016,6 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
             headers={"Cache-Control": "public, max-age=86400"},
         )
 
-    n_steps = int((end - start).total_seconds() // (step_minutes * 60)) + 1
     times = [start + timedelta(minutes=step_minutes * i) for i in range(n_steps)]
 
     # MARC gives heights + currents on a regular grid (when covered); SHOM
@@ -1042,6 +1076,39 @@ async def _api_marc_overlay(request: Request) -> JSONResponse:
     )
 
 
+class PathScopedGZipMiddleware:
+    """Compress the REST responses, and only those.
+
+    ``/mcp`` is a streaming transport: FastMCP answers with a long-lived SSE
+    body, and a blanket GZipMiddleware would either buffer it or stamp a
+    ``Content-Encoding`` on a stream clients read incrementally. Rather than
+    reason about which of the two happens in the current SDK version, the
+    compressor never sees that path at all.
+
+    Everything under ``/api/v1`` is JSON that compresses 5 to 10x (a sweep
+    response reaches several MB in clear text, and the overlay endpoint was
+    measured at 8.4 KB uncompressed per corridor point), which is the whole
+    point of the exercise for a mobile client on a marina 4G link.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        prefix: str = "/api/v1",
+        minimum_size: int = 1024,
+    ) -> None:
+        self.app = app
+        self._prefix = prefix
+        self._gzip = GZipMiddleware(app, minimum_size=minimum_size)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path", "").startswith(self._prefix):
+            await self._gzip(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
 def build_app(mcp_app: Any) -> Starlette:
     """Assemble the parent Starlette app around a mounted FastMCP app.
 
@@ -1077,8 +1144,16 @@ def build_app(mcp_app: Any) -> Starlette:
                 # copy ended up hard-coding "une minute" for a 5-minute window.
                 expose_headers=["Retry-After"],
             ),
+            # Compression sits inside CORS (so the negotiated headers are
+            # never rewritten by the compressor) and outside everything that
+            # can answer on its own, so a 429 or a 413 is compressed on the
+            # same terms as a 200.
+            Middleware(PathScopedGZipMiddleware),
             Middleware(SecurityHeadersMiddleware),
             Middleware(RateLimitMiddleware),
+            # Innermost: an over-sized body is refused after it has been
+            # counted against the caller's quota, never before.
+            Middleware(BodySizeLimitMiddleware),
         ],
         lifespan=mcp_app.router.lifespan_context,
     )

--- a/packages/hf-space/security.py
+++ b/packages/hf-space/security.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 """Deployment-side hardening for the public Space: CORS allowlist, per-IP
-rate limiting, security headers.
+rate limiting, request-body ceiling, security headers.
 
 This lives in ``hf-space/`` on purpose. It is infrastructure for *this*
 deployment, not domain logic — a Fly.io or Modal wrapper would solve the same
@@ -266,13 +266,26 @@ class _SlidingWindowCounter:
         return len(self._hits)
 
 
-# Only the POST planners are limited. They are the sole routes that can fan out
-# into many upstream Open-Meteo calls (a sweep walks up to MAX_SWEEP_WINDOWS
-# departures), which is what actually needs protecting — both for our own CPU
-# and to stay a good citizen on a keyless public API. GET /archetypes is a
-# constant, /marine/marc reads local atlases, and /mcp is left alone so a
-# legitimate MCP session doing many tool calls is never throttled.
+# Only the POST planners are on the strict bucket. They are the sole routes
+# that can fan out into many upstream Open-Meteo calls (a sweep walks up to
+# MAX_SWEEP_WINDOWS departures), which is what actually needs protecting —
+# both for our own CPU and to stay a good citizen on a keyless public API.
+# GET /archetypes is a constant and /mcp is left alone so a legitimate MCP
+# session doing many tool calls is never throttled.
 DEFAULT_LIMITED_PATHS = ("/api/v1/passage", "/api/v1/passage-by-eta")
+
+# The tidal-atlas overlay gets its own, wider bucket rather than the blanket
+# exemption it used to have. It reads local atlases so it never touches an
+# upstream API, but it is not free either: the SHOM predictor runs a Python
+# loop per requested instant (~1 ms each, measured 2026-09) on the event loop,
+# so an unthrottled caller can hold the single worker hostage and stall MCP
+# sessions along with it.
+#
+# It cannot share the 30/min bucket: the web app calls it once per corridor
+# point, up to 60 per computation, so the planners' quota would reject a
+# single legitimate plan. 120/min leaves room for two full computations a
+# minute per IP while still bounding a scripted loop.
+DEFAULT_MARC_LIMITED_PATHS = ("/api/v1/marine/marc",)
 
 # 30 requests per 60s, not per 300s. The bucket key is an IP, so everyone
 # behind one NAT shares it: a marina wifi, an office, a mobile carrier on
@@ -290,10 +303,20 @@ DEFAULT_LIMITED_PATHS = ("/api/v1/passage", "/api/v1/passage-by-eta")
 RATE_LIMIT_MAX_REQUESTS = int(os.environ.get("OPENWIND_RATE_LIMIT_REQUESTS", "30"))
 RATE_LIMIT_WINDOW_S = float(os.environ.get("OPENWIND_RATE_LIMIT_WINDOW_S", "60"))
 RATE_LIMIT_MAX_IPS = int(os.environ.get("OPENWIND_RATE_LIMIT_MAX_IPS", "5000"))
+# Same window and same tracked-IP ceiling as the strict bucket above; only
+# the threshold differs.
+MARC_RATE_LIMIT_MAX_REQUESTS = int(os.environ.get("OPENWIND_MARC_RATE_LIMIT", "120"))
 
 
 class RateLimitMiddleware:
-    """Per-IP sliding-window limit on the expensive POST routes."""
+    """Per-IP sliding-window limits, on two buckets with different thresholds.
+
+    The strict bucket covers the POST planners (upstream fan-out); the wide
+    one covers the tidal-atlas overlay, which is CPU-bound rather than
+    upstream-bound and is called once per corridor point by the web app. The
+    two never share a counter: a plan would otherwise spend the planners'
+    whole quota on its overlay calls.
+    """
 
     def __init__(
         self,
@@ -301,6 +324,8 @@ class RateLimitMiddleware:
         *,
         limited_paths: Iterable[str] = DEFAULT_LIMITED_PATHS,
         max_requests: int = RATE_LIMIT_MAX_REQUESTS,
+        marc_paths: Iterable[str] = DEFAULT_MARC_LIMITED_PATHS,
+        marc_max_requests: int = MARC_RATE_LIMIT_MAX_REQUESTS,
         window_s: float = RATE_LIMIT_WINDOW_S,
         max_tracked_ips: int = RATE_LIMIT_MAX_IPS,
     ) -> None:
@@ -311,20 +336,39 @@ class RateLimitMiddleware:
             window_s=window_s,
             max_tracked_ips=max_tracked_ips,
         )
+        self._marc_limited = frozenset(marc_paths)
+        # A second store, so the memory bound stated on _SlidingWindowCounter
+        # becomes (max_requests + marc_max_requests) x max_tracked_ips
+        # timestamps in the worst case. Reaching it would require thousands of
+        # distinct IPs each saturating both buckets inside one window, which
+        # is far beyond what this single worker can serve at all.
+        self._marc_counter = _SlidingWindowCounter(
+            max_requests=marc_max_requests,
+            window_s=window_s,
+            max_tracked_ips=max_tracked_ips,
+        )
+
+    def _counter_for(self, path: str) -> _SlidingWindowCounter | None:
+        if path in self._limited:
+            return self._counter
+        if path in self._marc_limited:
+            return self._marc_counter
+        return None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # Preflight is never limited: an OPTIONS carries no body and no cost,
         # and 429-ing it would surface in the browser as an opaque CORS
         # failure rather than the real reason.
-        if (
-            scope["type"] != "http"
-            or scope.get("method") == "OPTIONS"
-            or scope.get("path") not in self._limited
-        ):
+        counter = (
+            self._counter_for(scope.get("path", ""))
+            if scope["type"] == "http" and scope.get("method") != "OPTIONS"
+            else None
+        )
+        if counter is None:
             await self.app(scope, receive, send)
             return
 
-        retry_after = self._counter.check(resolve_client_ip(scope))
+        retry_after = counter.check(resolve_client_ip(scope))
         if retry_after is None:
             await self.app(scope, receive, send)
             return
@@ -340,6 +384,124 @@ class RateLimitMiddleware:
             },
         )
         await response(scope, receive, send)
+
+
+# ------------------------------------------------------------- body ceiling
+
+# 4 MiB. The web client's biggest legitimate POST measured 811 KB (61 corridor
+# points x 168 h of forecast_cache), so this leaves a factor of five of head
+# room while keeping the worst case an order of magnitude below the 65 MB
+# payload the 2026-09 audit showed one caller could push through
+# ``request.json()``: 768 ms of blocking JSON decode before a single
+# validation ran, on a single-worker deployment.
+#
+# The per-payload ceilings in ``cache_backed.py`` (points, hours) are the
+# domain-side guard and stay where the payload is parsed; this one is the
+# transport-side guard and refuses the bytes before anything reads them.
+MAX_BODY_BYTES = int(os.environ.get("OPENWIND_MAX_BODY_BYTES", str(4 * 1024 * 1024)))
+
+# Scoped to the REST surface on purpose. ``/mcp`` is left untouched: its
+# transport owns its own framing, and buffering a request body there would
+# interfere with a streaming session for no benefit.
+DEFAULT_BODY_LIMITED_PREFIX = "/api/v1"
+
+
+class BodySizeLimitMiddleware:
+    """Refuse an over-sized request body on the REST routes with a 413.
+
+    Two paths, because a client may or may not announce the size:
+
+    - ``Content-Length`` present: the verdict is immediate and no byte of the
+      body is read. The server it sits behind enforces the declared length, so
+      the header cannot under-report the real payload.
+    - ``Content-Length`` absent (chunked upload): the body is buffered here up
+      to the ceiling and replayed to the app. Buffering costs nothing extra,
+      since the handlers call ``request.json()`` and read the whole body
+      anyway, and it is the only way to stop a chunked stream before the
+      handler has committed to it.
+
+    Placed inside the rate limiter so an over-sized request still counts
+    against its quota: a caller hammering the endpoint with 4 MB bodies is
+    exactly who the limiter is for.
+    """
+
+    _BODYLESS_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "DELETE"})
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        max_bytes: int = MAX_BODY_BYTES,
+        prefix: str = DEFAULT_BODY_LIMITED_PREFIX,
+    ) -> None:
+        self.app = app
+        self._max_bytes = max_bytes
+        self._prefix = prefix
+
+    def _too_large_response(self) -> JSONResponse:
+        megabytes = self._max_bytes / (1024 * 1024)
+        rendered = f"{megabytes:.0f}" if megabytes >= 1 else f"{megabytes:.2f}"
+        return JSONResponse(
+            {"error": f"request body too large (max {rendered} MB)"},
+            status_code=413,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope["type"] != "http"
+            or scope.get("method", "").upper() in self._BODYLESS_METHODS
+            or not scope.get("path", "").startswith(self._prefix)
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        declared = _content_length(scope)
+        if declared is not None:
+            if declared > self._max_bytes:
+                await self._too_large_response()(scope, receive, send)
+                return
+            # Announced and within budget: nothing to buffer, the transport
+            # will not deliver more bytes than it declared.
+            await self.app(scope, receive, send)
+            return
+
+        buffered: list[Message] = []
+        total = 0
+        more = True
+        while more:
+            message = await receive()
+            if message["type"] != "http.request":
+                # A disconnect mid-upload: hand it straight to the app, which
+                # already knows how to unwind.
+                buffered.append(message)
+                break
+            total += len(message.get("body", b""))
+            if total > self._max_bytes:
+                await self._too_large_response()(scope, receive, send)
+                return
+            buffered.append(message)
+            more = message.get("more_body", False)
+
+        queued = iter(buffered)
+
+        async def replay() -> Message:
+            try:
+                return next(queued)
+            except StopIteration:
+                return await receive()
+
+        await self.app(scope, replay, send)
+
+
+def _content_length(scope: Scope) -> int | None:
+    """Declared body length, or None when absent or unparseable."""
+    for name, value in scope.get("headers", ()):
+        if name == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None
 
 
 # ---------------------------------------------------------- security headers

--- a/packages/hf-space/tests/test_api_limits.py
+++ b/packages/hf-space/tests/test_api_limits.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""Transport-level ceilings and response shaping on the public REST surface.
+
+Everything here is about the *cost* of a request rather than its meaning: how
+many bytes a caller may push, how many bytes we push back, and which routes
+share a rate-limit bucket. The handlers' JSON stays byte-for-byte what it was;
+only status codes for previously unbounded inputs, and headers, are new.
+
+The MCP mount is asserted alongside the REST routes on purpose: it is a
+streaming transport sharing the same middleware stack, and the easiest way to
+break it is to wrap it in something that buffers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import pathlib
+
+import pytest
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+import security  # sys.path prepared by conftest.py
+
+_HF_DIR = pathlib.Path(__file__).parents[1].resolve()
+
+# Big enough that the compressor would take it if it ever saw this path, so
+# "no content-encoding on /mcp" means something.
+_MCP_BODY = "streamed mcp payload " * 200
+
+
+def _load_app():
+    spec = importlib.util.spec_from_file_location("hf_app_limits", _HF_DIR / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _StubMcpApp:
+    """Stands in for FastMCP's streamable-http app: a route and a no-op lifespan."""
+
+    class _Router:
+        @staticmethod
+        def lifespan_context(_app):
+            @contextlib.asynccontextmanager
+            async def _noop(_):
+                yield
+
+            return _noop(_app)
+
+    router = _Router()
+
+    async def __call__(self, scope, receive, send):
+        await PlainTextResponse(_MCP_BODY)(scope, receive, send)
+
+
+@pytest.fixture
+def client():
+    return TestClient(_load_app().build_app(_StubMcpApp()))
+
+
+# ------------------------------------------------------------- body ceiling
+
+
+def _over_the_cap() -> bytes:
+    return b"x" * (security.MAX_BODY_BYTES + 1)
+
+
+@pytest.mark.parametrize("path", ["/api/v1/passage", "/api/v1/passage-by-eta"])
+def test_declared_oversized_body_is_refused(client, path) -> None:
+    resp = client.post(path, content=_over_the_cap(), headers={"Content-Type": "application/json"})
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "request body too large (max 4 MB)"}
+
+
+def test_chunked_oversized_body_is_refused(client) -> None:
+    """No Content-Length to trust, so the ceiling has to hold on the stream.
+
+    An httpx request built from an iterator carries ``Transfer-Encoding:
+    chunked``: the size is unknown until the last byte arrives, which is the
+    case the header check cannot cover.
+    """
+
+    def chunks():
+        for _ in range(5):
+            yield b"y" * (1024 * 1024)
+
+    resp = client.post(
+        "/api/v1/passage",
+        content=chunks(),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 413
+    assert "too large" in resp.json()["error"]
+
+
+def test_a_body_within_the_ceiling_still_reaches_the_handler(client) -> None:
+    # Same 422 and same wording as before the ceiling existed: the middleware
+    # is invisible to every request that was already legitimate.
+    resp = client.post("/api/v1/passage", json={})
+    assert resp.status_code == 422
+    assert resp.json()["error"].startswith("missing fields")
+
+
+def test_a_chunked_body_within_the_ceiling_is_replayed_intact(client) -> None:
+    # The buffering path must hand the app the exact bytes it swallowed.
+    def chunks():
+        yield b'{"waypoints": [[43.3, 5.35], [43.0, 6.2]], '
+        yield b'"departure": "not-a-date", "archetype": "cruiser_30ft"}'
+
+    resp = client.post(
+        "/api/v1/passage",
+        content=chunks(),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert "invalid departure" in resp.json()["error"]
+
+
+def test_the_ceiling_defaults_to_four_mebibytes() -> None:
+    assert security.MAX_BODY_BYTES == 4 * 1024 * 1024
+
+
+def test_the_ceiling_is_configurable() -> None:
+    # OPENWIND_MAX_BODY_BYTES feeds this parameter at import; the message
+    # follows the configured value rather than a hard-coded "4 MB".
+    limited = security.BodySizeLimitMiddleware(None, max_bytes=2 * 1024 * 1024)
+    assert limited._too_large_response().status_code == 413
+    assert b"max 2 MB" in limited._too_large_response().body
+
+
+def test_the_mcp_transport_is_left_alone(client) -> None:
+    # Buffering a request body on a streaming transport is the one way this
+    # middleware could break MCP, so it never sees that path.
+    resp = client.post("/mcp-probe", content=b"z" * 128)
+    assert resp.status_code == 200
+    assert resp.text == _MCP_BODY
+
+
+# -------------------------------------------------------------- compression
+
+
+def test_json_responses_are_compressed_on_demand(client) -> None:
+    resp = client.get("/api/v1/archetypes", headers={"Accept-Encoding": "gzip"})
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    # Same payload as before, only smaller on the wire.
+    assert isinstance(resp.json(), list)
+
+
+def test_uncompressed_when_the_client_does_not_ask(client) -> None:
+    resp = client.get("/api/v1/archetypes", headers={"Accept-Encoding": "identity"})
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+
+
+def test_compression_actually_saves_bytes(client) -> None:
+    plain = client.get("/api/v1/archetypes", headers={"Accept-Encoding": "identity"})
+    gzipped = client.get("/api/v1/archetypes", headers={"Accept-Encoding": "gzip"})
+    assert int(gzipped.headers["content-length"]) < int(plain.headers["content-length"]) / 2
+
+
+def test_the_mcp_transport_is_never_compressed(client) -> None:
+    """A streamed SSE body must not be handed to a compressor.
+
+    The stub answers with a body well over the 1 KB threshold, so this asserts
+    the path exclusion rather than the size threshold.
+    """
+    resp = client.get("/mcp-probe", headers={"Accept-Encoding": "gzip"})
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+    assert len(_MCP_BODY) > 1024
+
+
+def test_small_responses_are_left_alone(client) -> None:
+    resp = client.get("/api/v1/_client", headers={"Accept-Encoding": "gzip"})
+    assert resp.status_code == 200
+    assert "content-encoding" not in resp.headers
+
+
+def test_security_headers_survive_compression(client) -> None:
+    resp = client.get("/api/v1/archetypes", headers={"Accept-Encoding": "gzip"})
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert "frame-ancestors" in resp.headers["content-security-policy"]
+
+
+# ------------------------------------------------------------- cacheability
+
+
+def test_the_archetype_table_is_cacheable_for_a_day(client) -> None:
+    # It is compiled into the image and a new build restarts the Space, so a
+    # stale answer is not reachable.
+    assert client.get("/api/v1/archetypes").headers["cache-control"] == "public, max-age=86400"
+
+
+def test_the_client_diagnostic_is_never_cached(client) -> None:
+    # It reports per-request state; caching it would make it lie.
+    assert client.get("/api/v1/_client").headers["cache-control"] == "no-store"
+
+
+# --------------------------------------------------------- rate-limit buckets
+
+
+def _init_with_limits(**overrides):
+    original = security.RateLimitMiddleware.__init__
+
+    def _init(self, app, **kwargs):
+        kwargs.update(overrides)
+        original(self, app, **kwargs)
+
+    return _init
+
+
+_MARC_QUERY = (
+    "/api/v1/marine/marc?lat=48.39&lon=-4.49"
+    "&start=2026-05-01T06:00:00%2B00:00&end=2026-05-01T12:00:00%2B00:00"
+)
+
+
+def test_the_overlay_does_not_share_the_planner_bucket(monkeypatch) -> None:
+    """The web app fires one overlay call per corridor point, up to 60.
+
+    On the planners' 30/min bucket a single computation would rate-limit
+    itself, which is why the route used to be exempt altogether.
+    """
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limits(max_requests=1))
+    client = TestClient(_load_app().build_app(_StubMcpApp()))
+    assert all(client.get(_MARC_QUERY).status_code == 200 for _ in range(5))
+
+
+def test_the_overlay_is_limited_on_its_own_bucket(monkeypatch) -> None:
+    # Exempt is not the same as free: each call runs a synchronous predictor
+    # on the event loop, so the wider bucket still has a ceiling.
+    monkeypatch.setattr(
+        security.RateLimitMiddleware, "__init__", _init_with_limits(marc_max_requests=2)
+    )
+    client = TestClient(_load_app().build_app(_StubMcpApp()))
+    codes = [client.get(_MARC_QUERY).status_code for _ in range(4)]
+    assert codes == [200, 200, 429, 429]
+
+
+def test_the_overlay_bucket_is_wider_than_the_planner_one() -> None:
+    assert security.MARC_RATE_LIMIT_MAX_REQUESTS > security.RATE_LIMIT_MAX_REQUESTS
+    # One computation's worth of corridor points must fit.
+    assert security.MARC_RATE_LIMIT_MAX_REQUESTS >= 60
+
+
+def test_filling_the_overlay_bucket_leaves_the_planners_alone(monkeypatch) -> None:
+    monkeypatch.setattr(
+        security.RateLimitMiddleware, "__init__", _init_with_limits(marc_max_requests=1)
+    )
+    client = TestClient(_load_app().build_app(_StubMcpApp()))
+    client.get(_MARC_QUERY)
+    assert client.get(_MARC_QUERY).status_code == 429
+    assert client.post("/api/v1/passage", json={}).status_code == 422

--- a/packages/hf-space/tests/test_api_marc_overlay.py
+++ b/packages/hf-space/tests/test_api_marc_overlay.py
@@ -122,6 +122,54 @@ class TestRejectedQueries:
         assert resp.status_code == 422
         assert "must be an integer" in _payload(resp)["error"]
 
+    async def test_too_many_steps_for_one_call(self) -> None:
+        # The window and the step were each bounded, their product was not:
+        # 30 days at a 5-minute step is 8641 instants, and the SHOM predictor
+        # runs a Python loop per instant on the event loop (~1 ms each), so
+        # one request could block the single worker for ~9 s, MCP included.
+        resp = await app._api_marc_overlay(
+            _FakeRequest(_params(end=(START + timedelta(days=30)).isoformat(), step_minutes="5"))
+        )
+        assert resp.status_code == 422
+        error = _payload(resp)["error"]
+        assert f"at most {app.MAX_MARC_STEPS}" in error
+        assert "step_minutes" in error
+
+    async def test_a_month_of_hourly_steps_is_still_allowed(self) -> None:
+        # 721 instants: the longest window the web app asks for, and the shape
+        # the 30-day ceiling was written to permit. It must stay under the
+        # step ceiling or the two rules contradict each other.
+        resp = await app._api_marc_overlay(
+            _FakeRequest(_params(end=(START + timedelta(days=30)).isoformat()))
+        )
+        assert resp.status_code == 200
+
+    async def test_the_step_ceiling_is_checked_before_any_prediction(self) -> None:
+        # Cheap-check-first: an over-sized request must cost arithmetic, not a
+        # registry lookup followed by a series materialisation.
+        called = False
+
+        class _ExplodingRegistry:
+            atlases = ()
+
+            def cell_at(self, *_args):
+                nonlocal called
+                called = True
+                raise AssertionError("coverage lookup ran on a rejected request")
+
+        original = app._MARC_REGISTRY
+        app._MARC_REGISTRY = _ExplodingRegistry()
+        try:
+            resp = await app._api_marc_overlay(
+                _FakeRequest(
+                    _params(end=(START + timedelta(days=30)).isoformat(), step_minutes="5")
+                )
+            )
+        finally:
+            app._MARC_REGISTRY = original
+        assert resp.status_code == 422
+        assert called is False
+
 
 class TestNaiveTimestamps:
     async def test_naive_timestamps_are_read_as_utc_not_rejected(self) -> None:

--- a/packages/hf-space/tests/test_api_passage_cache.py
+++ b/packages/hf-space/tests/test_api_passage_cache.py
@@ -127,6 +127,31 @@ async def test_malformed_cache_returns_422(monkeypatch) -> None:
     assert "forecast_cache" in _resp_json(resp)["error"]
 
 
+@pytest.mark.asyncio
+async def test_oversized_cache_returns_422_naming_the_ceiling() -> None:
+    """A payload the domain refuses must surface as 422, not 500.
+
+    The ceilings live in ``cache_backed.from_payload`` (that is where the
+    payload is parsed and where the cost is), and reach the client through the
+    same ValueError channel as every other shape error. What this pins is that
+    the message says which ceiling was hit: "invalid forecast_cache" alone
+    would send a caller hunting for a typo that is not there.
+    """
+    from openwind_data.adapters.cache_backed import MAX_CACHE_POINTS
+
+    cache = _corridor_cache()
+    origin = cache["points"][0]
+    cache["points"] = [
+        {**origin, "lat": origin["lat"] + i / 1000} for i in range(MAX_CACHE_POINTS + 1)
+    ]
+
+    resp = await app._api_passage(_FakeRequest(_single_body(forecast_cache=cache)))
+    assert resp.status_code == 422
+    error = _resp_json(resp)["error"]
+    assert error.startswith("invalid forecast_cache: ")
+    assert f"at most {MAX_CACHE_POINTS} accepted" in error
+
+
 # --------------------------------------------------------------- wiring capture
 
 


### PR DESCRIPTION
Lot 0, PR 0.5 du plan de rework (`plan/audit-2026-09/01-plan-rework.md`), plus les points C1, C2 et Mo2 de l'annexe backend et le constat 10 de l'annexe web.

Aucun changement de contrat : les JSON de réponse existants restent identiques octet pour octet. Ce qui est nouveau est additif, soit un code de statut sur une entrée qui n'était pas bornée, soit un en-tête, soit une compression négociée.

## Ce qui change

### 1. Plafonds `forecast_cache` (C1)
`CacheBackedAdapter.from_payload` refuse plus de 120 points de corridor ou plus de 400 entrées dans `times_ms`. Les deux contrôles passent avant la boucle de parsing : l'intérêt d'un plafond est de refuser le travail, pas de le faire puis de se plaindre. Le message dit lequel des deux plafonds a été touché, et remonte tel quel dans le 422 existant (`invalid forecast_cache: points has 121 entries, at most 120 accepted`).

Le web envoie au maximum 60 points (`forecastCache.ts:38`) sur un horizon de 336 h : les plafonds gardent un facteur deux de marge sur l'usage légitime.

### 2. Taille du body (C1)
Nouveau `BodySizeLimitMiddleware` dans `security.py`, appliqué à `/api/v1` seulement. Deux chemins, parce qu'un client annonce ou non la taille :

- `Content-Length` présent : verdict immédiat, aucun octet du body n'est lu.
- `Content-Length` absent (upload chunked) : le body est bufferisé jusqu'au plafond puis rejoué à l'application. Le buffering ne coûte rien de plus, les handlers lisent de toute façon le body entier via `request.json()`.

Plafond 4 MiB, configurable par `OPENWIND_MAX_BODY_BYTES`. Le middleware est placé à l'intérieur du limiteur : une requête trop grosse est comptée dans le quota avant d'être refusée. `/mcp` n'est pas concerné.

### 3. GZip sur les routes REST (Mo2, constat 10)
`PathScopedGZipMiddleware` délègue à `GZipMiddleware` de Starlette uniquement quand le chemin commence par `/api/v1`. `/mcp` streame du SSE et ne doit jamais traverser un compresseur : plutôt que de raisonner sur ce que fait la version courante du SDK, le compresseur ne voit pas ce chemin du tout.

### 4. `Cache-Control` sur `/api/v1/archetypes` (Mo2)
`public, max-age=86400`. La table est compilée dans l'image, et un nouveau build redémarre le Space : une réponse périmée n'est pas atteignable. Le web refetch cette route à chaque montage de `/plan`.

### 5. `/api/v1/marine/marc` (C2)
La fenêtre et le pas étaient bornés séparément, leur produit ne l'était pas : 30 jours au pas de 5 minutes font 8641 instants, et le prédicteur SHOM tourne une boucle Python par instant (environ 1 ms chacun) sur la boucle d'événements. `n_steps` est désormais borné à 800, 422 au-delà. 30 jours horaires (721 instants) restent autorisés.

La route sort de l'exemption totale du limiteur et reçoit son propre bucket à 120 req/min (`OPENWIND_MARC_RATE_LIMIT`). Elle ne peut pas partager le bucket des planners à 30/min : le web l'appelle une fois par point de corridor, jusqu'à 60 fois pour un seul calcul, donc un calcul légitime se serait auto-limité.

## Mesures avant/après

Serveur local `uv run python app.py`, dataset atlas absent.

| Réponse | Sans gzip | Avec gzip | Gain |
|---|---|---|---|
| `GET /api/v1/archetypes` | 1 421 o | 428 o | 70 % |
| `POST /api/v1/passage` (Marseille vers Porquerolles, 5 tronçons) | 4 267 o | 1 342 o | 69 % |
| `GET /api/v1/marine/marc`, 7 jours horaires (payload réel du Space prod) | 8 463 o | 2 046 o | 76 % |

La ligne `marine/marc` utilise la réponse réelle du Space de prod (l'atlas n'est pas chargé en local), soit exactement le payload que l'annexe A avait mesuré à 8 434 o non compressés par point de corridor. Sur un corridor de 41 points cela ramène 347 Ko à 84 Ko.

Bornes vérifiées en direct sur le serveur local :

```
POST /api/v1/passage, 5 MB déclarés   -> 413 {"error":"request body too large (max 4 MB)"}
POST /api/v1/passage, 5 MB chunked    -> 413 {"error":"request body too large (max 4 MB)"}
GET  /marine/marc 30 j au pas de 5 min -> 422 {"error":"requested 8641 steps, at most 800: shorten the window or widen step_minutes"}
GET  /marine/marc 30 j horaires        -> 200
```

## Smoke local

REST, appel réel Open-Meteo, un seul :

```
GET  /api/v1/archetypes  Accept-Encoding: identity -> 200, 1421 o
GET  /api/v1/archetypes  Accept-Encoding: gzip     -> 200, 428 o, content-encoding: gzip,
                                                     cache-control: public, max-age=86400
POST /api/v1/passage  Marseille (43.29, 5.37) vers Porquerolles (43.0, 6.2),
     départ 2026-09-03T09:00+02:00, cruiser_30ft, sans forecast_cache
     -> 200, objet passage, 5 tronçons, AROME, 14,86 h, 40,3 NM, complexité 2 modéré
```

MCP, client `mcp` en streamable HTTP sur `http://localhost:7860/mcp` :

```
initialize   -> OK, ohmywind 1.27.2
list_tools   -> get_marine_forecast, list_boat_archetypes, plan_passage, read_me
plan_passage -> même route, même départ : 14,86 h, 40,3 NM, AROME, 5 tronçons,
                complexité 2 modéré (identique au REST)
```

En-têtes de la réponse `/mcp` : ni `content-encoding` ni `vary`, la session streame normalement.

## Tests

| Suite | Avant | Après |
|---|---|---|
| data-adapters | 279 réussis, 3 ignorés | 283 réussis, 3 ignorés |
| hf-space | 125 | 149 |
| mcp-core | 66 | 66 |

Ruff check et format propres sur les trois paquets.

Nouveau fichier `packages/hf-space/tests/test_api_limits.py` (20 tests) : 413 déclaré et chunked, rejeu intact d'un body chunked sous le plafond, `/mcp` épargné par le plafond comme par la compression, compression négociée et gain réel, en-têtes de sécurité qui survivent à la compression, `Cache-Control`, et les quatre propriétés des buckets de limitation.

## Reste à faire

Le web n'est pas touché : il continue d'envoyer ses 60 points et ses appels overlay point par point. C'est la PR 0.11 qui les réduit, avec l'endpoint de couverture des atlas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
