### PR TITLE
fix(web): rend le champ de recherche identifiable

### DIFF
--- a/packages/web/src/components/SpotSearch.tsx
+++ b/packages/web/src/components/SpotSearch.tsx
@@ -27,6 +27,14 @@ const DEBOUNCE_MS = 250;
     for no benefit, since only the recent queries are ever revisited. */
 const CACHE_MAX = 40;
 
+/** Ids of the two halves of the combobox. Fixed rather than derived from
+    useId because the dropdown is portalled to document.body and the outside
+    click handler looks it up by id; a single Header, so a single SpotSearch,
+    is mounted at a time. INPUT_ID also gives the field the `id` that Chrome
+    and Lighthouse ask of every form control. */
+const INPUT_ID = "ow-search-input";
+const LISTBOX_ID = "ow-search-dropdown-portal";
+
 const searchCache = new Map<string, PlaceResult[]>();
 /** Shared empty array: a fresh literal each render would defeat memoization. */
 const NO_RESULTS: PlaceResult[] = [];
@@ -147,7 +155,7 @@ export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: Spot
     function handleClick(e: MouseEvent) {
       const target = e.target as Node;
       if (containerRef.current?.contains(target)) return;
-      const dropdown = document.getElementById("ow-search-dropdown-portal");
+      const dropdown = document.getElementById(LISTBOX_ID);
       if (dropdown?.contains(target)) return;
       setOpen(false);
     }
@@ -189,7 +197,6 @@ export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: Spot
     }
   }
 
-  const listboxId = "ow-search-listbox";
   const showDropdown = open && pos !== null;
 
   return (
@@ -201,9 +208,18 @@ export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: Spot
         </svg>
         <input
           type="text"
+          id={INPUT_ID}
+          name="spot-search"
+          // The suggestion list is ours, rendered below. Without this, naming
+          // the field lets the browser stack its own history dropdown on top
+          // of it.
+          autoComplete="off"
           role="combobox"
           aria-expanded={showDropdown}
-          aria-controls={listboxId}
+          // Used to point at "ow-search-listbox", an id nothing carried, while
+          // the list portalled into document.body is ow-search-dropdown-portal:
+          // the relation was announced to assistive tech and resolved nowhere.
+          aria-controls={LISTBOX_ID}
           aria-autocomplete="list"
           aria-activedescendant={showDropdown && rows[activeIndex] ? `ow-opt-${rows[activeIndex].id}` : undefined}
           aria-label="Rechercher un lieu"
@@ -217,7 +233,7 @@ export function SpotSearch({ onSelect, nearLat, nearLon, savedSpots = [] }: Spot
       </div>
       {showDropdown && createPortal(
         <ul
-          id="ow-search-dropdown-portal"
+          id={LISTBOX_ID}
           role="listbox"
           aria-label="Résultats de recherche"
           className="ow-search-dropdown rounded-xl overflow-hidden animate-fade-in"


### PR DESCRIPTION
Dernier point d'accessibilité relevé à la vérification finale du lot 0, déjà signalé en annexe E.

## Le problème

Chrome affiche « A form field element should have an id or name attribute » dans le panneau Issues à chaque chargement, et Lighthouse le remonte. Le champ de recherche de lieux n'avait ni `id` ni `name`.

## Ce que ça change

Le champ porte désormais `id="ow-search-input"` et `name="spot-search"`, plus `autocomplete="off"`. Ce dernier n'est pas décoratif : nommer un champ suffit à autoriser le navigateur à empiler sa propre liste d'historique par-dessus la liste de suggestions de l'application, ce qui aurait changé le comportement au lieu de le préserver.

L'`aria-label` « Rechercher un lieu » était déjà en place et ne bouge pas. Aucune classe de style n'est touchée.

Au passage, un défaut de câblage du même champ : `aria-controls` désignait `ow-search-listbox`, un identifiant que rien ne portait, alors que la liste rendue par portail dans `document.body` s'appelle `ow-search-dropdown-portal`. La relation était annoncée aux technologies d'assistance et n'aboutissait nulle part. Les deux identifiants viennent maintenant de constantes partagées.

## Avant / après

Build de production servi en local, contexte de navigation neuf.

| Mesure | Avant | Après |
|---|---|---|
| Issues de la console au chargement | 1 (« A form field element should have an id or name attribute ») | 0 |
| `id` du champ | absent | `ow-search-input` |
| `name` du champ | absent | `spot-search` |
| `aria-controls` résout vers un élément | non | oui, vers le `role="listbox"` |
| `aria-activedescendant` | `ow-opt-coords` | `ow-opt-coords` |
| Classes de style | `ow-search-input w-full pl-9 pr-3 py-2.5 min-h-[44px] rounded-xl text-sm transition-all` | identiques |

Comportement vérifié sur ce même build : saisie de « 43.30, 5.35 », la ligne de coordonnées apparaît en tête, les résultats du géocodeur suivent, la sélection referme la liste et remplit le champ. Aucune liste native du navigateur ne se superpose.

Reste au journal réseau une 404 sur `/api/v1/marine/marc/coverage` : le build local pointe vers le Space de prod, qui n'a pas encore l'endpoint livré en #319 sur dev. Sans rapport avec cette PR.

## Vérifications

`npm run typecheck`, `npm run lint:budget` (11 erreurs pour un budget de 11, inchangé), `npm run test` (374 tests) et `npm run build` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
