### PR TITLE
feat(api): expose la couverture des atlas de marée

### DIFF
--- a/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
+++ b/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
@@ -218,6 +218,52 @@ class ShomC2dRegistry:
         idx, dist_km = self._nearest(lat, lon)
         return idx is not None and dist_km <= self._MAX_NEAREST_KM
 
+    def coverage_zones(self) -> tuple[tuple[str, tuple[float, float, float, float]], ...]:
+        """One bounding box per SHOM zone, sorted by zone name.
+
+        Exists so a caller can decide *not* to ask. The point cloud covers a
+        few French Atlantic cartouches and nothing else, so a client planning
+        in the Mediterranean can skip the round trip entirely rather than
+        collect ``covered: false`` once per corridor point.
+
+        Each box is the zone's own extent padded by the same tolerance
+        :meth:`covers` applies, which buys the invariant that makes the
+        endpoint safe to trust: **a point outside every returned box is a
+        point ``covers`` refuses**. The converse does not hold, and cannot:
+        the cloud is scattered, so a box contains land and gaps that
+        ``covers`` rejects on the distance test. Skipping outside the boxes
+        loses nothing; a call inside one may still come back uncovered.
+
+        Boxes are ``(lat_min, lon_min, lat_max, lon_max)`` in WGS84 degrees,
+        matching :attr:`bbox` and ``AtlasMeta.bbox`` on the MARC side.
+        Returns an empty tuple for an empty registry.
+        """
+        if not self.lats.size:
+            return ()
+        # The tolerance is expressed in the same scaled space _nearest uses:
+        # latitude degrees straight, longitude degrees divided by the mean
+        # cosine. Padding in that space is what keeps the invariant exact
+        # rather than approximately right.
+        lat_pad = self._MAX_NEAREST_KM / 111.0
+        lon_pad = lat_pad / max(self._cos_mean_lat, 1e-6)
+        boxes: list[tuple[str, tuple[float, float, float, float]]] = []
+        for name in sorted({str(z) for z in self.zone_names}):
+            mask = self.zone_names == name
+            lats = self.lats[mask]
+            lons = self.lons[mask]
+            boxes.append(
+                (
+                    name,
+                    (
+                        float(lats.min()) - lat_pad,
+                        float(lons.min()) - lon_pad,
+                        float(lats.max()) + lat_pad,
+                        float(lons.max()) + lon_pad,
+                    ),
+                )
+            )
+        return tuple(boxes)
+
     def _nearest(self, lat: float, lon: float) -> tuple[int | None, float]:
         """Index of the nearest C2D point + distance in km, or ``(None, inf)``.
 

--- a/packages/data-adapters/tests/currents/test_shom_c2d_registry.py
+++ b/packages/data-adapters/tests/currents/test_shom_c2d_registry.py
@@ -110,6 +110,46 @@ def _write_synthetic_registry(out: Path) -> None:
     (out / "shom_c2d_ref_ports.json").write_text(json.dumps(ports, ensure_ascii=False))
 
 
+def test_coverage_zones_is_empty_without_artefacts(tmp_path: Path) -> None:
+    assert ShomC2dRegistry.from_directory(tmp_path).coverage_zones() == ()
+
+
+def test_coverage_zones_reports_each_zone_once(tmp_path: Path) -> None:
+    _write_synthetic_registry(tmp_path)
+    zones = ShomC2dRegistry.from_directory(tmp_path).coverage_zones()
+    assert [name for name, _ in zones] == ["TEST_ZONE"]
+    lat_min, lon_min, lat_max, lon_max = zones[0][1]
+    # The synthetic cloud spans 47.49..47.51 / -2.91..-2.89, padded outward.
+    assert lat_min < 47.49 and lat_max > 47.51
+    assert lon_min < -2.91 and lon_max > -2.89
+
+
+def test_every_covered_point_falls_inside_a_zone_box(tmp_path: Path) -> None:
+    """The invariant the coverage endpoint sells: outside the boxes, no data.
+
+    A client that skips the round trip for points outside every box must not
+    lose a single covered point. Sampled on a grid straddling the cloud, so
+    it catches a box that is padded too little as well as one padded on the
+    wrong axis.
+    """
+    _write_synthetic_registry(tmp_path)
+    reg = ShomC2dRegistry.from_directory(tmp_path)
+    boxes = [box for _, box in reg.coverage_zones()]
+
+    def inside_any(lat: float, lon: float) -> bool:
+        return any(
+            lat_min <= lat <= lat_max and lon_min <= lon <= lon_max
+            for lat_min, lon_min, lat_max, lon_max in boxes
+        )
+
+    for i in range(-20, 21):
+        for j in range(-20, 21):
+            lat = 47.50 + i * 0.01
+            lon = -2.90 + j * 0.01
+            if reg.covers(lat, lon):
+                assert inside_any(lat, lon), (lat, lon)
+
+
 def test_from_directory_returns_empty_when_artefacts_missing(tmp_path: Path) -> None:
     reg = ShomC2dRegistry.from_directory(tmp_path)  # nothing on disk
     assert reg.lats.size == 0

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -98,6 +98,7 @@ JSON, no key and no account required.
 | `/api/v1/passage` | POST | Passage plan from a departure time. Sweeps departures when `latest_departure` is set. |
 | `/api/v1/passage-by-eta` | POST | Passage plan from a target arrival. |
 | `/api/v1/marine/marc` | GET | SHOM and MARC tidal atlas overlay for one point. Always 200, `covered` tells you whether there was anything to give. |
+| `/api/v1/marine/marc/coverage` | GET | Bounding boxes of the loaded atlases, so a client can skip the calls that cannot return anything. `Cache-Control: public, max-age=86400`. |
 | `/api/v1/_client` | GET | How this deployment sees the caller, for rate-limit diagnosis. |
 | `/mcp` | POST | The MCP endpoint. Streaming transport, never compressed. |
 
@@ -119,6 +120,14 @@ on the deployment.
 | `forecast_cache` corridor points | 120, `422` beyond | fixed in `openwind-data` |
 | `forecast_cache` time axis | 400 hours, `422` beyond | fixed in `openwind-data` |
 | Steps per `/api/v1/marine/marc` call | 800, `422` beyond | fixed in the wrapper |
+
+`/api/v1/marine/marc/coverage` answers
+`{"atlases": [{"name": "FINIS", "source": "marc", "bbox": [lat_min, lon_min,
+lat_max, lon_max]}, ...]}`, in WGS84 degrees, latitude first, sorted by source
+then name. It is an empty list on a Space that ships without the tidal atlas
+dataset. The promise runs one way only: outside every box there is nothing to
+fetch, inside one there may still be nothing (the SHOM boxes wrap a scattered
+point cloud that contains land and gaps).
 
 The overlay endpoint has its own, wider bucket because the web app calls it
 once per corridor point, up to 60 times for one computation. Its step ceiling

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -1109,6 +1109,74 @@ class PathScopedGZipMiddleware:
         await self.app(scope, receive, send)
 
 
+# One ten-thousandth of a degree, about 11 m. Fine enough that rounding is
+# invisible to a client deciding whether to call, coarse enough to keep the
+# payload readable.
+_BBOX_QUANTUM = 1e-4
+
+
+def _widen_to_quantum(bbox: tuple[float, float, float, float]) -> list[float]:
+    """Round a bounding box outward, never inward.
+
+    The boxes carry a promise: a point outside every one of them is a point
+    the atlases do not cover. Rounding a bound the wrong way would shave a
+    few metres off that promise and silently drop a covered point, so the
+    minima floor and the maxima ceil.
+    """
+    lat_min, lon_min, lat_max, lon_max = bbox
+    return [
+        math.floor(lat_min / _BBOX_QUANTUM) * _BBOX_QUANTUM,
+        math.floor(lon_min / _BBOX_QUANTUM) * _BBOX_QUANTUM,
+        math.ceil(lat_max / _BBOX_QUANTUM) * _BBOX_QUANTUM,
+        math.ceil(lon_max / _BBOX_QUANTUM) * _BBOX_QUANTUM,
+    ]
+
+
+async def _api_marc_coverage(_request: Request) -> JSONResponse:
+    """Where the tidal atlases have anything to say, as bounding boxes.
+
+    Exists so a client can decide not to ask. ``/api/v1/marine/marc`` answers
+    200 with ``covered: false`` outside coverage, which is the right contract
+    for a single point and the wrong cost for a route: a Mediterranean plan
+    measured 14 uncovered answers out of 14 calls, one per corridor point,
+    every one of them a round trip that could not have returned anything.
+
+    Response::
+
+        {"atlases": [{"name": "FINIS", "source": "marc",
+                      "bbox": [lat_min, lon_min, lat_max, lon_max]}, ...]}
+
+    Degrees WGS84, latitude first, matching the ``lat``/``lon`` order of the
+    overlay's own query parameters. Sorted by source then name so a client can
+    diff two answers, and an empty list when the Space ships without the
+    dataset (the same state the overlay reports as ``covered: false``).
+
+    What the boxes promise is one-directional: outside every box there is
+    nothing to fetch, inside one there may still be nothing. MARC boxes come
+    from each atlas's coverage polygon, which the registry itself tests before
+    looking at a tile; SHOM boxes wrap a scattered point cloud that contains
+    land and gaps. A client skipping outside them loses no data; a client
+    assuming coverage inside them would be wrong.
+    """
+    atlases: list[dict[str, Any]] = [
+        {"name": atlas.name, "source": "marc", "bbox": _widen_to_quantum(atlas.bbox)}
+        for atlas in _MARC_REGISTRY.atlases
+    ]
+    atlases += [
+        {"name": name, "source": "shom", "bbox": _widen_to_quantum(bbox)}
+        for name, bbox in _SHOM_REGISTRY.coverage_zones()
+    ]
+    atlases.sort(key=lambda entry: (entry["source"], entry["name"]))
+    # An empty answer is cached briefly, exactly like the overlay's "no atlas
+    # dataset loaded" case: a Space that boots before the dataset is attached
+    # would otherwise tell every client to skip the atlases for a whole day.
+    max_age = 86400 if atlases else 300
+    return JSONResponse(
+        {"atlases": atlases},
+        headers={"Cache-Control": f"public, max-age={max_age}"},
+    )
+
+
 def build_app(mcp_app: Any) -> Starlette:
     """Assemble the parent Starlette app around a mounted FastMCP app.
 
@@ -1125,6 +1193,7 @@ def build_app(mcp_app: Any) -> Starlette:
             Route("/api/v1/passage", _api_passage, methods=["POST"]),
             Route("/api/v1/passage-by-eta", _api_passage_by_eta, methods=["POST"]),
             Route("/api/v1/marine/marc", _api_marc_overlay, methods=["GET"]),
+            Route("/api/v1/marine/marc/coverage", _api_marc_coverage, methods=["GET"]),
             Mount("/", app=mcp_app),
         ],
         # Order matters: the first entry is the outermost wrapper. CORS sits

--- a/packages/hf-space/tests/test_api_limits.py
+++ b/packages/hf-space/tests/test_api_limits.py
@@ -256,3 +256,29 @@ def test_filling_the_overlay_bucket_leaves_the_planners_alone(monkeypatch) -> No
     client.get(_MARC_QUERY)
     assert client.get(_MARC_QUERY).status_code == 429
     assert client.post("/api/v1/passage", json={}).status_code == 422
+
+
+def test_the_atlas_coverage_route_is_never_rate_limited(monkeypatch) -> None:
+    """It is a constant read out of memory, and it is what saves the calls.
+
+    A client fetches it once to learn which corridor points are worth an
+    overlay call. Throttling it would push that client back to calling the
+    overlay blind, which is the traffic this endpoint exists to remove.
+    """
+    monkeypatch.setattr(
+        security.RateLimitMiddleware,
+        "__init__",
+        _init_with_limits(max_requests=1, marc_max_requests=1),
+    )
+    client = TestClient(_load_app().build_app(_StubMcpApp()))
+    responses = [client.get("/api/v1/marine/marc/coverage") for _ in range(5)]
+    assert [r.status_code for r in responses] == [200] * 5
+    assert all(r.json() == {"atlases": []} for r in responses)
+
+
+def test_the_atlas_coverage_route_answers_cross_origin(client) -> None:
+    # The web app calls it from ohmywind.fr before it starts a computation.
+    resp = client.get("/api/v1/marine/marc/coverage", headers={"Origin": "https://ohmywind.fr"})
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "*"
+    assert "atlases" in resp.json()

--- a/packages/hf-space/tests/test_api_marc_overlay.py
+++ b/packages/hf-space/tests/test_api_marc_overlay.py
@@ -185,6 +185,114 @@ class TestNaiveTimestamps:
         assert resp.status_code == 200
 
 
+class TestCoverage:
+    """``GET /api/v1/marine/marc/coverage``: where it is worth asking at all.
+
+    The overlay answers 200 with ``covered: false`` outside coverage, once per
+    corridor point. A Mediterranean plan measured 14 such answers out of 14
+    calls. This endpoint exists so the client can skip them, which only works
+    if the boxes are complete, ordered, and cheap to cache.
+    """
+
+    class _StubMarcAtlas:
+        def __init__(self, name, bbox):
+            self.name = name
+            self.bbox = bbox
+
+    class _StubMarcRegistry:
+        def __init__(self, atlases):
+            self.atlases = tuple(atlases)
+
+    class _StubShomRegistry:
+        def __init__(self, zones):
+            self._zones = tuple(zones)
+
+        def coverage_zones(self):
+            return self._zones
+
+    @pytest.fixture
+    def loaded(self, monkeypatch):
+        """A Space with both datasets, declared out of alphabetical order."""
+        monkeypatch.setattr(
+            app,
+            "_MARC_REGISTRY",
+            self._StubMarcRegistry(
+                [
+                    self._StubMarcAtlas("MANGA", (48.0, -5.0, 50.0, 0.0)),
+                    self._StubMarcAtlas("FINIS", (47.5, -5.5, 48.9, -3.5)),
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            app,
+            "_SHOM_REGISTRY",
+            self._StubShomRegistry(
+                [
+                    ("MORBIHAN", (47.4, -3.2, 47.7, -2.6)),
+                    ("BREST", (48.2, -4.8, 48.5, -4.2)),
+                ]
+            ),
+        )
+
+    async def test_reports_every_loaded_atlas_and_zone(self, loaded) -> None:
+        payload = _payload(await app._api_marc_coverage(None))
+        assert [(a["source"], a["name"]) for a in payload["atlases"]] == [
+            ("marc", "FINIS"),
+            ("marc", "MANGA"),
+            ("shom", "BREST"),
+            ("shom", "MORBIHAN"),
+        ]
+
+    async def test_boxes_are_lat_lon_in_that_order(self, loaded) -> None:
+        # Same order as the overlay's own lat/lon query params. Swapping them
+        # would put every French box in the Indian Ocean and the client would
+        # skip every call.
+        finis = next(a for a in _payload(await app._api_marc_coverage(None))["atlases"])
+        lat_min, lon_min, lat_max, lon_max = finis["bbox"]
+        assert 47.0 < lat_min < lat_max < 49.0
+        assert -6.0 < lon_min < lon_max < -3.0
+
+    async def test_ordering_is_stable_across_calls(self, loaded) -> None:
+        first = _payload(await app._api_marc_coverage(None))
+        second = _payload(await app._api_marc_coverage(None))
+        assert first == second
+
+    async def test_rounding_only_ever_widens_a_box(self, monkeypatch) -> None:
+        # A box is a promise that there is nothing outside it. Rounding a
+        # bound inward would shave metres off that promise and silently drop
+        # a covered point.
+        raw = (47.123456789, -3.987654321, 48.111111111, -2.000000001)
+        monkeypatch.setattr(
+            app, "_MARC_REGISTRY", self._StubMarcRegistry([self._StubMarcAtlas("X", raw)])
+        )
+        monkeypatch.setattr(app, "_SHOM_REGISTRY", self._StubShomRegistry([]))
+        lat_min, lon_min, lat_max, lon_max = _payload(await app._api_marc_coverage(None))[
+            "atlases"
+        ][0]["bbox"]
+        assert lat_min <= raw[0] and lon_min <= raw[1]
+        assert lat_max >= raw[2] and lon_max >= raw[3]
+
+    async def test_answers_an_empty_list_without_a_dataset(self) -> None:
+        # The registries are empty in CI, which is also the Space's state
+        # whenever the dataset was not pulled at build time.
+        resp = await app._api_marc_coverage(None)
+        assert resp.status_code == 200
+        assert _payload(resp) == {"atlases": []}
+
+    async def test_an_empty_answer_is_only_cached_briefly(self) -> None:
+        # Attaching the dataset must not take a day to become visible.
+        assert app._MARC_REGISTRY.atlases == ()
+        assert _payload(await app._api_marc_coverage(None)) == {"atlases": []}
+        assert (await app._api_marc_coverage(None)).headers["cache-control"] == (
+            "public, max-age=300"
+        )
+
+    async def test_a_loaded_answer_is_cached_for_a_day(self, loaded) -> None:
+        # It only changes when a new image ships, and that restarts the Space.
+        resp = await app._api_marc_coverage(None)
+        assert resp.headers["cache-control"] == "public, max-age=86400"
+
+
 class TestLanding:
     async def test_landing_serves_html(self) -> None:
         resp = await app._index(None)


### PR DESCRIPTION
Suite de #317, déjà mergée sur `dev` pendant l'écriture de celle-ci : la branche a été rebasée sur `dev`, le diff ne contient plus que cet endpoint.

Endpoint de couverture demandé par la PR 0.11 du lot 0 (`plan/audit-2026-09/01-plan-rework.md`), moitié serveur. Le web n'est pas touché ici.

## Le problème

Le client appelle `/api/v1/marine/marc` une fois par point de corridor, jusqu'à 60 fois pour un seul calcul. La route répond 200 avec `covered: false` hors couverture, ce qui est le bon contrat pour un point isolé et le mauvais coût pour une route. La mesure live sur un plan méditerranéen a donné 14 réponses non couvertes sur 14 appels : aucun de ces allers-retours ne pouvait rien rapporter, et les atlas ne couvrent que quelques cartouches de l'Atlantique français.

## Ce qui est ajouté

`GET /api/v1/marine/marc/coverage` :

```json
{"atlases": [
  {"name": "FINIS", "source": "marc", "bbox": [47.5, -5.5, 49.0, -4.5]},
  {"name": "TEST_ZONE", "source": "shom", "bbox": [47.4449, -2.9767, 47.5551, -2.8233]}
]}
```

Degrés WGS84, latitude d'abord, dans le même ordre que les paramètres `lat`/`lon` de la route overlay. Trié par source puis par nom, donc deux réponses sont comparables. Liste vide et 200 quand le Space tourne sans le dataset, ce qui est son état habituel en CI et sur un build sans le secret HF. Hors limiteur de débit, CORS comme les autres routes.

**Cache-Control :** `public, max-age=86400` quand au moins un atlas est chargé, `public, max-age=300` quand la liste est vide. C'est un écart assumé par rapport à un `86400` uniforme : la route overlay applique déjà exactement cette distinction (`app.py`, cas « no atlas dataset loaded »), et cacher une liste vide une journée entière voudrait dire qu'un Space démarré avant que le dataset soit attaché dit à tous ses clients d'ignorer les atlas jusqu'au lendemain. Le cas chargé, lui, ne change qu'avec une nouvelle image, qui redémarre le Space.

## L'invariant qui rend l'endpoint utilisable

Les boîtes ne promettent qu'un seul sens : **hors de toutes les boîtes, il n'y a rien à chercher ; à l'intérieur d'une boîte, il peut quand même n'y avoir rien.** Un client qui saute les appels hors des boîtes ne perd aucune donnée ; un client qui supposerait la couverture à l'intérieur aurait tort.

- **MARC** : la boîte est le polygone de couverture de l'atlas, que le registre teste lui-même avant de regarder une tuile. Hors boîte, `covers()` refuse par construction.
- **SHOM** : nouveau helper en lecture seule `ShomC2dRegistry.coverage_zones()`, une boîte par zone, élargie de la tolérance que `covers()` applique déjà (5 km, exprimés dans l'espace mis à l'échelle que `_nearest` utilise, donc l'élargissement est exact et pas approximatif). Le nuage SHOM est épars : une boîte contient de la terre et des trous que `covers()` rejette au test de distance.

L'arrondi des bornes est fait vers l'extérieur (`floor` sur les minima, `ceil` sur les maxima, pas de 1e-4 degré soit environ 11 m) pour la même raison : arrondir une borne vers l'intérieur rognerait la promesse de quelques mètres et ferait silencieusement sauter un point couvert.

## Smoke local

Serveur local monté sur les fixtures d'atlas des tests (`MARC_ATLAS_DIR`, `SHOM_C2D_DIR`), pour exercer les vrais registres et pas des stubs :

```
GET /api/v1/marine/marc/coverage
  -> 200, cache-control: public, max-age=86400
  {"atlases":[{"name":"FINIS","source":"marc","bbox":[47.5,-5.5,49.0,-4.5]},
              {"name":"TEST_ZONE","source":"shom","bbox":[47.4449,-2.9767,47.5551,-2.8233]}]}

GET /api/v1/marine/marc?lat=48.35&lon=-4.80   (dans la boîte FINIS)
  -> 200 covered: true, current_source marc_finis_250m, tide_height_m et
     current_speed_kn renseignés : overlay inchangé

GET /api/v1/marine/marc?lat=43.0&lon=6.2      (Méditerranée, hors de toutes les boîtes)
  -> 200 {"covered": false}   <- exactement l'appel que le client saute désormais
```

Sans dataset (état de la CI et d'un Space sans le secret) :

```
GET /api/v1/marine/marc/coverage -> 200, cache-control: public, max-age=300, {"atlases":[]}
```

REST, un seul appel réel Open-Meteo :

```
GET  /api/v1/archetypes  identity -> 200, 1421 o ; gzip -> 200, 428 o
POST /api/v1/passage  Marseille (43.29, 5.37) vers Porquerolles (43.0, 6.2),
     départ 2026-09-03T09:00+02:00, cruiser_30ft, sans forecast_cache
     -> 200, objet passage, 5 tronçons, AROME, 14,86 h, 40,3 NM, complexité 2 modéré
```

MCP, client `mcp` en streamable HTTP sur `http://localhost:7860/mcp` :

```
initialize   -> OK, ohmywind 1.27.2
list_tools   -> get_marine_forecast, list_boat_archetypes, plan_passage, read_me
plan_passage -> même route : 14,86 h, 40,3 NM, AROME, 5 tronçons, complexité 2 modéré
```

Réponse `/mcp` sans `content-encoding`, session qui streame normalement.

## Tests

| Suite | Avant (dev, après #317) | Après |
|---|---|---|
| data-adapters | 283 réussis, 3 ignorés | 286 réussis, 3 ignorés |
| hf-space | 149 | 158 |
| mcp-core | 66 | 66 |

Ruff check et format propres sur les trois paquets.

Côté data-adapters : liste vide sans artefacts, une entrée par zone, et surtout le test d'invariant, qui balaie une grille de 41 x 41 points autour du nuage synthétique et vérifie que chacun des 12 points que `covers()` accepte tombe bien dans une boîte. C'est ce test qui autorise le client à sauter les appels.

Côté hf-space : forme et tri de la réponse, ordre latitude/longitude, stabilité entre deux appels, arrondi qui n'élargit jamais vers l'intérieur, cas vide, les deux valeurs de `Cache-Control`, absence de limitation de débit et CORS.

## Reste à faire

La moitié client de la PR 0.11 : consommer cet endpoint dans `api/marine.ts` pour court-circuiter les appels overlay hors couverture, et regrouper les appels Marine Open-Meteo en une requête multi-coordonnées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
