### PR TITLE
refacto(web): une seule décision d'état initial pour /plan, cache validé

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,59 @@
         "packages/web"
       ]
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -1548,6 +1601,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "dev": true,
@@ -1681,6 +1887,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2503,6 +2727,69 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -2518,6 +2805,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3090,6 +3385,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -3108,6 +3414,17 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3267,6 +3584,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -3561,9 +3888,75 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3633,6 +4026,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3727,6 +4127,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4981,6 +5389,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5382,6 +5803,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5618,6 +6046,121 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -5857,6 +6400,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6219,6 +6773,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -7194,6 +7755,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -7240,6 +7831,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7687,6 +8286,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -8146,6 +8758,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "dev": true,
@@ -8264,6 +8883,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -8460,6 +9112,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -8936,6 +9598,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8952,6 +9627,16 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -9354,6 +10039,23 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "dev": true,
@@ -9420,6 +10122,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.7",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -9429,6 +10133,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^30.0.1",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
@@ -39,6 +41,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/packages/web/src/components/Onboarding.tsx
+++ b/packages/web/src/components/Onboarding.tsx
@@ -4,10 +4,10 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import { STORAGE_KEY as CUSTOM_SPOTS_KEY } from "../hooks/useCustomSpots";
 import { migrateLegacyKey } from "../utils/localStorageMigration";
+import { LAST_SIMULATION_KEY } from "../plan/lastSimulation";
 
 const STORAGE_KEY = "ohmywind:onboarding-v1";
 const LEGACY_STORAGE_KEY = "openwind:onboarding-v1";
-const LAST_SIMULATION_KEY = "ow_last_simulation_v1";
 // Time between page load and the planner hint surfacing — for first-time
 // users only. The check is a snapshot at mount; subsequent state changes
 // (adding/removing spots during the 15 s) don't cancel the popup.

--- a/packages/web/src/plan/ModeToggle.test.tsx
+++ b/packages/web/src/plan/ModeToggle.test.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Smoke test for the jsdom project: proves that rendering a real component,
+ * querying it by its accessible role and driving it with a user event all work
+ * end to end. `ModeToggle` is the smallest component of `/plan` that carries
+ * actual behaviour (three visual states, one callback), so it exercises the
+ * infrastructure without standing in for the coverage the reducer tests owe.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ModeToggle, TimeAnchorToggle } from "./ModeToggle";
+
+describe("ModeToggle", () => {
+  it("marks the active mode as the selected tab", () => {
+    render(<ModeToggle value="compare" onChange={() => {}} />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0].getAttribute("aria-selected")).toBe("false");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("reports the clicked mode", async () => {
+    const onChange = vi.fn();
+    render(<ModeToggle value="single" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("tab", { name: /Comparer les fenêtres/ }));
+    expect(onChange).toHaveBeenCalledWith("compare");
+  });
+
+  it("stays silent while locked", async () => {
+    const onChange = vi.fn();
+    render(<ModeToggle value="single" onChange={onChange} locked />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.every((t) => (t as HTMLButtonElement).disabled)).toBe(true);
+    await userEvent.click(tabs[1]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows no tab as selected while pristine, so the user has to pick one", () => {
+    render(<ModeToggle value="single" onChange={() => {}} pristine />);
+    for (const tab of screen.getAllByRole("tab")) {
+      expect(tab.getAttribute("aria-selected")).toBe("false");
+    }
+  });
+});
+
+describe("TimeAnchorToggle", () => {
+  it("switches between departure and arrival", async () => {
+    const onChange = vi.fn();
+    render(<TimeAnchorToggle value="departure" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("tab", { name: /Définir l'arrivée/ }));
+    expect(onChange).toHaveBeenCalledWith("arrival");
+  });
+});

--- a/packages/web/src/plan/lastSimulation.test.ts
+++ b/packages/web/src/plan/lastSimulation.test.ts
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect } from "vitest";
+import {
+  parseLastSimulation,
+  waypointsEqual,
+  LAST_SIMULATION_VERSION,
+  LAST_SIMULATION_LIMITS,
+} from "./lastSimulation";
+import type { LastSimulation } from "./lastSimulation";
+import type { PassageReport, ComplexityScore, PassageWindow } from "./types";
+
+const passage = (): PassageReport => ({
+  archetype: "cruiser_30ft",
+  departure_time: "2026-09-03T08:00:00+02:00",
+  arrival_time: "2026-09-03T18:00:00+02:00",
+  duration_h: 10,
+  distance_nm: 55,
+  efficiency: 0.75,
+  model: "meteofrance_arome_france_hd",
+  segments: [{ distance_nm: 55 }] as unknown as PassageReport["segments"],
+  warnings: [],
+});
+
+const complexity = (): ComplexityScore => ({
+  level: 2,
+  label: "Modéré",
+  wind_level: 2,
+  wind_label: "Modéré",
+  sea_level: 1,
+  sea_label: "Calme",
+  tws_max_kn: 14,
+  hs_max_m: 0.8,
+  rationale: "",
+});
+
+const window_ = (i: number): PassageWindow => ({
+  departure: `2026-09-0${(i % 9) + 1}T08:00:00+02:00`,
+  arrival: `2026-09-0${(i % 9) + 1}T18:00:00+02:00`,
+  duration_h: 10,
+  distance_nm: 55,
+  complexity: { level: 2, label: "Modéré", tws_max_kn: 14, rationale: "" },
+  conditions_summary: {
+    tws_min_kn: 8,
+    tws_max_kn: 14,
+    predominant_sail_angle: "largue",
+    hs_min_m: 0.3,
+    hs_max_m: 0.8,
+  },
+  warnings: [],
+});
+
+const full = (over: Partial<LastSimulation> = {}): LastSimulation => ({
+  v: LAST_SIMULATION_VERSION,
+  waypoints: [
+    [43.29, 5.37],
+    [43.0, 6.2],
+  ],
+  archetype: "cruiser_30ft",
+  configFingerprint: "arome|cruiser_30ft||c0.75",
+  mode: "single",
+  single: {
+    departure: "2026-09-03T08:00",
+    passage: passage(),
+    complexity: complexity(),
+    forecastUpdatedAt: "2026-09-02T06:00:00Z",
+  },
+  cachedAt: 1_756_000_000_000,
+  ...over,
+});
+
+describe("parseLastSimulation", () => {
+  it("round-trips a well formed payload", () => {
+    const parsed = parseLastSimulation(JSON.stringify(full()));
+    expect(parsed?.waypoints).toEqual([
+      [43.29, 5.37],
+      [43.0, 6.2],
+    ]);
+    expect(parsed?.single?.passage.distance_nm).toBe(55);
+    expect(parsed?.v).toBe(LAST_SIMULATION_VERSION);
+  });
+
+  it.each([
+    ["not JSON at all", "{nope"],
+    ["a JSON scalar", '"nope"'],
+    ["a JSON array", "[1,2,3]"],
+    ["no waypoints", JSON.stringify({ ...full(), waypoints: undefined })],
+    ["waypoints that are not pairs", JSON.stringify({ ...full(), waypoints: [[1]] })],
+    [
+      "waypoints out of range",
+      JSON.stringify({ ...full(), waypoints: [[999, 5]] }),
+    ],
+    ["no archetype", JSON.stringify({ ...full(), archetype: "" })],
+    ["no cachedAt", JSON.stringify({ ...full(), cachedAt: "hier" })],
+    ["a version from the future", JSON.stringify({ ...full(), v: 99 })],
+  ])("rejects %s", (_label, raw) => {
+    expect(parseLastSimulation(raw)).toBeNull();
+  });
+
+  it("accepts a legacy payload with no version field", () => {
+    const legacy = full();
+    delete legacy.v;
+    expect(parseLastSimulation(JSON.stringify(legacy))?.v).toBe(LAST_SIMULATION_VERSION);
+  });
+
+  it("infers compare mode on a legacy payload that only has a sweep", () => {
+    const legacy = {
+      ...full({ single: undefined }),
+      mode: undefined,
+      compare: {
+        sweepEarliest: "2026-09-03T08:00",
+        sweepLatest: "2026-09-05T08:00",
+        sweepIntervalHours: 3,
+        windows: [window_(0)],
+        metaWarnings: [],
+        forecastUpdatedAt: "2026-09-02T06:00:00Z",
+      },
+    };
+    expect(parseLastSimulation(JSON.stringify(legacy))?.mode).toBe("compare");
+  });
+
+  it("infers single mode on a legacy payload with no mode and no sweep", () => {
+    const legacy = { ...full(), mode: undefined };
+    expect(parseLastSimulation(JSON.stringify(legacy))?.mode).toBe("single");
+  });
+
+  it("drops a corrupted single block but keeps the route", () => {
+    const broken = full({
+      single: { departure: "2026-09-03T08:00" } as unknown as LastSimulation["single"],
+    });
+    const parsed = parseLastSimulation(JSON.stringify(broken));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.single).toBeUndefined();
+    expect(parsed?.waypoints).toHaveLength(2);
+  });
+
+  it("drops a corrupted compare block without touching the single one", () => {
+    const broken = full({
+      compare: {
+        sweepEarliest: "2026-09-03T08:00",
+        sweepLatest: "2026-09-05T08:00",
+        sweepIntervalHours: 3,
+        windows: [{ departure: "nope" }],
+        metaWarnings: [],
+        forecastUpdatedAt: "2026-09-02T06:00:00Z",
+      } as unknown as LastSimulation["compare"],
+    });
+    const parsed = parseLastSimulation(JSON.stringify(broken));
+    expect(parsed?.compare).toBeUndefined();
+    expect(parsed?.single?.passage.duration_h).toBe(10);
+  });
+
+  it("empties bad meta warnings rather than losing the table they annotate", () => {
+    const sim = full({
+      compare: {
+        sweepEarliest: "2026-09-03T08:00",
+        sweepLatest: "2026-09-05T08:00",
+        sweepIntervalHours: 3,
+        windows: [window_(0)],
+        metaWarnings: [{ oops: true }],
+        forecastUpdatedAt: "2026-09-02T06:00:00Z",
+      } as unknown as LastSimulation["compare"],
+    });
+    const parsed = parseLastSimulation(JSON.stringify(sim));
+    expect(parsed?.compare?.windows).toHaveLength(1);
+    expect(parsed?.compare?.metaWarnings).toEqual([]);
+  });
+});
+
+// `saveLastSimulation` writes through localStorage, absent from the node
+// environment the unit project runs in. A minimal in-memory stand-in is enough
+// to observe what the budget actually wrote.
+function withFakeStorage(run: (read: () => string | null) => void) {
+  let stored: string | null = null;
+  const fake = {
+    getItem: () => stored,
+    setItem: (_k: string, v: string) => {
+      stored = v;
+    },
+    removeItem: () => {
+      stored = null;
+    },
+  };
+  const g = globalThis as unknown as { localStorage?: unknown };
+  const previous = g.localStorage;
+  g.localStorage = fake;
+  try {
+    run(() => stored);
+  } finally {
+    g.localStorage = previous;
+  }
+}
+
+describe("saveLastSimulation size budget", () => {
+  it("keeps at most MAX_WINDOWS windows", async () => {
+    const { saveLastSimulation } = await import("./lastSimulation");
+    withFakeStorage((read) => {
+      saveLastSimulation(
+        full({
+          mode: "compare",
+          single: undefined,
+          compare: {
+            sweepEarliest: "2026-09-03T08:00",
+            sweepLatest: "2026-09-30T08:00",
+            sweepIntervalHours: 1,
+            windows: Array.from({ length: 200 }, (_, i) => window_(i)),
+            metaWarnings: [],
+            forecastUpdatedAt: "2026-09-02T06:00:00Z",
+          },
+        }),
+      );
+      const written = parseLastSimulation(read()!);
+      expect(written?.compare?.windows).toHaveLength(LAST_SIMULATION_LIMITS.MAX_WINDOWS);
+    });
+  });
+
+  it("strips the per-window detail before dropping the sweep, and keeps single", async () => {
+    const { saveLastSimulation } = await import("./lastSimulation");
+    // Each window carries a fat passage: 48 of them blow past MAX_BYTES, so
+    // tier 2 of the budget has to fire.
+    const fat = (i: number): PassageWindow => ({
+      ...window_(i),
+      passage: {
+        ...passage(),
+        segments: Array.from({ length: 400 }, () => ({
+          note: "x".repeat(40),
+        })) as unknown as PassageReport["segments"],
+      },
+      complexity_full: complexity(),
+    });
+    withFakeStorage((read) => {
+      saveLastSimulation(
+        full({
+          mode: "compare",
+          compare: {
+            sweepEarliest: "2026-09-03T08:00",
+            sweepLatest: "2026-09-09T08:00",
+            sweepIntervalHours: 3,
+            windows: Array.from({ length: 48 }, (_, i) => fat(i)),
+            metaWarnings: [],
+            forecastUpdatedAt: "2026-09-02T06:00:00Z",
+          },
+        }),
+      );
+      const raw = read()!;
+      expect(raw.length).toBeLessThanOrEqual(LAST_SIMULATION_LIMITS.MAX_BYTES);
+      const written = parseLastSimulation(raw);
+      expect(written?.compare?.windows).toHaveLength(48);
+      expect(written?.compare?.windows[0].passage).toBeUndefined();
+      // The result the user is actually looking at survives untouched.
+      expect(written?.single?.passage.distance_nm).toBe(55);
+    });
+  });
+
+  it("drops the sweep entirely when stripping is not enough", async () => {
+    const { saveLastSimulation } = await import("./lastSimulation");
+    const huge = (i: number): PassageWindow => ({
+      ...window_(i),
+      warnings: [ "y".repeat(20_000) ],
+    });
+    withFakeStorage((read) => {
+      saveLastSimulation(
+        full({
+          mode: "compare",
+          compare: {
+            sweepEarliest: "2026-09-03T08:00",
+            sweepLatest: "2026-09-09T08:00",
+            sweepIntervalHours: 3,
+            windows: Array.from({ length: 48 }, (_, i) => huge(i)),
+            metaWarnings: [],
+            forecastUpdatedAt: "2026-09-02T06:00:00Z",
+          },
+        }),
+      );
+      const raw = read()!;
+      expect(raw.length).toBeLessThanOrEqual(LAST_SIMULATION_LIMITS.MAX_BYTES);
+      const written = parseLastSimulation(raw);
+      expect(written?.compare).toBeUndefined();
+      expect(written?.single?.passage.distance_nm).toBe(55);
+    });
+  });
+
+  it("leaves a payload under budget untouched", async () => {
+    const { saveLastSimulation } = await import("./lastSimulation");
+    withFakeStorage((read) => {
+      saveLastSimulation(full());
+      const written = parseLastSimulation(read()!);
+      expect(written?.single?.passage.arrival_time).toBe("2026-09-03T18:00:00+02:00");
+      expect(written?.v).toBe(LAST_SIMULATION_VERSION);
+    });
+  });
+});
+
+describe("waypointsEqual", () => {
+  it("tolerates the rounding of a URL round-trip", () => {
+    expect(
+      waypointsEqual(
+        [[43.290004, 5.370004]],
+        [[43.29, 5.37]],
+      ),
+    ).toBe(true);
+  });
+
+  it("separates two different routes", () => {
+    expect(waypointsEqual([[43.29, 5.37]], [[43.29, 5.37], [43.0, 6.2]])).toBe(false);
+    expect(waypointsEqual([[43.29, 5.37]], [[43.4, 5.37]])).toBe(false);
+  });
+});

--- a/packages/web/src/plan/lastSimulation.ts
+++ b/packages/web/src/plan/lastSimulation.ts
@@ -12,9 +12,33 @@ import type {
 // no re-fetch, no empty form. Cache is invalidated implicitly when the URL
 // route changes (we restore only when waypoints + archetype match the URL).
 
-const STORAGE_KEY = "ow_last_simulation_v1";
+/** Exported so the one other reader of this cache (the onboarding hint, which
+    only probes for existence) cannot drift from the writer. It used to repeat
+    the literal. */
+export const LAST_SIMULATION_KEY = "ow_last_simulation_v1";
+
+/** Payload version. Absent in everything written before this module started
+    validating, which is why `undefined` is accepted as "legacy v1" rather
+    than rejected: those caches are perfectly usable and dropping them would
+    empty the planner of returning users for no reason. A version we do not
+    know (a newer build, then a rollback) is rejected: better an empty planner
+    than a half-read shape. */
+export const LAST_SIMULATION_VERSION = 1;
+
+/** Above this many windows the compare payload stops being worth its weight in
+    the localStorage budget: 48 windows is 6 days at the 3 h default step, well
+    past what a comparison table is actually read on. */
+const MAX_WINDOWS = 48;
+
+/** Serialized size beyond which the compare payload is cut down. localStorage
+    quotas start around 5 MB per origin and are shared with every other key of
+    the app, so a single simulation has no business claiming more than this. */
+const MAX_BYTES = 500_000;
 
 export interface LastSimulation {
+  /** See LAST_SIMULATION_VERSION. Written by `saveLastSimulation`, optional on
+      the way in for the caches that predate it. */
+  v?: number;
   waypoints: [number, number][];
   archetype: string;
   // Fingerprint of the /config preferences in effect when the simulation ran
@@ -45,9 +69,198 @@ export interface LastSimulation {
   cachedAt: number;
 }
 
+// ── shape validation ─────────────────────────────────────────────────────────
+//
+// The cache is JSON the app wrote itself, but it outlives the build that wrote
+// it. A payload from a deploy whose types have since moved, or scrambled by an
+// extension, used to reach the page cast as a `PassageReport` and blow up the
+// sidebar on the first `passage.segments.map`. Everything below is a *light*
+// structural check: required fields with the right primitive kind, nothing
+// about values. An invalid sub-block is dropped on its own rather than taking
+// the whole cache with it, so a corrupted sweep never costs the user the
+// single-mode result they were looking at.
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isCoordPair(v: unknown): v is [number, number] {
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    typeof v[0] === "number" &&
+    typeof v[1] === "number" &&
+    Number.isFinite(v[0]) &&
+    Number.isFinite(v[1]) &&
+    Math.abs(v[0]) <= 90 &&
+    Math.abs(v[1]) <= 180
+  );
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((s) => typeof s === "string");
+}
+
+function isPassageReport(v: unknown): v is PassageReport {
+  if (!isRecord(v)) return false;
+  return (
+    typeof v.departure_time === "string" &&
+    typeof v.arrival_time === "string" &&
+    typeof v.duration_h === "number" &&
+    typeof v.distance_nm === "number" &&
+    Array.isArray(v.segments) &&
+    v.segments.every(isRecord) &&
+    isStringArray(v.warnings)
+  );
+}
+
+function isComplexityScore(v: unknown): v is ComplexityScore {
+  if (!isRecord(v)) return false;
+  return typeof v.level === "number" && typeof v.label === "string";
+}
+
+function isPassageWindow(v: unknown): v is PassageWindow {
+  if (!isRecord(v)) return false;
+  return (
+    typeof v.departure === "string" &&
+    typeof v.arrival === "string" &&
+    typeof v.duration_h === "number" &&
+    isRecord(v.complexity) &&
+    typeof v.complexity.level === "number"
+  );
+}
+
+function parseSingle(v: unknown): LastSimulation["single"] {
+  if (!isRecord(v)) return undefined;
+  if (typeof v.departure !== "string" || v.departure === "") return undefined;
+  if (!isPassageReport(v.passage)) return undefined;
+  if (!isComplexityScore(v.complexity)) return undefined;
+  if (typeof v.forecastUpdatedAt !== "string") return undefined;
+  return {
+    departure: v.departure,
+    passage: v.passage,
+    complexity: v.complexity,
+    forecastUpdatedAt: v.forecastUpdatedAt,
+  };
+}
+
+function parseCompare(v: unknown): LastSimulation["compare"] {
+  if (!isRecord(v)) return undefined;
+  if (typeof v.sweepEarliest !== "string" || typeof v.sweepLatest !== "string") {
+    return undefined;
+  }
+  if (typeof v.sweepIntervalHours !== "number" || !Number.isFinite(v.sweepIntervalHours)) {
+    return undefined;
+  }
+  if (!Array.isArray(v.windows) || !v.windows.every(isPassageWindow)) return undefined;
+  if (typeof v.forecastUpdatedAt !== "string") return undefined;
+  return {
+    sweepEarliest: v.sweepEarliest,
+    sweepLatest: v.sweepLatest,
+    sweepIntervalHours: v.sweepIntervalHours,
+    sweepTargetEta: typeof v.sweepTargetEta === "string" ? v.sweepTargetEta : undefined,
+    windows: v.windows,
+    // Warnings are decoration: a bad list is emptied, not a reason to lose the
+    // table it annotates.
+    metaWarnings: isStringArray(v.metaWarnings) ? v.metaWarnings : [],
+    forecastUpdatedAt: v.forecastUpdatedAt,
+  };
+}
+
+/**
+ * Parse a raw localStorage payload into a usable cache, or null.
+ *
+ * Exported for the tests: they are the only place where a corrupted, oversized
+ * or legacy payload can be produced on purpose.
+ */
+export function parseLastSimulation(raw: string): LastSimulation | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  if (parsed.v !== undefined && parsed.v !== LAST_SIMULATION_VERSION) return null;
+  if (!Array.isArray(parsed.waypoints) || !parsed.waypoints.every(isCoordPair)) return null;
+  if (typeof parsed.archetype !== "string" || parsed.archetype === "") return null;
+  if (typeof parsed.cachedAt !== "number" || !Number.isFinite(parsed.cachedAt)) return null;
+
+  const single = parseSingle(parsed.single);
+  const compare = parseCompare(parsed.compare);
+
+  // Caches written before `mode` existed default to single: that's the mode
+  // the user was last looking at if their cache only has `single`, and a safe
+  // fallback if it has `compare` (the table reappears as soon as they toggle,
+  // no data lost).
+  const mode =
+    parsed.mode === "single" || parsed.mode === "compare"
+      ? parsed.mode
+      : compare && !single
+        ? "compare"
+        : "single";
+
+  return {
+    v: LAST_SIMULATION_VERSION,
+    waypoints: parsed.waypoints,
+    archetype: parsed.archetype,
+    configFingerprint:
+      typeof parsed.configFingerprint === "string" ? parsed.configFingerprint : undefined,
+    mode,
+    single,
+    compare,
+    cachedAt: parsed.cachedAt,
+  };
+}
+
+/**
+ * Trim a simulation until it fits the budget, in three steps that each cost
+ * strictly more than the one before:
+ *
+ * 1. keep at most MAX_WINDOWS windows;
+ * 2. still over MAX_BYTES: strip the per-window `passage` / `complexity_full`.
+ *    Drill-down then re-fetches, which is exactly the fallback
+ *    `handleWindowSelect` already ships for older server deployments;
+ * 3. still over MAX_BYTES: drop the compare block entirely, keeping `single`.
+ *
+ * Until now an oversized payload simply threw QuotaExceededError, and the
+ * whole cache, single-mode result included, was silently not written.
+ */
+function fitToBudget(sim: LastSimulation): string {
+  let out = sim;
+  if (out.compare && out.compare.windows.length > MAX_WINDOWS) {
+    out = {
+      ...out,
+      compare: { ...out.compare, windows: out.compare.windows.slice(0, MAX_WINDOWS) },
+    };
+  }
+  let json = JSON.stringify(out);
+  if (json.length <= MAX_BYTES || !out.compare) return json;
+
+  out = {
+    ...out,
+    compare: {
+      ...out.compare,
+      windows: out.compare.windows.map((w) => {
+        const light: PassageWindow = { ...w };
+        delete light.passage;
+        delete light.complexity_full;
+        return light;
+      }),
+    },
+  };
+  json = JSON.stringify(out);
+  if (json.length <= MAX_BYTES) return json;
+
+  return JSON.stringify({ ...out, compare: undefined });
+}
+
 export function saveLastSimulation(sim: LastSimulation): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(sim));
+    localStorage.setItem(
+      LAST_SIMULATION_KEY,
+      fitToBudget({ ...sim, v: LAST_SIMULATION_VERSION }),
+    );
   } catch {
     // localStorage unavailable / full — silently skip; next load just won't
     // restore. Better than crashing the success path.
@@ -56,17 +269,8 @@ export function saveLastSimulation(sim: LastSimulation): void {
 
 export function loadLastSimulation(): LastSimulation | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as LastSimulation;
-    // Caches written before `mode` existed default to single — that's the
-    // mode the user was last looking at if their cache only has `single`,
-    // and a safe fallback if it has `compare` (the table reappears as soon
-    // as they toggle, no data lost).
-    if (parsed.mode !== "single" && parsed.mode !== "compare") {
-      parsed.mode = parsed.compare && !parsed.single ? "compare" : "single";
-    }
-    return parsed;
+    const raw = localStorage.getItem(LAST_SIMULATION_KEY);
+    return raw ? parseLastSimulation(raw) : null;
   } catch {
     return null;
   }
@@ -74,11 +278,15 @@ export function loadLastSimulation(): LastSimulation | null {
 
 export function clearLastSimulation(): void {
   try {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(LAST_SIMULATION_KEY);
   } catch {
     // best-effort
   }
 }
+
+/** Budget constants, exported so the tests describe the contract instead of
+    re-encoding the magic numbers next to it. */
+export const LAST_SIMULATION_LIMITS = { MAX_WINDOWS, MAX_BYTES } as const;
 
 // Tolerance ~10 m at typical latitudes — accounts for floating-point round-trip
 // through the URL. Tighter than human eyeball precision, looser than IEEE bits.

--- a/packages/web/src/plan/session/initial.test.ts
+++ b/packages/web/src/plan/session/initial.test.ts
@@ -119,7 +119,7 @@ function resolve(over: Partial<InitialSessionInput> = {}, polar?: PolarConfig) {
   });
 }
 
-describe("resolveInitialSession — route precedence", () => {
+describe("resolveInitialSession: route precedence", () => {
   it.each([
     [
       "draft over URL and cache",
@@ -159,7 +159,7 @@ describe("resolveInitialSession — route precedence", () => {
   });
 });
 
-describe("resolveInitialSession — boat precedence", () => {
+describe("resolveInitialSession: boat precedence", () => {
   const customized: PolarConfig = { ...defaultPolarConfig(), base: "racer_40ft", spi: "asymmetric" };
 
   it.each([
@@ -196,7 +196,7 @@ describe("resolveInitialSession — boat precedence", () => {
   });
 });
 
-describe("resolveInitialSession — departure precedence and freshness", () => {
+describe("resolveInitialSession: departure precedence and freshness", () => {
   it.each([
     ["the draft", { draft: draft({ departure: "2026-09-11T09:00" }) }, "2026-09-11T09:00", "draft"],
     [
@@ -252,7 +252,7 @@ describe("resolveInitialSession — departure precedence and freshness", () => {
   });
 });
 
-describe("resolveInitialSession — mode and staleness", () => {
+describe("resolveInitialSession: mode and staleness", () => {
   it("opens on the drafted mode, then the cached one, then single", () => {
     expect(resolve({ draft: draft({ mode: "compare" }) }).mode).toBe("compare");
     expect(resolve({ cache: cache({ mode: "compare" }) }).mode).toBe("compare");
@@ -279,7 +279,7 @@ describe("resolveInitialSession — mode and staleness", () => {
   });
 });
 
-describe("resolveInitialSession — restoring results from the URL (path A)", () => {
+describe("resolveInitialSession: restoring results from the URL (path A)", () => {
   const url = parsePlanUrl(
     `?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=${FUTURE}&archetype=cruiser_30ft`,
   );
@@ -334,7 +334,7 @@ describe("resolveInitialSession — restoring results from the URL (path A)", ()
   });
 });
 
-describe("resolveInitialSession — restoring results from the cache (path B)", () => {
+describe("resolveInitialSession: restoring results from the cache (path B)", () => {
   it("restores and rewrites the address bar without touching the network", () => {
     const s = resolve({ cache: cache({ compare: compareBlock() }) });
     expect(s.passage?.distance_nm).toBe(55);
@@ -370,7 +370,7 @@ describe("resolveInitialSession — restoring results from the cache (path B)", 
   });
 });
 
-describe("resolveInitialSession — malformed URL", () => {
+describe("resolveInitialSession: malformed URL", () => {
   it("reports the parse error and still seeds from the cache", () => {
     const s = resolve({ url: parsePlanUrl("?wpts=nope;nope"), cache: cache() });
     expect(s.urlError).toMatch(/Waypoints invalides/);

--- a/packages/web/src/plan/session/initial.test.ts
+++ b/packages/web/src/plan/session/initial.test.ts
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveInitialSession,
+  tomorrowRoundedLocal,
+  defaultSweepLatest,
+  toNaiveLocal,
+  type InitialSessionInput,
+} from "./initial";
+import { parsePlanUrl } from "../parseUrl";
+import type { PlanDraft } from "../draft";
+import type { LastSimulation } from "../lastSimulation";
+import type { PassageReport, ComplexityScore, PassageWindow } from "../types";
+import { defaultPolarConfig, type PolarConfig } from "../../config/polarConfig";
+
+// Fixed clock, well before every timestamp below unless stated otherwise.
+const NOW = new Date("2026-09-02T10:00:00").getTime();
+const FUTURE = "2026-09-10T08:00";
+const PAST = "2026-01-01T08:00";
+const FINGERPRINT = "arome|cruiser_30ft||c0.75";
+
+const MARSEILLE: [number, number] = [43.29, 5.37];
+const PORQUEROLLES: [number, number] = [43.0, 6.2];
+const TOULON: [number, number] = [43.1, 5.93];
+
+const passage = (): PassageReport => ({
+  archetype: "cruiser_30ft",
+  departure_time: "2026-09-10T08:00:00+02:00",
+  arrival_time: "2026-09-10T18:00:00+02:00",
+  duration_h: 10,
+  distance_nm: 55,
+  efficiency: 0.75,
+  model: "meteofrance_arome_france_hd",
+  segments: [],
+  warnings: [],
+});
+
+const complexity = (): ComplexityScore => ({
+  level: 2,
+  label: "Modéré",
+  wind_level: 2,
+  wind_label: "Modéré",
+  sea_level: 1,
+  sea_label: "Calme",
+  tws_max_kn: 14,
+  hs_max_m: 0.8,
+  rationale: "",
+});
+
+const aWindow = (): PassageWindow => ({
+  departure: "2026-09-10T08:00:00+02:00",
+  arrival: "2026-09-10T18:00:00+02:00",
+  duration_h: 10,
+  distance_nm: 55,
+  complexity: { level: 2, label: "Modéré", tws_max_kn: 14, rationale: "" },
+  conditions_summary: {
+    tws_min_kn: 8,
+    tws_max_kn: 14,
+    predominant_sail_angle: "largue",
+    hs_min_m: 0.3,
+    hs_max_m: 0.8,
+  },
+  warnings: [],
+});
+
+const cache = (over: Partial<LastSimulation> = {}): LastSimulation => ({
+  v: 1,
+  waypoints: [MARSEILLE, PORQUEROLLES],
+  archetype: "cruiser_30ft",
+  configFingerprint: FINGERPRINT,
+  mode: "single",
+  single: {
+    departure: FUTURE,
+    passage: passage(),
+    complexity: complexity(),
+    forecastUpdatedAt: "2026-09-02T06:00:00Z",
+  },
+  cachedAt: NOW - 3600_000,
+  ...over,
+});
+
+const compareBlock = (over: Partial<NonNullable<LastSimulation["compare"]>> = {}) => ({
+  sweepEarliest: "2026-09-11T06:00",
+  sweepLatest: "2026-09-13T06:00",
+  sweepIntervalHours: 6,
+  windows: [aWindow()],
+  metaWarnings: ["modèle dégradé"],
+  forecastUpdatedAt: "2026-09-02T05:00:00Z",
+  ...over,
+});
+
+const draft = (over: Partial<PlanDraft> = {}): PlanDraft => ({
+  waypoints: [TOULON, PORQUEROLLES],
+  departure: FUTURE,
+  timeAnchor: "departure",
+  archetype: "racer_35ft",
+  mode: "compare",
+  sweepEarliest: "2026-09-12T06:00",
+  sweepLatest: "2026-09-14T06:00",
+  sweepIntervalHours: 2,
+  savedAt: NOW - 60_000,
+  ...over,
+});
+
+const wptsParam = (wpts: [number, number][]) =>
+  wpts.map(([lat, lon]) => `${lat.toFixed(5)},${lon.toFixed(5)}`).join(";");
+
+function resolve(over: Partial<InitialSessionInput> = {}, polar?: PolarConfig) {
+  return resolveInitialSession({
+    url: parsePlanUrl(""),
+    draft: null,
+    cache: null,
+    polarConfig: polar ?? defaultPolarConfig(),
+    configFingerprint: FINGERPRINT,
+    now: NOW,
+    ...over,
+  });
+}
+
+describe("resolveInitialSession — route precedence", () => {
+  it.each([
+    [
+      "draft over URL and cache",
+      { draft: draft(), url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}`), cache: cache() },
+      "draft",
+      [TOULON, PORQUEROLLES],
+    ],
+    [
+      "URL over cache",
+      { url: parsePlanUrl(`?wpts=${wptsParam([TOULON, PORQUEROLLES])}`), cache: cache() },
+      "url",
+      [TOULON, PORQUEROLLES],
+    ],
+    ["cache when the URL is silent", { cache: cache() }, "cache", [MARSEILLE, PORQUEROLLES]],
+    ["nothing at all", {}, "none", []],
+  ])("takes %s", (_label, input, source, waypoints) => {
+    const s = resolve(input);
+    expect(s.sources.route).toBe(source);
+    // The URL rounds to 5 decimals, so compare on that precision.
+    expect(s.waypoints.map(([a, b]) => [+a.toFixed(5), +b.toFixed(5)])).toEqual(waypoints);
+  });
+
+  it("ignores a URL carrying a single waypoint, and falls back to the cache", () => {
+    const s = resolve({
+      url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE])}`),
+      cache: cache(),
+    });
+    // One waypoint is a parse error, so nothing usable comes out of the URL.
+    expect(s.urlError).not.toBeNull();
+    expect(s.sources.route).toBe("cache");
+  });
+
+  it("ignores a cache holding fewer than two waypoints", () => {
+    const s = resolve({ cache: cache({ waypoints: [MARSEILLE] }) });
+    expect(s.sources.route).toBe("none");
+    expect(s.waypoints).toEqual([]);
+  });
+});
+
+describe("resolveInitialSession — boat precedence", () => {
+  const customized: PolarConfig = { ...defaultPolarConfig(), base: "racer_40ft", spi: "asymmetric" };
+
+  it.each([
+    [
+      "a customized polar over everything",
+      customized,
+      { url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft`), cache: cache() },
+      "racer_40ft",
+      "polar",
+    ],
+    [
+      "the draft over the URL",
+      undefined,
+      {
+        draft: draft(),
+        url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft`),
+      },
+      "racer_35ft",
+      "draft",
+    ],
+    [
+      "the URL over the cache",
+      undefined,
+      { url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft`), cache: cache() },
+      "cata_38ft",
+      "url",
+    ],
+    ["the cache over the default", undefined, { cache: cache({ archetype: "cata_38ft" }) }, "cata_38ft", "cache"],
+    ["the /config default", undefined, {}, "cruiser_30ft", "default"],
+  ])("takes %s", (_label, polar, input, slug, source) => {
+    const s = resolve(input, polar);
+    expect(s.archetype).toBe(slug);
+    expect(s.sources.boat).toBe(source);
+  });
+});
+
+describe("resolveInitialSession — departure precedence and freshness", () => {
+  it.each([
+    ["the draft", { draft: draft({ departure: "2026-09-11T09:00" }) }, "2026-09-11T09:00", "draft"],
+    [
+      "the URL",
+      { url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=2026-09-12T07:00`) },
+      "2026-09-12T07:00",
+      "url",
+    ],
+    ["the cached single-mode run", { cache: cache() }, FUTURE, "cache"],
+    [
+      "the cached sweep start when there is no single run",
+      { cache: cache({ single: undefined, mode: "compare", compare: compareBlock() }) },
+      "2026-09-11T06:00",
+      "cache",
+    ],
+  ])("takes %s", (_label, input, departure, source) => {
+    const s = resolve(input);
+    expect(s.departure).toBe(departure);
+    expect(s.sources.departure).toBe(source);
+  });
+
+  it.each([
+    ["a draft left overnight", { draft: draft({ departure: PAST }) }],
+    [
+      "a bookmarked link from last winter",
+      { url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=${PAST}`) },
+    ],
+    ["an expired cache", { cache: cache({ single: undefined, mode: "compare", compare: compareBlock({ sweepEarliest: PAST }) }) }],
+  ])("falls back to tomorrow rather than seeding a past departure from %s", (_label, input) => {
+    const s = resolve(input);
+    expect(s.departure).toBe(tomorrowRoundedLocal(NOW));
+    expect(s.sources.departure).toBe("default");
+  });
+
+  it("derives the sweep range from the resolved departure by default", () => {
+    const s = resolve();
+    expect(s.sweepEarliest).toBe(s.departure);
+    expect(s.sweepLatest).toBe(defaultSweepLatest(s.departure));
+    expect(s.sweepIntervalHours).toBe(3);
+  });
+
+  it("prefers the draft sweep, then the cached one", () => {
+    expect(resolve({ draft: draft(), cache: cache({ compare: compareBlock() }) })).toMatchObject({
+      sweepEarliest: "2026-09-12T06:00",
+      sweepLatest: "2026-09-14T06:00",
+      sweepIntervalHours: 2,
+    });
+    expect(resolve({ cache: cache({ compare: compareBlock() }) })).toMatchObject({
+      sweepEarliest: "2026-09-11T06:00",
+      sweepLatest: "2026-09-13T06:00",
+      sweepIntervalHours: 6,
+    });
+  });
+});
+
+describe("resolveInitialSession — mode and staleness", () => {
+  it("opens on the drafted mode, then the cached one, then single", () => {
+    expect(resolve({ draft: draft({ mode: "compare" }) }).mode).toBe("compare");
+    expect(resolve({ cache: cache({ mode: "compare" }) }).mode).toBe("compare");
+    expect(resolve().mode).toBe("single");
+  });
+
+  it("opens stale on a restored draft, and computes nothing", () => {
+    const s = resolve({ draft: draft(), cache: cache() });
+    expect(s.isStale).toBe(true);
+    expect(s.passage).toBeNull();
+    expect(s.windows).toBeNull();
+    expect(s.mount).toEqual({ rewriteUrl: false, fetch: false });
+  });
+
+  it("is not stale when the route came from the URL or the cache", () => {
+    expect(resolve({ cache: cache() }).isStale).toBe(false);
+  });
+
+  it("skips the pick-a-mode step as soon as a route exists", () => {
+    expect(resolve({ cache: cache() }).actionTaken).toBe(true);
+    expect(resolve({ draft: draft() }).actionTaken).toBe(true);
+    expect(resolve({ draft: draft({ waypoints: [TOULON] }) }).actionTaken).toBe(false);
+    expect(resolve().actionTaken).toBe(false);
+  });
+});
+
+describe("resolveInitialSession — restoring results from the URL (path A)", () => {
+  const url = parsePlanUrl(
+    `?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=${FUTURE}&archetype=cruiser_30ft`,
+  );
+
+  it("restores the passage when route, boat, fingerprint and departure all match", () => {
+    const s = resolve({ url, cache: cache() });
+    expect(s.passage?.distance_nm).toBe(55);
+    expect(s.complexity?.level).toBe(2);
+    expect(s.forecastUpdatedAt).toBe("2026-09-02T06:00:00Z");
+    expect(s.mount).toEqual({ rewriteUrl: false, fetch: false });
+  });
+
+  it.each([
+    ["another route", cache({ waypoints: [TOULON, PORQUEROLLES] })],
+    ["another boat", cache({ archetype: "cata_38ft" })],
+    ["another /config fingerprint", cache({ configFingerprint: "gfs|cruiser_30ft||c1" })],
+    ["no fingerprint at all (pre-config era)", cache({ configFingerprint: undefined })],
+  ])("computes instead of restoring a cache about %s", (_label, stale) => {
+    const s = resolve({ url, cache: stale });
+    expect(s.passage).toBeNull();
+    expect(s.mount).toEqual({ rewriteUrl: false, fetch: true });
+  });
+
+  it("restores the sweep table even when the departure does not match", () => {
+    const s = resolve({
+      url,
+      cache: cache({ mode: "compare", single: undefined, compare: compareBlock() }),
+    });
+    expect(s.windows).toHaveLength(1);
+    expect(s.metaWarnings).toEqual(["modèle dégradé"]);
+    // The sweep's own stamp is used when no single-mode block was restored.
+    expect(s.forecastUpdatedAt).toBe("2026-09-02T05:00:00Z");
+    expect(s.mount.fetch).toBe(false);
+  });
+
+  it("computes when there is no cache at all", () => {
+    expect(resolve({ url }).mount).toEqual({ rewriteUrl: false, fetch: true });
+  });
+
+  it("keeps the historic quirk: a matching cache whose single departure differs restores nothing and computes nothing", () => {
+    const s = resolve({
+      url: parsePlanUrl(
+        `?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=${PAST}&archetype=cruiser_30ft`,
+      ),
+      cache: cache({ single: { ...cache().single!, departure: PAST } }),
+    });
+    // The URL departure has passed, so the slider falls back to tomorrow and
+    // no longer lines up with the cached run.
+    expect(s.departure).toBe(tomorrowRoundedLocal(NOW));
+    expect(s.passage).toBeNull();
+    expect(s.mount).toEqual({ rewriteUrl: false, fetch: false });
+  });
+});
+
+describe("resolveInitialSession — restoring results from the cache (path B)", () => {
+  it("restores and rewrites the address bar without touching the network", () => {
+    const s = resolve({ cache: cache({ compare: compareBlock() }) });
+    expect(s.passage?.distance_nm).toBe(55);
+    expect(s.windows).toHaveLength(1);
+    expect(s.forecastUpdatedAt).toBe("2026-09-02T06:00:00Z");
+    expect(s.mount).toEqual({ rewriteUrl: true, fetch: false });
+  });
+
+  it.each([
+    ["the /config fingerprint moved", cache({ configFingerprint: "gfs|cruiser_30ft||c1" })],
+    ["the customized polar re-pinned the boat", cache({ archetype: "cata_38ft" })],
+  ])("recomputes when %s, keeping the route seeded", (_label, stale) => {
+    const polar: PolarConfig = { ...defaultPolarConfig(), base: "cruiser_30ft", spi: "asymmetric" };
+    const s = resolveInitialSession({
+      url: parsePlanUrl(""),
+      draft: null,
+      cache: stale,
+      polarConfig: polar,
+      configFingerprint: FINGERPRINT,
+      now: NOW,
+    });
+    expect(s.waypoints).toHaveLength(2);
+    expect(s.passage).toBeNull();
+    expect(s.mount).toEqual({ rewriteUrl: true, fetch: true });
+  });
+
+  it("does not require the departure to match, unlike path A", () => {
+    const s = resolve({
+      cache: cache({ single: { ...cache().single!, departure: PAST } }),
+    });
+    expect(s.departure).toBe(tomorrowRoundedLocal(NOW));
+    expect(s.passage?.distance_nm).toBe(55);
+  });
+});
+
+describe("resolveInitialSession — malformed URL", () => {
+  it("reports the parse error and still seeds from the cache", () => {
+    const s = resolve({ url: parsePlanUrl("?wpts=nope;nope"), cache: cache() });
+    expect(s.urlError).toMatch(/Waypoints invalides/);
+    expect(s.sources.route).toBe("cache");
+  });
+
+  it("carries the map centre hint through", () => {
+    expect(resolve({ url: parsePlanUrl("?center=43.29,5.37") }).center).toEqual([43.29, 5.37]);
+  });
+});
+
+describe("date helpers", () => {
+  it("puts tomorrow's default on the hour, same hour as now", () => {
+    const d = new Date("2026-09-02T10:37:42");
+    expect(tomorrowRoundedLocal(d.getTime())).toBe("2026-09-03T10:00");
+  });
+
+  it("ends a default sweep two days after its start", () => {
+    expect(defaultSweepLatest("2026-09-03T10:00")).toBe("2026-09-05T10:00");
+  });
+
+  it("formats a Date as the naive local string the slider and the URL share", () => {
+    expect(toNaiveLocal(new Date("2026-01-05T07:04:00"))).toBe("2026-01-05T07:04");
+  });
+});

--- a/packages/web/src/plan/session/initial.ts
+++ b/packages/web/src/plan/session/initial.ts
@@ -253,13 +253,13 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
 
   // ── results ────────────────────────────────────────────────────────────────
 
-  // Path 0 — a draft was restored: it is this tab's most recent state, and by
+  // Path 0, a draft was restored. It is this tab's most recent state, and by
   // definition it has no results yet. Hydrating the URL's or the cache's
   // results on top would show a passage that does not match the route on
   // screen, and computing would spend a request the user did not ask for.
   if (draft) return base;
 
-  // Path A — the URL carries a route: respect it, restore from cache when the
+  // Path A, the URL carries a route. Respect it, restore from cache when the
   // cache is about the same route + boat + preferences, otherwise compute. The
   // boat compared here is the resolved one, not the raw URL slug: a customized
   // polar overrides the URL's boat and the results shown must be the ones
@@ -290,7 +290,7 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
     return { ...base, mount: { rewriteUrl: false, fetch: true } };
   }
 
-  // Path B — the URL is silent and the cache supplied the route: sync the
+  // Path B, the URL is silent and the cache supplied the route. Sync the
   // address bar so reload and share work, and skip the network.
   if (useCachedRoute) {
     // Discard the persisted results and recompute when /config changed since

--- a/packages/web/src/plan/session/initial.ts
+++ b/packages/web/src/plan/session/initial.ts
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * What `/plan` looks like the instant it mounts.
+ *
+ * Three media persist a plan, and each of them used to be consulted from a
+ * different place in `PlanPage`: twenty `useState` initialisers picked the
+ * route, the boat and the departure, then a mount effect went back over the
+ * same three sources to decide whether to restore results, rewrite the URL or
+ * compute. The rules were correct but nowhere written down, `loadLastSimulation`
+ * ran on every render, and none of it was testable. This module is that
+ * decision, once, as a pure function.
+ *
+ * ## The three media
+ *
+ * | Medium | Written when | Lifetime |
+ * |---|---|---|
+ * | `sessionStorage` draft (`plan/draft.ts`) | on every edit, while results are stale | the tab |
+ * | the `/plan` URL | after a successful computation | the link |
+ * | `localStorage` cache (`plan/lastSimulation.ts`) | after a successful computation | the browser |
+ *
+ * ## Precedence
+ *
+ * | Field | Order |
+ * |---|---|
+ * | route (waypoints) | draft > URL (2 points or more) > cache (2 points or more) > empty |
+ * | boat | custom polar (pinned) > draft > URL > cache > /config default |
+ * | departure | draft > URL > cache > tomorrow, same hour, on the hour |
+ * | time anchor | draft > departure |
+ * | mode | draft > cache > single |
+ * | sweep range and step | draft > cache > derived from the departure |
+ *
+ * Two rules cut across the table:
+ *
+ * - **Freshness.** A departure already behind us is never seeded, whatever
+ *   supplied it: a draft left overnight or a bookmarked link from last week
+ *   falls through to the default rather than putting the slider in the past.
+ * - **The cache only speaks when the URL is silent.** The URL carries a route,
+ *   so a link is authoritative over what this browser last computed; the cache
+ *   is then read only to *restore results* for that same route, never to seed
+ *   the route itself.
+ *
+ * ## Restoring results
+ *
+ * Persisted results are handed back only when the cache is about the same
+ * route, the same boat and the same `/config` fingerprint. A departure that
+ * does not match the seeded one keeps the single-mode block out but leaves the
+ * compare table in, since the sweep range is not encoded in the URL.
+ *
+ * ## What the caller still has to do
+ *
+ * `mount.rewriteUrl` and `mount.fetch` say whether the address bar has to be
+ * synced with the restored session and whether a computation is owed. A
+ * restored draft asks for neither: it is by construction the most recent state
+ * and it has no results, so the page opens stale and waits for « Recalculer ».
+ */
+
+import type { ParseResult } from "../parseUrl";
+import { isParsedOk } from "../parseUrl";
+import type { PlanDraft } from "../draft";
+import type { LastSimulation } from "../lastSimulation";
+import { waypointsEqual } from "../lastSimulation";
+import type { PassageReport, ComplexityScore, PassageWindow } from "../types";
+import type { PolarConfig } from "../../config/polarConfig";
+import { initialPlanBoat, isPersoActive } from "../../config/polarConfig";
+import type { TimeAnchor, PlanMode } from "../ModeToggle";
+
+export type RouteSource = "draft" | "url" | "cache" | "none";
+export type BoatSource = "polar" | "draft" | "url" | "cache" | "default";
+export type DepartureSource = "draft" | "url" | "cache" | "default";
+
+export interface InitialSessionInput {
+  /** Result of `parsePlanUrl(location.search)`. An unparseable query string is
+      handled like an empty one for seeding, and reported through `urlError`. */
+  url: ParseResult;
+  /** This tab's uncommitted state, or null. */
+  draft: PlanDraft | null;
+  /** The persisted last simulation, read once. */
+  cache: LastSimulation | null;
+  polarConfig: PolarConfig;
+  /** `activeModels + polarFingerprint` at mount, used to reject results
+      computed under other preferences. */
+  configFingerprint: string;
+  /** Epoch ms. Injected so the freshness rules are testable. */
+  now: number;
+}
+
+export interface InitialSession {
+  waypoints: [number, number][];
+  archetype: string;
+  /** Naive local "YYYY-MM-DDTHH:MM". In arrival mode this is a target ETA. */
+  departure: string;
+  timeAnchor: TimeAnchor;
+  mode: PlanMode;
+  sweepEarliest: string;
+  sweepLatest: string;
+  sweepIntervalHours: number;
+
+  /** Results restored from the cache, all null when nothing was restored. */
+  passage: PassageReport | null;
+  complexity: ComplexityScore | null;
+  windows: PassageWindow[] | null;
+  metaWarnings: string[];
+  forecastUpdatedAt: string | null;
+
+  /** "Edited since the last computation". True for a restored draft. */
+  isStale: boolean;
+  /** Mobile only: skip the compact "pick a mode" step, we already have a route. */
+  actionTaken: boolean;
+
+  /** Map centre hint carried by the home compass FAB. */
+  center: [number, number] | null;
+  /** Non-null when the query string could not be parsed. */
+  urlError: string | null;
+
+  mount: {
+    /** Sync the address bar with the restored session (URL was silent). */
+    rewriteUrl: boolean;
+    /** Nothing usable was restored for this route: compute it. */
+    fetch: boolean;
+  };
+
+  sources: {
+    route: RouteSource;
+    boat: BoatSource;
+    departure: DepartureSource;
+  };
+}
+
+/** "YYYY-MM-DDTHH:MM" in local time, the format the slider and the URL share. */
+export function toNaiveLocal(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Slider lands on J+1 by default: a now-anchored start is rarely what a
+    sailor wants when planning, and the "Maintenant" tick under the slider
+    remains one click away. */
+export function tomorrowRoundedLocal(now: number): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + 1);
+  d.setMinutes(0, 0, 0);
+  return toNaiveLocal(d);
+}
+
+/** Default end of a sweep: two days after its start. */
+export function defaultSweepLatest(departure: string): string {
+  const d = new Date(departure);
+  d.setDate(d.getDate() + 2);
+  return toNaiveLocal(d);
+}
+
+/** A departure is only seeded while it is still ahead of us. */
+function isFuture(value: string | undefined | null, now: number): value is string {
+  return !!value && new Date(value).getTime() >= now;
+}
+
+export function resolveInitialSession(input: InitialSessionInput): InitialSession {
+  const { url, draft, cache, polarConfig, configFingerprint, now } = input;
+
+  const urlOk = isParsedOk(url);
+  const urlWaypoints = urlOk ? url.waypoints : [];
+  const urlHasWaypoints = urlWaypoints.length >= 2;
+
+  // The cache seeds nothing while the URL carries a route: a shared link wins
+  // over what this browser happens to have computed last.
+  const seedCache = urlHasWaypoints ? null : cache;
+  const useCachedRoute = !!(seedCache && seedCache.waypoints.length >= 2);
+
+  // ── route ──────────────────────────────────────────────────────────────────
+  let waypoints: [number, number][] = [];
+  let routeSource: RouteSource = "none";
+  if (draft) {
+    waypoints = draft.waypoints;
+    routeSource = "draft";
+  } else if (urlHasWaypoints) {
+    waypoints = urlWaypoints;
+    routeSource = "url";
+  } else if (useCachedRoute) {
+    waypoints = seedCache.waypoints;
+    routeSource = "cache";
+  }
+
+  // ── boat ───────────────────────────────────────────────────────────────────
+  // A customized polar pins the boat to cfg.base, the hull the tuning was built
+  // on and the one the selector displays, so a stale URL or cache slug from an
+  // earlier session cannot silently re-board the plan on another boat (#220).
+  const draftOrUrlSlug = draft?.archetype ?? (urlOk ? url.archetype : null);
+  const cachedSlug = useCachedRoute ? seedCache.archetype : null;
+  const archetype = initialPlanBoat(polarConfig, draftOrUrlSlug, cachedSlug);
+  const boatSource: BoatSource = isPersoActive(polarConfig)
+    ? "polar"
+    : draftOrUrlSlug
+      ? draft?.archetype
+        ? "draft"
+        : "url"
+      : cachedSlug
+        ? "cache"
+        : "default";
+
+  // ── departure ──────────────────────────────────────────────────────────────
+  // Prefer the single-mode departure, then the sweep's earliest timestamp so a
+  // compare-only cache still seeds the slider.
+  const cachedDeparture = seedCache?.single?.departure ?? seedCache?.compare?.sweepEarliest;
+  let departure: string;
+  let departureSource: DepartureSource;
+  if (isFuture(draft?.departure, now)) {
+    departure = draft.departure;
+    departureSource = "draft";
+  } else if (urlOk && isFuture(url.departure, now)) {
+    departure = url.departure;
+    departureSource = "url";
+  } else if (isFuture(cachedDeparture, now)) {
+    departure = cachedDeparture;
+    departureSource = "cache";
+  } else {
+    departure = tomorrowRoundedLocal(now);
+    departureSource = "default";
+  }
+
+  // ── mode, anchor, sweep ────────────────────────────────────────────────────
+  const timeAnchor: TimeAnchor = draft?.timeAnchor ?? "departure";
+  const mode: PlanMode = draft?.mode ?? seedCache?.mode ?? "single";
+  const sweepEarliest =
+    draft?.sweepEarliest ?? seedCache?.compare?.sweepEarliest ?? departure;
+  const sweepLatest =
+    draft?.sweepLatest ?? seedCache?.compare?.sweepLatest ?? defaultSweepLatest(departure);
+  const sweepIntervalHours =
+    draft?.sweepIntervalHours ?? seedCache?.compare?.sweepIntervalHours ?? 3;
+
+  const base = {
+    waypoints,
+    archetype,
+    departure,
+    timeAnchor,
+    mode,
+    sweepEarliest,
+    sweepLatest,
+    sweepIntervalHours,
+    passage: null,
+    complexity: null,
+    windows: null,
+    metaWarnings: [] as string[],
+    forecastUpdatedAt: null,
+    isStale: draft != null,
+    actionTaken: urlHasWaypoints || useCachedRoute || (draft?.waypoints.length ?? 0) >= 2,
+    center: urlOk ? url.center : null,
+    urlError: urlOk ? null : url.error,
+    mount: { rewriteUrl: false, fetch: false },
+    sources: { route: routeSource, boat: boatSource, departure: departureSource },
+  } satisfies InitialSession;
+
+  // ── results ────────────────────────────────────────────────────────────────
+
+  // Path 0 — a draft was restored: it is this tab's most recent state, and by
+  // definition it has no results yet. Hydrating the URL's or the cache's
+  // results on top would show a passage that does not match the route on
+  // screen, and computing would spend a request the user did not ask for.
+  if (draft) return base;
+
+  // Path A — the URL carries a route: respect it, restore from cache when the
+  // cache is about the same route + boat + preferences, otherwise compute. The
+  // boat compared here is the resolved one, not the raw URL slug: a customized
+  // polar overrides the URL's boat and the results shown must be the ones
+  // computed on the boat the recap displays (#220).
+  if (urlHasWaypoints) {
+    const matches =
+      cache &&
+      waypointsEqual(cache.waypoints, urlWaypoints) &&
+      cache.archetype === archetype &&
+      // Reject the cache if the user tweaked /config since the simulation ran:
+      // the persisted result is stale relative to the active preferences. A
+      // missing fingerprint is a pre-config-era cache and never matches.
+      cache.configFingerprint === configFingerprint;
+    if (matches) {
+      // The single-mode block is restored only when its departure is the one
+      // seeded above: the URL owns the departure here, and showing a passage
+      // computed for another hour under that slider would be a lie. The sweep
+      // table has no such constraint, its range is not encoded in the URL.
+      const restored = restoreFrom(cache, { requireDepartureMatch: departure });
+      // Historic quirk, kept deliberately: a cache holding only a single-mode
+      // result whose departure does not match the seeded one restores nothing
+      // and still does not compute. Reachable by opening an old link whose
+      // departure has passed, since the seeded departure then falls back to
+      // tomorrow. Changing it would fire a computation on mount for a user who
+      // only followed a stale bookmark, so it belongs to its own decision.
+      if (cache.single || cache.compare) return { ...base, ...restored };
+    }
+    return { ...base, mount: { rewriteUrl: false, fetch: true } };
+  }
+
+  // Path B — the URL is silent and the cache supplied the route: sync the
+  // address bar so reload and share work, and skip the network.
+  if (useCachedRoute) {
+    // Discard the persisted results and recompute when /config changed since
+    // the cache was written, or when the cached simulation ran on another boat
+    // than the seeded one (a customized polar re-pins the boat to its base, and
+    // the cached run may predate the fix for #220). Route, boat and departure
+    // stay seeded either way.
+    if (seedCache.configFingerprint !== configFingerprint || seedCache.archetype !== archetype) {
+      return { ...base, mount: { rewriteUrl: true, fetch: true } };
+    }
+    // No departure check here, unlike path A: the departure itself was seeded
+    // from this very cache, and when the cached one has expired the user is
+    // looking at their last plan with a fresh slider under it, which is the
+    // starting point for the recomputation they are about to ask for.
+    return {
+      ...base,
+      ...restoreFrom(seedCache, {}),
+      mount: { rewriteUrl: true, fetch: false },
+    };
+  }
+
+  return base;
+}
+
+/** The subset of the state that comes back from a matching cache. */
+function restoreFrom(
+  cache: LastSimulation,
+  opts: { requireDepartureMatch?: string },
+): Pick<
+  InitialSession,
+  "passage" | "complexity" | "windows" | "metaWarnings" | "forecastUpdatedAt"
+> {
+  const single =
+    cache.single &&
+    (opts.requireDepartureMatch === undefined ||
+      cache.single.departure === opts.requireDepartureMatch)
+      ? cache.single
+      : null;
+  return {
+    passage: single?.passage ?? null,
+    complexity: single?.complexity ?? null,
+    windows: cache.compare?.windows ?? null,
+    metaWarnings: cache.compare?.metaWarnings ?? [],
+    // The single-mode block owns the freshness stamp when it was restored; the
+    // sweep's own stamp is used only when it was not.
+    forecastUpdatedAt:
+      single?.forecastUpdatedAt ?? cache.compare?.forecastUpdatedAt ?? null,
+  };
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { useState, useEffect, useMemo, useRef, useCallback, forwardRef, useImperativeHandle } from "react";
-import { parsePlanUrl, isParsedOk, buildPlanUrl } from "../plan/parseUrl";
+import { parsePlanUrl, buildPlanUrl } from "../plan/parseUrl";
 import { PlanMap, type PlanMapHandle } from "../plan/PlanMap";
 import { PlanSidebar } from "../plan/PlanSidebar";
 import { fetchPassage, fetchPassageByEta, fetchPassageWindows, fetchArchetypes, friendlyError, type PlanOverrides } from "../api/passage";
@@ -17,13 +17,19 @@ import {
   saveLastSimulation,
   clearLastSimulation,
   waypointsEqual,
-  type LastSimulation,
 } from "../plan/lastSimulation";
+import {
+  resolveInitialSession,
+  toNaiveLocal,
+  tomorrowRoundedLocal,
+  defaultSweepLatest,
+  type InitialSession,
+} from "../plan/session/initial";
 import { type TimeAnchor } from "../plan/ModeToggle";
 import { computeLegSegmentRanges } from "../plan/aggregateLegs";
 import { toTzAware } from "../plan/departureTz";
 import { activeModels, loadModelConfig } from "../config/modelConfig";
-import { effectivePolar, initialPlanBoat, isPersoActive, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
+import { effectivePolar, isPersoActive, isPolarCustomized, loadPolarConfig, planEfficiency, polarFingerprint, savePolarConfig } from "../config/polarConfig";
 import { LocateButton } from "../components/LocateButton";
 import { SeamarkButton } from "../components/SeamarkButton";
 import { useSeamarks } from "../hooks/useSeamarks";
@@ -77,20 +83,7 @@ function currentConfigFingerprint(): string {
 // `toTzAware`'s inverse — used to round-trip a server-resolved departure
 // back into the slider/URL format.
 function isoToLocal(iso: string): string {
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-// Slider lands on J+1 by default — a now-anchored start is rarely what a
-// sailor wants when planning, and the "Maintenant" tick under the slider
-// remains one click away.
-function tomorrowRoundedLocal(): string {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  d.setMinutes(0, 0, 0);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return toNaiveLocal(new Date(iso));
 }
 
 function fmtTime(iso: string) {
@@ -432,85 +425,46 @@ export function PlanPage() {
     });
   }, [locate]);
   const drawerRef = useRef<DrawerHandle>(null);
-  const initialParsed = parsePlanUrl(window.location.search);
 
-  // If the URL is empty (typical after a /plan FAB click from the home page),
-  // fall back to the cached last simulation so the user lands back on their
-  // route + archetype + departure instead of an empty plan. Captured once at
-  // mount so all useState initializers see the same snapshot.
-  const urlHasWaypoints = isParsedOk(initialParsed) && initialParsed.waypoints.length >= 2;
-  const cachedAtMount = !urlHasWaypoints ? loadLastSimulation() : null;
-  const useCachedRoute = !!(cachedAtMount && cachedAtMount.waypoints.length >= 2);
-  // Uncommitted state of THIS tab, if any. It outranks both the URL and the
-  // cache because both are written only after a successful computation, so a
-  // draft is by construction the more recent of the three. Read once at mount.
-  const [draftAtMount] = useState(loadPlanDraft);
+  // Everything the three persistence media (this tab's draft, the URL, the
+  // cached last simulation) have to say about the page, decided once, in one
+  // pure place. `plan/session/initial.ts` carries the precedence table and the
+  // freshness rules; here we only spread the answer into React state.
+  const [initial] = useState<InitialSession>(() =>
+    resolveInitialSession({
+      url: parsePlanUrl(window.location.search),
+      draft: loadPlanDraft(),
+      cache: loadLastSimulation(),
+      polarConfig: loadPolarConfig(),
+      configFingerprint: currentConfigFingerprint(),
+      now: Date.now(),
+    }),
+  );
 
-  const [waypoints, setWaypoints] = useState<[number, number][]>(() => {
-    if (draftAtMount) return draftAtMount.waypoints;
-    if (urlHasWaypoints) return (initialParsed as { waypoints: [number, number][] }).waypoints;
-    if (useCachedRoute) return cachedAtMount!.waypoints;
-    return [];
-  });
+  const [waypoints, setWaypoints] = useState<[number, number][]>(initial.waypoints);
   const waypointDepths = useWaypointDepths(waypoints);
-  const [archetype, setArchetype] = useState(() =>
-    // A customized polar pins the boat to cfg.base — the hull the tuning was
-    // built on and the one the selector displays — so a stale URL/cache slug
-    // from an earlier session can't silently re-board the plan on another
-    // boat (#220). Otherwise: URL, then cache, then the /config default.
-    initialPlanBoat(
-      loadPolarConfig(),
-      draftAtMount?.archetype ?? (isParsedOk(initialParsed) ? initialParsed.archetype : null),
-      useCachedRoute ? cachedAtMount!.archetype : null,
-    ),
-  );
-  const [departure, setDeparture] = useState(() => {
-    // Same freshness rule as the URL below: a draft left overnight must not
-    // seed the slider with a departure that is already behind us.
-    const drafted = draftAtMount?.departure;
-    if (drafted && new Date(drafted) >= new Date()) return drafted;
-    const raw = isParsedOk(initialParsed) ? initialParsed.departure : "";
-    if (raw && new Date(raw) >= new Date()) return raw;
-    // Try cache: prefer the single-mode departure, then fall back to the
-    // sweep's earliest timestamp so compare-only caches still seed the slider.
-    const cachedDep =
-      cachedAtMount?.single?.departure ?? cachedAtMount?.compare?.sweepEarliest;
-    if (cachedDep && new Date(cachedDep) >= new Date()) return cachedDep;
-    return tomorrowRoundedLocal();
-  });
-  const [timeAnchor, setTimeAnchor] = useState<TimeAnchor>(
-    () => draftAtMount?.timeAnchor ?? "departure",
-  );
+  const [archetype, setArchetype] = useState(initial.archetype);
+  const [departure, setDeparture] = useState(initial.departure);
+  const [timeAnchor, setTimeAnchor] = useState<TimeAnchor>(initial.timeAnchor);
 
-  const [passage, setPassage] = useState<PassageReport | null>(null);
-  const [complexity, setComplexity] = useState<ComplexityScore | null>(null);
+  const [passage, setPassage] = useState<PassageReport | null>(initial.passage);
+  const [complexity, setComplexity] = useState<ComplexityScore | null>(initial.complexity);
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [archetypes, setArchetypes] = useState<Archetype[]>([]);
-  const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(null);
+  const [forecastUpdatedAt, setForecastUpdatedAt] = useState<string | null>(
+    initial.forecastUpdatedAt,
+  );
   // "Edits not yet computed". A restored draft is exactly that, so it starts
   // the page stale: the sidebar offers Recalculer instead of pretending the
   // route on screen has results behind it.
-  const [isStale, setIsStale] = useState(() => draftAtMount != null);
+  const [isStale, setIsStale] = useState(initial.isStale);
 
   // Compare-windows mode (lifted from PlanSidebar in step 2)
-  const [planMode, setPlanMode] = useState<"single" | "compare">(
-    () => draftAtMount?.mode ?? cachedAtMount?.mode ?? "single",
-  );
-  const [sweepEarliest, setSweepEarliest] = useState(
-    () => draftAtMount?.sweepEarliest ?? cachedAtMount?.compare?.sweepEarliest ?? departure,
-  );
-  const [sweepLatest, setSweepLatest] = useState(() => {
-    if (draftAtMount?.sweepLatest) return draftAtMount.sweepLatest;
-    if (cachedAtMount?.compare?.sweepLatest) return cachedAtMount.compare.sweepLatest;
-    const d = new Date(departure);
-    d.setDate(d.getDate() + 2);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  });
-  const [sweepInterval, setSweepInterval] = useState<number>(
-    () => draftAtMount?.sweepIntervalHours ?? cachedAtMount?.compare?.sweepIntervalHours ?? 3,
-  );
+  const [planMode, setPlanMode] = useState<"single" | "compare">(initial.mode);
+  const [sweepEarliest, setSweepEarliest] = useState(initial.sweepEarliest);
+  const [sweepLatest, setSweepLatest] = useState(initial.sweepLatest);
+  const [sweepInterval, setSweepInterval] = useState<number>(initial.sweepIntervalHours);
   // Selected leg for the sidebar's expanded "Comment c'est calculé" — also
   // drives the highlight overlay on the map. Cleared whenever the route or
   // its segments change so we never highlight stale ranges.
@@ -519,16 +473,14 @@ export function PlanPage() {
   // Back collapses the open leg rather than leaving the planner (issue #300).
   const collapseLeg = useCallback(() => setSelectedLegIdx(null), []);
   useBackDismiss(selectedLegIdx !== null, collapseLeg);
-  const [windows, setWindows] = useState<PassageWindow[] | null>(null);
-  const [metaWarnings, setMetaWarnings] = useState<string[]>([]);
+  const [windows, setWindows] = useState<PassageWindow[] | null>(initial.windows);
+  const [metaWarnings, setMetaWarnings] = useState<string[]>(initial.metaWarnings);
   // Compact "pick a mode" state on mobile: drops the sidebar to just the
   // mode pills + reset button (and shrinks the bottom drawer) until the
   // user actively confirms their mode choice. Initialised true when we
   // already have a route to display (cached / URL) so reload doesn't hide
   // the user's previous context.
-  const [actionTaken, setActionTaken] = useState<boolean>(
-    () => urlHasWaypoints || useCachedRoute || (draftAtMount?.waypoints.length ?? 0) >= 2,
-  );
+  const [actionTaken, setActionTaken] = useState<boolean>(initial.actionTaken);
   // Reset to compact whenever the user drops back below 2 waypoints so the
   // next time they reach 2 they get the pick-a-mode step again.
   useEffect(() => {
@@ -660,80 +612,20 @@ export function PlanPage() {
     sweepInterval,
   ]);
 
+  // Everything the resolved session could seed synchronously already is, in
+  // the initializers above. What is left needs the outside world: syncing the
+  // address bar when the cache supplied the route (so reload and share work),
+  // and computing when nothing usable could be restored.
   useEffect(() => {
-    // Path 0 — a draft was restored: it is this tab's most recent state, and
-    // by definition it has no results yet. Seeding already happened in the
-    // initializers above; hydrating the URL's or the cache's results on top
-    // would show a passage that does not match the route on screen, and
-    // fetching would spend a computation the user did not ask for.
-    if (draftAtMount) return;
-
-    // Path A — URL has waypoints: respect the URL, restore from cache if it
-    // matches the same route + boat, otherwise fetch fresh. The boat is the
-    // seeded `archetype` state, not the raw URL slug: a customized polar
-    // overrides the URL's boat (see initialPlanBoat), and the results shown
-    // must be the ones computed on the boat the recap displays (#220).
-    if (urlHasWaypoints) {
-      const cached: LastSimulation | null = loadLastSimulation();
-      const cacheMatches =
-        cached &&
-        waypointsEqual(cached.waypoints, initialParsed.waypoints) &&
-        cached.archetype === archetype &&
-        // Reject the cache if the user tweaked /config since the simulation
-        // ran — the persisted result is stale relative to the active
-        // preferences. Treat missing fingerprint as "pre-config-era" cache.
-        cached.configFingerprint === currentConfigFingerprint();
-      if (cacheMatches) {
-        if (cached.single && cached.single.departure === departure) {
-          setPassage(cached.single.passage);
-          setComplexity(cached.single.complexity);
-          setForecastUpdatedAt(cached.single.forecastUpdatedAt);
-        }
-        // Always restore compare-mode windows + sweep params if present —
-        // sweep range isn't encoded in the URL, so we trust the cache.
-        if (cached.compare) {
-          setWindows(cached.compare.windows);
-          setMetaWarnings(cached.compare.metaWarnings);
-          if (!cached.single || cached.single.departure !== departure) {
-            setForecastUpdatedAt(cached.compare.forecastUpdatedAt);
-          }
-        }
-        if (cached.single || cached.compare) return;
-      }
-      doFetch(initialParsed.waypoints, archetype, departure);
-      return;
+    if (initial.mount.rewriteUrl) {
+      window.history.replaceState(
+        null,
+        "",
+        buildPlanUrl(initial.waypoints, initial.departure, initial.archetype),
+      );
     }
-
-    // Path B — URL is empty: state was already seeded from cache by the
-    // useState initializers above. Hydrate the simulation results, sync the
-    // URL so reload/share works, and skip any network call.
-    if (useCachedRoute && cachedAtMount) {
-      const url = buildPlanUrl(cachedAtMount.waypoints, departure, archetype);
-      window.history.replaceState(null, "", url);
-      // Discard the persisted results and refetch when /config changed since
-      // the cache was written, or when the cached simulation ran on another
-      // boat than the seeded one (a customized polar re-pins the boat to its
-      // base — the cached run may predate the fix for #220). Route + boat +
-      // departure remain seeded.
-      if (
-        cachedAtMount.configFingerprint !== currentConfigFingerprint() ||
-        cachedAtMount.archetype !== archetype
-      ) {
-        doFetch(cachedAtMount.waypoints, archetype, departure);
-        return;
-      }
-      if (cachedAtMount.single) {
-        setPassage(cachedAtMount.single.passage);
-        setComplexity(cachedAtMount.single.complexity);
-        setForecastUpdatedAt(cachedAtMount.single.forecastUpdatedAt);
-      }
-      if (cachedAtMount.compare) {
-        setWindows(cachedAtMount.compare.windows);
-        setMetaWarnings(cachedAtMount.compare.metaWarnings);
-        if (!cachedAtMount.single) {
-          setForecastUpdatedAt(cachedAtMount.compare.forecastUpdatedAt);
-        }
-      }
+    if (initial.mount.fetch) {
+      doFetch(initial.waypoints, initial.archetype, initial.departure);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -875,13 +767,10 @@ export function PlanPage() {
     setPlanMode("single");
     setTimeAnchor("departure");
     setArchetype(loadPolarConfig().base);
-    const dep = tomorrowRoundedLocal();
+    const dep = tomorrowRoundedLocal(Date.now());
     setDeparture(dep);
     setSweepEarliest(dep);
-    const d = new Date(dep);
-    d.setDate(d.getDate() + 2);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    setSweepLatest(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`);
+    setSweepLatest(defaultSweepLatest(dep));
     setSweepInterval(3);
     window.history.replaceState(null, "", "/plan");
   }
@@ -905,9 +794,7 @@ export function PlanPage() {
   // Fallback: older HF Space deployments don't include those fields → call
   // doFetch as before so the UX still works during deployment lag.
   function handleWindowSelect(w: PassageWindow) {
-    const d = new Date(w.departure);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    const naiveDep = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    const naiveDep = toNaiveLocal(new Date(w.departure));
 
     setPlanMode("single");
     setDeparture(naiveDep);
@@ -955,7 +842,7 @@ export function PlanPage() {
     }
   }
 
-  if (!isParsedOk(initialParsed)) {
+  if (initial.urlError !== null) {
     return (
       <div
         className="h-dvh flex flex-col items-center justify-center px-6"
@@ -964,7 +851,7 @@ export function PlanPage() {
         <div className="max-w-sm text-center space-y-4">
           <p className="text-4xl">⚓</p>
           <h1 className="text-xl font-bold">URL invalide</h1>
-          <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>{initialParsed.error}</p>
+          <p className="text-sm leading-relaxed" style={{ color: "var(--ow-fg-1)" }}>{initial.urlError}</p>
           <a
             href={`/${mapViewQuery(mapView)}`}
             className="inline-block mt-4 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
@@ -1049,7 +936,7 @@ export function PlanPage() {
             onWptAdd={waypoints.length >= 2 ? handleWptAdd : undefined}
             onWptDelete={handleWptDelete}
             onMapClick={handleMapClick}
-            initialCenter={isParsedOk(initialParsed) ? initialParsed.center : null}
+            initialCenter={initial.center}
             userPosition={userPosition}
             onViewChange={onViewChange}
             initialZoom={handedView?.zoom ?? null}

--- a/packages/web/src/test/setupDom.ts
+++ b/packages/web/src/test/setupDom.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Setup shared by every jsdom test (the `dom` project of `vitest.config.ts`).
+ *
+ * Testing Library unmounts its containers automatically only when the test
+ * globals are injected (`test.globals: true`). We import `describe`/`it`/
+ * `expect` explicitly everywhere, so the hook has to be registered by hand:
+ * without it, each test leaves its tree in `document.body` and the next
+ * `getByRole` sees two copies of the component.
+ */
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/web/tsconfig.node.json
+++ b/packages/web/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Test-only configuration, kept out of `vite.config.ts` on purpose.
+ *
+ * Vitest picks `vitest.config.ts` over `vite.config.ts` when both exist, and
+ * we merge the build config in so the resolver, the plugins and the aliases
+ * stay bit for bit those of the app. Nothing here reaches a production build.
+ *
+ * Two projects rather than a single environment:
+ *
+ * - `unit` runs every `*.test.ts` in Node, as they always have. They are pure
+ *   modules (parsers, geometry, formatting) and never touch a DOM, so paying
+ *   for a jsdom instance per file would slow the suite down for nothing.
+ * - `dom` runs every `*.test.tsx` in jsdom, for component tests.
+ *
+ * Vitest 4 dropped `environmentMatchGlobs`, and the per-file
+ * `// @vitest-environment jsdom` pragma relies on every author remembering it.
+ * Projects put the rule in the config, where it cannot be forgotten.
+ */
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: "unit",
+            environment: "node",
+            include: ["src/**/*.test.ts"],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: "dom",
+            environment: "jsdom",
+            include: ["src/**/*.test.tsx"],
+            setupFiles: ["./src/test/setupDom.ts"],
+          },
+        },
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
PR 1.2 du lot 1. **Empilée sur #323** (branche `refacto/plan-test-infra`) : à merger après elle, ou rebaser sur `dev` si #323 passe en second.

## Le problème

Trois médias persistent un plan et chacun était consulté depuis un endroit différent de `PlanPage` : une vingtaine d'initialiseurs `useState` choisissaient la route, le bateau et le départ (lignes 441 à 520), puis un effet de montage (607 à 676) repassait sur les mêmes trois sources pour décider s'il fallait restaurer des résultats, réécrire l'URL ou calculer. Les règles étaient justes mais écrites nulle part, `loadLastSimulation()` tournait à chaque render, et rien de tout ça n'était testable.

## `plan/session/initial.ts`

`resolveInitialSession({ url, draft, cache, polarConfig, configFingerprint, now })` rend l'état initial complet : route, bateau, départ, ancrage horaire, mode, paramètres de balayage, résultats restaurés, `isStale`, `actionTaken`, l'erreur d'URL éventuelle, la source retenue pour chaque champ, et ce qu'il reste à faire au montage (`mount.rewriteUrl`, `mount.fetch`).

Le commentaire de module porte la table de précédence :

| Champ | Ordre |
|---|---|
| route | brouillon > URL (2 points ou plus) > cache (2 points ou plus) > vide |
| bateau | polaire perso (épinglée) > brouillon > URL > cache > défaut /config |
| départ | brouillon > URL > cache > demain, même heure, à l'heure ronde |
| ancrage | brouillon > départ |
| mode | brouillon > cache > simple |
| balayage | brouillon > cache > dérivé du départ |

Plus les deux règles transverses : un départ déjà passé n'est jamais réutilisé, quelle qu'en soit la source ; et le cache ne sert à semer la route que quand l'URL se tait (un lien partagé fait autorité), il ne sert plus qu'à restaurer des résultats sinon.

`PlanPage` répand la réponse dans ses `useState` et l'effet de montage se réduit à ce qui touche le monde extérieur. `PlanPage.tsx` : **1147 → 1034 lignes**.

## `plan/lastSimulation.ts`

- champ `v` versionné (absent = payload d'avant la validation, accepté ; version inconnue, donc plus récente, rejetée) ;
- `parseLastSimulation(raw)` défensif sur le modèle de `draft.ts`. Un sous-bloc corrompu est retiré seul : un balayage abîmé ne coûte plus le résultat simple qu'on est en train de regarder ;
- plafond de taille en trois paliers, chacun plus coûteux que le précédent : 48 fenêtres au plus, puis retrait du `passage` / `complexity_full` par fenêtre (le drill-down retombe sur le refetch déjà prévu pour les vieux déploiements), puis abandon complet du balayage au-delà de 500 Ko. Jusqu'ici un payload trop gros levait QuotaExceededError et **rien** n'était écrit, résultat simple compris ;
- clé exportée : `Onboarding.tsx` l'importe au lieu de répéter `"ow_last_simulation_v1"` ;
- lecture unique au montage au lieu d'une lecture par render.

## Tests

63 tests ajoutés, tous en `.test.ts` (pas de DOM nécessaire) :

- `plan/session/initial.test.ts`, 41 tests table-driven : chaque règle de précédence pour la route, le bateau et le départ, la fraîcheur sur les trois sources, mode et staleness, restauration par l'URL (chemin A) et par le cache (chemin B), les quatre motifs de rejet du cache (route, bateau, empreinte différente, empreinte absente), l'URL malformée ;
- `plan/lastSimulation.test.ts`, 22 tests : payloads corrompus (9 formes), payload hérité sans version ni mode, sous-blocs abîmés, les trois paliers du plafond.

## Comportement

Identique, à deux détails près, tous deux vérifiés en preview contre `mcp-dev.ohmywind.fr` :

1. **Les résultats restaurés depuis le cache peignent dès la première frame** au lieu de la seconde. Ils passaient par un `setState` d'effet de montage, ils sont maintenant dans la valeur initiale du `useState`. L'état final est le même, la frame vide intermédiaire disparaît.
2. Le quirk historique du chemin A est **conservé volontairement** et documenté dans le code et par un test : un cache qui correspond mais dont le départ du bloc simple ne correspond pas ne restaure rien et ne calcule rien non plus. Il est atteignable en ouvrant un vieux lien dont le départ est passé. Le corriger déclencherait un calcul au montage pour un utilisateur qui a juste suivi un signet périmé : ça mérite sa propre décision, pas un effet de bord de refacto.

## Vérifications

| | Avant | Après |
|---|---|---|
| `npm run test` | 379 tests | 442 tests, 1,36 s |
| `npm run typecheck` | vert | vert |
| `npm run lint:budget` | 11 / budget 11 | 11 / budget 11 (inchangé, c'est la PR 1.3 qui les enlève) |
| `npm run build` | vert | vert |
| `PlanPage.tsx` | 1147 lignes | 1034 lignes |

Vérification manuelle en preview (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`), un seul calcul consommé :

- lien profond `/plan?wpts=…` : calcule une fois, écrit le cache en `v: 1` ;
- `/plan` nu ensuite : restaure le passage, réécrit la barre d'adresse, zéro requête de calcul (seul `/archetypes` part, comme avant) ;
- le même lien profond rechargé : restaure depuis le cache, zéro requête de calcul ;
- `/plan?wpts=nope;nope` : page « URL invalide » avec le message de `parsePlanUrl` ;
- console propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)