### PR TITLE
perf(web): arrondit les coordonnées du forecast_cache à 4 décimales

### DIFF
--- a/packages/web/src/api/forecastCache.test.ts
+++ b/packages/web/src/api/forecastCache.test.ts
@@ -317,6 +317,57 @@ describe("assembleForecastCache", () => {
     expect(cache.points[0].wind_by_model["meteofrance_arome_france"].speed_kn).toEqual([11.1, 12.0]);
   });
 
+  it("rounds corridor coordinates to 4 decimals", () => {
+    // Parsed from strings rather than written as literals: these are the
+    // 17-significant-digit doubles interpolateGreatCircle actually emits, and
+    // no-loss-of-precision rejects them as source literals.
+    const raw: SampledPoint[] = [
+      {
+        lat: Number("43.29999999999998"),
+        lon: Number("5.350000000000001"),
+        models: [model("AROME", [10, 10, 10])],
+        marine: marine("openmeteo_smoc"),
+      },
+      {
+        lat: Number("43.123456789012345"),
+        lon: Number("6.198765432109876"),
+        models: [model("AROME", [10, 10, 10])],
+        marine: null,
+      },
+    ];
+    const cache = assembleForecastCache(raw);
+    expect(cache.points.map((p) => [p.lat, p.lon])).toEqual([
+      [43.3, 5.35],
+      [43.1235, 6.1988],
+    ]);
+    // Within the nearest-neighbour tolerance: 4 dp is ~11 m, corridor spacing
+    // is kilometres.
+    expect(cache.points[1].lat).toBeCloseTo(raw[1].lat, 4);
+    expect(cache.points[1].lon).toBeCloseTo(raw[1].lon, 4);
+  });
+
+  it("serialises no float longer than its documented precision", () => {
+    const route = routeOf(200, 3);
+    const corridor = planCorridor(route);
+    const cache = assembleForecastCache(
+      corridor.map((p) => ({
+        lat: p.lat,
+        lon: p.lon,
+        models: [model("AROME", [10.04, 11.06, 12.0])],
+        marine: marine("openmeteo_smoc"),
+      })),
+    );
+    // No number anywhere in the payload carries more than 4 decimals, and the
+    // corridor is the part that used to (raw great-circle doubles).
+    for (const num of JSON.stringify(cache).match(/-?\d+\.\d+/g) ?? []) {
+      expect(num.split(".")[1].length).toBeLessThanOrEqual(4);
+    }
+    for (const pt of cache.points) {
+      expect(Number(pt.lat.toFixed(4))).toBe(pt.lat);
+      expect(Number(pt.lon.toFixed(4))).toBe(pt.lon);
+    }
+  });
+
   it("throws when no sample carries a backend-mappable model", () => {
     const onlyUnmappable: SampledPoint[] = [
       { lat: MARSEILLE[0], lon: MARSEILLE[1], models: [model("ARPEGE_EU", [8, 8, 8])], marine: null },

--- a/packages/web/src/api/forecastCache.ts
+++ b/packages/web/src/api/forecastCache.ts
@@ -96,9 +96,38 @@ export interface CacheWindow {
   endMs?: number;
 }
 
+// Numeric precision of the serialised cache, field by field. Every float that
+// reaches the wire goes through one of these two helpers; nothing else in the
+// payload is a float (times_ms are integer epoch-ms, models and current_source
+// are strings). Why round at all: JSON.stringify writes the shortest decimal
+// that round-trips the double, so an unrounded value costs up to 17 significant
+// digits where 4 to 6 carry everything the server can act on.
+//
+//   lat / lon ..................... 4 dp (~11 m), see COORD_DP below
+//   speed_kn / gust_kn ............ 1 dp (0.1 kn), the model's own resolution
+//   direction_deg ................. 0 dp (1 deg)
+//   wave_height_m / tide_height_m . 2 dp (1 cm)
+//   wave_period_s ................. 1 dp (0.1 s)
+//   wave_direction_deg ............ 0 dp (1 deg)
+//   current_speed_kn .............. 2 dp (0.01 kn), the 0.3 kn reporting
+//                                   threshold needs the centikn
+//   current_direction_to_deg ...... 0 dp (1 deg)
 function roundOrNull(v: number | null | undefined, dp: number): number | null {
   if (v == null) return null;
   return Number(v.toFixed(dp));
+}
+
+// Corridor coordinates: 4 decimals, about 11 m of latitude. The server never
+// reads these as a position to compute from, only as a lookup key: it segments
+// its own route from the full-precision waypoints of the request and resolves
+// each segment midpoint by nearest neighbour over the cache points (see
+// adapters/cache_backed.py). Corridor points are kilometres apart, so an 11 m
+// nudge cannot change which one is nearest. Emitting them at double precision
+// costs up to 17 significant digits twice per point for nothing.
+const COORD_DP = 4;
+
+function roundCoord(v: number): number {
+  return Number(v.toFixed(COORD_DP));
 }
 
 // Interpolate sample points along the waypoint polyline at ~spacingNm. Mirrors
@@ -237,7 +266,8 @@ export function etaWindowMs(waypoints: [number, number][], arrivalMs: number): C
 // Assemble a ForecastCache from already-fetched corridor samples. Pure (no
 // network): converts every Open-Meteo Paris-naive timestamp to UTC epoch-ms via
 // parisIsoToUtcMs, builds one shared ascending time axis (optionally clamped to
-// `window`), and index-aligns each per-model wind + sea series onto it. Throws
+// `window`), index-aligns each per-model wind + sea series onto it and rounds
+// every float to the precision table above. Throws
 // when no sample carries a backend-mappable model, so the caller falls back to
 // the live server path rather than posting an empty chain.
 export function assembleForecastCache(
@@ -293,7 +323,12 @@ export function assembleForecastCache(
         slugOrder.push(slug);
       }
     }
-    return { lat: s.lat, lon: s.lon, wind_by_model: windByModel, sea: buildSea(s.marine, idxByMs, n) };
+    return {
+      lat: roundCoord(s.lat),
+      lon: roundCoord(s.lon),
+      wind_by_model: windByModel,
+      sea: buildSea(s.marine, idxByMs, n),
+    };
   });
 
   // 3. Model chain: priority by first appearance, gfs_seamless as last resort


### PR DESCRIPTION
Quick win 0.12 du lot 0, volet « arrondi ». Les latitudes et longitudes des points du corridor partaient en double précision (jusqu'à 17 chiffres significatifs) alors que toutes les séries étaient déjà arrondies.

## Ce que ça change

`assembleForecastCache` arrondit `lat` / `lon` à 4 décimales, soit environ 11 m. Le serveur ne lit jamais ces coordonnées comme une position à calculer : il segmente sa propre route à partir des waypoints pleine précision de la requête, puis résout chaque milieu de segment au plus proche voisin sur les points du cache (`adapters/cache_backed.py`). Les points du corridor sont espacés de plusieurs kilomètres, un décalage de 11 m ne peut donc pas changer lequel est le plus proche.

Un commentaire donne désormais la table de précision champ par champ (coordonnées 4 décimales, vitesses 1, directions 0, hauteurs 2, courant 2). Aucun autre flottant du payload n'était laissé brut : l'axe temporel reste en entiers epoch-ms, `models` et `current_source` sont des chaînes.

## Avant / après

Mesure sur un cache synthétique reproduisant la forme observée en live : 63 NM, 15 points de corridor, axe de 35 h, les 4 modèles actifs par défaut (AROME, ICON, ECMWF, GFS).

| Mesure | Avant | Après |
|---|---|---|
| Payload complet | 48 730 o | 48 409 o (-321 o, -0,7 %) |
| dont `points` | 48 126 o | 47 805 o |
| dont les seules coordonnées | 515 o | 194 o (-62 %) |
| Le même payload gzippé | 1 668 o | 1 507 o (-9,7 %) |

Le gain brut est modeste, comme attendu : 15 points ne portent que 30 nombres. Le gain après gzip est proportionnellement bien plus net, parce que des décimales aléatoires sur 17 chiffres sont incompressibles alors que des valeurs sur 4 décimales se répètent.

## Où sont les octets restants, pour la suite

Sur ces 47 805 o de `points` : environ 5 754 o de noms de clés répétés 15 fois, le reste étant les séries elles-mêmes (18 séries par point sur cet axe, 4 modèles x 3 + 6 séries de mer). Sur un axe plus long, les `null` deviennent le premier poste : sur un axe de 104 h, AROME s'arrêtant à 51 h et ICON à 78 h, on compte 3 555 jetons `null`, soit 17 775 o sur 132 805.

Conclusion pour le volet compression du quick win 0.12 : c'est bien la compression du body qui apporte l'essentiel. Sur cet échantillon, gzip fait passer 48 409 o à 1 507 o, soit -96,9 %. L'arrondi des coordonnées reste utile en amont, il rend le flux plus compressible.

## Vérifications

`npm run typecheck`, `npm run lint:budget` (11 erreurs pour un budget de 11, inchangé), `npm run test` (376 tests) et `npm run build` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
