### PR TITLE
feat(api): rend la couverture des atlas exploitable au niveau tuile

### DIFF
--- a/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
+++ b/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
@@ -21,6 +21,7 @@ convention "to" (0° = current setting toward the north).
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
@@ -111,6 +112,99 @@ def _tile_path(atlas: AtlasMeta, lat: float, lon: float) -> Path:
     )
 
 
+# One rectangle in degrees, ``(lat_min, lon_min, lat_max, lon_max)``, same
+# order as ``AtlasMeta.bbox``.
+_Box = tuple[float, float, float, float]
+_Boxes = tuple[_Box, ...]
+
+
+def _tile_origin(dir_name: str) -> float | None:
+    """Read the degree value out of a ``tile_lat=48.0`` / ``tile_lon=-5.0`` name."""
+    _, _, raw = dir_name.partition("=")
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _tile_has_rows(parquet_path: Path) -> bool:
+    """Whether a tile holds at least one cell, from the footer alone.
+
+    ``pl.len()`` over a scan is answered from the Parquet metadata: measured
+    1.0 ms on a 41 MB tile against 52 ms for a full read, and the same 0.9 ms
+    on a 3-row tile, so the cost is the file open and not the payload. Reading
+    the columns here would be catastrophic: a single 250 m tile is 30 k cells
+    x 183 columns, and an atlas has thousands of tiles.
+    """
+    try:
+        return pl.scan_parquet(parquet_path).select(pl.len()).collect().item() > 0
+    except Exception:
+        # A truncated or half-written tile is not coverage. ``covers`` would
+        # skip it too (``_read_tile`` -> empty frame -> next candidate), so
+        # dropping it here keeps the two consistent.
+        return False
+
+
+def _merge_tiles_into_rectangles(tiles: Iterable[tuple[float, float]]) -> _Boxes:
+    """Coalesce ``(tile_lat, tile_lon)`` origins into as few boxes as possible.
+
+    Run-length along longitude inside each latitude row: a row of adjacent
+    tiles becomes one rectangle, a gap starts a new one. Rows stay separate,
+    which keeps the merge O(n log n) and its output stable whatever order the
+    filesystem hands the tiles back.
+
+    Boxes are ``(lat_min, lon_min, lat_max, lon_max)``, sorted by latitude
+    then longitude, and closed on all four sides where a tile is half-open on
+    its upper edges. That makes a point on a seam belong to both neighbours
+    rather than to neither, which is the direction that never loses coverage.
+    """
+    rows: dict[float, list[float]] = {}
+    for tile_lat, tile_lon in tiles:
+        rows.setdefault(tile_lat, []).append(tile_lon)
+
+    boxes: list[_Box] = []
+    for tile_lat in sorted(rows):
+        lons = sorted(rows[tile_lat])
+        run_start = run_end = lons[0]
+        for lon in lons[1:]:
+            if abs(lon - run_end - _TILE_SIZE_DEG) < 1e-9:
+                run_end = lon
+                continue
+            boxes.append((tile_lat, run_start, tile_lat + _TILE_SIZE_DEG, run_end + _TILE_SIZE_DEG))
+            run_start = run_end = lon
+        boxes.append((tile_lat, run_start, tile_lat + _TILE_SIZE_DEG, run_end + _TILE_SIZE_DEG))
+    return tuple(boxes)
+
+
+@lru_cache(maxsize=32)
+def _atlas_coverage_cells(parquet_dir: str) -> _Boxes:
+    """Rectangles covering the non-empty tiles of one atlas directory.
+
+    Module-level cache rather than per-instance state on purpose: the
+    registries are built twice in the current deployment (once for the REST
+    routes, once inside ``build_server``), and both copies of the same atlas
+    directory should pay the directory walk once between them. Keyed by path,
+    so a test building a fresh atlas under a new ``tmp_path`` never reads a
+    previous one's answer.
+    """
+    root = Path(parquet_dir)
+    if not root.is_dir():
+        return ()
+    tiles: list[tuple[float, float]] = []
+    for lat_dir in sorted(root.glob("tile_lat=*")):
+        tile_lat = _tile_origin(lat_dir.name)
+        if tile_lat is None or not lat_dir.is_dir():
+            continue
+        for lon_dir in sorted(lat_dir.glob("tile_lon=*")):
+            tile_lon = _tile_origin(lon_dir.name)
+            if tile_lon is None:
+                continue
+            parquet = lon_dir / "data.parquet"
+            if parquet.is_file() and _tile_has_rows(parquet):
+                tiles.append((tile_lat, tile_lon))
+    return _merge_tiles_into_rectangles(tiles)
+
+
 def _nearest_cell_in_tile(
     df: pl.DataFrame, lat: float, lon: float, required_col: str | None = None
 ) -> int | None:
@@ -181,6 +275,34 @@ class MarcAtlasRegistry:
             if atlas is not None:
                 found.append(atlas)
         return cls(atlases=tuple(found))
+
+    def coverage_cells(self) -> tuple[tuple[str, _Boxes], ...]:
+        """Where each atlas actually holds data, as rectangles of whole tiles.
+
+        Exists because :attr:`AtlasMeta.bbox` is far too coarse to decide with.
+        The build writes coverage polygons as bounding boxes, so ATLNE's runs
+        from 39.98 N to 64.99 N and from 20.03 W to 15.00 E: it swallows the
+        entire Mediterranean, where the model has no valid cell at all. A
+        client filtering on ``bbox`` alone skips nothing in the Med, which is
+        precisely the case worth skipping (14 uncovered answers out of 14 in
+        the live measurement).
+
+        The contract, and it is exact rather than approximate: **a point
+        outside every rectangle is a point :meth:`covers` refuses**;
+        :attr:`AtlasMeta.bbox` stays the outer envelope. ``covers`` reads the
+        single tile the point falls in and moves on when that tile is missing
+        or empty, so a point outside every non-empty tile cannot be covered.
+        The converse still does not hold: a tile is 0.5 degrees wide and
+        contains land, so a point inside a rectangle may sit further than the
+        distance threshold from any real cell.
+
+        Result is ``(atlas name, boxes)`` per atlas, boxes as
+        ``(lat_min, lon_min, lat_max, lon_max)``, ordered by latitude then
+        longitude. Cached for the life of the process, keyed by atlas
+        directory: the walk reads one Parquet footer per tile and nothing
+        else, but that is still thousands of file opens on a large atlas.
+        """
+        return tuple((a.name, _atlas_coverage_cells(str(a.parquet_dir))) for a in self.atlases)
 
     # Tolerance for "the nearest cell is close enough to be considered valid".
     # Coverage polygons are bbox-only at build time, so the bbox can extend

--- a/packages/data-adapters/tests/currents/test_marc_atlas.py
+++ b/packages/data-adapters/tests/currents/test_marc_atlas.py
@@ -225,3 +225,195 @@ def test_finer_atlas_wins_when_overlap(tmp_path: Path) -> None:
     assert chosen is not None
     assert chosen.name == "FINIS"
     assert chosen.rank == 2
+
+
+# ------------------------------------------------------------- coverage cells
+
+
+def _write_tile(atlas_dir: Path, tile_lat: float, tile_lon: float, *, rows: int) -> None:
+    """Write one tile at a partition path the runtime will look for.
+
+    ``rows=0`` writes a real Parquet file with the right schema and no cell,
+    which is what a partial or interrupted build leaves behind.
+    """
+    tile_dir = atlas_dir / f"tile_lat={tile_lat:.1f}" / f"tile_lon={tile_lon:.1f}"
+    tile_dir.mkdir(parents=True, exist_ok=True)
+    lats = [tile_lat + 0.25] * rows
+    lons = [tile_lon + 0.25] * rows
+    pl.DataFrame(
+        {
+            "lat": pl.Series(lats, dtype=pl.Float64),
+            "lon": pl.Series(lons, dtype=pl.Float64),
+            "z0_hydro_m": pl.Series([0.0] * rows, dtype=pl.Float64),
+            "M2_h_amp": pl.Series([1.0] * rows, dtype=pl.Float64),
+            "M2_h_g": pl.Series([0.0] * rows, dtype=pl.Float64),
+        }
+    ).write_parquet(tile_dir / "data.parquet", compression="zstd")
+
+
+def _write_atlas(root: Path, name: str, bbox: tuple[float, float, float, float]) -> Path:
+    """An atlas directory with metadata and a bbox coverage polygon, no tiles."""
+    atlas_dir = root / name
+    atlas_dir.mkdir(parents=True, exist_ok=True)
+    (atlas_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "atlas": name,
+                "rank": 0,
+                "resolution_m": 2000,
+                "constituents_h": ["M2"],
+                "constituents_u": [],
+                "constituents_v": [],
+                "schema_version": 2,
+            }
+        )
+    )
+    lat_min, lon_min, lat_max, lon_max = bbox
+    (atlas_dir / "coverage.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"atlas": name},
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [
+                                    [lon_min, lat_min],
+                                    [lon_max, lat_min],
+                                    [lon_max, lat_max],
+                                    [lon_min, lat_max],
+                                    [lon_min, lat_min],
+                                ]
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    return atlas_dir
+
+
+def test_coverage_cells_merges_a_contiguous_run(tmp_path: Path) -> None:
+    # Three tiles side by side along one latitude row collapse into one
+    # rectangle. Without the merge the response would carry a box per tile,
+    # and a real atlas has thousands of them.
+    atlas_dir = _write_atlas(tmp_path, "RUN", (48.0, -5.0, 48.5, -3.5))
+    for tile_lon in (-5.0, -4.5, -4.0):
+        _write_tile(atlas_dir, 48.0, tile_lon, rows=2)
+
+    cells = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()
+    assert cells == (("RUN", ((48.0, -5.0, 48.5, -3.5),)),)
+
+
+def test_coverage_cells_keeps_a_gap_as_two_rectangles(tmp_path: Path) -> None:
+    # A hole in the middle of a row must stay a hole: merging across it would
+    # claim coverage where the atlas has no tile at all.
+    atlas_dir = _write_atlas(tmp_path, "GAP", (48.0, -6.0, 48.5, -3.5))
+    for tile_lon in (-6.0, -4.0):
+        _write_tile(atlas_dir, 48.0, tile_lon, rows=1)
+
+    boxes = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()[0][1]
+    assert boxes == ((48.0, -6.0, 48.5, -5.5), (48.0, -4.0, 48.5, -3.5))
+
+
+def test_coverage_cells_skips_an_empty_tile(tmp_path: Path) -> None:
+    # An interrupted build can leave a tile file with the right schema and no
+    # row. ``covers`` skips it (empty frame, next candidate), so the coverage
+    # answer has to skip it too or the two disagree.
+    atlas_dir = _write_atlas(tmp_path, "EMPTY", (48.0, -6.0, 48.5, -3.5))
+    _write_tile(atlas_dir, 48.0, -6.0, rows=3)
+    _write_tile(atlas_dir, 48.0, -5.5, rows=0)
+
+    boxes = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()[0][1]
+    assert boxes == ((48.0, -6.0, 48.5, -5.5),)
+
+
+def test_coverage_cells_keeps_latitude_rows_separate(tmp_path: Path) -> None:
+    atlas_dir = _write_atlas(tmp_path, "ROWS", (47.5, -5.0, 48.5, -4.0))
+    _write_tile(atlas_dir, 47.5, -5.0, rows=1)
+    _write_tile(atlas_dir, 48.0, -5.0, rows=1)
+    _write_tile(atlas_dir, 48.0, -4.5, rows=1)
+
+    boxes = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()[0][1]
+    assert boxes == ((47.5, -5.0, 48.0, -4.5), (48.0, -5.0, 48.5, -4.0))
+
+
+def test_coverage_cells_is_empty_for_an_atlas_without_tiles(tmp_path: Path) -> None:
+    _write_atlas(tmp_path, "NOTILES", (48.0, -5.0, 48.5, -4.5))
+    assert MarcAtlasRegistry.from_directory(tmp_path).coverage_cells() == (("NOTILES", ()),)
+
+
+def test_a_mediterranean_point_sits_in_the_bbox_but_in_no_cell(tmp_path: Path) -> None:
+    """The reason this method exists, reproduced at fixture scale.
+
+    ATLNE's coverage polygon is a bounding box spanning 39.98 N to 64.99 N and
+    20.03 W to 15.00 E, so Porquerolles (43.0, 6.2) falls inside it while the
+    overlay answers ``covered: false`` there, 14 times out of 14 in the live
+    measurement. A client filtering on the bbox skips nothing in the
+    Mediterranean; filtering on the cells, it skips every call.
+    """
+    atlas_dir = _write_atlas(tmp_path, "ATLNE", (39.98, -20.03, 64.99, 15.0))
+    # Atlantic tiles only, exactly like the real atlas.
+    for tile_lon in (-5.0, -4.5):
+        _write_tile(atlas_dir, 48.0, tile_lon, rows=2)
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+
+    med = (43.0, 6.2)
+    atlas = registry.atlases[0]
+    assert atlas.bbox[0] <= med[0] <= atlas.bbox[2]
+    assert atlas.bbox[1] <= med[1] <= atlas.bbox[3]
+
+    boxes = registry.coverage_cells()[0][1]
+    assert not any(
+        lat_min <= med[0] <= lat_max and lon_min <= med[1] <= lon_max
+        for lat_min, lon_min, lat_max, lon_max in boxes
+    )
+    # And the endpoint's promise holds where it matters: no cell, no coverage.
+    assert registry.covers(*med) is None
+
+
+def test_no_point_outside_the_cells_is_ever_covered(tmp_path: Path) -> None:
+    """The invariant the client relies on to skip a call.
+
+    Swept over a grid that straddles the tiles, their seams and the empty
+    tile, so a rectangle that is one tile too narrow fails here rather than in
+    production as a silently missing current.
+    """
+    atlas_dir = _write_atlas(tmp_path, "SWEEP", (47.0, -6.0, 49.0, -3.0))
+    for tile_lat, tile_lon in ((48.0, -5.0), (48.0, -4.5), (47.5, -3.5)):
+        _write_tile(atlas_dir, tile_lat, tile_lon, rows=4)
+    _write_tile(atlas_dir, 48.5, -5.0, rows=0)
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+    boxes = registry.coverage_cells()[0][1]
+
+    covered_seen = 0
+    for i in range(41):
+        for j in range(61):
+            lat = 47.0 + i * 0.05
+            lon = -6.0 + j * 0.05
+            if registry.covers(lat, lon) is None:
+                continue
+            covered_seen += 1
+            assert any(
+                lat_min <= lat <= lat_max and lon_min <= lon <= lon_max
+                for lat_min, lon_min, lat_max, lon_max in boxes
+            ), (lat, lon)
+    assert covered_seen > 0
+
+
+def test_coverage_cells_is_memoised_per_directory(tmp_path: Path) -> None:
+    # Two registries over the same atlas share the answer: the deployment
+    # builds one for the REST routes and one inside build_server, and the
+    # directory walk should not happen twice.
+    atlas_dir = _write_atlas(tmp_path, "MEMO", (48.0, -5.0, 48.5, -4.5))
+    _write_tile(atlas_dir, 48.0, -5.0, rows=1)
+
+    first = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()
+    # Add a tile behind its back: a cached answer must not see it.
+    _write_tile(atlas_dir, 48.0, -4.5, rows=1)
+    second = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()
+    assert first == second

--- a/packages/hf-space/README.md
+++ b/packages/hf-space/README.md
@@ -123,11 +123,20 @@ on the deployment.
 
 `/api/v1/marine/marc/coverage` answers
 `{"atlases": [{"name": "FINIS", "source": "marc", "bbox": [lat_min, lon_min,
-lat_max, lon_max]}, ...]}`, in WGS84 degrees, latitude first, sorted by source
-then name. It is an empty list on a Space that ships without the tidal atlas
-dataset. The promise runs one way only: outside every box there is nothing to
-fetch, inside one there may still be nothing (the SHOM boxes wrap a scattered
-point cloud that contains land and gaps).
+lat_max, lon_max], "cells": [[lat_min, lon_min, lat_max, lon_max], ...]}, ...]}`,
+in WGS84 degrees, latitude first, sorted by source then name. It is an empty
+list on a Space that ships without the tidal atlas dataset.
+
+**Filter on `cells`, not on `bbox`.** MARC coverage polygons are written as
+bounding boxes at build time, so the ATLNE envelope spans 39.98 N to 64.99 N
+and 20.03 W to 15.00 E and swallows the whole Mediterranean, where the model
+holds no cell at all. `cells` lists the tiles that actually carry data, merged
+into rectangles; for SHOM it is the zone box, which is already tight. `bbox` is
+kept for the clients already reading it.
+
+The promise runs one way only, for both fields: outside every box there is
+nothing to fetch, inside one there may still be nothing (a MARC tile is half a
+degree wide and contains land, and the SHOM cloud is scattered).
 
 The overlay endpoint has its own, wider bucket because the web app calls it
 once per corridor point, up to 60 times for one computation. Its step ceiling

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -19,10 +19,13 @@ Re-evaluate if traffic plateaus.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import dataclasses
 import logging
 import math
 import os
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -1124,11 +1127,16 @@ def _widen_to_quantum(bbox: tuple[float, float, float, float]) -> list[float]:
     minima floor and the maxima ceil.
     """
     lat_min, lon_min, lat_max, lon_max = bbox
+    # The final round only cancels the binary representation error the
+    # multiplication leaves behind (-20.0295 came out as -20.029500000000002
+    # on the deployed answer). It moves a bound by ~1e-15 degrees, fifteen
+    # orders of magnitude below the quantum the floor and ceil just added, so
+    # the outward guarantee survives it intact.
     return [
-        math.floor(lat_min / _BBOX_QUANTUM) * _BBOX_QUANTUM,
-        math.floor(lon_min / _BBOX_QUANTUM) * _BBOX_QUANTUM,
-        math.ceil(lat_max / _BBOX_QUANTUM) * _BBOX_QUANTUM,
-        math.ceil(lon_max / _BBOX_QUANTUM) * _BBOX_QUANTUM,
+        round(math.floor(lat_min / _BBOX_QUANTUM) * _BBOX_QUANTUM, 4),
+        round(math.floor(lon_min / _BBOX_QUANTUM) * _BBOX_QUANTUM, 4),
+        round(math.ceil(lat_max / _BBOX_QUANTUM) * _BBOX_QUANTUM, 4),
+        round(math.ceil(lon_max / _BBOX_QUANTUM) * _BBOX_QUANTUM, 4),
     ]
 
 
@@ -1144,26 +1152,55 @@ async def _api_marc_coverage(_request: Request) -> JSONResponse:
     Response::
 
         {"atlases": [{"name": "FINIS", "source": "marc",
-                      "bbox": [lat_min, lon_min, lat_max, lon_max]}, ...]}
+                      "bbox": [lat_min, lon_min, lat_max, lon_max],
+                      "cells": [[lat_min, lon_min, lat_max, lon_max], ...]}, ...]}
 
     Degrees WGS84, latitude first, matching the ``lat``/``lon`` order of the
     overlay's own query parameters. Sorted by source then name so a client can
     diff two answers, and an empty list when the Space ships without the
     dataset (the same state the overlay reports as ``covered: false``).
 
-    What the boxes promise is one-directional: outside every box there is
-    nothing to fetch, inside one there may still be nothing. MARC boxes come
-    from each atlas's coverage polygon, which the registry itself tests before
-    looking at a tile; SHOM boxes wrap a scattered point cloud that contains
-    land and gaps. A client skipping outside them loses no data; a client
-    assuming coverage inside them would be wrong.
+    **Filter on ``cells``, not on ``bbox``.** A point outside every ``cells``
+    entry is a point the atlases refuse; ``bbox`` is only the outer envelope
+    and it is far too coarse to decide with. MARC coverage polygons are
+    written as bounding boxes at build time, so ATLNE's runs from 39.98 N to
+    64.99 N and from 20.03 W to 15.00 E and swallows the whole Mediterranean,
+    where the model holds no valid cell: filtering on ``bbox`` alone skips
+    nothing there, which is exactly where skipping pays (14 uncovered answers
+    out of 14 in the live measurement). ``cells`` is the set of tiles that
+    actually hold data, merged into rectangles; for SHOM it is the single
+    zone box, which is already tight.
+
+    The promise runs one way only, for both fields: outside every box there
+    is nothing to fetch, inside one there may still be nothing. A MARC tile is
+    half a degree wide and contains land; the SHOM cloud is scattered and has
+    gaps. A client skipping outside them loses no data; a client assuming
+    coverage inside them would be wrong.
+
+    ``bbox`` is kept unchanged for the clients already reading it.
     """
+    # Off the event loop: on a cold cache this walks one Parquet footer per
+    # tile, measured 2.4 s for an ATLNE-sized 3500-tile atlas. The startup
+    # warm-up below normally gets there first and this returns in microseconds.
+    marc_cells = dict(await asyncio.to_thread(_MARC_REGISTRY.coverage_cells))
     atlases: list[dict[str, Any]] = [
-        {"name": atlas.name, "source": "marc", "bbox": _widen_to_quantum(atlas.bbox)}
+        {
+            "name": atlas.name,
+            "source": "marc",
+            "bbox": _widen_to_quantum(atlas.bbox),
+            "cells": [_widen_to_quantum(cell) for cell in marc_cells.get(atlas.name, ())],
+        }
         for atlas in _MARC_REGISTRY.atlases
     ]
     atlases += [
-        {"name": name, "source": "shom", "bbox": _widen_to_quantum(bbox)}
+        {
+            "name": name,
+            "source": "shom",
+            "bbox": _widen_to_quantum(bbox),
+            # The zone box already wraps the points themselves rather than a
+            # build-time envelope, so there is nothing finer to say.
+            "cells": [_widen_to_quantum(bbox)],
+        }
         for name, bbox in _SHOM_REGISTRY.coverage_zones()
     ]
     atlases.sort(key=lambda entry: (entry["source"], entry["name"]))
@@ -1175,6 +1212,67 @@ async def _api_marc_coverage(_request: Request) -> JSONResponse:
         {"atlases": atlases},
         headers={"Cache-Control": f"public, max-age={max_age}"},
     )
+
+
+async def _warm_atlas_coverage() -> None:
+    """Compute the MARC coverage rectangles once, in a worker thread.
+
+    The walk reads one Parquet footer per tile and nothing else, but an
+    ATLNE-sized atlas has thousands of them: 2.4 s measured over 3500 tiles.
+    Doing it at startup rather than on the first request keeps that cost off
+    the critical path of whoever asks first, and doing it in a thread keeps it
+    off the event loop, where 2.4 s would stall every MCP session on the
+    single worker.
+
+    Deliberately not awaited before the app starts serving: the Space already
+    takes ~5 s to wake, and delaying the first request by another 2.4 s to
+    pre-compute an answer it may never ask for is the wrong trade. A request
+    landing mid-warm-up recomputes rather than waiting on this task, which
+    costs one duplicated walk in a thread and never a wrong answer.
+
+    Never raises: a warm-up that fails must not take the Space down with it,
+    the endpoint would simply pay the cost itself.
+    """
+    started = time.perf_counter()
+    try:
+        cells = await asyncio.to_thread(_MARC_REGISTRY.coverage_cells)
+    except Exception:
+        _logger.exception("atlas coverage warm-up failed; the endpoint will compute on demand")
+        return
+    # The one number that says whether this dataset still fits the design.
+    # 2.4 s over 3500 tiles locally; if it ever creeps into the tens of
+    # seconds the walk needs an index rather than a bigger thread.
+    _logger.info(
+        "atlas coverage warmed in %.2f s: %d atlas(es), %d rectangle(s)",
+        time.perf_counter() - started,
+        len(cells),
+        sum(len(boxes) for _, boxes in cells),
+    )
+
+
+def _lifespan_with_warm_coverage(mcp_app: Any) -> Any:
+    """The MCP app's own lifespan, plus the coverage warm-up alongside it.
+
+    The inner lifespan is what starts and stops FastMCP's session manager, so
+    it must still run exactly as before: without it the MCP endpoint answers
+    500. This only adds a background task around it.
+    """
+
+    @contextlib.asynccontextmanager
+    async def _lifespan(app: Starlette):
+        warm = asyncio.create_task(_warm_atlas_coverage())
+        try:
+            async with mcp_app.router.lifespan_context(app):
+                yield
+        finally:
+            warm.cancel()
+            # The thread it may be sitting in cannot be interrupted, but
+            # awaiting the cancellation keeps shutdown free of "task was
+            # destroyed but it is pending".
+            with contextlib.suppress(asyncio.CancelledError):
+                await warm
+
+    return _lifespan
 
 
 def build_app(mcp_app: Any) -> Starlette:
@@ -1224,7 +1322,7 @@ def build_app(mcp_app: Any) -> Starlette:
             # counted against the caller's quota, never before.
             Middleware(BodySizeLimitMiddleware),
         ],
-        lifespan=mcp_app.router.lifespan_context,
+        lifespan=_lifespan_with_warm_coverage(mcp_app),
     )
 
 

--- a/packages/hf-space/tests/test_api_limits.py
+++ b/packages/hf-space/tests/test_api_limits.py
@@ -282,3 +282,34 @@ def test_the_atlas_coverage_route_answers_cross_origin(client) -> None:
     assert resp.status_code == 200
     assert resp.headers["access-control-allow-origin"] == "*"
     assert "atlases" in resp.json()
+
+
+def test_the_app_starts_and_stops_with_the_coverage_warm_up() -> None:
+    """The warm-up runs beside the MCP lifespan, never instead of it.
+
+    FastMCP's session manager is started by the inner lifespan the parent app
+    borrows; losing it while wrapping the lifespan would leave /mcp answering
+    500 with nothing in the logs. Entering TestClient as a context manager is
+    what actually runs startup and shutdown.
+    """
+    app = _load_app()
+    with TestClient(app.build_app(_StubMcpApp())) as client:
+        assert client.get("/api/v1/archetypes").status_code == 200
+        assert client.get("/mcp-probe").text == _MCP_BODY
+        assert client.get("/api/v1/marine/marc/coverage").json() == {"atlases": []}
+
+
+def test_the_warm_up_survives_a_broken_registry(monkeypatch) -> None:
+    # A dataset that fails to read must not take the Space down at boot: the
+    # endpoint would simply pay the cost itself on the first call.
+    app = _load_app()
+
+    class _BrokenRegistry:
+        atlases = ()
+
+        def coverage_cells(self):
+            raise OSError("dataset volume not mounted")
+
+    monkeypatch.setattr(app, "_MARC_REGISTRY", _BrokenRegistry())
+    with TestClient(app.build_app(_StubMcpApp())) as client:
+        assert client.get("/api/v1/archetypes").status_code == 200

--- a/packages/hf-space/tests/test_api_marc_overlay.py
+++ b/packages/hf-space/tests/test_api_marc_overlay.py
@@ -195,13 +195,17 @@ class TestCoverage:
     """
 
     class _StubMarcAtlas:
-        def __init__(self, name, bbox):
+        def __init__(self, name, bbox, cells=()):
             self.name = name
             self.bbox = bbox
+            self.cells = tuple(cells)
 
     class _StubMarcRegistry:
         def __init__(self, atlases):
             self.atlases = tuple(atlases)
+
+        def coverage_cells(self):
+            return tuple((a.name, a.cells) for a in self.atlases)
 
     class _StubShomRegistry:
         def __init__(self, zones):
@@ -218,8 +222,17 @@ class TestCoverage:
             "_MARC_REGISTRY",
             self._StubMarcRegistry(
                 [
-                    self._StubMarcAtlas("MANGA", (48.0, -5.0, 50.0, 0.0)),
-                    self._StubMarcAtlas("FINIS", (47.5, -5.5, 48.9, -3.5)),
+                    # Declared out of alphabetical order, and with a coverage
+                    # envelope wider than the tiles that hold data, which is
+                    # the real shape of every MARC atlas.
+                    self._StubMarcAtlas(
+                        "MANGA", (48.0, -5.0, 50.0, 0.0), [(49.0, -2.0, 49.5, -1.0)]
+                    ),
+                    self._StubMarcAtlas(
+                        "FINIS",
+                        (47.5, -5.5, 48.9, -3.5),
+                        [(48.0, -5.0, 48.5, -4.0), (48.5, -5.0, 49.0, -4.5)],
+                    ),
                 ]
             ),
         )
@@ -263,7 +276,7 @@ class TestCoverage:
         # a covered point.
         raw = (47.123456789, -3.987654321, 48.111111111, -2.000000001)
         monkeypatch.setattr(
-            app, "_MARC_REGISTRY", self._StubMarcRegistry([self._StubMarcAtlas("X", raw)])
+            app, "_MARC_REGISTRY", self._StubMarcRegistry([self._StubMarcAtlas("X", raw, [raw])])
         )
         monkeypatch.setattr(app, "_SHOM_REGISTRY", self._StubShomRegistry([]))
         lat_min, lon_min, lat_max, lon_max = _payload(await app._api_marc_coverage(None))[
@@ -271,6 +284,172 @@ class TestCoverage:
         ][0]["bbox"]
         assert lat_min <= raw[0] and lon_min <= raw[1]
         assert lat_max >= raw[2] and lon_max >= raw[3]
+
+    async def test_every_entry_carries_its_cells(self, loaded) -> None:
+        payload = _payload(await app._api_marc_coverage(None))
+        by_name = {a["name"]: a for a in payload["atlases"]}
+        assert by_name["FINIS"]["cells"] == [
+            [48.0, -5.0, 48.5, -4.0],
+            [48.5, -5.0, 49.0, -4.5],
+        ]
+        # SHOM has nothing finer than its zone box, which already wraps the
+        # points themselves rather than a build-time envelope.
+        assert by_name["MORBIHAN"]["cells"] == [by_name["MORBIHAN"]["bbox"]]
+
+    async def test_bbox_is_unchanged_by_the_arrival_of_cells(self, loaded) -> None:
+        # A client already reads bbox off the deployed answer; cells is added
+        # beside it, not in its place.
+        finis = next(
+            a
+            for a in _payload(await app._api_marc_coverage(None))["atlases"]
+            if a["name"] == "FINIS"
+        )
+        assert finis["bbox"] == [47.5, -5.5, 48.9, -3.5]
+
+    async def test_cells_stay_within_one_tile_of_the_bbox_they_refine(self, loaded) -> None:
+        """A cell may overrun the envelope, by at most one tile.
+
+        Tiles are aligned on a half-degree grid while a coverage polygon ends
+        wherever the model grid ends, so the topmost tile of an atlas whose
+        bbox stops at 48.9 legitimately reaches 49.0. Anything further than
+        that means the two are describing different atlases.
+        """
+        tile = 0.5
+        for entry in _payload(await app._api_marc_coverage(None))["atlases"]:
+            lat_min, lon_min, lat_max, lon_max = entry["bbox"]
+            for cell in entry["cells"]:
+                assert cell[0] >= lat_min - tile and cell[2] <= lat_max + tile, entry["name"]
+                assert cell[1] >= lon_min - tile and cell[3] <= lon_max + tile, entry["name"]
+
+    async def test_a_mediterranean_point_is_in_the_bbox_and_in_no_cell(self, monkeypatch) -> None:
+        """The whole reason ``cells`` exists, at the endpoint level.
+
+        ATLNE's build-time coverage polygon is a bounding box that reaches
+        from Madeira's latitude to Norway and from mid-Atlantic to Poland, so
+        Porquerolles sits inside it while the overlay answers uncovered there,
+        14 times out of 14 in the live measurement. Filtering on ``bbox`` a
+        Mediterranean client skips nothing; filtering on ``cells`` it skips
+        every call.
+        """
+        monkeypatch.setattr(
+            app,
+            "_MARC_REGISTRY",
+            self._StubMarcRegistry(
+                [
+                    self._StubMarcAtlas(
+                        "ATLNE",
+                        (39.982, -20.0295, 64.9911, 15.0004),
+                        [(48.0, -5.0, 48.5, -4.0)],
+                    )
+                ]
+            ),
+        )
+        monkeypatch.setattr(app, "_SHOM_REGISTRY", self._StubShomRegistry([]))
+        entry = _payload(await app._api_marc_coverage(None))["atlases"][0]
+
+        porquerolles = (43.0, 6.2)
+
+        def contains(box):
+            return box[0] <= porquerolles[0] <= box[2] and box[1] <= porquerolles[1] <= box[3]
+
+        assert contains(entry["bbox"])
+        assert not any(contains(cell) for cell in entry["cells"])
+
+    async def test_no_float_artefacts_in_the_answer(self, monkeypatch) -> None:
+        # The deployed answer carried -20.029500000000002. It is harmless
+        # arithmetically and it makes the payload look broken.
+        monkeypatch.setattr(
+            app,
+            "_MARC_REGISTRY",
+            self._StubMarcRegistry(
+                [
+                    self._StubMarcAtlas(
+                        "ATLNE", (39.982, -20.0295, 64.9911, 15.0004), [(48.0, -5.0, 48.5, -4.0)]
+                    )
+                ]
+            ),
+        )
+        monkeypatch.setattr(app, "_SHOM_REGISTRY", self._StubShomRegistry([]))
+        raw = bytes((await app._api_marc_coverage(None)).body).decode()
+        assert "-20.0295," in raw
+        assert "0000000" not in raw
+
+    async def test_reads_real_tiles_off_disk(self, monkeypatch, tmp_path) -> None:
+        """End to end through the real registry, not a stub.
+
+        The handler joins ``registry.atlases`` to ``coverage_cells()`` by
+        atlas name. A stub cannot catch that join going wrong, and if it did
+        every atlas would silently report an empty ``cells`` list, which a
+        client would read as "skip everything".
+        """
+        import json
+
+        import polars as pl
+        from openwind_data.currents.marc_atlas import MarcAtlasRegistry
+
+        atlas_dir = tmp_path / "FINIS"
+        atlas_dir.mkdir()
+        (atlas_dir / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "atlas": "FINIS",
+                    "rank": 2,
+                    "resolution_m": 250,
+                    "constituents_h": ["M2"],
+                    "constituents_u": [],
+                    "constituents_v": [],
+                    "schema_version": 2,
+                }
+            )
+        )
+        (atlas_dir / "coverage.geojson").write_text(
+            json.dumps(
+                {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "properties": {},
+                            "geometry": {
+                                "type": "Polygon",
+                                "coordinates": [
+                                    [
+                                        [-5.5, 47.5],
+                                        [-4.5, 47.5],
+                                        [-4.5, 49.0],
+                                        [-5.5, 49.0],
+                                        [-5.5, 47.5],
+                                    ]
+                                ],
+                            },
+                        }
+                    ],
+                }
+            )
+        )
+        tile = atlas_dir / "tile_lat=48.0" / "tile_lon=-5.0"
+        tile.mkdir(parents=True)
+        pl.DataFrame(
+            {
+                "lat": [48.35],
+                "lon": [-4.80],
+                "z0_hydro_m": [0.0],
+                "M2_h_amp": [1.0],
+                "M2_h_g": [0.0],
+            }
+        ).write_parquet(tile / "data.parquet", compression="zstd")
+
+        monkeypatch.setattr(app, "_MARC_REGISTRY", MarcAtlasRegistry.from_directory(tmp_path))
+        monkeypatch.setattr(app, "_SHOM_REGISTRY", self._StubShomRegistry([]))
+
+        entry = _payload(await app._api_marc_coverage(None))["atlases"][0]
+        assert entry["name"] == "FINIS"
+        assert entry["cells"] == [[48.0, -5.0, 48.5, -4.5]]
+        assert entry["bbox"] == [47.5, -5.5, 49.0, -4.5]
+
+    async def test_an_empty_answer_still_has_no_cells_to_report(self) -> None:
+        payload = _payload(await app._api_marc_coverage(None))
+        assert payload == {"atlases": []}
 
     async def test_answers_an_empty_list_without_a_dataset(self) -> None:
         # The registries are empty in CI, which is also the Space's state


### PR DESCRIPTION
Suite de #319. L'endpoint de couverture est live sur le Space dev, et tel quel il ne permet pas le court-circuit visé par la PR 0.11 : la bbox est trop grossière pour décider.

## Le constat

Sur https://mcp-dev.ohmywind.fr/api/v1/marine/marc/coverage, l'atlas MARC ATLNE annonce `[39.982, -20.0295, 64.9911, 15.0004]`. C'est une enveloppe qui va de la latitude de Madère à la Norvège et du milieu de l'Atlantique à la Pologne : elle englobe toute la Méditerranée, où le modèle n'a aucune cellule valide. Porquerolles (43.0, 6.2) tombe dedans, alors que l'overlay y répond `covered: false`, 14 fois sur 14 dans la mesure live. Un client qui filtre sur `bbox` ne saute donc aucun appel en Méditerranée, c'est-à-dire exactement là où sauter rapporte tout.

Ce n'est pas un bug : les polygones de couverture sont écrits comme des bbox à la construction, et le commentaire de `covers()` (`marc_atlas.py`) documente déjà ce faux positif ATLNE. La bbox est une enveloppe, pas une couverture.

## Ce qui est ajouté

### `MarcAtlasRegistry.coverage_cells()`

Énumère les tuiles présentes sur disque (`parquet_dir / tile_lat=XX.X / tile_lon=YY.Y / data.parquet`, pas de 0,5 degré), ne garde que celles qui portent au moins une ligne, puis fusionne les tuiles adjacentes par ligne de latitude en rectangles (run-length sur les longitudes).

Le test « au moins une ligne » lit **uniquement le pied de page Parquet** : `pl.scan_parquet(p).select(pl.len()).collect()`. Mesuré sur une tuile de 41 Mo au format réel (30 k cellules x 183 colonnes) : 1,03 ms, contre 52,5 ms pour une lecture complète, et 0,90 ms sur une tuile de 3 lignes. Le coût est celui de l'ouverture du fichier, pas de la charge utile. pyarrow n'est pas une dépendance du paquet et ne le devient pas ici.

Mémoïsé par répertoire d'atlas pour la vie du process, au niveau module comme `_read_tile` : le déploiement construit deux registres (un pour les routes REST, un dans `build_server`) et les deux partagent la réponse.

**L'invariant, exact et pas approximatif :** `covers()` lit la seule tuile qui contient le point et passe son chemin quand elle est absente ou vide, donc un point hors de tous les rectangles est un point que `covers()` refuse. La réciproque reste fausse, et c'est documenté : une tuile fait un demi-degré et contient de la terre. Sauter à l'extérieur ne perd rien, supposer la couverture à l'intérieur serait faux.

### Champ `cells` dans la réponse

Chaque entrée porte désormais `cells`, arrondi vers l'extérieur comme `bbox` : pour MARC les rectangles fusionnés, pour SHOM la boîte de zone (déjà serrée, elle enveloppe les points eux-mêmes et pas une enveloppe de build). `bbox` est inchangé pour les clients qui le lisent déjà.

Au passage, les artefacts flottants de la réponse live (`-20.029500000000002`) disparaissent : un `round(x, 4)` est appliqué après le `floor` / `ceil`. Il ne déplace une borne que de 1e-15 degré, quinze ordres de grandeur sous le quantum d'arrondi, donc la garantie « vers l'extérieur » reste intacte.

### Préchauffage au démarrage

Mesure sur un atlas synthétique de la taille d'ATLNE (50 lignes x 70 colonnes = 3500 tuiles) : **2,49 s à froid**, 4 µs à chaud, 50 rectangles. Au-dessus du seuil de 2 s, donc le calcul est lancé au démarrage.

Deux précautions plutôt qu'une :

- Le préchauffage tourne dans un thread, lancé à côté du lifespan MCP (qui doit continuer à démarrer le session manager, sans quoi `/mcp` répond 500) et **sans le retarder** : le Space met déjà 5 s à se réveiller, lui ajouter 2,5 s pour précalculer une réponse qui ne sera peut-être pas demandée serait le mauvais compromis.
- L'endpoint lui-même passe par `asyncio.to_thread`, donc un appel à froid (dataset attaché après le boot, préchauffage en échec) ne bloque jamais la boucle d'événements. C'est la leçon de C2 : 2,5 s sur la boucle, ce sont toutes les sessions MCP figées.

Le prix est une marche dupliquée si un appel arrive pendant le préchauffage : 2,5 s de CPU dans un thread, une fois, jamais une mauvaise réponse.

Le préchauffage ne lève jamais : un dataset illisible ne doit pas empêcher le Space de démarrer, l'endpoint paierait simplement le calcul lui-même. Il journalise sa durée, seul chiffre qui dira si le dataset sort un jour du cadre.

## Smoke local

Le dataset est absent en local, donc les fixtures des tests sont montées via `MARC_ATLAS_DIR` et `SHOM_C2D_DIR`, avec un atlas façonné comme le vrai ATLNE : enveloppe géante, tuiles atlantiques seulement.

```
GET /api/v1/marine/marc/coverage  -> 200, cache-control: public, max-age=86400
{"atlases":[
 {"name":"ATLNE","source":"marc",
  "bbox":[39.982,-20.0295,64.9911,15.0004],
  "cells":[[47.0,-2.5,47.5,-2.0],[48.0,-5.0,48.5,-3.5],[48.5,-5.0,49.0,-4.5]]},
 {"name":"FINIS","source":"marc","bbox":[47.5,-5.5,49.0,-4.5],
  "cells":[[48.0,-5.0,48.5,-4.5]]},
 {"name":"TEST_ZONE","source":"shom","bbox":[47.4449,-2.9767,47.5551,-2.8233],
  "cells":[[47.4449,-2.9767,47.5551,-2.8233]]}]}
```

Trois tuiles contiguës en 48.0 fusionnées en un rectangle, plus de `-20.029500000000002`, et le court-circuit vérifié bout en bout :

```
Porquerolles (43.0, 6.2)
  ATLNE      dans la bbox = True    dans une cell = False
  FINIS      dans la bbox = False   dans une cell = False
  TEST_ZONE  dans la bbox = False   dans une cell = False
  -> le client saute l'appel : True
GET /api/v1/marine/marc?lat=43.0&lon=6.2  -> {"covered": false}   (l'appel évité)
GET /api/v1/marine/marc?lat=48.25&lon=-4.75 -> covered: true, marc_finis_250m,
    tide_height_m et current_speed_kn renseignés : overlay inchangé
```

Tailles, sur l'atlas de 3500 tuiles qui rend 50 rectangles (le cas réaliste, pas le fixture à 3 rectangles) :

| Réponse | Sans gzip | Avec gzip |
|---|---|---|
| `/api/v1/marine/marc/coverage`, ATLNE 50 rectangles | 1 369 o | 378 o |
| même route, fixture à 4 rectangles | 379 o | 379 o (sous le seuil de 1 Ko) |
| `/api/v1/archetypes` (inchangé) | 1 421 o | 428 o |

Préchauffage et boucle d'événements, sur le même atlas de 3500 tuiles :

```
INFO: Application startup complete.
INFO: atlas coverage warmed in 2.49 s: 1 atlas(es), 50 rectangle(s)
sondes /api/v1/archetypes émises pendant le préchauffage :
  0,00103 s  0,00091 s  0,00086 s  0,00087 s  0,00081 s  0,00080 s
premier appel /coverage après préchauffage : 0,0011 s
```

REST et MCP, un seul appel réel Open-Meteo, dataset absent comme en CI :

```
GET  /api/v1/marine/marc/coverage -> 200, max-age=300, {"atlases":[]}
POST /api/v1/passage  Marseille (43.29, 5.37) vers Porquerolles (43.0, 6.2),
     départ 2026-09-03T09:00+02:00, cruiser_30ft, sans forecast_cache
     -> 200, 5 tronçons, AROME, 14,86 h, 40,3 NM, complexité 2 modéré
initialize   -> OK, ohmywind 1.27.2   (le lifespan MCP démarre toujours)
list_tools   -> get_marine_forecast, list_boat_archetypes, plan_passage, read_me
plan_passage -> 14,86 h, 40,3 NM, AROME, 5 tronçons, complexité 2 modéré
/mcp : pas de content-encoding, session qui streame normalement
```

## Tests

| Suite | Avant (dev, après #319) | Après |
|---|---|---|
| data-adapters | 286 réussis, 3 ignorés | 294 réussis, 3 ignorés |
| hf-space | 158 | 167 |
| mcp-core | 66 | 66 |

Ruff check et format propres sur les trois paquets.

Côté data-adapters : fusion de trois tuiles contiguës en un rectangle, trou conservé en deux rectangles, tuile vide (0 ligne, schéma correct, ce que laisse un build interrompu) exclue, lignes de latitude gardées séparées, atlas sans tuile, mémoïsation par répertoire. Plus les deux tests qui portent la valeur : le point méditerranéen dans la bbox d'un ATLNE de fixture et dans aucune cell, et un balayage de 41 x 61 points qui vérifie que **tout** point accepté par `covers()` tombe dans un rectangle.

Côté hf-space : `cells` sur chaque entrée, `bbox` inchangé, cells à moins d'une tuile de la bbox qu'elles affinent (une tuile déborde légitimement l'enveloppe, elle est alignée sur la grille du demi-degré), absence d'artefacts flottants, réponse bâtie sur un vrai registre lu sur disque et pas sur un stub (c'est la jointure par nom d'atlas qui est en jeu : si elle casse, tous les `cells` sont vides et le client saute tout), démarrage et arrêt complets avec le préchauffage, et un registre qui lève au démarrage sans empêcher le Space de servir.

## Reste à faire

La moitié client de la PR 0.11 : lire `cells` dans `api/marine.ts` pour court-circuiter les appels overlay, et regrouper les appels Marine Open-Meteo en une requête multi-coordonnées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
