### PR TITLE
perf(web): une seule requête marine pour le corridor, MARC court-circuité hors couverture

### DIFF
--- a/packages/web/src/api/forecastCache.ts
+++ b/packages/web/src/api/forecastCache.ts
@@ -13,7 +13,7 @@ import type { ModelForecast, MarineHourly } from "../types";
 import type { ModelName } from "../config/modelConfig";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
 import { fetchWindCorridor } from "./openmeteo";
-import { fetchMarine, parisIsoToUtcMs } from "./marine";
+import { fetchMarineCorridor, parisIsoToUtcMs } from "./marine";
 import { haversineNm, interpolateGreatCircle, type GeoPoint } from "../plan/geo";
 
 export const CACHE_VERSION = 1;
@@ -263,9 +263,10 @@ function buildSea(
 }
 
 // Sample the route corridor in the browser and assemble the cache. Reuses
-// fetchAllModels (multi-model wind, kn, 30-min cache, fallback chain) and
-// fetchMarine (waves + SMOC currents + MARC overlay) — both already per-point
-// cached and deduped. Throws on no mappable model so the caller can fall back.
+// fetchWindCorridor (multi-model wind, kn, 30-min cache, fallback chain) and
+// fetchMarineCorridor (waves + SMOC currents + MARC overlay) — both one request
+// for the whole corridor, both per-point cached and deduped. Throws on no
+// mappable model so the caller can fall back.
 // Backend-mappable models among the user's active set, in priority order. The
 // cache only carries models the server can route on; an empty result means the
 // user disabled every mappable model, so buildForecastCache yields no usable
@@ -283,12 +284,13 @@ export async function buildForecastCache(
   const corridor = interpolateCorridor(waypoints, spacing);
   const models = mappableActiveModels();
   // Wind: ONE request per model for the whole corridor (multi-coordinate).
-  // Marine: kept per-point because fetchMarine merges the per-location MARC/SHOM
-  // overlay; both are already 30-min cached and run in parallel. Far fewer
+  // Marine: ONE request for the whole corridor too, the endpoint taking the
+  // same comma-separated coordinates. The per-location MARC/SHOM overlay stays
+  // per point, but is only asked for where an atlas could answer. Far fewer
   // requests than models×points → fewer browser connection waves → faster.
   const [windByCoord, marineByCoord] = await Promise.all([
     fetchWindCorridor(corridor, models),
-    Promise.all(corridor.map((p) => fetchMarine(p.lat, p.lon))),
+    fetchMarineCorridor(corridor),
   ]);
   const samples: SampledPoint[] = corridor.map((p, i) => ({
     lat: p.lat,

--- a/packages/web/src/api/marine.test.ts
+++ b/packages/web/src/api/marine.test.ts
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
+  clearMarcCoverageCache,
+  clearMarineCache,
+  fetchMarineCorridor,
   isCurrentsRelevant,
   isTidesRelevant,
   isWavesRelevant,
+  marcMayCover,
   mergeMarcOverlay,
+  parseMarcCoverage,
   parisIsoToUtcMs,
+  type MarcAtlasBox,
   type MarcOverlay,
 } from "./marine";
 import type { MarineHourly } from "../types";
@@ -291,5 +297,317 @@ describe("isTidesRelevant with MARC ZH", () => {
     const m = emptyMarine();
     m.tide_height_zh_m = [1.0, 1.1, 1.2]; // range = 0.20, below 0.5 m
     expect(isTidesRelevant(m)).toBe(false);
+  });
+});
+
+// ── MARC coverage and the corridor batch ─────────────────────────────────────
+
+const MED_BOX: MarcAtlasBox = {
+  // Deliberately nowhere near the Mediterranean: the audit measured 14 MARC
+  // answers out of 14 saying `covered: false` on a Corsican leg.
+  name: "FINIS",
+  source: "marc",
+  bbox: [47.5, -6.0, 49.0, -3.5],
+};
+
+describe("parseMarcCoverage", () => {
+  it("reads the documented body", () => {
+    expect(parseMarcCoverage({ atlases: [MED_BOX] })).toEqual([MED_BOX]);
+  });
+
+  it("accepts an empty list, which is a real answer", () => {
+    // A Space that booted without the atlas dataset. Nothing to ask.
+    expect(parseMarcCoverage({ atlases: [] })).toEqual([]);
+  });
+
+  it("rejects a body that is not the documented shape", () => {
+    // The caller then falls back to asking MARC, point by point, as before.
+    expect(parseMarcCoverage(null)).toBeNull();
+    expect(parseMarcCoverage("Not Found")).toBeNull();
+    expect(parseMarcCoverage({})).toBeNull();
+    expect(parseMarcCoverage({ atlases: {} })).toBeNull();
+  });
+
+  it("drops an unreadable entry instead of the whole answer", () => {
+    // One atlas we cannot read is no reason to spend a request on every point
+    // of every other one. Dropping it can only make the client ask more.
+    const body = {
+      atlases: [
+        { name: "X", source: "marc" },
+        { name: "Y", source: "marc", bbox: [1, 2, 3] },
+        { name: "Z", source: "marc", bbox: [1, 2, 3, "4"] },
+        { name: "W", source: "marc", bbox: [9, 2, 1, 4] },
+        MED_BOX,
+      ],
+    };
+    expect(parseMarcCoverage(body)).toEqual([MED_BOX]);
+  });
+
+  it("reads the exact tiles when the entry carries them", () => {
+    const withCells = {
+      ...MED_BOX,
+      cells: [
+        [47.5, -6.0, 48.0, -5.0],
+        [48.0, -5.0, 49.0, -3.5],
+      ],
+    };
+    expect(parseMarcCoverage({ atlases: [withCells] })).toEqual([withCells]);
+  });
+
+  it("keeps the bbox in charge when the tiles are unreadable", () => {
+    const parsed = parseMarcCoverage({
+      atlases: [{ ...MED_BOX, cells: [[1, 2, 3], "nope"] }],
+    });
+    expect(parsed).toEqual([MED_BOX]);
+    expect(parsed![0].cells).toBeUndefined();
+  });
+
+  it("keeps only the readable tiles of a partly broken list", () => {
+    const parsed = parseMarcCoverage({
+      atlases: [{ ...MED_BOX, cells: [[47.5, -6.0, 48.0, -5.0], [1, 2, 3]] }],
+    });
+    expect(parsed![0].cells).toEqual([[47.5, -6.0, 48.0, -5.0]]);
+  });
+});
+
+describe("marcMayCover", () => {
+  it("says yes inside a box", () => {
+    expect(marcMayCover(48.3, -4.5, [MED_BOX])).toBe(true);
+  });
+
+  it("says no outside every box", () => {
+    expect(marcMayCover(42.1, 6.9, [MED_BOX])).toBe(false);
+  });
+
+  it("includes the edges, the boxes being widened server-side already", () => {
+    expect(marcMayCover(47.5, -6.0, [MED_BOX])).toBe(true);
+    expect(marcMayCover(49.0, -3.5, [MED_BOX])).toBe(true);
+  });
+
+  it("asks when coverage is unknown, which is the old behaviour", () => {
+    expect(marcMayCover(42.1, 6.9, null)).toBe(true);
+  });
+
+  it("asks nothing when the server publishes no atlas at all", () => {
+    expect(marcMayCover(48.3, -4.5, [])).toBe(false);
+  });
+
+  // MARC's ATLNE bbox spans [39.98, -20.03] to [64.99, 15.00]: it swallows the
+  // whole western Mediterranean while holding no tile there. The bbox alone
+  // would send every Corsican corridor point back to MARC for nothing.
+  const ATLNE: MarcAtlasBox = {
+    name: "ATLNE",
+    source: "marc",
+    bbox: [39.98, -20.03, 64.99, 15.0],
+    cells: [
+      [47.0, -6.0, 51.0, 0.0],
+      [43.0, -3.0, 47.0, 0.0],
+    ],
+  };
+
+  it("tests the tiles, not the bbox, when the entry carries them", () => {
+    // Corsica: inside the bbox, outside every tile.
+    expect(marcMayCover(42.1, 6.9, [ATLNE])).toBe(false);
+    // Iroise: inside a tile.
+    expect(marcMayCover(48.3, -4.5, [ATLNE])).toBe(true);
+  });
+
+  it("falls back to the bbox for an entry without tiles", () => {
+    const noCells: MarcAtlasBox = { name: ATLNE.name, source: ATLNE.source, bbox: ATLNE.bbox };
+    expect(marcMayCover(42.1, 6.9, [noCells])).toBe(true);
+  });
+
+  it("still covers a point any single atlas covers", () => {
+    expect(marcMayCover(48.3, -4.5, [MED_BOX, ATLNE])).toBe(true);
+  });
+});
+
+describe("fetchMarineCorridor", () => {
+  /** One Open-Meteo Marine element: three hours, one usable wave height. */
+  function omPoint(waveHeight: number) {
+    return {
+      hourly: {
+        time: ["2026-05-08T00:00", "2026-05-08T01:00", "2026-05-08T02:00"],
+        wave_height: [waveHeight, waveHeight, waveHeight],
+        ocean_current_velocity: [1.852, 1.852, 1.852],
+      },
+    };
+  }
+
+  interface Calls {
+    marine: string[];
+    marc: string[];
+    coverage: number;
+  }
+
+  /** Stubs fetch and records what was asked of whom. */
+  function stubFetch(coverage: { status: number; body?: unknown }, points: number): Calls {
+    const calls: Calls = { marine: [], marc: [], coverage: 0 };
+    vi.stubGlobal("fetch", async (input: string) => {
+      const url = String(input);
+      if (url.includes("/marine/marc/coverage")) {
+        calls.coverage += 1;
+        return {
+          ok: coverage.status === 200,
+          status: coverage.status,
+          json: async () => coverage.body,
+        };
+      }
+      if (url.includes("/marine/marc")) {
+        calls.marc.push(url);
+        return { ok: true, status: 200, json: async () => ({ covered: false }) };
+      }
+      calls.marine.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => Array.from({ length: points }, (_, i) => omPoint(0.5 + i / 10)),
+      };
+    });
+    return calls;
+  }
+
+  const MED_CORRIDOR = [
+    { lat: 41.903, lon: 6.284 },
+    { lat: 42.006, lon: 6.609 },
+    { lat: 42.109, lon: 6.934 },
+    { lat: 42.212, lon: 7.257 },
+  ];
+
+  beforeEach(() => {
+    clearMarineCache();
+    clearMarcCoverageCache();
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("asks Open-Meteo once for the whole corridor", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 4);
+    const out = await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marine).toHaveLength(1);
+    // Coordinates travel comma-separated, in order, latitudes and longitudes
+    // in parallel lists — the same shape the wind corridor uses.
+    expect(calls.marine[0]).toContain("latitude=41.903,42.006,42.109,42.212");
+    expect(calls.marine[0]).toContain("longitude=6.284,6.609,6.934,7.257");
+    expect(out).toHaveLength(4);
+    expect(out.every((m) => m !== null)).toBe(true);
+    // Order preserved: element k of the answer belongs to coordinate k.
+    expect(out[0]!.wave_height_m[0]).toBe(0.5);
+    expect(out[3]!.wave_height_m[0]).toBeCloseTo(0.8);
+  });
+
+  it("converts currents from km/h to knots, like the single-point path", async () => {
+    // 1.852 km/h is exactly one knot.
+    stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 1);
+    const out = await fetchMarineCorridor(MED_CORRIDOR.slice(0, 1));
+    expect(out[0]!.current_speed_kn[0]).toBeCloseTo(1);
+  });
+
+  it("skips MARC entirely outside every atlas", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    // The measured case: 14 calls for 14 answers that could not carry data.
+    expect(calls.marc).toEqual([]);
+    expect(calls.coverage).toBe(1);
+  });
+
+  it("still asks MARC inside an atlas", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 2);
+    await fetchMarineCorridor([
+      { lat: 48.3, lon: -4.5 },
+      { lat: 48.4, lon: -4.6 },
+    ]);
+    expect(calls.marc).toHaveLength(2);
+    expect(calls.marc[0]).toContain("lat=48.3");
+  });
+
+  it("falls back to asking every point when the endpoint is missing", async () => {
+    // A Space deployed before the coverage route exists answers 404.
+    const calls = stubFetch({ status: 404 }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toHaveLength(4);
+  });
+
+  it("falls back the same way on a malformed body", async () => {
+    const calls = stubFetch({ status: 200, body: { oops: true } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toHaveLength(4);
+  });
+
+  it("asks the coverage endpoint once per session, not once per point", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    clearMarineCache();
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.coverage).toBe(1);
+    expect(calls.marine).toHaveLength(2);
+  });
+
+  it("serves a second plan over the same route from cache, no request at all", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    const again = await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marine).toHaveLength(1);
+    expect(again.every((m) => m !== null)).toBe(true);
+  });
+
+  it("asks once for two corridor points in the same grid cell", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 1);
+    const out = await fetchMarineCorridor([
+      { lat: 42.10001, lon: 6.9 },
+      { lat: 42.10002, lon: 6.9 },
+    ]);
+    expect(calls.marine[0]).toContain("latitude=42.10001&");
+    expect(out[0]).toBe(out[1]);
+  });
+
+  it("returns nulls rather than throwing when Open-Meteo refuses", async () => {
+    vi.stubGlobal("fetch", async (input: string) => {
+      if (String(input).includes("coverage")) {
+        return { ok: true, status: 200, json: async () => ({ atlases: [] }) };
+      }
+      return { ok: false, status: 429, json: async () => ({}) };
+    });
+    expect(await fetchMarineCorridor(MED_CORRIDOR)).toEqual([null, null, null, null]);
+  });
+
+  it("skips MARC on a bbox that swallows the route but holds no tile there", async () => {
+    // ATLNE's bbox reaches the Balearics; its tiles stop at the Bay of Biscay.
+    const atlne: MarcAtlasBox = {
+      name: "ATLNE",
+      source: "marc",
+      bbox: [39.98, -20.03, 64.99, 15.0],
+      cells: [[43.0, -6.0, 51.0, 0.0]],
+    };
+    const calls = stubFetch({ status: 200, body: { atlases: [atlne] } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toEqual([]);
+  });
+
+  it("still asks on the same bbox when the entry carries no tile list", async () => {
+    // The contract before `cells` existed: the bbox is all we have, so we ask.
+    const calls = stubFetch(
+      {
+        status: 200,
+        body: { atlases: [{ name: "ATLNE", source: "marc", bbox: [39.98, -20.03, 64.99, 15.0] }] },
+      },
+      4,
+    );
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toHaveLength(4);
+  });
+
+  it("returns an empty result for an empty corridor without asking anything", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [] } }, 0);
+    expect(await fetchMarineCorridor([])).toEqual([]);
+    expect(calls.marine).toEqual([]);
+    expect(calls.coverage).toBe(0);
   });
 });

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -137,6 +137,187 @@ async function fetchMarcOverlay(
   }
 }
 
+// ── MARC coverage ────────────────────────────────────────────────────────────
+//
+// `/api/v1/marine/marc` answers 200 with `covered: false` outside the atlases,
+// which is the right contract for one point and the wrong cost for a route: a
+// Mediterranean plan measured 14 uncovered answers out of 14 calls, one per
+// corridor point, none of which could ever have carried data. The Space now
+// publishes the bounding boxes so a client can decide not to ask.
+//
+// The promise is one-directional, and the server says so: outside every box
+// there is nothing to fetch, inside one there may still be nothing (the SHOM
+// boxes wrap a scattered point cloud with land and gaps in it). Skipping
+// outside them loses no data; assuming coverage inside them would be wrong,
+// which is why the overlay is still fetched and still merged only when it
+// reports `covered`.
+//
+// A bounding box alone is too coarse to be useful everywhere: MARC's ATLNE
+// spans [39.98, -20.03] to [64.99, 15.00], which swallows the whole western
+// Mediterranean while holding no data there. Entries therefore also carry
+// `cells`, the exact union of their non-empty tiles, and that is what a point
+// is tested against when it is present.
+
+/** [lat_min, lon_min, lat_max, lon_max] in degrees WGS84, latitude first. */
+export type CoverageRect = [number, number, number, number];
+
+export interface MarcAtlasBox {
+  name: string;
+  source: string;
+  bbox: CoverageRect;
+  /** Non-empty tiles of this atlas. When present and non-empty it is what
+      decides, the bbox merely wrapping it. Absent on a Space that predates
+      the field, and the bbox then decides on its own. */
+  cells?: CoverageRect[];
+}
+
+const COVERAGE_URL = `${MARC_URL}/coverage`;
+const COVERAGE_STORAGE_KEY = "ow_marc_coverage_v1";
+/** The server sends `max-age=86400` on a real answer. Mirrored here so a
+    reload does not re-ask, and so the HTTP cache is not the only line of
+    defence (Chrome on Android evicts it under pressure). */
+const COVERAGE_TTL_MS = 24 * 3600 * 1000;
+/** An empty list is what a Space that booted without the atlas dataset
+    reports, and the server caches that answer for 5 minutes only. Persisting
+    it for a day would tell a client to skip the atlases long after they came
+    back. */
+const COVERAGE_EMPTY_TTL_MS = 5 * 60 * 1000;
+
+/** Four finite numbers, latitude first, mins before maxes. */
+function toRect(value: unknown): CoverageRect | null {
+  if (!Array.isArray(value) || value.length !== 4) return null;
+  if (!value.every((v) => typeof v === "number" && Number.isFinite(v))) return null;
+  const [latMin, lonMin, latMax, lonMax] = value as CoverageRect;
+  if (latMin > latMax || lonMin > lonMax) return null;
+  return [latMin, lonMin, latMax, lonMax];
+}
+
+function inRect(lat: number, lon: number, [latMin, lonMin, latMax, lonMax]: CoverageRect): boolean {
+  return lat >= latMin && lat <= latMax && lon >= lonMin && lon <= lonMax;
+}
+
+/**
+ * Shape check on the coverage payload. Returns `null` for anything that is
+ * not the documented body, which the callers read as "unknown coverage" and
+ * therefore as "ask MARC, like before".
+ *
+ * An entry that does not parse is dropped rather than taken as grounds to
+ * reject the whole answer: one atlas the client cannot read is no reason to
+ * spend a request on every point of every other. Dropping it can only make
+ * the client ask more often, never less.
+ */
+export function parseMarcCoverage(body: unknown): MarcAtlasBox[] | null {
+  if (typeof body !== "object" || body === null) return null;
+  const atlases = (body as { atlases?: unknown }).atlases;
+  if (!Array.isArray(atlases)) return null;
+  const out: MarcAtlasBox[] = [];
+  for (const entry of atlases) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const { name, source, bbox, cells } = entry as Record<string, unknown>;
+    if (typeof name !== "string" || typeof source !== "string") continue;
+    const box = toRect(bbox);
+    if (!box) continue;
+    const parsed: MarcAtlasBox = { name, source, bbox: box };
+    if (Array.isArray(cells)) {
+      const rects = cells.map(toRect).filter((r): r is CoverageRect => r !== null);
+      // A `cells` list that survives validation is what decides. One that does
+      // not (empty, or nothing readable in it) leaves the bbox in charge,
+      // which is the coarser and safer of the two answers.
+      if (rects.length > 0) parsed.cells = rects;
+    }
+    out.push(parsed);
+  }
+  return out;
+}
+
+/**
+ * Whether the atlases could have anything to say at this point.
+ *
+ * `null` means we do not know (endpoint missing, offline, malformed body):
+ * the answer is then "ask", which is exactly the behaviour that shipped
+ * before this existed.
+ */
+export function marcMayCover(lat: number, lon: number, atlases: MarcAtlasBox[] | null): boolean {
+  if (atlases === null) return true;
+  return atlases.some((atlas) =>
+    atlas.cells && atlas.cells.length > 0
+      ? atlas.cells.some((cell) => inRect(lat, lon, cell))
+      : inRect(lat, lon, atlas.bbox),
+  );
+}
+
+function readStoredCoverage(now: number): MarcAtlasBox[] | null {
+  try {
+    const raw = localStorage.getItem(COVERAGE_STORAGE_KEY);
+    if (!raw) return null;
+    const stored = JSON.parse(raw) as { fetchedAt?: unknown; atlases?: unknown };
+    if (typeof stored.fetchedAt !== "number") return null;
+    const atlases = parseMarcCoverage(stored);
+    if (!atlases) return null;
+    const ttl = atlases.length > 0 ? COVERAGE_TTL_MS : COVERAGE_EMPTY_TTL_MS;
+    return now - stored.fetchedAt < ttl ? atlases : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeCoverage(atlases: MarcAtlasBox[]): void {
+  try {
+    localStorage.setItem(
+      COVERAGE_STORAGE_KEY,
+      JSON.stringify({ fetchedAt: Date.now(), atlases }),
+    );
+  } catch {
+    // Storage full or disabled. The session cache still saves the repeats.
+  }
+}
+
+let coverageInFlight: Promise<MarcAtlasBox[] | null> | undefined;
+
+/**
+ * The atlas bounding boxes, once per session.
+ *
+ * Resolves to `null` when the endpoint is missing or unreadable, which is not
+ * an error: a Space that predates the route answers 404, and every caller then
+ * falls back to asking MARC per point. Memoised either way so a deploy lag
+ * costs one request, not one per corridor point.
+ */
+export function fetchMarcCoverage(): Promise<MarcAtlasBox[] | null> {
+  if (coverageInFlight) return coverageInFlight;
+  coverageInFlight = (async () => {
+    const stored = readStoredCoverage(Date.now());
+    if (stored) return stored;
+    try {
+      const resp = await fetch(COVERAGE_URL);
+      if (!resp.ok) return null;
+      const atlases = parseMarcCoverage(await resp.json());
+      if (!atlases) return null;
+      storeCoverage(atlases);
+      return atlases;
+    } catch {
+      return null;
+    }
+  })();
+  return coverageInFlight;
+}
+
+/** Test seam: forget the session's coverage answer. Not used by the app. */
+export function clearMarcCoverageCache(): void {
+  coverageInFlight = undefined;
+}
+
+/** The overlay for one point, or nothing when the atlases cannot cover it. */
+function fetchMarcOverlayIfCovered(
+  lat: number,
+  lon: number,
+  startUtcIso: string,
+  endUtcIso: string,
+  atlases: MarcAtlasBox[] | null,
+): Promise<MarcOverlay | null> {
+  if (!marcMayCover(lat, lon, atlases)) return Promise.resolve(null);
+  return fetchMarcOverlay(lat, lon, startUtcIso, endUtcIso);
+}
+
 // Merge MARC overlay into the OM-shaped MarineHourly, index-by-index. Tide
 // and current arrays from MARC override SMOC on matching hours; uncovered or
 // non-matching hours keep SMOC. Always populates ``tide_height_zh_m`` when
@@ -212,35 +393,19 @@ function marcWindow(): [string, string] {
   return [new Date(startMs).toISOString(), new Date(endMs).toISOString()];
 }
 
-export async function fetchMarine(lat: number, lon: number): Promise<MarineHourly | null> {
-  const key = `${lat.toFixed(4)},${lon.toFixed(4)}`;
-  const cached = cache.get(key);
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
-    return cached.data;
-  }
-  const url =
-    `${MARINE_URL}?latitude=${lat}&longitude=${lon}` +
-    `&hourly=${MARINE_VARS}&timezone=Europe/Paris&forecast_days=7`;
-  const [startIso, endIso] = marcWindow();
-  let raw: { hourly?: RawHourly } | null;
-  let overlay: MarcOverlay | null = null;
-  try {
-    const [omResp, marcOverlay] = await Promise.all([
-      fetch(url).then(async (r) =>
-        r.ok ? ((await r.json()) as { hourly?: RawHourly }) : null,
-      ),
-      fetchMarcOverlay(lat, lon, startIso, endIso),
-    ]);
-    if (!omResp) return null;
-    raw = omResp;
-    overlay = marcOverlay;
-  } catch {
-    return null;
-  }
-  const h = raw.hourly;
+/** Cache key. 4 decimals is ~11 m: two points closer than that would have
+    returned the same forecast anyway. Shared by the single-point and the
+    corridor paths so one fills the other's cache. */
+function marineCacheKey(lat: number, lon: number): string {
+  return `${lat.toFixed(4)},${lon.toFixed(4)}`;
+}
+
+/** Open-Meteo's hourly block, reshaped into our units and null-padded. */
+function toMarineHourly(raw: { hourly?: RawHourly } | null): MarineHourly | null {
+  const h = raw?.hourly;
   if (!h || !h.time) return null;
   const n = h.time.length;
-  const baseData: MarineHourly = {
+  return {
     time: h.time,
     wave_height_m: pad(h.wave_height, n),
     wave_period_s: pad(h.wave_period, n),
@@ -251,9 +416,133 @@ export async function fetchMarine(lat: number, lon: number): Promise<MarineHourl
     current_direction_to_deg: pad(h.ocean_current_direction, n),
     tide_height_m: pad(h.sea_level_height_msl, n),
   };
+}
+
+const MARINE_QUERY = `hourly=${MARINE_VARS}&timezone=Europe/Paris&forecast_days=7`;
+
+export async function fetchMarine(lat: number, lon: number): Promise<MarineHourly | null> {
+  const key = marineCacheKey(lat, lon);
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
+    return cached.data;
+  }
+  const url = `${MARINE_URL}?latitude=${lat}&longitude=${lon}&${MARINE_QUERY}`;
+  const [startIso, endIso] = marcWindow();
+  let raw: { hourly?: RawHourly } | null;
+  let overlay: MarcOverlay | null = null;
+  try {
+    // Coverage is resolved in parallel with the forecast, and the overlay
+    // chains off it, so the only cost of asking is on a cold session: after
+    // that the answer comes from memory or from localStorage.
+    const [omResp, marcOverlay] = await Promise.all([
+      fetch(url).then(async (r) =>
+        r.ok ? ((await r.json()) as { hourly?: RawHourly }) : null,
+      ),
+      fetchMarcCoverage().then((atlases) =>
+        fetchMarcOverlayIfCovered(lat, lon, startIso, endIso, atlases),
+      ),
+    ]);
+    if (!omResp) return null;
+    raw = omResp;
+    overlay = marcOverlay;
+  } catch {
+    return null;
+  }
+  const baseData = toMarineHourly(raw);
+  if (!baseData) return null;
   const data = mergeMarcOverlay(baseData, overlay);
   cache.set(key, { data, fetchedAt: Date.now() });
   return data;
+}
+
+/**
+ * Marine data for a whole route corridor, in ONE Open-Meteo request.
+ *
+ * The Marine endpoint takes comma-separated coordinates and answers with an
+ * array in the same order, exactly like the forecast endpoint the wind
+ * corridor already uses. Asking point by point cost one request per corridor
+ * point: 14 of them measured on a 63 NM Mediterranean leg, each a round trip
+ * of its own on a browser that opens six connections at a time.
+ *
+ * The MARC overlay stays per point, because it is per location by nature, but
+ * it is now only requested where an atlas could answer.
+ *
+ * Results land in the same 30-minute per-point cache `fetchMarine` uses, so a
+ * spot already looked at costs nothing here, and a corridor point looked at
+ * here costs nothing on the spot page.
+ */
+export async function fetchMarineCorridor(
+  coords: { lat: number; lon: number }[],
+): Promise<(MarineHourly | null)[]> {
+  const out: (MarineHourly | null)[] = coords.map(() => null);
+  if (coords.length === 0) return out;
+
+  // What the cache already holds, and what has to be asked for. Two plans
+  // over the same route share most of their points, so a boat change or a
+  // departure tweak usually finds everything here.
+  const now = Date.now();
+  const missing: number[] = [];
+  const indicesByKey = new Map<string, number[]>();
+  for (let i = 0; i < coords.length; i++) {
+    const key = marineCacheKey(coords[i].lat, coords[i].lon);
+    const hit = cache.get(key);
+    if (hit && now - hit.fetchedAt < CACHE_TTL) {
+      out[i] = hit.data;
+      continue;
+    }
+    const seen = indicesByKey.get(key);
+    if (seen) {
+      // Same grid cell as an earlier point: one request answers both.
+      seen.push(i);
+      continue;
+    }
+    indicesByKey.set(key, [i]);
+    missing.push(i);
+  }
+  if (missing.length === 0) return out;
+
+  const coveragePromise = fetchMarcCoverage();
+  const lats = missing.map((i) => coords[i].lat).join(",");
+  const lons = missing.map((i) => coords[i].lon).join(",");
+  const url = `${MARINE_URL}?latitude=${lats}&longitude=${lons}&${MARINE_QUERY}`;
+
+  let byMissingIndex: ({ hourly?: RawHourly } | null)[];
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) return out;
+    const json: unknown = await resp.json();
+    // Multi-coordinate answers with an array; a single coordinate may come
+    // back as a bare object, so normalise before aligning to `missing`.
+    const arr: unknown[] = Array.isArray(json) ? json : [json];
+    byMissingIndex = missing.map((_, k) => (arr[k] ?? null) as { hourly?: RawHourly } | null);
+  } catch {
+    return out;
+  }
+
+  const [startIso, endIso] = marcWindow();
+  const atlases = await coveragePromise;
+  const overlays = await Promise.all(
+    missing.map((i) =>
+      fetchMarcOverlayIfCovered(coords[i].lat, coords[i].lon, startIso, endIso, atlases),
+    ),
+  );
+
+  const fetchedAt = Date.now();
+  for (let k = 0; k < missing.length; k++) {
+    const i = missing[k];
+    const baseData = toMarineHourly(byMissingIndex[k]);
+    if (!baseData) continue;
+    const data = mergeMarcOverlay(baseData, overlays[k]);
+    const key = marineCacheKey(coords[i].lat, coords[i].lon);
+    cache.set(key, { data, fetchedAt });
+    for (const idx of indicesByKey.get(key) ?? [i]) out[idx] = data;
+  }
+  return out;
+}
+
+/** Test seam: drop every cached point. Not used by the app. */
+export function clearMarineCache(): void {
+  cache.clear();
 }
 
 export function isCurrentsRelevant(marine: MarineHourly | null): boolean {

--- a/packages/web/src/hooks/useWaypointDepths.test.ts
+++ b/packages/web/src/hooks/useWaypointDepths.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect } from "vitest";
+import { parseStoredDepths } from "./useWaypointDepths";
+
+describe("parseStoredDepths", () => {
+  it("reads a cell-to-depth map", () => {
+    expect(parseStoredDepths('{"48.390,-4.486":37.5,"48.400,-4.500":12}')).toEqual({
+      "48.390,-4.486": 37.5,
+      "48.400,-4.500": 12,
+    });
+  });
+
+  it("keeps null apart from a depth", () => {
+    // null is "there is no sounding here", which is an answer worth
+    // remembering: re-asking EMODnet would cost a request for the same null.
+    expect(parseStoredDepths('{"48.390,-4.486":null}')).toEqual({ "48.390,-4.486": null });
+  });
+
+  it("reads an empty map", () => {
+    expect(parseStoredDepths("{}")).toEqual({});
+  });
+
+  it("discards anything that is not such a map", () => {
+    expect(parseStoredDepths("{oops")).toBeNull();
+    expect(parseStoredDepths("null")).toBeNull();
+    expect(parseStoredDepths("[1,2]")).toBeNull();
+    expect(parseStoredDepths('"48.390,-4.486"')).toBeNull();
+    expect(parseStoredDepths('{"48.390,-4.486":"37.5"}')).toBeNull();
+    expect(parseStoredDepths('{"48.390,-4.486":true}')).toBeNull();
+  });
+
+  it("discards a map holding a non-finite depth", () => {
+    // JSON has no NaN, but a hand-edited or truncated payload can produce one
+    // through a string that parses to a number-shaped nothing.
+    expect(parseStoredDepths('{"48.390,-4.486":1e999}')).toBeNull();
+  });
+});

--- a/packages/web/src/hooks/useWaypointDepths.ts
+++ b/packages/web/src/hooks/useWaypointDepths.ts
@@ -5,6 +5,68 @@ import { useEffect, useState } from "react";
 import { fetchDepthM, depthGridKey } from "../api/bathymetry";
 
 /**
+ * Soundings already resolved in this tab.
+ *
+ * The EMODnet DTM is a static product, so a value never goes stale, yet a
+ * reload used to re-ask for every waypoint: two GetFeatureInfo round trips of
+ * 570 to 760 ms each measured on a two-waypoint plan restored from the URL,
+ * for numbers the tab had already been told. `sessionStorage` rather than
+ * `localStorage`: this is a convenience for the plan in front of the reader,
+ * not a dataset worth keeping across visits.
+ */
+const STORAGE_KEY = "ow_waypoint_depths_v1";
+
+/** A route has a handful of waypoints. The cap only guards a tab that keeps
+    planning all day from growing the entry without bound. */
+const MAX_CELLS = 200;
+
+type DepthsByCell = Record<string, number | null>;
+
+/** Exported for the tests: anything that is not a cell-to-depth map is
+    discarded rather than trusted. */
+export function parseStoredDepths(raw: string): DepthsByCell | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const out: DepthsByCell = {};
+    for (const [cell, depth] of Object.entries(parsed as Record<string, unknown>)) {
+      if (depth === null) {
+        out[cell] = null;
+      } else if (typeof depth === "number" && Number.isFinite(depth)) {
+        out[cell] = depth;
+      } else {
+        return null;
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function loadDepths(): DepthsByCell {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return (raw && parseStoredDepths(raw)) || {};
+  } catch {
+    return {};
+  }
+}
+
+function saveDepths(byCell: DepthsByCell): void {
+  try {
+    const entries = Object.entries(byCell);
+    // Oldest first in insertion order, so the tail is what a long session
+    // most recently looked at.
+    const kept = entries.length > MAX_CELLS ? entries.slice(-MAX_CELLS) : entries;
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(kept)));
+  } catch {
+    // Storage disabled or full: the lookups still work, they just cost a
+    // request again after a reload.
+  }
+}
+
+/**
  * Sounding under each waypoint, in the same order as the waypoints.
  *
  * `undefined` means the lookup has not landed yet, `null` means there is no
@@ -19,12 +81,16 @@ import { fetchDepthM, depthGridKey } from "../api/bathymetry";
  * every waypoint can be asked again on every change without a request.
  */
 export function useWaypointDepths(waypoints: [number, number][]): (number | null | undefined)[] {
-  const [byCell, setByCell] = useState<Record<string, number | null>>({});
+  const [byCell, setByCell] = useState<DepthsByCell>(loadDepths);
 
   useEffect(() => {
     let cancelled = false;
     for (const [lat, lon] of waypoints) {
       const cell = depthGridKey(lat, lon);
+      // Known cell, whatever the answer was: the DTM cannot have changed, so
+      // there is nothing to ask again. This is what makes the persisted map
+      // save a request rather than only a render.
+      if (cell in byCell) continue;
       void fetchDepthM(lat, lon).then((depth) => {
         if (cancelled) return;
         setByCell((prev) => (cell in prev ? prev : { ...prev, [cell]: depth }));
@@ -33,7 +99,11 @@ export function useWaypointDepths(waypoints: [number, number][]): (number | null
     return () => {
       cancelled = true;
     };
-  }, [waypoints]);
+  }, [waypoints, byCell]);
+
+  useEffect(() => {
+    saveDepths(byCell);
+  }, [byCell]);
 
   return waypoints.map(([lat, lon]) => byCell[depthGridKey(lat, lon)]);
 }


### PR DESCRIPTION
Rapport A, finding 2 ; rapport E, problème 5 et 7 ; plan de rework, PR 0.11.

## Une requête marine pour tout le corridor

Le point d'entrée Marine d'Open-Meteo accepte les coordonnées séparées par des virgules et répond par un tableau dans le même ordre, exactement comme le point d'entrée prévision dont le corridor de vent tire déjà parti. Vérifié en direct :

```
GET marine-api.open-meteo.com/v1/marine?latitude=41.90296,42.10,42.31043&longitude=6.28418,6.93,7.58057&...
-> 200, tableau de 3 éléments, un par coordonnée, dans l'ordre
```

Le calcul de passage demandait un point à la fois : 14 requêtes mesurées sur un tronçon méditerranéen de 63 NM, chacune un aller-retour propre sur un navigateur qui ouvre six connexions à la fois. `fetchMarineCorridor` demande tous les points non cachés en une requête, alimente le même cache 30 minutes par point que `fetchMarine`, et déduplique deux points tombant dans la même cellule. Le cache est partagé dans les deux sens : un spot déjà consulté ne coûte rien au corridor, un point de corridor ne coûte rien à la fiche spot.

## MARC court-circuité hors couverture

La surcouche MARC reste par point, elle est par nature par localisation, mais elle n'est plus demandée que là où un atlas peut répondre. Le Space publie les emprises via `GET /api/v1/marine/marc/coverage` (PR #319) ; le client les lit une fois par session, les persiste 24 h dans `localStorage` sous une clé versionnée, et saute l'appel pour les points hors couverture.

Une `bbox` seule ne suffit pas : celle de l'atlas MARC ATLNE va de `[39.98, -20.03]` à `[64.99, 15.00]` et englobe toute la Méditerranée occidentale sans y détenir la moindre donnée. Chaque entrée porte donc un champ optionnel `cells`, l'union exacte de ses tuiles non vides ; quand il est présent et non vide c'est lui qui tranche, sinon la `bbox` reprend la main, ce qui est le contrat d'aujourd'hui. Les rectangles sont validés comme la bbox (quatre nombres finis, minimums avant maximums) ; une entrée illisible est écartée plutôt que de faire rejeter toute la réponse, et une liste `cells` illisible laisse la bbox décider, les deux replis ne pouvant que faire demander plus, jamais moins.

Détection de fonctionnalité : endpoint absent (404 sur un Space antérieur à la route), hors ligne, ou corps malformé, et on retombe sur le comportement actuel, un appel MARC par point. La réponse vide, qui est celle d'un Space démarré sans le jeu de données, n'est persistée que 5 minutes, comme le `max-age` que le serveur lui met.

## Sondes EMODnet persistées

Le DTM EMODnet est un produit statique, pourtant un rechargement redemandait deux `GetFeatureInfo` de 570 à 760 ms chacun pour des valeurs que l'onglet connaissait déjà. Elles sont désormais gardées par cellule de grille dans `sessionStorage`, validées à la lecture, plafonnées à 200 entrées, et l'effet ne relance plus de requête pour une cellule connue.

## Mesures live

Deux builds de prod (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`) servis par `vite preview`, contextes isolés, même route méditerranéenne 41.90296,6.28418 vers 42.31043,7.58057, un seul calcul de chaque côté sur le backend dev.

| Requêtes du calcul, 63 NM | avant (`dev`) | après |
|---|---|---|
| `marine-api.open-meteo.com` | 14 | **1** |
| `/api/v1/marine/marc` | 14 | 14 (voir ci-dessous) |
| `/api/v1/marine/marc/coverage` | 0 | 1 |
| Vent (corridor multi-points) | 4 | 4 |
| `POST /api/v1/passage` | 1 | 1 |
| `/api/v1/archetypes` | 1 | 1 |
| EMODnet | 2 | 2 |
| **Total** | **36** | **24** |

Et au rechargement du plan, restauré depuis l'URL et le cache :

| Requêtes au rechargement | avant | après |
|---|---|---|
| EMODnet | 2 | **0** |
| `/marine/marc/coverage` | 0 | 0 (localStorage) |

Résultat identique des deux côtés : 62,7 nm, 17h43, arrivée 01:42, même avertissement de vent faible. Le lot ne change aucune donnée, seulement le nombre d'allers-retours pour l'obtenir.

**Les 14 appels MARC restants sont attendus à cette date** : l'endpoint de couverture est bien déployé sur dev, mais la PR backend qui ajoute `cells` ne l'est pas encore, et la seule `bbox` d'ATLNE couvre la Corse. Le court-circuit est implémenté et testé côté client ; il prendra effet en Méditerranée dès que `cells` sera servi, sans nouveau déploiement web.

## Tests

`marine.test.ts` monte à 55 cas, avec un `fetch` bouchonné : une seule requête Marine pour N points et l'ordre préservé, conversion km/h vers nœuds inchangée, MARC sauté hors emprise et appelé dedans, bbox englobante mais `cells` disjointes qui saute l'appel alors que la même entrée sans `cells` le fait, repli sur 404 et sur corps malformé, couverture demandée une fois par session, second plan sur la même route servi sans aucune requête, deux points d'une même cellule fusionnés, et `null` plutôt qu'une exception quand Open-Meteo refuse. Plus `parseStoredDepths` dans `useWaypointDepths.test.ts`.

`npm run typecheck`, `npm run lint:budget` (11 erreurs, budget 11, inchangé), `npm run test` (354 tests), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
