### PR TITLE
refacto(api): un seul adaptateur marin et un seul jeu d'atlas pour REST et MCP

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -4,10 +4,16 @@ The OhMyWind REST API as a library: a Starlette application, and nothing about
 where it runs.
 
 ```python
-from openwind_api import Settings, create_app
+from openwind_api import Services, Settings, create_app
 
 app = create_app(Settings.from_env())  # REST only
 app = create_app(settings, mcp_app=mounted_mcp)  # REST + an MCP server at "/"
+
+# A deployment that serves both hands the same objects to both shells, so one
+# process holds one HTTP connection pool, one forecast cache and one copy of
+# the tidal atlases.
+services = Services.from_settings(settings)
+app = create_app(settings, mcp_app=build_mcp(services.marine), services=services)
 ```
 
 ## Why it is its own package
@@ -38,7 +44,9 @@ test asserts it by importing the package with the name `mcp` blocked.
 - `routes/`: one module per resource. Handlers stay thin.
 - `parsing.py`: reading an untrusted request, once for both passage routes.
 - `errors.py`: one mapping from exception to `(status, message, code)`.
-- `services.py`: the tidal atlases, loaded once, on `app.state.services`.
+- `services.py`: the tidal atlases and the marine adapter, built once, on
+  `app.state.services`. A request with no `forecast_cache` is planned through
+  that adapter, so a live REST plan reads the same currents as the MCP tools.
 - `security.py`: rate limiting, body ceiling, security headers, client IP.
 - `static/landing.html`: the landing page. Its media ship with the deployment.
 

--- a/packages/api/src/openwind_api/app.py
+++ b/packages/api/src/openwind_api/app.py
@@ -75,13 +75,17 @@ class PathScopedGZipMiddleware:
 
 
 def _lifespan(services: Services, mcp_app: ASGIApp | None):
-    """Warm the atlas coverage, and run the mounted app's own lifespan.
+    """Warm the atlas coverage, run the mounted app's lifespan, close the pool.
 
     FastMCP's session manager is started and stopped by the inner app's
     lifespan, and a parent Starlette does NOT propagate a child's: without
     handing it through here the MCP endpoint answers 500 because the
     streamable-http session manager never initialised. With no ``mcp_app``
     there is nothing to hand through, and the warm-up runs alone.
+
+    The shared HTTP client is closed last. It outlives every request by
+    design, so no request is in a position to close it, and a process that
+    exits without doing so leaves sockets open in the container.
     """
 
     @contextlib.asynccontextmanager
@@ -100,11 +104,17 @@ def _lifespan(services: Services, mcp_app: ASGIApp | None):
             # destroyed but it is pending".
             with contextlib.suppress(asyncio.CancelledError):
                 await warm
+            await services.aclose()
 
     return lifespan
 
 
-def create_app(settings: Settings, mcp_app: ASGIApp | None = None) -> Starlette:
+def create_app(
+    settings: Settings,
+    mcp_app: ASGIApp | None = None,
+    *,
+    services: Services | None = None,
+) -> Starlette:
     """Build the REST application.
 
     Args:
@@ -112,11 +122,19 @@ def create_app(settings: Settings, mcp_app: ASGIApp | None = None) -> Starlette:
         mcp_app: an ASGI app to mount at ``/``, or ``None``. Mounted last so
             the exact-match routes above are tried first: MCP traffic on
             ``/mcp`` is unaffected either way.
+        services: already-built process-wide objects, or ``None`` to build
+            them here. A deployment that also runs an MCP server needs them
+            *before* this call, because the same marine adapter has to reach
+            ``build_server()`` for the two shells to share one cache, one
+            connection pool and one set of atlases. Everyone else leaves it
+            out.
 
     The application keeps its ``Services`` on ``app.state.services``, which is
-    how a handler reaches the atlases and how a test replaces them.
+    how a handler reaches the atlases and the adapter, and how a test replaces
+    them.
     """
-    services = Services.from_settings(settings)
+    if services is None:
+        services = Services.from_settings(settings)
 
     routes = [
         Route("/", index),

--- a/packages/api/src/openwind_api/routes/passage.py
+++ b/packages/api/src/openwind_api/routes/passage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from openwind_data.adapters.base import MarineDataAdapter
 from openwind_data.routing.complexity import score_complexity
 from openwind_data.routing.passage import (
     estimate_passage,
@@ -51,6 +52,22 @@ async def _json_body(request: Request) -> Any:
         raise RequestError("invalid JSON body", "invalid_json") from exc
 
 
+def _adapter(request: Request, parsed: PassageRequest) -> MarineDataAdapter:
+    """Where the weather for this request comes from.
+
+    Two doors, and the request picks which one. A ``forecast_cache`` in the
+    body means the browser already sampled the corridor from its own IP, and
+    reading it back costs no upstream call at all. Without one, the passage is
+    planned live, and it goes through the process-wide adapter: the same
+    connection pool, the same 30 min cache, and the same SHOM > MARC > SMOC
+    cascade the MCP tools use. Until PR 2.3 this branch let the engine build
+    itself a bare ``OpenMeteoAdapter`` instead, so a live REST plan through
+    the Raz de Sein read its currents off an 8 km global model while the
+    identical plan asked over MCP read them off the SHOM atlas (audit M2).
+    """
+    return parsed.adapter or request.app.state.services.marine
+
+
 async def api_passage(request: Request) -> JSONResponse:
     """Plan a passage from a departure time, or sweep a range of them.
 
@@ -61,10 +78,11 @@ async def api_passage(request: Request) -> JSONResponse:
     try:
         body = await _json_body(request)
         departure, parsed = parse_passage_request(body, timestamp_field="departure")
+        adapter = _adapter(request, parsed)
         latest_raw = body.get("latest_departure")
         if latest_raw is not None:
-            return await _sweep(body, departure, parsed, latest_raw)
-        return await _single(departure, parsed)
+            return await _sweep(body, departure, parsed, latest_raw, adapter)
+        return await _single(departure, parsed, adapter)
     except RequestError as exc:
         return exc.response()
 
@@ -81,6 +99,7 @@ async def api_passage_by_eta(request: Request) -> JSONResponse:
     try:
         body = await _json_body(request)
         target_arrival, parsed = parse_passage_request(body, timestamp_field="target_arrival")
+        adapter = _adapter(request, parsed)
     except RequestError as exc:
         return exc.response()
 
@@ -93,7 +112,7 @@ async def api_passage_by_eta(request: Request) -> JSONResponse:
             model="auto",
             polar_override=parsed.polar_override,
             model_chain=parsed.model_chain,
-            adapter=parsed.adapter,
+            adapter=adapter,
         )
     except Exception as exc:
         response = engine_error_response(exc)
@@ -111,7 +130,9 @@ async def api_passage_by_eta(request: Request) -> JSONResponse:
     )
 
 
-async def _single(departure: datetime, parsed: PassageRequest) -> JSONResponse:
+async def _single(
+    departure: datetime, parsed: PassageRequest, adapter: MarineDataAdapter
+) -> JSONResponse:
     try:
         passage = await estimate_passage(
             parsed.waypoints,
@@ -121,7 +142,7 @@ async def _single(departure: datetime, parsed: PassageRequest) -> JSONResponse:
             model="auto",
             polar_override=parsed.polar_override,
             model_chain=parsed.model_chain,
-            adapter=parsed.adapter,
+            adapter=adapter,
         )
     except Exception as exc:
         response = engine_error_response(exc)
@@ -137,7 +158,11 @@ async def _single(departure: datetime, parsed: PassageRequest) -> JSONResponse:
 
 
 async def _sweep(
-    body: Any, departure: datetime, parsed: PassageRequest, latest_raw: Any
+    body: Any,
+    departure: datetime,
+    parsed: PassageRequest,
+    latest_raw: Any,
+    adapter: MarineDataAdapter,
 ) -> JSONResponse:
     latest_departure = parse_timestamp(latest_raw, "latest_departure")
     sweep_interval = parse_sweep_interval(body.get("sweep_interval_hours"))
@@ -155,7 +180,7 @@ async def _sweep(
             model="auto",
             polar_override=parsed.polar_override,
             model_chain=parsed.model_chain,
-            adapter=parsed.adapter,
+            adapter=adapter,
         )
     except Exception as exc:
         response = engine_error_response(exc)

--- a/packages/api/src/openwind_api/services.py
+++ b/packages/api/src/openwind_api/services.py
@@ -12,9 +12,18 @@ process, which the 2026-09 audit filed as M5. This holds one copy, built once
 by ``create_app`` and reachable from any handler through
 ``request.app.state.services``.
 
-Sharing the same instance with the MCP server is the next step (PR 2.3) and
-needs the composite adapter to move here too; this package deliberately knows
-nothing about MCP, so that wiring belongs to whoever mounts both.
+Since PR 2.3 it also holds the *marine adapter*, and that is what closed the
+other half of the audit's finding (M2). A REST request carrying no
+``forecast_cache`` used to let the engine build itself a bare
+``OpenMeteoAdapter``: no atlases, so the currents in the Raz de Sein came from
+an 8 km global model while the same passage asked over MCP got SHOM; no cache
+shared with the next request; and an ``httpx.AsyncClient`` opened and closed
+around every upstream call. One adapter here, handed to both shells, retires
+the three at once.
+
+Nothing in this module knows about MCP. Handing the same adapter to
+``build_server()`` is the deployment's job, which is what keeps this package
+free of the MCP SDK.
 """
 
 from __future__ import annotations
@@ -24,32 +33,70 @@ import logging
 import time
 from dataclasses import dataclass
 
+import httpx
+from openwind_data.adapters.base import MarineDataAdapter
+from openwind_data.adapters.openmeteo import OpenMeteoAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
+from openwind_data.currents.router import compose_marine_adapter
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 
 from openwind_api.settings import Settings
 
 _logger = logging.getLogger(__name__)
 
+# Matches ``OpenMeteoAdapter``'s own default. Named here because the client is
+# now built outside the adapter, and a shared client with no timeout would
+# pin a worker on an upstream that stops answering mid-body.
+UPSTREAM_TIMEOUT_S = 10.0
+
+# Connection pool for the whole process. Open-Meteo is two hosts (forecast and
+# marine), the deployment runs a single uvicorn worker, and a passage fans out
+# a dozen or so concurrent calls before the adapter's own 10 req/s pacing
+# throttles them, so a small pool is plenty and bounds what a burst can open.
+_POOL_LIMITS = httpx.Limits(max_connections=16, max_keepalive_connections=8)
+
 
 @dataclass(frozen=True, slots=True)
 class Services:
-    """The atlases, loaded once.
+    """The atlases and the upstream adapter, built once.
 
     Both registries answer honestly when empty (no coverage anywhere), which
     is the state of any deployment built without the dataset secret, so
     nothing downstream needs to know whether they were populated.
+
+    ``marine`` is the adapter every live passage goes through: an
+    ``OpenMeteoAdapter`` on the shared HTTP client, wrapped in the SHOM > MARC
+    > SMOC cascade when the shipped datasets can feed it. Requests that arrive
+    with a ``forecast_cache`` still read from that instead: the browser
+    already sampled the corridor, and the point of that payload is to keep the
+    upstream load off the single deployment IP.
     """
 
     marc: MarcAtlasRegistry
     shom: ShomC2dRegistry
+    http: httpx.AsyncClient
+    marine: MarineDataAdapter
 
     @classmethod
     def from_settings(cls, settings: Settings) -> Services:
+        marc = MarcAtlasRegistry.from_directory(settings.marc_atlas_dir)
+        shom = ShomC2dRegistry.from_directory(settings.shom_c2d_dir)
+        # Constructed outside a running loop on purpose: httpx binds nothing
+        # at construction, and building it here rather than in the lifespan is
+        # what lets ``create_app`` stay synchronous and lets a deployment hand
+        # the same adapter to an MCP server before any loop exists. The
+        # lifespan closes it.
+        http = httpx.AsyncClient(timeout=UPSTREAM_TIMEOUT_S, limits=_POOL_LIMITS)
         return cls(
-            marc=MarcAtlasRegistry.from_directory(settings.marc_atlas_dir),
-            shom=ShomC2dRegistry.from_directory(settings.shom_c2d_dir),
+            marc=marc,
+            shom=shom,
+            http=http,
+            marine=compose_marine_adapter(OpenMeteoAdapter(http), marc, shom),
         )
+
+    async def aclose(self) -> None:
+        """Release the shared connection pool. Called by the app's lifespan."""
+        await self.http.aclose()
 
     async def warm_atlas_coverage(self) -> None:
         """Compute the MARC coverage rectangles once, in a worker thread.

--- a/packages/api/tests/fake_requests.py
+++ b/packages/api/tests/fake_requests.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""One stand-in request for the handler-level tests.
+
+Six test modules had written the same three-line class, and PR 2.3 gave the
+passage handlers a second thing to read off the request (the process-wide
+marine adapter, on ``app.state.services``), which would have meant editing the
+same three lines six times. One copy, so the next field costs one edit.
+
+Deliberately not a Starlette ``Request``: these tests call the handler
+directly, with no app and no transport, precisely to keep the assertion on the
+handler rather than on the middleware stack. The routes' behaviour through the
+real stack is covered by the goldens and by ``test_api_limits``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from openwind_data.testing import DeterministicMarineAdapter
+
+
+class FakeRequest:
+    """A JSON body, and the services a handler resolves its adapter from.
+
+    ``body`` may be an ``Exception``, which ``json()`` then raises: that is how
+    a malformed payload is simulated, since Starlette surfaces a decode
+    failure the same way.
+
+    The default adapter is the deterministic stub rather than a live one, so a
+    test that reaches the engine by accident fails on an assertion rather than
+    on a network call.
+    """
+
+    def __init__(self, body: Any, *, marine: Any = None) -> None:
+        self._body = body
+        self.app = SimpleNamespace(
+            state=SimpleNamespace(
+                services=SimpleNamespace(marine=marine or DeterministicMarineAdapter())
+            )
+        )
+
+    async def json(self) -> Any:
+        if isinstance(self._body, Exception):
+            raise self._body
+        return self._body

--- a/packages/api/tests/test_api_by_eta.py
+++ b/packages/api/tests/test_api_by_eta.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 
 import httpx
 import pytest
+from fake_requests import FakeRequest
 from openwind_data.adapters.base import ForecastHorizonError, UpstreamRateLimitError
 
 from openwind_api.routes import passage as passage_routes
@@ -28,16 +29,6 @@ from openwind_api.routes import passage as passage_routes
 ARRIVAL = datetime(2026, 5, 1, 18, 0, tzinfo=UTC)
 MARSEILLE = [43.30, 5.35]
 PORQUEROLLES = [43.00, 6.20]
-
-
-class _FakeRequest:
-    def __init__(self, body: object) -> None:
-        self._body = body
-
-    async def json(self) -> object:
-        if isinstance(self._body, Exception):
-            raise self._body
-        return self._body
 
 
 @dataclasses.dataclass
@@ -84,7 +75,7 @@ def solved(monkeypatch):
 
 class TestEnvelope:
     async def test_success_returns_passage_complexity_and_eta(self, solved) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert resp.status_code == 200
         payload = _payload(resp)
         assert set(payload) == {"passage", "complexity", "eta", "forecast_updated_at"}
@@ -94,17 +85,17 @@ class TestEnvelope:
     async def test_eta_block_echoes_the_resolved_arrival(self, solved) -> None:
         # The client reads this back to show what the solver actually hit,
         # which can differ from what was asked within the tolerance.
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert _payload(resp)["eta"] == {"target_arrival": ARRIVAL.isoformat()}
 
     async def test_freshness_stamp_is_present_and_iso(self, solved) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         datetime.fromisoformat(_payload(resp)["forecast_updated_at"])
 
 
 class TestRejectedBodies:
     async def test_unparseable_json(self) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(ValueError("nope")))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(ValueError("nope")))
         assert resp.status_code == 422
         assert _payload(resp)["error"] == "invalid JSON body"
 
@@ -112,17 +103,17 @@ class TestRejectedBodies:
     async def test_missing_required_field(self, field) -> None:
         body = _body()
         del body[field]
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(body))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(body))
         assert resp.status_code == 422
         assert field in _payload(resp)["error"]
 
     async def test_unparseable_arrival(self) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body(target_arrival="soon")))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body(target_arrival="soon")))
         assert resp.status_code == 422
         assert "invalid target_arrival" in _payload(resp)["error"]
 
     async def test_malformed_waypoints(self) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body(waypoints=[[43.3]])))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body(waypoints=[[43.3]])))
         assert resp.status_code == 422
         assert "invalid waypoints" in _payload(resp)["error"]
 
@@ -135,19 +126,19 @@ class TestRejectedBodies:
 
         monkeypatch.setattr(passage_routes, "estimate_passage_for_arrival", _explode)
         resp = await passage_routes.api_passage_by_eta(
-            _FakeRequest(_body(waypoints=[[999.0, 5.35], PORQUEROLLES]))
+            FakeRequest(_body(waypoints=[[999.0, 5.35], PORQUEROLLES]))
         )
         assert resp.status_code == 422
 
     async def test_single_waypoint_message_is_passed_through_verbatim(self) -> None:
         # The web client maps on this exact wording, so it is part of the
         # contract rather than an internal detail.
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body(waypoints=[MARSEILLE])))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body(waypoints=[MARSEILLE])))
         assert resp.status_code == 422
         assert "at least 2 waypoints" in _payload(resp)["error"]
 
     async def test_invalid_efficiency(self) -> None:
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body(efficiency="fast")))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body(efficiency="fast")))
         assert resp.status_code == 422
         assert "invalid efficiency" in _payload(resp)["error"]
 
@@ -158,7 +149,7 @@ class TestUpstreamFailures:
             raise KeyError("sloop_of_theseus")
 
         monkeypatch.setattr(passage_routes, "estimate_passage_for_arrival", _stub)
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert resp.status_code == 422
         assert "unknown archetype" in _payload(resp)["error"]
 
@@ -167,7 +158,7 @@ class TestUpstreamFailures:
             raise ForecastHorizonError("arome", ARRIVAL)
 
         monkeypatch.setattr(passage_routes, "estimate_passage_for_arrival", _stub)
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert resp.status_code == 422
         # The message names the fallback models, which is what the front
         # turns into its "try a longer-range model" hint.
@@ -180,7 +171,7 @@ class TestUpstreamFailures:
             raise httpx.TimeoutException("too slow")
 
         monkeypatch.setattr(passage_routes, "estimate_passage_for_arrival", _stub)
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert resp.status_code == 503
         assert "did not respond in time" in _payload(resp)["error"]
 
@@ -192,7 +183,7 @@ class TestUpstreamFailures:
             raise UpstreamRateLimitError("Minutely API request limit exceeded.")
 
         monkeypatch.setattr(passage_routes, "estimate_passage_for_arrival", _stub)
-        resp = await passage_routes.api_passage_by_eta(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage_by_eta(FakeRequest(_body()))
         assert resp.status_code == 503
         error = _payload(resp)["error"]
         assert "upstream weather service rate limit reached" in error

--- a/packages/api/tests/test_api_passage_cache.py
+++ b/packages/api/tests/test_api_passage_cache.py
@@ -15,6 +15,7 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from fake_requests import FakeRequest
 from openwind_data.adapters.cache_backed import CacheBackedAdapter
 from openwind_data.routing.passage import NoModelCoveredError
 
@@ -23,14 +24,6 @@ from openwind_api.routes import passage as passage_routes
 DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
 MARSEILLE = (43.30, 5.35)
 PORQUEROLLES = (43.00, 6.20)
-
-
-class _FakeRequest:
-    def __init__(self, body: dict) -> None:
-        self._body = body
-
-    async def json(self) -> dict:
-        return self._body
 
 
 def _resp_json(resp) -> dict:
@@ -101,7 +94,7 @@ async def test_single_with_cache_returns_200_from_cache(monkeypatch) -> None:
     monkeypatch.setattr(httpx.AsyncClient, "get", _boom)
 
     resp = await passage_routes.api_passage(
-        _FakeRequest(_single_body(forecast_cache=_corridor_cache()))
+        FakeRequest(_single_body(forecast_cache=_corridor_cache()))
     )
     assert resp.status_code == 200
     payload = _resp_json(resp)
@@ -112,7 +105,7 @@ async def test_single_with_cache_returns_200_from_cache(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_malformed_cache_returns_422(monkeypatch) -> None:
     resp = await passage_routes.api_passage(
-        _FakeRequest(
+        FakeRequest(
             _single_body(
                 forecast_cache={"version": 999, "models": [], "times_ms": [], "points": []}
             )
@@ -140,7 +133,7 @@ async def test_oversized_cache_returns_422_naming_the_ceiling() -> None:
         {**origin, "lat": origin["lat"] + i / 1000} for i in range(MAX_CACHE_POINTS + 1)
     ]
 
-    resp = await passage_routes.api_passage(_FakeRequest(_single_body(forecast_cache=cache)))
+    resp = await passage_routes.api_passage(FakeRequest(_single_body(forecast_cache=cache)))
     assert resp.status_code == 422
     error = _resp_json(resp)["error"]
     assert error.startswith("invalid forecast_cache: ")
@@ -162,14 +155,18 @@ async def test_single_passes_cache_adapter(monkeypatch) -> None:
     monkeypatch.setattr(passage_routes, "estimate_passage", _stub)
 
     # With cache -> CacheBackedAdapter + chain from cache models.
-    await passage_routes.api_passage(_FakeRequest(_single_body(forecast_cache=_corridor_cache())))
+    await passage_routes.api_passage(FakeRequest(_single_body(forecast_cache=_corridor_cache())))
     assert isinstance(captured["adapter"], CacheBackedAdapter)
     assert captured["model_chain"] == ("meteofrance_arome_france", "icon_eu")
 
-    # Without cache -> adapter None (MCP/live path unchanged).
+    # Without cache -> the process-wide adapter, the same object the MCP
+    # tools fetch through. It used to be None, which left the engine to build
+    # itself a bare Open-Meteo client per request: no atlases, no shared
+    # cache, no shared connection pool (audit M2).
     captured.clear()
-    await passage_routes.api_passage(_FakeRequest(_single_body()))
-    assert captured["adapter"] is None
+    request = FakeRequest(_single_body())
+    await passage_routes.api_passage(request)
+    assert captured["adapter"] is request.app.state.services.marine
 
 
 @pytest.mark.asyncio
@@ -186,7 +183,7 @@ async def test_sweep_passes_cache_adapter(monkeypatch) -> None:
         latest_departure=(DEPARTURE + timedelta(hours=6)).isoformat(),
         sweep_interval_hours=3,
     )
-    await passage_routes.api_passage(_FakeRequest(body))
+    await passage_routes.api_passage(FakeRequest(body))
     assert isinstance(captured["adapter"], CacheBackedAdapter)
 
 
@@ -205,5 +202,5 @@ async def test_by_eta_passes_cache_adapter(monkeypatch) -> None:
         "archetype": "cruiser_40ft",
         "forecast_cache": _corridor_cache(),
     }
-    await passage_routes.api_passage_by_eta(_FakeRequest(body))
+    await passage_routes.api_passage_by_eta(FakeRequest(body))
     assert isinstance(captured["adapter"], CacheBackedAdapter)

--- a/packages/api/tests/test_api_sweep.py
+++ b/packages/api/tests/test_api_sweep.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
+from fake_requests import FakeRequest
 from openwind_data import views
 
 from openwind_api.routes import passage as passage_routes
@@ -23,14 +24,6 @@ from openwind_api.routes import passage as passage_routes
 DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
 MARSEILLE = [43.30, 5.35]
 PORQUEROLLES = [43.00, 6.20]
-
-
-class _FakeRequest:
-    def __init__(self, body: dict) -> None:
-        self._body = body
-
-    async def json(self) -> dict:
-        return self._body
 
 
 def _sweep_body(**extra) -> dict:
@@ -61,7 +54,7 @@ def no_windows(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_sweep_without_target_eta_returns_multi_window(no_windows) -> None:
-    resp = await passage_routes.api_passage(_FakeRequest(_sweep_body()))
+    resp = await passage_routes.api_passage(FakeRequest(_sweep_body()))
     assert resp.status_code == 200
     body = _payload(resp)
     assert body["mode"] == "multi_window"
@@ -72,7 +65,7 @@ async def test_sweep_without_target_eta_returns_multi_window(no_windows) -> None
 async def test_sweep_with_target_eta_reaches_the_filter(no_windows) -> None:
     # The regression: this branch is the only one that touches timedelta.
     target = (DEPARTURE + timedelta(hours=10)).isoformat()
-    resp = await passage_routes.api_passage(_FakeRequest(_sweep_body(target_eta=target)))
+    resp = await passage_routes.api_passage(FakeRequest(_sweep_body(target_eta=target)))
     assert resp.status_code == 200
     body = _payload(resp)
     assert any("target_eta" in w for w in body["meta_warnings"])
@@ -80,7 +73,7 @@ async def test_sweep_with_target_eta_reaches_the_filter(no_windows) -> None:
 
 @pytest.mark.asyncio
 async def test_invalid_target_eta_returns_422() -> None:
-    resp = await passage_routes.api_passage(_FakeRequest(_sweep_body(target_eta="not-a-date")))
+    resp = await passage_routes.api_passage(FakeRequest(_sweep_body(target_eta="not-a-date")))
     assert resp.status_code == 422
     assert "target_eta" in _payload(resp)["error"]
 
@@ -93,7 +86,7 @@ async def test_skipped_windows_surface_a_meta_warning(monkeypatch) -> None:
         return []
 
     monkeypatch.setattr(passage_routes, "estimate_passage_windows", _stub)
-    resp = await passage_routes.api_passage(_FakeRequest(_sweep_body()))
+    resp = await passage_routes.api_passage(FakeRequest(_sweep_body()))
     warnings = _payload(resp)["meta_warnings"]
     assert any("ignorée" in w for w in warnings)
 
@@ -142,7 +135,7 @@ def widened_sweep(monkeypatch):
 async def test_widened_sweep_advertises_the_interval_it_ran(widened_sweep) -> None:
     body = _payload(
         await passage_routes.api_passage(
-            _FakeRequest(
+            FakeRequest(
                 _sweep_body(
                     latest_departure=(DEPARTURE + timedelta(days=13)).isoformat(),
                     sweep_interval_hours=1,
@@ -163,7 +156,7 @@ async def test_widened_sweep_does_not_report_phantom_dropped_windows(widened_swe
     """
     body = _payload(
         await passage_routes.api_passage(
-            _FakeRequest(
+            FakeRequest(
                 _sweep_body(
                     latest_departure=(DEPARTURE + timedelta(days=13)).isoformat(),
                     sweep_interval_hours=1,

--- a/packages/api/tests/test_api_validation.py
+++ b/packages/api/tests/test_api_validation.py
@@ -17,6 +17,8 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from fake_requests import FakeRequest
+from openwind_data.adapters.openmeteo import OpenMeteoAdapter
 from openwind_data.routing import MAX_WAYPOINTS
 
 from openwind_api.routes import marine as marine_routes
@@ -27,14 +29,6 @@ from openwind_api.settings import Settings
 DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
 MARSEILLE = [43.30, 5.35]
 PORQUEROLLES = [43.00, 6.20]
-
-
-class _FakeRequest:
-    def __init__(self, body: dict) -> None:
-        self._body = body
-
-    async def json(self) -> dict:
-        return self._body
 
 
 class _FakeQueryRequest:
@@ -77,7 +71,7 @@ def _no_network(monkeypatch):
 @pytest.mark.asyncio
 async def test_lat_out_of_range_returns_422() -> None:
     resp = await passage_routes.api_passage(
-        _FakeRequest(_body(waypoints=[[999, 5.35], PORQUEROLLES]))
+        FakeRequest(_body(waypoints=[[999, 5.35], PORQUEROLLES]))
     )
     assert resp.status_code == 422
     assert "out of range [-90, 90]" in _error(resp)
@@ -85,7 +79,7 @@ async def test_lat_out_of_range_returns_422() -> None:
 
 @pytest.mark.asyncio
 async def test_lon_out_of_range_returns_422() -> None:
-    resp = await passage_routes.api_passage(_FakeRequest(_body(waypoints=[MARSEILLE, [43.0, 999]])))
+    resp = await passage_routes.api_passage(FakeRequest(_body(waypoints=[MARSEILLE, [43.0, 999]])))
     assert resp.status_code == 422
     assert "out of range [-180, 180]" in _error(resp)
 
@@ -95,7 +89,7 @@ async def test_nan_coordinate_returns_422() -> None:
     # json.loads accepts the bare NaN literal, so this really is reachable
     # from a hand-rolled POST body.
     resp = await passage_routes.api_passage(
-        _FakeRequest(_body(waypoints=[[float("nan"), 5.35], PORQUEROLLES]))
+        FakeRequest(_body(waypoints=[[float("nan"), 5.35], PORQUEROLLES]))
     )
     assert resp.status_code == 422
     assert "out of range" in _error(resp)
@@ -104,7 +98,7 @@ async def test_nan_coordinate_returns_422() -> None:
 @pytest.mark.asyncio
 async def test_single_waypoint_message_unchanged() -> None:
     # Byte-identical to the pre-existing wording: the web maps this string.
-    resp = await passage_routes.api_passage(_FakeRequest(_body(waypoints=[MARSEILLE])))
+    resp = await passage_routes.api_passage(FakeRequest(_body(waypoints=[MARSEILLE])))
     assert resp.status_code == 422
     assert _error(resp) == "at least 2 waypoints required"
 
@@ -112,7 +106,7 @@ async def test_single_waypoint_message_unchanged() -> None:
 @pytest.mark.asyncio
 async def test_too_many_waypoints_returns_422() -> None:
     route = [[43.0 + i * 0.001, 5.0] for i in range(MAX_WAYPOINTS + 1)]
-    resp = await passage_routes.api_passage(_FakeRequest(_body(waypoints=route)))
+    resp = await passage_routes.api_passage(FakeRequest(_body(waypoints=route)))
     assert resp.status_code == 422
     assert "too many waypoints" in _error(resp)
 
@@ -120,9 +114,14 @@ async def test_too_many_waypoints_returns_422() -> None:
 @pytest.mark.asyncio
 async def test_waypoint_count_at_cap_is_not_rejected_by_bounds() -> None:
     # Must fail for some *other* reason (no network here), never for the cap.
+    # A live adapter on purpose: reaching the upstream is the proof that the
+    # bounds check let this route through, so the stub every other test in
+    # this module gets would make the assertion vacuous.
     route = [[43.0 + i * 0.001, 5.0] for i in range(MAX_WAYPOINTS)]
     with pytest.raises(AssertionError, match="before any upstream fetch"):
-        await passage_routes.api_passage(_FakeRequest(_body(waypoints=route)))
+        await passage_routes.api_passage(
+            FakeRequest(_body(waypoints=route), marine=OpenMeteoAdapter())
+        )
 
 
 # ----------------------------------------------------- POST /passage-by-eta
@@ -131,7 +130,7 @@ async def test_waypoint_count_at_cap_is_not_rejected_by_bounds() -> None:
 @pytest.mark.asyncio
 async def test_by_eta_lat_out_of_range_returns_422() -> None:
     resp = await passage_routes.api_passage_by_eta(
-        _FakeRequest(
+        FakeRequest(
             {
                 "waypoints": [[999, 5.35], PORQUEROLLES],
                 "target_arrival": DEPARTURE.isoformat(),
@@ -146,7 +145,7 @@ async def test_by_eta_lat_out_of_range_returns_422() -> None:
 @pytest.mark.asyncio
 async def test_by_eta_single_waypoint_message_unchanged() -> None:
     resp = await passage_routes.api_passage_by_eta(
-        _FakeRequest(
+        FakeRequest(
             {
                 "waypoints": [MARSEILLE],
                 "target_arrival": DEPARTURE.isoformat(),

--- a/packages/api/tests/test_error_codes.py
+++ b/packages/api/tests/test_error_codes.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
+from fake_requests import FakeRequest
 from openwind_data.adapters.base import ForecastHorizonError, UpstreamRateLimitError
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
@@ -47,16 +48,6 @@ def _body(**extra) -> dict:
     return body
 
 
-class _FakeRequest:
-    def __init__(self, body: object) -> None:
-        self._body = body
-
-    async def json(self) -> object:
-        if isinstance(self._body, Exception):
-            raise self._body
-        return self._body
-
-
 def _payload(resp) -> dict:
     import json
 
@@ -79,7 +70,7 @@ class TestEngineFailures:
             "estimate_passage",
             _raising(ForecastHorizonError("meteofrance_arome_france", DEPARTURE)),
         )
-        resp = await passage_routes.api_passage(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage(FakeRequest(_body()))
         assert resp.status_code == 422
         assert _payload(resp)["code"] == "forecast_horizon"
 
@@ -87,7 +78,7 @@ class TestEngineFailures:
         monkeypatch.setattr(
             passage_routes, "estimate_passage", _raising(httpx.ReadTimeout("too slow"))
         )
-        resp = await passage_routes.api_passage(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage(FakeRequest(_body()))
         assert resp.status_code == 503
         assert _payload(resp)["code"] == "upstream_timeout"
 
@@ -99,14 +90,14 @@ class TestEngineFailures:
             "estimate_passage",
             _raising(UpstreamRateLimitError("Minutely API request limit exceeded.")),
         )
-        resp = await passage_routes.api_passage(_FakeRequest(_body()))
+        resp = await passage_routes.api_passage(FakeRequest(_body()))
         assert resp.status_code == 503
         assert _payload(resp)["code"] == "upstream_rate_limited"
 
     async def test_sweep_too_large(self) -> None:
         # 14 days of hourly departures is the documented cap; ask for a month.
         resp = await passage_routes.api_passage(
-            _FakeRequest(
+            FakeRequest(
                 _body(
                     latest_departure=(DEPARTURE + timedelta(days=30)).isoformat(),
                     sweep_interval_hours=1,
@@ -122,18 +113,18 @@ class TestEngineFailures:
         # their own mistake.
         monkeypatch.setattr(passage_routes, "estimate_passage", _raising(ZeroDivisionError("bug")))
         with pytest.raises(ZeroDivisionError):
-            await passage_routes.api_passage(_FakeRequest(_body()))
+            await passage_routes.api_passage(FakeRequest(_body()))
 
 
 class TestMalformedBody:
     async def test_unparseable_json(self) -> None:
-        resp = await passage_routes.api_passage(_FakeRequest(ValueError("not json")))
+        resp = await passage_routes.api_passage(FakeRequest(ValueError("not json")))
         assert resp.status_code == 422
         assert _payload(resp)["code"] == "invalid_json"
 
     async def test_a_body_that_is_not_an_object(self) -> None:
         # A JSON array used to reach ``body.get`` and surface as a 500.
-        resp = await passage_routes.api_passage(_FakeRequest([1, 2, 3]))
+        resp = await passage_routes.api_passage(FakeRequest([1, 2, 3]))
         assert resp.status_code == 422
         assert _payload(resp)["code"] == "invalid_json"
 

--- a/packages/api/tests/test_live_currents.py
+++ b/packages/api/tests/test_live_currents.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""A live REST passage reads its currents off the same atlases the MCP tools do.
+
+This is audit finding M2, pinned. A request without a ``forecast_cache`` used
+to let the passage engine build itself a bare ``OpenMeteoAdapter``, which knows
+nothing about the tidal atlases shipped in the image: the same waypoint in the
+Morbihan answered ``shom_c2d_558_test_zone`` over MCP and ``openmeteo_smoc``
+over REST, from one process, with both datasets loaded in memory. A 0.9 kn
+spring stream reported as 0.2 kn is a wrong ETA through a pass, not a cosmetic
+divergence.
+
+The registries here are the synthetic ones the data-adapters suite builds: a
+MARC atlas of a single cell, and a SHOM zone of three points anchored on
+Brest. What is asserted is provenance and wiring, never the numbers, which
+have their own tests where the predictors live.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import UTC, datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+from openwind_data.testing import (
+    DeterministicMarineAdapter,
+    browser_cache_payload,
+    hourly_axis,
+)
+from starlette.testclient import TestClient
+
+from openwind_api.app import create_app
+from openwind_api.settings import Settings
+
+# Inside the synthetic SHOM zone (three points around 47.50, -2.90) and inside
+# the synthetic MARC atlas below, which is what the cascade needs to reach its
+# top tier: SHOM alone does not compose (see ``compose_marine_adapter``).
+MORBIHAN = [[47.50, -2.90], [47.51, -2.89]]
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+
+
+def _write_shom_registry(out: Path) -> None:
+    """Three points on one zone, referred to Brest. Mirrors the domain fixture."""
+    out.mkdir(parents=True, exist_ok=True)
+    hours = list(range(-6, 7))
+    u_ve = [math.sin(math.pi * h / 6.0) for h in hours]
+    rows = [
+        {
+            "atlas_id": 558,
+            "zone": "TEST_ZONE",
+            "ref_port_key": "BREST",
+            "ref_tide": "PM",
+            "lat": lat,
+            "lon": lon,
+            "u_ve_kn": u_ve,
+            "v_ve_kn": [0.0 for _ in hours],
+            "u_me_kn": [0.5 * v for v in u_ve],
+            "v_me_kn": [0.0 for _ in hours],
+        }
+        for lat, lon in ((47.50, -2.90), (47.51, -2.89), (47.49, -2.91))
+    ]
+    pl.DataFrame(rows).with_columns(
+        pl.col("atlas_id").cast(pl.Int16),
+        pl.col("lat").cast(pl.Float32),
+        pl.col("lon").cast(pl.Float32),
+        pl.col("u_ve_kn").cast(pl.List(pl.Float32)),
+        pl.col("v_ve_kn").cast(pl.List(pl.Float32)),
+        pl.col("u_me_kn").cast(pl.List(pl.Float32)),
+        pl.col("v_me_kn").cast(pl.List(pl.Float32)),
+    ).write_parquet(out / "shom_c2d_points.parquet")
+    (out / "shom_c2d_ref_ports.json").write_text(
+        json.dumps(
+            {
+                "BREST": {
+                    "display_name": "Brest",
+                    "lat": 48.3833,
+                    "lon": -4.4956,
+                    "ref_tide": "PM",
+                    "constants": {"M2": [2.0, 150.0], "S2": [0.7, 200.0]},
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def _write_marc_atlas(out: Path) -> None:
+    """One 250 m cell covering the same water, so the cascade composes."""
+    atlas = out / "MORBI"
+    tile = atlas / "tile_lat=47.5" / "tile_lon=-3.0"
+    tile.mkdir(parents=True, exist_ok=True)
+    (atlas / "metadata.json").write_text(
+        json.dumps(
+            {
+                "atlas": "MORBI",
+                "rank": 2,
+                "resolution_m": 250,
+                "constituents_h": ["M2"],
+                "constituents_u": ["M2"],
+                "constituents_v": ["M2"],
+            }
+        )
+    )
+    (atlas / "coverage.geojson").write_text(
+        json.dumps(
+            {
+                "features": [
+                    {
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [[-3.0, 47.4], [-2.8, 47.4], [-2.8, 47.6], [-3.0, 47.6]]
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+    )
+    pl.DataFrame(
+        {
+            "lat": [47.505],
+            "lon": [-2.895],
+            "z0_hydro_m": [-3.10],
+            "M2_h_amp": [2.05],
+            "M2_h_g": [108.0],
+            "M2_u_amp": [0.5],
+            "M2_u_g": [80.0],
+            "M2_v_amp": [0.3],
+            "M2_v_g": [120.0],
+        }
+    ).write_parquet(tile / "data.parquet", compression="zstd")
+
+
+@pytest.fixture
+def atlas_dirs(tmp_path):
+    _write_shom_registry(tmp_path / "shom")
+    _write_marc_atlas(tmp_path / "marc")
+    return tmp_path / "marc", tmp_path / "shom"
+
+
+@pytest.fixture
+def client(atlas_dirs):
+    """The real app on real registries, with only the weather stubbed.
+
+    The stub replaces the composite's *upstream*, not the composite: the
+    cascade under test is the shipped one, and what it overrides is a bundle
+    of deterministic SMOC values rather than a live Open-Meteo answer.
+    """
+    marc_dir, shom_dir = atlas_dirs
+    app = create_app(Settings(marc_atlas_dir=str(marc_dir), shom_c2d_dir=str(shom_dir)))
+    app.state.services.marine.upstream = DeterministicMarineAdapter()
+    return TestClient(app)
+
+
+def _body(**extra) -> dict:
+    body = {
+        "waypoints": MORBIHAN,
+        "departure": DEPARTURE.isoformat(),
+        "archetype": "cruiser_30ft",
+    }
+    body.update(extra)
+    return body
+
+
+def test_a_live_passage_reports_the_shom_atlas_as_its_current_source(client) -> None:
+    resp = client.post("/api/v1/passage", json=_body())
+    assert resp.status_code == 200, resp.text
+    sources = {seg["current_source"] for seg in resp.json()["passage"]["segments"]}
+    assert sources == {"shom_c2d_558_test_zone"}
+
+
+def test_the_same_request_off_the_browser_cache_keeps_the_browser_provenance(client) -> None:
+    """The other door, unchanged and deliberately so.
+
+    A ``forecast_cache`` is the browser's own sampling, overlaid client-side
+    with whatever ``/api/v1/marine/marc`` gave it. The server does not
+    second-guess it: reading the atlases again here would cost the CPU the
+    payload exists to save, and would silently disagree with what the user is
+    looking at on the map.
+    """
+    axis = hourly_axis(DEPARTURE, DEPARTURE.replace(hour=18))
+    payload = browser_cache_payload([(47.50, -2.90), (47.51, -2.89)], axis)
+    resp = client.post("/api/v1/passage", json=_body(forecast_cache=payload))
+    assert resp.status_code == 200, resp.text
+    sources = {seg["current_source"] for seg in resp.json()["passage"]["segments"]}
+    assert sources == {"openmeteo_smoc"}
+
+
+def test_the_atlases_are_loaded_once_for_the_whole_process(client) -> None:
+    """One registry object, reachable both ways: as data and through the adapter.
+
+    Two copies is what the audit measured (M5), and the only observable
+    difference between one and two is memory, which no assertion can see. The
+    identity can.
+    """
+    services = client.app.state.services
+    assert services.marine.shom is services.shom
+    assert services.marine.marc is services.marc

--- a/packages/api/tests/test_parse_polar.py
+++ b/packages/api/tests/test_parse_polar.py
@@ -13,6 +13,7 @@ import json
 from datetime import UTC, datetime
 
 import pytest
+from fake_requests import FakeRequest
 from openwind_data.routing.archetypes import effective_min_upwind_twa
 
 from openwind_api import parsing
@@ -142,19 +143,12 @@ class TestMinUpwind:
 
 @pytest.mark.asyncio
 async def test_endpoint_returns_422_on_bad_min_upwind() -> None:
-    class _FakeRequest:
-        def __init__(self, body: dict) -> None:
-            self._body = body
-
-        async def json(self) -> dict:
-            return self._body
-
     body = {
         "waypoints": [[43.30, 5.35], [43.00, 6.20]],
         "departure": datetime(2026, 5, 1, 6, 0, tzinfo=UTC).isoformat(),
         "archetype": "cruiser_40ft",
         "polar": _payload(min_upwind_twa_deg=120),
     }
-    resp = await passage_routes.api_passage(_FakeRequest(body))
+    resp = await passage_routes.api_passage(FakeRequest(body))
     assert resp.status_code == 422
     assert "min_upwind_twa_deg" in json.loads(bytes(resp.body))["error"]

--- a/packages/api/tests/test_rest_goldens.py
+++ b/packages/api/tests/test_rest_goldens.py
@@ -26,6 +26,7 @@ below is produced without an MCP server in the process.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 import polars as pl
@@ -81,10 +82,24 @@ def _frozen_datetime(instant: datetime) -> type[datetime]:
 def deterministic_world(monkeypatch):
     """No clock, no network, no atlas dataset. Only arithmetic."""
     monkeypatch.setattr(passage_routes, "datetime", _frozen_datetime(FROZEN_NOW))
-    # The engine builds its own adapter when the request carries no
-    # ``forecast_cache``; substituting the class is what makes the live REST
-    # path deterministic without changing a line of the handler.
+    # Belt and braces: nothing should reach for the engine's own adapter now
+    # that the live path is handed one, but a regression that put the old
+    # branch back would otherwise dial Open-Meteo from CI rather than fail.
     monkeypatch.setattr(passage_engine, "OpenMeteoAdapter", DeterministicMarineAdapter)
+
+
+def _deterministic_app(settings: Settings) -> TestClient:
+    """The real app, with the stub adapter in the place of the live one.
+
+    A request without a ``forecast_cache`` is planned through
+    ``app.state.services.marine``, so that is where the determinism has to be
+    installed. Swapping it here rather than patching a module global is the
+    same gesture a deployment makes when it hands its own services in, and it
+    keeps every other part of the app genuinely real.
+    """
+    app = create_app(settings)
+    app.state.services = replace(app.state.services, marine=DeterministicMarineAdapter())
+    return TestClient(app)
 
 
 @pytest.fixture
@@ -95,7 +110,7 @@ def client():
     counter: the goldens fire more requests at ``/api/v1/passage`` than one
     bucket allows in a minute.
     """
-    return TestClient(create_app(Settings()))
+    return _deterministic_app(Settings())
 
 
 def _passage_body(**extra) -> dict:
@@ -272,7 +287,7 @@ def atlas_client(atlas_dir):
     deployment says it, and it is the only path that exercises
     ``Services.from_settings``.
     """
-    return TestClient(create_app(Settings(marc_atlas_dir=str(atlas_dir))))
+    return _deterministic_app(Settings(marc_atlas_dir=str(atlas_dir)))
 
 
 class TestMarineOverlay:

--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -105,6 +105,21 @@ class _CacheEntry:
     bundle: ForecastBundle  # bundle.start / bundle.end define the cached window
 
 
+@dataclass(frozen=True, slots=True)
+class _Flight:
+    """A fetch already in the air for one cache key.
+
+    ``start``/``end`` are the *widened* window that request asked upstream
+    for, not the caller's: a second caller joins only when the answer coming
+    back will cover what it needs. One that needs more issues its own request
+    rather than waiting for a result it would have to throw away.
+    """
+
+    start: datetime
+    end: datetime
+    future: asyncio.Future[ForecastBundle]
+
+
 class OpenMeteoAdapter:
     """Fetches wind (multi-model) and sea state from Open-Meteo's keyless APIs.
 
@@ -116,6 +131,18 @@ class OpenMeteoAdapter:
     [start, end] ever requested for a given key and slices on read; subsequent
     requests that fall inside a cached window are served without an HTTP call,
     even if the requested time window differs from the original.
+
+    Single-flight: concurrent identical fetches share one HTTP round-trip.
+    The cache only helps callers that arrive *after* an answer landed, and a
+    passage fans its segments out with ``asyncio.gather``, so several of them
+    routinely ask for the same AROME cell at the same instant and every one of
+    them used to pay for its own request. The first caller registers its
+    flight, the others await it and slice the same bundle.
+
+    Client lifecycle: an injected ``httpx.AsyncClient`` is borrowed, never
+    closed — the process that opened it decides when it dies. Without one, a
+    client is opened and closed around every call, which is what the local
+    stdio runner and the tests get.
 
     Default model is AROME (Mediterranean focus, high-resolution capture of thermal
     and local winds).
@@ -131,6 +158,7 @@ class OpenMeteoAdapter:
         self._client = client
         self._timeout = timeout
         self._cache: dict[_CacheKey, _CacheEntry] = {}
+        self._inflight: dict[_CacheKey, _Flight] = {}
         self._http_min_interval_s = http_min_interval_s
         self._http_lock = asyncio.Lock()
         self._last_http_at: float = 0.0
@@ -222,33 +250,80 @@ class OpenMeteoAdapter:
             fetch_end = max(fetch_end, cached.bundle.end)
         fetch_end = min(fetch_end, api_max_end)
 
-        owns_client = self._client is None
-        client = self._client or httpx.AsyncClient(timeout=self._timeout)
-        try:
-            wind_tasks = [
-                self._fetch_wind(client, lat, lon, fetch_start, fetch_end, m) for m in models
-            ]
-            sea_task = self._fetch_sea(client, lat, lon, fetch_start, fetch_end)
-            results = await asyncio.gather(*wind_tasks, sea_task)
-        finally:
-            if owns_client:
-                await client.aclose()
+        # Single-flight. A request already in the air for this key, over a
+        # window that covers ours, answers us too: we wait for it instead of
+        # opening a second identical round-trip. ``shield`` because the future
+        # belongs to the caller that created it — a cancelled follower must
+        # not cancel the fetch every other follower is waiting on.
+        flight = self._inflight.get(key)
+        if flight is not None and flight.start <= start_utc and flight.end >= end_utc:
+            joined = await asyncio.shield(flight.future)
+            return _slice_bundle(joined, start_utc, end_utc)
 
-        wind_series_list: list[WindSeries] = list(results[:-1])
-        sea_series: SeaSeries = results[-1]
-        full_bundle = ForecastBundle(
-            lat=lat,
-            lon=lon,
-            start=fetch_start,
-            end=fetch_end,
-            wind_by_model={w.model: w for w in wind_series_list},
-            sea=sea_series,
-            requested_at=now,
+        full_bundle = await self._fetch_and_cache(
+            key, lat, lon, fetch_start, fetch_end, models, now
         )
-        if len(self._cache) >= CACHE_MAX_ENTRIES and key not in self._cache:
-            self._cache.pop(next(iter(self._cache)))  # FIFO eviction
-        self._cache[key] = _CacheEntry(fetched_at=now, bundle=full_bundle)
         return _slice_bundle(full_bundle, start_utc, end_utc)
+
+    async def _fetch_and_cache(
+        self,
+        key: _CacheKey,
+        lat: float,
+        lon: float,
+        fetch_start: datetime,
+        fetch_end: datetime,
+        models: list[str],
+        now: datetime,
+    ) -> ForecastBundle:
+        """Run one upstream round-trip, publish it to the cache and to joiners.
+
+        Registered as the in-flight request for ``key`` for its whole
+        duration, including the failure path: a follower that joined inherits
+        the same exception rather than firing a second doomed request at an
+        upstream that just refused us.
+        """
+        future: asyncio.Future[ForecastBundle] = asyncio.get_running_loop().create_future()
+        # Nobody may ever join, and an unretrieved exception on a discarded
+        # future is logged by asyncio at shutdown as an unhandled error. The
+        # callback reads it so the real one, raised below, is the only one.
+        future.add_done_callback(lambda f: None if f.cancelled() else f.exception())
+        self._inflight[key] = _Flight(fetch_start, fetch_end, future)
+        try:
+            owns_client = self._client is None
+            client = self._client or httpx.AsyncClient(timeout=self._timeout)
+            try:
+                wind_tasks = [
+                    self._fetch_wind(client, lat, lon, fetch_start, fetch_end, m) for m in models
+                ]
+                sea_task = self._fetch_sea(client, lat, lon, fetch_start, fetch_end)
+                results = await asyncio.gather(*wind_tasks, sea_task)
+            finally:
+                if owns_client:
+                    await client.aclose()
+
+            wind_series_list: list[WindSeries] = list(results[:-1])
+            sea_series: SeaSeries = results[-1]
+            full_bundle = ForecastBundle(
+                lat=lat,
+                lon=lon,
+                start=fetch_start,
+                end=fetch_end,
+                wind_by_model={w.model: w for w in wind_series_list},
+                sea=sea_series,
+                requested_at=now,
+            )
+            self._cache_put(key, now, full_bundle)
+            # Publish before deregistering, and with no await in between, so
+            # a joiner either waits on a future that is about to resolve or
+            # reads the cache entry that resolved it. Never neither.
+            future.set_result(full_bundle)
+            return full_bundle
+        except BaseException as exc:
+            if not future.done():
+                future.set_exception(exc)
+            raise
+        finally:
+            self._inflight.pop(key, None)
 
     async def _fetch_wind(
         self,

--- a/packages/data-adapters/src/openwind_data/currents/__init__.py
+++ b/packages/data-adapters/src/openwind_data/currents/__init__.py
@@ -8,5 +8,7 @@ Provides:
   currents from harmonic constants. Standard Greenwich-phase convention,
   validated against PREVIMER MARC + REFMAR Brest.
 - ``marc_atlas`` (Phase 2): Parquet-backed loader for the MARC atlases.
-- ``router`` (Phase 2): cascade MARC → Open-Meteo SMOC.
+- ``router`` (Phase 2): cascade SHOM → MARC → Open-Meteo SMOC, and the
+  ``compose_marine_adapter`` factory that decides which tiers a deployment
+  can actually feed.
 """

--- a/packages/data-adapters/src/openwind_data/currents/router.py
+++ b/packages/data-adapters/src/openwind_data/currents/router.py
@@ -51,8 +51,15 @@ class CompositeMarineAdapter:
     """``MarineDataAdapter`` that overrides Open-Meteo currents/tide via the
     SHOM > MARC > SMOC cascade.
 
-    Methods on the upstream adapter (e.g. ``aclose``) are not delegated;
-    callers manage the lifecycle of the upstream they pass in.
+    Lifecycle methods on the upstream adapter (e.g. ``aclose``) are not
+    delegated; callers manage the lifecycle of the upstream they pass in.
+    ``prewarm_batch`` is delegated, because it is not lifecycle: it is the
+    optimisation that turns one fetch per route segment into one batched call
+    for the whole corridor, and an engine probing this adapter with
+    ``hasattr`` would otherwise silently lose it the moment the cascade is
+    wired in front of Open-Meteo. The overrides are applied on read, in
+    ``fetch``, so warming the upstream cache changes nothing but the number of
+    round-trips.
 
     ``shom`` is optional; when omitted (or empty), the cascade reduces to
     MARC > SMOC and the adapter behaves identically to the previous
@@ -63,6 +70,24 @@ class CompositeMarineAdapter:
     upstream: MarineDataAdapter
     marc: MarcAtlasRegistry
     shom: ShomC2dRegistry | None = None
+
+    async def prewarm_batch(
+        self,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+        models: list[str] | None = None,
+    ) -> None:
+        """Hand the corridor to the upstream's batched warm-up, if it has one.
+
+        Best-effort on both counts: an upstream without the method (a browser
+        cache, a stub) simply has nothing to warm, and the upstream's own
+        implementation already swallows its failures.
+        """
+        warm = getattr(self.upstream, "prewarm_batch", None)
+        if warm is None:
+            return
+        await warm(points, start, end, models=models)
 
     async def fetch(
         self,
@@ -172,3 +197,35 @@ class CompositeMarineAdapter:
             sea=SeaSeries(points=tuple(new_points)),
             requested_at=bundle.requested_at,
         )
+
+
+def compose_marine_adapter(
+    upstream: MarineDataAdapter,
+    marc: MarcAtlasRegistry | None,
+    shom: ShomC2dRegistry | None,
+) -> MarineDataAdapter:
+    """Wrap ``upstream`` in the cascade the shipped datasets can actually feed.
+
+    The rule used to be written twice, once in ``build_server()`` for the MCP
+    tools and nowhere at all for the REST live path, which is how the two
+    ended up answering different currents for the same waypoint (audit M2).
+    It is a rule worth stating once:
+
+    - no MARC atlas, no composite. SHOM alone would give a route that jumps
+      between hand-curated cartouches and 8 km SMOC with nothing in between,
+      which reads as noise rather than as detail. MARC is what makes the
+      cascade continuous, so without it the plain upstream is the honest
+      answer.
+    - MARC present: compose, and add SHOM on top when it has points.
+
+    An empty registry is treated as an absent one: a deployment built without
+    the dataset secret gets objects that load fine and cover nothing.
+    """
+    if marc is None or not marc.atlases:
+        return upstream
+    shom_available = shom is not None and shom.lats.size > 0
+    return CompositeMarineAdapter(
+        upstream=upstream,
+        marc=marc,
+        shom=shom if shom_available else None,
+    )

--- a/packages/data-adapters/tests/currents/test_router.py
+++ b/packages/data-adapters/tests/currents/test_router.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-"""Tests for the MARC ↔ Open-Meteo composite adapter."""
+"""Tests for the SHOM ↔ MARC ↔ Open-Meteo composite adapter and its factory."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from openwind_data.adapters.base import (
     WindSeries,
 )
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
-from openwind_data.currents.router import CompositeMarineAdapter
+from openwind_data.currents.router import CompositeMarineAdapter, compose_marine_adapter
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 
 
@@ -266,3 +266,68 @@ async def test_marc_kicks_in_outside_shom_coverage(fixture_atlas: Path, tmp_path
     out = await composite.fetch(48.355, -4.795, bundle.start, bundle.end)
     for p in out.sea.points:
         assert p.current_source == "marc_finis_250m"
+
+
+# ------------------------------------------------- composition and prewarming
+
+
+class _WarmingUpstream(_MockUpstream):
+    """An upstream that also implements the batched cache warm-up."""
+
+    def __init__(self, bundle: ForecastBundle) -> None:
+        super().__init__(bundle)
+        self.warmed: list[tuple] = []
+
+    async def prewarm_batch(
+        self,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+        models: list[str] | None = None,
+    ) -> None:
+        self.warmed.append((tuple(points), start, end, models))
+
+
+async def test_prewarm_reaches_the_upstream_through_the_cascade():
+    """Otherwise wiring the cascade in silently costs one request per segment.
+
+    The engine probes its adapter with ``hasattr``: a composite that does not
+    forward ``prewarm_batch`` answers "no" and every segment falls back to its
+    own round-trip. That is a regression the composite's own results cannot
+    show, because the numbers are identical either way.
+    """
+    upstream = _WarmingUpstream(_make_bundle(48.35, -4.80))
+    adapter = CompositeMarineAdapter(upstream=upstream, marc=MarcAtlasRegistry.from_directory(""))
+    start = datetime(2024, 6, 15, 12, tzinfo=UTC)
+
+    await adapter.prewarm_batch(
+        [(48.35, -4.80), (48.40, -4.70)], start, start + timedelta(hours=6), models=["icon_eu"]
+    )
+
+    assert upstream.warmed == [
+        (((48.35, -4.80), (48.40, -4.70)), start, start + timedelta(hours=6), ["icon_eu"])
+    ]
+
+
+async def test_prewarm_is_a_no_op_on_an_upstream_without_one():
+    """A browser cache or a stub has nothing to warm, and must not raise."""
+    upstream = _MockUpstream(_make_bundle(48.35, -4.80))
+    adapter = CompositeMarineAdapter(upstream=upstream, marc=MarcAtlasRegistry.from_directory(""))
+    start = datetime(2024, 6, 15, 12, tzinfo=UTC)
+
+    await adapter.prewarm_batch([(48.35, -4.80)], start, start + timedelta(hours=6))
+
+    assert upstream.calls == []
+
+
+def test_composition_falls_back_to_the_upstream_without_a_marc_atlas(tmp_path: Path):
+    """The rule the REST and MCP shells now share, stated once.
+
+    Without MARC the cascade has nothing continuous to stand on, so the plain
+    upstream is the answer rather than a composite that would jump between
+    hand-curated SHOM cartouches and 8 km SMOC with nothing in between.
+    """
+    upstream = _MockUpstream(_make_bundle(48.35, -4.80))
+    composed = compose_marine_adapter(upstream, MarcAtlasRegistry.from_directory(""), None)
+    assert composed is upstream
+    assert compose_marine_adapter(upstream, None, None) is upstream

--- a/packages/data-adapters/tests/test_openmeteo_single_flight.py
+++ b/packages/data-adapters/tests/test_openmeteo_single_flight.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""Concurrent identical fetches share one round-trip, and a borrowed client lives on.
+
+Both properties matter for the same reason: on the deployment there is a
+single egress IP, Open-Meteo counts requests against it, and a passage fans
+its segments out with ``asyncio.gather``. The cache only helps a caller that
+arrives after an answer landed; several segments asking for the same AROME
+cell in the same tick all missed it and all paid, which the 2026-09 audit
+filed as Mo3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+import respx
+
+from openwind_data.adapters.base import UpstreamRateLimitError
+from openwind_data.adapters.openmeteo import (
+    FORECAST_URL,
+    MARINE_URL,
+    OpenMeteoAdapter,
+)
+
+START = datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
+END = datetime(2026, 4, 26, 23, 0, tzinfo=UTC)
+
+
+def _slow(payload: dict, delay: float = 0.02):
+    """A responder that yields to the loop, so callers really do overlap.
+
+    Without the await, respx answers inline and the first fetch is finished
+    before the second one is even scheduled: the test would pass with no
+    single-flight at all.
+    """
+
+    async def _respond(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(delay)
+        return httpx.Response(200, json=payload)
+
+    return _respond
+
+
+@respx.mock
+async def test_concurrent_identical_fetches_make_one_request(
+    forecast_marseille_arome, marine_porquerolles
+):
+    forecast = respx.get(FORECAST_URL).mock(side_effect=_slow(forecast_marseille_arome))
+    marine = respx.get(MARINE_URL).mock(side_effect=_slow(marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    bundles = await asyncio.gather(
+        *[adapter.fetch(lat=43.30, lon=5.35, start=START, end=END) for _ in range(6)]
+    )
+
+    assert forecast.call_count == 1
+    assert marine.call_count == 1
+    # Every joiner gets the same numbers as the caller that did the work.
+    first = bundles[0].wind_by_model["meteofrance_arome_france"].points
+    for bundle in bundles[1:]:
+        assert bundle.wind_by_model["meteofrance_arome_france"].points == first
+        assert bundle.start == bundles[0].start
+        assert bundle.end == bundles[0].end
+
+
+@respx.mock
+async def test_a_joiner_asking_for_a_wider_window_fetches_on_its_own(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """Sharing is only sound when the answer covers the joiner's window.
+
+    Same cache key, later window: the flight already in the air was widened
+    around the first caller's dates, and nothing guarantees it reaches the
+    second one. It issues its own request rather than silently returning a
+    slice with no points in it.
+    """
+    forecast = respx.get(FORECAST_URL).mock(side_effect=_slow(forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(side_effect=_slow(marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    far = START.replace(year=2026, month=5, day=8)
+    await asyncio.gather(
+        adapter.fetch(lat=43.30, lon=5.35, start=START, end=END),
+        adapter.fetch(lat=43.30, lon=5.35, start=far, end=far.replace(hour=23)),
+    )
+
+    assert forecast.call_count == 2
+
+
+@respx.mock
+async def test_a_failing_flight_fails_its_joiners_too(marine_porquerolles):
+    """One refusal, not six.
+
+    A 429 answered to six concurrent identical fetches used to become six
+    requests at the address Open-Meteo just told us to slow down on.
+    """
+    forecast = respx.get(FORECAST_URL).mock(
+        side_effect=lambda _r: httpx.Response(
+            429, headers={"Retry-After": "600"}, json={"reason": "Daily API request limit exceeded"}
+        )
+    )
+    respx.get(MARINE_URL).mock(side_effect=_slow(marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    results = await asyncio.gather(
+        *[adapter.fetch(lat=43.30, lon=5.35, start=START, end=END) for _ in range(6)],
+        return_exceptions=True,
+    )
+
+    assert forecast.call_count == 1
+    assert all(isinstance(r, UpstreamRateLimitError) for r in results), results
+
+
+@respx.mock
+async def test_the_flight_is_forgotten_after_it_fails(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """A failure must not poison the key: the next caller retries for real."""
+    responses = [
+        httpx.Response(500, json={"reason": "upstream is having a day"}),
+        httpx.Response(200, json=forecast_marseille_arome),
+    ]
+    forecast = respx.get(FORECAST_URL).mock(side_effect=responses)
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    with pytest.raises(httpx.HTTPStatusError):
+        await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+    bundle = await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+
+    assert forecast.call_count == 2
+    assert bundle.wind_by_model["meteofrance_arome_france"].points
+
+
+@respx.mock
+async def test_a_cancelled_joiner_does_not_cancel_the_others(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """The flight belongs to whoever started it, not to whoever waits on it.
+
+    A browser that gives up mid-sweep cancels its task; without shielding, the
+    future it was awaiting would be cancelled under every other segment.
+    """
+    respx.get(FORECAST_URL).mock(side_effect=_slow(forecast_marseille_arome, delay=0.05))
+    respx.get(MARINE_URL).mock(side_effect=_slow(marine_porquerolles, delay=0.05))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    leader = asyncio.create_task(adapter.fetch(lat=43.30, lon=5.35, start=START, end=END))
+    await asyncio.sleep(0)  # let the leader register its flight
+    joiner = asyncio.create_task(adapter.fetch(lat=43.30, lon=5.35, start=START, end=END))
+    await asyncio.sleep(0.01)
+    joiner.cancel()
+
+    bundle = await leader
+    assert bundle.wind_by_model["meteofrance_arome_france"].points
+    assert joiner.cancelled()
+
+
+@respx.mock
+async def test_an_injected_client_is_reused_and_never_closed(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """The process that opened the client decides when it dies.
+
+    This is what lets one client, one connection pool and one cache serve the
+    whole deployment instead of one client per upstream call.
+    """
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    client = httpx.AsyncClient()
+    adapter = OpenMeteoAdapter(client, http_min_interval_s=0)
+    await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+    assert not client.is_closed
+    await adapter.fetch(lat=44.10, lon=5.35, start=START, end=END)
+    assert not client.is_closed
+    await client.aclose()
+
+
+@respx.mock
+async def test_without_an_injected_client_one_is_opened_per_call(
+    forecast_marseille_arome, marine_porquerolles
+):
+    """The unchanged default, kept for the local stdio runner and the tests.
+
+    Recorded here because it is the baseline the shared-client deployment is
+    measured against: N upstream fetches used to mean N connection pools.
+    """
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    opened: list[httpx.AsyncClient] = []
+    original = httpx.AsyncClient.__init__
+
+    def _counting_init(self, *args, **kwargs):
+        original(self, *args, **kwargs)
+        opened.append(self)
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    httpx.AsyncClient.__init__ = _counting_init  # type: ignore[method-assign]
+    try:
+        await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+        await adapter.fetch(lat=44.10, lon=5.35, start=START, end=END)
+    finally:
+        httpx.AsyncClient.__init__ = original  # type: ignore[method-assign]
+
+    assert len(opened) == 2
+    assert all(client.is_closed for client in opened)

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -31,7 +31,7 @@ from typing import Any
 
 import uvicorn
 from mcp.server.transport_security import TransportSecuritySettings
-from openwind_api import Settings, create_app
+from openwind_api import Services, Settings, create_app
 from openwind_api.security import warn_if_edge_secret_missing
 from openwind_mcp_core import build_server
 
@@ -70,9 +70,16 @@ def settings_from_env() -> Settings:
     )
 
 
-def build_mcp_app() -> Any:
-    """The FastMCP streamable-http app, with the Space's hosts allowed."""
-    server = build_server()
+def build_mcp_app(adapter: Any) -> Any:
+    """The FastMCP streamable-http app, with the Space's hosts allowed.
+
+    The adapter is the API's ``MarineDataAdapter``, handed in rather than
+    built here. Passing it is what makes this one process hold one HTTP
+    connection pool, one forecast cache and one copy of the tidal atlases
+    instead of two of each, and what makes a passage planned over REST and
+    the same passage planned over MCP read their currents off one source.
+    """
+    server = build_server(adapter=adapter)
     server.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=ALLOWED_HOSTS,
@@ -80,10 +87,22 @@ def build_mcp_app() -> Any:
     return server.streamable_http_app()
 
 
+def build_app() -> Any:
+    """The whole deployment, assembled: REST in front, MCP mounted behind.
+
+    The atlases, the HTTP connection pool and the forecast cache are built
+    once here and handed to both shells. Freezing the MCP surface is dropping
+    the ``mcp_app`` argument; nothing else in this function would change.
+    """
+    settings = settings_from_env()
+    services = Services.from_settings(settings)
+    return create_app(settings, mcp_app=build_mcp_app(services.marine), services=services)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     warn_if_edge_secret_missing()
-    app = create_app(settings_from_env(), mcp_app=build_mcp_app())
+    app = build_app()
     # Run uvicorn explicitly (rather than ``server.run(transport=...)``) so we
     # can enable ``proxy_headers``/``forwarded_allow_ips``. HF terminates TLS
     # at the edge; without these flags ASGI sees ``http`` + the internal Host

--- a/packages/hf-space/tests/test_wrapper.py
+++ b/packages/hf-space/tests/test_wrapper.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import pathlib
+import types
 
 import pytest
 from starlette.responses import PlainTextResponse
@@ -90,3 +91,43 @@ def test_the_space_hostnames_are_allowed_through_the_rebinding_guard(wrapper) ->
     # FastMCP refuses any Host outside localhost by default; on HF that is a
     # 421 on every request, which is how this was found the first time.
     assert "mcp.ohmywind.fr" in wrapper.ALLOWED_HOSTS
+
+
+def test_the_rest_api_and_the_mcp_server_share_one_marine_adapter(wrapper, monkeypatch) -> None:
+    """The point of the wiring, and invisible from either library's own tests.
+
+    ``openwind_api`` knows nothing about MCP and ``openwind_mcp_core`` knows
+    nothing about the REST app, so neither can notice this coming apart. Here
+    it is the difference between one HTTP connection pool, one 30 min
+    forecast cache and one copy of the tidal atlases, and two of each in a
+    container sized for one (audit M5) -- with the two halves answering
+    different currents for the same waypoint (audit M2).
+    """
+    captured: dict = {}
+
+    class _StubServer:
+        settings = types.SimpleNamespace(transport_security=None)
+
+        @staticmethod
+        def streamable_http_app():
+            return _StubMcpApp()
+
+    def _fake_build_server(*, adapter=None):
+        captured["adapter"] = adapter
+        return _StubServer()
+
+    monkeypatch.setattr(wrapper, "build_server", _fake_build_server)
+    app = wrapper.build_app()
+
+    assert captured["adapter"] is app.state.services.marine
+    assert captured["adapter"] is not None
+
+
+def test_the_shared_client_is_closed_when_the_process_stops(wrapper, monkeypatch) -> None:
+    """Nothing else can close it: it outlives every request by construction."""
+    monkeypatch.setattr(wrapper, "build_mcp_app", lambda _adapter: _StubMcpApp())
+    app = wrapper.build_app()
+    with TestClient(app) as client:
+        assert client.get("/api/v1/archetypes").status_code == 200
+        assert not app.state.services.http.is_closed
+    assert app.state.services.http.is_closed

--- a/packages/mcp-core/src/openwind_mcp_core/server.py
+++ b/packages/mcp-core/src/openwind_mcp_core/server.py
@@ -44,7 +44,7 @@ from mcp.types import ToolAnnotations
 from openwind_data.adapters.base import MarineDataAdapter
 from openwind_data.adapters.openmeteo import AUTO_MODEL, OpenMeteoAdapter
 from openwind_data.currents.marc_atlas import MarcAtlasRegistry
-from openwind_data.currents.router import CompositeMarineAdapter
+from openwind_data.currents.router import compose_marine_adapter
 from openwind_data.currents.shom_c2d_registry import ShomC2dRegistry
 from openwind_data.routing import (
     BoatPolar,
@@ -564,6 +564,13 @@ def build_server(
             ``MARC_ATLAS_DIR``. Either or both can be absent; the cascade
             degrades gracefully (SHOM > MARC > SMOC). Override the whole
             adapter in tests.
+
+            A deployment that also serves the REST API passes the adapter
+            the API built, so the two shells share one HTTP connection pool,
+            one 30 min forecast cache and one copy of the atlases. Left to
+            itself this factory loads its own registries, which is right for
+            the stdio runner (the only process where it is alone) and was
+            5 MB and 51 ms of pure duplication in the Space (audit M5).
     """
     # ``stateless_http=True`` disables the in-memory session table that
     # otherwise tracks an ``mcp-session-id`` per client across requests.
@@ -590,26 +597,17 @@ def build_server(
     if adapter is not None:
         fetch_adapter: MarineDataAdapter = adapter
     else:
-        upstream = OpenMeteoAdapter()
         marc_dir = os.environ.get("MARC_ATLAS_DIR")
         shom_dir = os.environ.get("SHOM_C2D_DIR")
-        marc_registry = MarcAtlasRegistry.from_directory(marc_dir) if marc_dir else None
-        shom_registry = ShomC2dRegistry.from_directory(shom_dir) if shom_dir else None
-        marc_available = marc_registry is not None and bool(marc_registry.atlases)
-        shom_available = shom_registry is not None and shom_registry.lats.size > 0
-        if marc_available:
-            fetch_adapter = CompositeMarineAdapter(
-                upstream=upstream,
-                marc=marc_registry,  # type: ignore[arg-type]
-                shom=shom_registry if shom_available else None,
-            )
-        else:
-            # Without MARC the composite adapter has nothing to override
-            # currents with on the shelf; we keep upstream Open-Meteo only.
-            # (SHOM alone in the composite would still work, but mixing
-            # SHOM-only zones with raw SMOC elsewhere is more readable
-            # via the existing two-tier composite once MARC lands.)
-            fetch_adapter = upstream
+        # ``compose_marine_adapter`` owns the "which tiers can this deployment
+        # actually feed" rule. It used to be written out here and nowhere on
+        # the REST side, which is how the same waypoint got SHOM currents over
+        # MCP and 8 km SMOC over REST (audit M2).
+        fetch_adapter = compose_marine_adapter(
+            OpenMeteoAdapter(),
+            MarcAtlasRegistry.from_directory(marc_dir) if marc_dir else None,
+            ShomC2dRegistry.from_directory(shom_dir) if shom_dir else None,
+        )
 
     @server.resource(
         PLAN_UI_RESOURCE_URI,


### PR DESCRIPTION
PR 2.3 du plan de rework (lot 2). Le REST live et le MCP partagent enfin un adaptateur, un pool de connexions, un cache et un seul jeu d'atlas.

## Le problème

Une requête `POST /api/v1/passage` sans `forecast_cache` (tout client MCP, et le web quand le navigateur n'a pas pu échantillonner le corridor) laissait le moteur se fabriquer un `OpenMeteoAdapter` nu :

- pas de SHOM, pas de MARC : les courants venaient d'un modèle global à 8 km alors que le même passage demandé en MCP lisait l'atlas SHOM ;
- aucun cache d'une requête à l'autre ;
- un `httpx.AsyncClient` ouvert puis refermé autour de chaque appel amont.

En face, `build_server()` construisait sa propre cascade, donc les registres d'atlas étaient chargés deux fois dans le même processus. C'est l'audit M2 et M5.

## Ce que fait la PR

1. `Services` (openwind_api) porte maintenant le client httpx partagé et l'adaptateur marin composite, en plus des deux registres. `create_app(settings, mcp_app, services=...)` accepte des services déjà construits ; le lifespan ferme le client.
2. `openwind_data.currents.router.compose_marine_adapter()` : la règle « quels étages cette instance peut-elle vraiment alimenter » écrite une fois, utilisée par l'API et par `build_server()`.
3. `packages/hf-space/app.py` construit les services une fois et les passe aux deux coquilles (`build_app()` extrait de `main()` pour être testable).
4. `OpenMeteoAdapter` : single-flight par clé de cache. Deux fetch identiques concurrents partagent un aller-retour ; celui qui a besoin d'une fenêtre plus large fait sa propre requête ; un vol qui échoue fait échouer ses passagers (une seule requête vers un amont qui vient de nous refuser) et n'empoisonne pas la clé. Le client injecté n'est jamais fermé par l'adaptateur.
5. `CompositeMarineAdapter` délègue `prewarm_batch`. Sans ça, câbler la cascade devant Open-Meteo aurait fait perdre le préchauffage groupé (le moteur sonde en `hasattr`) et coûté une requête par tronçon.

## Mesures

Registres et mémoire d'un processus de déploiement, sur les vrais datasets locaux (`build/marc` 5,3 Go, `build/shom_c2d`) :

| | avant | après |
|---|---|---|
| chargements `MarcAtlasRegistry` | 2 | 1 |
| chargements `ShomC2dRegistry` | 2 | 1 |
| assemblage de l'app | 311 ms | 231 ms |
| RSS ajoutée par l'assemblage | +70,5 Mio | +54,1 Mio |

24 plans live successifs (Marseille -> Porquerolles, départs horaires, sans `forecast_cache`, amont mocké par respx) :

| | avant | après |
|---|---|---|
| clients httpx ouverts | 24 | 0 (un seul, partagé, créé au démarrage) |
| requêtes amont | 48 | 2 |

Rafale concurrente de 8 fetch identiques (le cas d'un itinéraire dont les tronçons tombent dans la même maille AROME) :

| | avant | après |
|---|---|---|
| requêtes amont | 16 | 2 |
| durée | 65 ms | 25 ms |

Correction de fond, Goulet de Brest -> Iroise en live (20 NM, atlas chargés) :

| | avant | après |
|---|---|---|
| `current_source` | `openmeteo_smoc`, `openmeteo_smoc` | `shom_c2d_560_rade_brest`, `shom_c2d_560_iroise` |
| courant du 2e tronçon | 1,84 kn (confiance `medium`) | 0,66 kn (confiance `high`) |
| durée | 5,30 h | 6,18 h |

C'est la même réponse que le MCP donnait déjà. Le REST live donnait l'autre.

## Tests

589 -> 604 sur les 4 paquets (data-adapters 313 -> 323, api 198 -> 201, mcp-core 70, hf-space 8 -> 10). Ruff propre, format propre.

Nouveaux :
- `packages/data-adapters/tests/test_openmeteo_single_flight.py` : 1 requête pour 6 fetch concurrents identiques, fenêtre plus large -> requête propre, échec partagé, clé non empoisonnée, passager annulé sans annuler le vol, client injecté jamais fermé, et le comportement par défaut (un client par appel) figé comme référence de mesure.
- `packages/api/tests/test_live_currents.py` : un plan live sur un point couvert par un atlas de test rapporte `shom_c2d_558_test_zone` ; la même requête via `forecast_cache` garde la provenance du navigateur ; les registres de `services.marine` sont les objets de `services`.
- `packages/hf-space/tests/test_wrapper.py` : `build_server` reçoit exactement `app.state.services.marine`, et le client partagé est fermé à l'arrêt du processus.
- `packages/data-adapters/tests/currents/test_router.py` : délégation de `prewarm_batch`, no-op sur un amont qui n'en a pas, et repli sur l'amont sans atlas MARC.

`packages/api/tests/fake_requests.py` remplace six copies de la même classe `_FakeRequest` (les handlers lisent maintenant un deuxième champ sur la requête, il aurait fallu éditer les six).

**Goldens REST et MCP inchangés, octet pour octet** (`git status` vide sur les deux dossiers `goldens/`).

## Smoke local (worktree, atlas montés)

- `GET /` 200, `GET /api/v1/archetypes` 200
- `POST /api/v1/passage` Marseille -> Porquerolles demain 09:00+02:00, cruiser_30ft : **200 en 263 ms**, 40,31 NM, 14,86 h, complexité 2 « modéré », 5 tronçons, AROME partout, `openmeteo_smoc` (Méditerranée, attendu)
- MCP streamable HTTP : `initialize` 200 (`ohmywind` 1.27.2), `tools/list` -> `read_me`, `list_boat_archetypes`, `get_marine_forecast`, `plan_passage`
- `plan_passage` sur le même trajet : **4 ms**, 14,86 h et 40,31 NM identiques au REST. Les 4 ms sont la preuve directe de la PR : le cache rempli par la requête REST a servi l'appel MCP.
- `atlas coverage warmed in 4.50 s: 7 atlas(es), 132 rectangle(s)` au démarrage, une seule fois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)