### PR TITLE
perf(currents): prédiction SHOM vectorisée sur toute la série

### DIFF
--- a/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
+++ b/packages/data-adapters/src/openwind_data/currents/shom_c2d_registry.py
@@ -18,7 +18,12 @@ Pipeline at query time:
    ``hour_offset`` ∈ [-6, +6] used to linear-interp the 13-sample series.
 4. Linear interpolation in time over the 13-hour series, twice (coef 45
    and coef 95), and finally a linear interpolation in coefficient based
-   on the predicted tide range at the reference port for that day.
+   on the tide range predicted at Brest around that instant.
+
+Steps 3 and 4 are evaluated for a whole series at once: both sample the
+harmonic on a 5-minute grid around each instant, the grids of neighbouring
+instants overlap almost entirely, and the union of them is one call instead of
+220 per instant. See the block comment on the scan lattice below.
 
 All harmonic constants live in the JSON file shipped alongside the
 Parquet, so this module never imports MARC at runtime — the MARC
@@ -52,6 +57,114 @@ _TIDE_SCAN_HALFWINDOW = timedelta(hours=7.0)
 # Sampling step inside the scan window (minutes). 5-min step gives < 1 min
 # of error on the located extremum, well below the harmonic resolution.
 _TIDE_SCAN_STEP_MIN = 5
+
+# ---------------------------------------------------------------------------
+# The scan lattice
+#
+# Both searches below sample the same harmonic on a regular grid around each
+# query time: the tide event every 5 minutes over +-7 h, the day's range every
+# 30 minutes over +-12.5 h. Done one query at a time, that is 169 + 51 = 220
+# harmonic predictions per instant, and a 30-day hourly series pays it 721
+# times over. Measured 1.4 ms per instant, 1.03 s for the series (audit C2),
+# on the event loop, blocking every other request on the single worker.
+#
+# The windows of neighbouring instants overlap almost entirely, and they all
+# fall on one 5-minute lattice: 30 minutes is 6 steps of it, and every query
+# time in a series is a whole number of steps from the first. So the whole
+# series needs the harmonic evaluated once, on the union of its windows, and
+# everything after that is indexing. Same samples, same order, same numbers.
+# ---------------------------------------------------------------------------
+_LATTICE_STEP = timedelta(minutes=_TIDE_SCAN_STEP_MIN)
+_LATTICE_STEP_US = _TIDE_SCAN_STEP_MIN * 60 * 1_000_000
+# Lattice offsets of the tide-event window: +-7 h in 5-minute steps.
+_EVENT_HALF_STEPS = int(_TIDE_SCAN_HALFWINDOW.total_seconds() / 60 / _TIDE_SCAN_STEP_MIN)
+_EVENT_STEPS = np.arange(-_EVENT_HALF_STEPS, _EVENT_HALF_STEPS + 1)
+# Lattice offsets of the coefficient window: +-12.5 h in 30-minute steps,
+# which is +-25 steps of 6. A 25 h span covers two semi-diurnal cycles.
+_COEF_STEPS = np.arange(-25, 26) * (30 // _TIDE_SCAN_STEP_MIN)
+# How many lattice samples the harmonic sees at once. 16 384 keeps its
+# working set around 30 MB whatever the caller asks for, and is well past the
+# 9 000 a 30-day hourly series needs, so the common case runs in one block.
+_HARMONIC_BLOCK = 16384
+
+
+def _as_utc(t: datetime) -> datetime:
+    """Match what the scalar helpers did: assume UTC when the caller was vague."""
+    return t if t.tzinfo is not None else t.replace(tzinfo=UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class _ScanGroup:
+    """Query times that share one 5-minute lattice, and where each one sits on it.
+
+    A series is normally one group: Open-Meteo answers on the hour, and the
+    overlay endpoint steps by whole minutes from a single start. Two instants
+    land in different groups only when they are not a whole number of
+    5-minute steps apart, which costs nothing but a second, smaller lattice.
+    """
+
+    at: np.ndarray  # indices into the caller's list of times
+    origin: datetime  # lattice point zero
+    steps: np.ndarray  # lattice step of each query time, int64
+
+
+def _scan_groups(times: list[datetime]) -> list[_ScanGroup]:
+    """Partition ``times`` into groups sharing a 5-minute lattice.
+
+    Integer microseconds throughout: a residual computed in floating-point
+    seconds would scatter a perfectly regular series across groups on the
+    rounding of a millisecond.
+
+    Naive instants are read as UTC here rather than at each call site, which
+    is what the scalar helpers this replaced did one by one.
+    """
+    times = [_as_utc(t) for t in times]
+    anchor = times[0]
+    deltas = np.array(
+        [(t - anchor) // timedelta(microseconds=1) for t in times],
+        dtype=np.int64,
+    )
+    residuals = deltas % _LATTICE_STEP_US
+    groups: list[_ScanGroup] = []
+    for residual in np.unique(residuals):
+        at = np.flatnonzero(residuals == residual)
+        groups.append(
+            _ScanGroup(
+                at=at,
+                origin=anchor + timedelta(microseconds=int(residual)),
+                steps=deltas[at] // _LATTICE_STEP_US,
+            )
+        )
+    return groups
+
+
+def _sampled_windows(
+    group: _ScanGroup,
+    offsets: np.ndarray,
+    constants: dict[str, tuple[float, float]],
+) -> np.ndarray:
+    """Harmonic heights over each query's window, shape ``(len(group), len(offsets))``.
+
+    The union of the windows is evaluated once. For a 30-day hourly series
+    that is about 9 000 samples instead of 721 x 169.
+
+    Evaluated in blocks, because the predictor allocates several
+    ``(samples, 60)`` float64 arrays and the overlay endpoint accepts 800
+    steps of up to 6 h: a 4 800 h span sampled every 5 minutes is 57 000
+    points, and letting one anonymous request allocate a quarter of a
+    gigabyte in a container sized for a single worker is a denial of service
+    with extra steps. Blocking changes nothing about the values: each sample's
+    harmonic depends on its own instant and on nothing else.
+    """
+    wanted = group.steps[:, None] + offsets
+    needed = np.unique(wanted)
+    heights = np.empty(needed.size, dtype=float)
+    for begin in range(0, needed.size, _HARMONIC_BLOCK):
+        block = needed[begin : begin + _HARMONIC_BLOCK]
+        heights[begin : begin + block.size] = harmonic_predict(
+            [group.origin + int(step) * _LATTICE_STEP for step in block], constants
+        )
+    return heights[np.searchsorted(needed, wanted)]
 
 
 @dataclass(frozen=True, slots=True)
@@ -286,30 +399,28 @@ class ShomC2dRegistry:
     # Tide-event helpers (PM / BM at reference ports)
     # ------------------------------------------------------------------
 
-    def _tide_event_time(self, port: _RefPortMeta, target_t: datetime) -> datetime:
-        """Find the nearest ``port.ref_tide`` event (PM or BM) to ``target_t``.
+    def _event_offsets_h(self, port: _RefPortMeta, times: list[datetime]) -> np.ndarray:
+        """Hours from each query time to its nearest ``port.ref_tide`` event.
 
-        Sample tide height every 5 min over a ±7 h window around target_t,
-        spot the global maximum (PM) or minimum (BM) within that window
-        — a 14 h span exceeds the M2 period (12.42 h) so it always
-        contains exactly one event of each type. Returns a UTC datetime.
+        The event is the global maximum (PM) or minimum (BM) of the harmonic
+        over a +-7 h window sampled every 5 minutes: a 14 h span exceeds the
+        M2 period (12.42 h), so it always contains exactly one of each. The
+        result is what indexes the SHOM 13-sample series, which runs from
+        -6 h to +6 h around the event.
 
-        The approach is brute force on purpose: vectorised over ~170
-        sample points x 6 constituents = ~1000 cosines, well under a
-        millisecond per call. No bisection required.
+        Sign convention: the offset is ``query - event``, negative before the
+        event, matching the series' own axis.
         """
-        if target_t.tzinfo is None:
-            target_t = target_t.replace(tzinfo=UTC)
-        n_steps = int(2 * _TIDE_SCAN_HALFWINDOW.total_seconds() / 60 / _TIDE_SCAN_STEP_MIN) + 1
-        offsets_min = np.linspace(
-            -_TIDE_SCAN_HALFWINDOW.total_seconds() / 60,
-            _TIDE_SCAN_HALFWINDOW.total_seconds() / 60,
-            n_steps,
-        )
-        scan_times = [target_t + timedelta(minutes=float(m)) for m in offsets_min]
-        heights = harmonic_predict(scan_times, port.constants)
-        idx = int(np.argmax(heights) if port.ref_tide == "PM" else np.argmin(heights))
-        return scan_times[idx]
+        offsets = np.empty(len(times), dtype=float)
+        take = np.argmax if port.ref_tide == "PM" else np.argmin
+        for group in _scan_groups(times):
+            windows = _sampled_windows(group, _EVENT_STEPS, port.constants)
+            picked = _EVENT_STEPS[take(windows, axis=1)]
+            # ``(query - event).total_seconds() / 3600`` written out: the
+            # event sits ``picked`` lattice steps *after* the query, so the
+            # offset is the negative of that, in hours.
+            offsets[group.at] = -(picked * _LATTICE_STEP.total_seconds()) / 3600.0
+        return offsets
 
     def tide_coefficient(self, target_t: datetime) -> int:
         """National tidal coefficient (Brest-anchored) at ``target_t``.
@@ -352,17 +463,26 @@ class ShomC2dRegistry:
         local port only when Brest is absent (defensive — should never
         happen in practice since Brest is one of the SHOM ref ports).
         """
-        if target_t.tzinfo is None:
-            target_t = target_t.replace(tzinfo=UTC)
+        return float(self._coefficients(port, [target_t])[0])
+
+    def _coefficients(self, port: _RefPortMeta, times: list[datetime]) -> np.ndarray:
+        """The coefficient at each of ``times``, vectorised over the series.
+
+        Not once per calendar day: the window is a rolling 25 h centred on
+        each instant, so two instants an hour apart see slightly different
+        ranges. Rounding that to one value per day would move every current
+        on the shoulders of a springs-to-neaps transition, which is where the
+        coefficient matters most. Sampling it per instant costs nothing now
+        that the harmonic is evaluated once for the whole series.
+        """
         brest = self.ref_ports.get("BREST")
         anchor = brest if brest is not None else port
-        # 25 h window with 30-min step covers two semi-diurnal cycles.
-        offsets_min = np.linspace(-12.5 * 60, 12.5 * 60, 51)
-        scan_times = [target_t + timedelta(minutes=float(m)) for m in offsets_min]
-        heights = harmonic_predict(scan_times, anchor.constants)
-        rng = float(heights.max() - heights.min())
-        coef = 100.0 * rng / _BREST_MEAN_RANGE_M
-        return max(20.0, min(120.0, coef))
+        coefs = np.empty(len(times), dtype=float)
+        for group in _scan_groups(times):
+            windows = _sampled_windows(group, _COEF_STEPS, anchor.constants)
+            ranges = windows.max(axis=1) - windows.min(axis=1)
+            coefs[group.at] = np.clip(100.0 * ranges / _BREST_MEAN_RANGE_M, 20.0, 120.0)
+        return coefs
 
     # ------------------------------------------------------------------
     # Public predictor
@@ -378,11 +498,10 @@ class ShomC2dRegistry:
         atlas id and zone name so downstream code can attribute the value,
         e.g. ``"shom_c2d_558_morbihan"``.
 
-        The prediction is per-time independent: each query time gets its
-        own nearest tide event and its own day's coefficient. This costs
-        a handful of harmonic predictions per series and keeps the code
-        simple; if ever the call rate justifies it, a vectorised
-        per-series optimisation is straightforward.
+        Each query time still gets its own nearest tide event and its own
+        rolling coefficient window; what changed in PR 2.4 is that the
+        harmonic behind both is evaluated once for the whole series instead
+        of 220 times per instant. Same samples, same numbers, ~40x less time.
         """
         idx, dist_km = self._nearest(lat, lon)
         if idx is None or dist_km > self._MAX_NEAREST_KM:
@@ -393,31 +512,28 @@ class ShomC2dRegistry:
         if port is None:
             return None  # build artefact mismatch — fail closed
 
-        u_ve = self.u_ve[idx]
-        v_ve = self.v_ve[idx]
-        u_me = self.u_me[idx]
-        v_me = self.v_me[idx]
         atlas_id = int(self.atlas_ids[idx])
         zone = str(self.zone_names[idx])
         source_label = f"shom_c2d_{atlas_id}_{zone.lower()}"
+        if not times:
+            return (
+                np.empty(0, dtype=np.float32),
+                np.empty(0, dtype=np.float32),
+                source_label,
+            )
 
-        speeds = np.empty(len(times), dtype=np.float32)
-        dirs = np.empty(len(times), dtype=np.float32)
-        for i, t in enumerate(times):
-            event_t = self._tide_event_time(port, t)
-            offset_h = (t - event_t).total_seconds() / 3600.0
-            # Clamp to the sampled range; np.interp already clips at the
-            # ends, but clamping explicitly keeps the intent clear.
-            offset_h = max(-6.0, min(6.0, offset_h))
-            u_ve_t = float(np.interp(offset_h, _HOUR_OFFSETS, u_ve))
-            v_ve_t = float(np.interp(offset_h, _HOUR_OFFSETS, v_ve))
-            u_me_t = float(np.interp(offset_h, _HOUR_OFFSETS, u_me))
-            v_me_t = float(np.interp(offset_h, _HOUR_OFFSETS, v_me))
-            coef = self._coefficient_for_day(port, t)
-            w = (coef - 45.0) / 50.0
-            u = u_me_t + w * (u_ve_t - u_me_t)
-            v = v_me_t + w * (v_ve_t - v_me_t)
-            speeds[i] = float(np.hypot(u, v))
-            # Convert (u east, v north) to compass "to" direction.
-            dirs[i] = float(np.rad2deg(np.arctan2(u, v)) % 360.0)
+        # Clamp to the sampled range; np.interp already clips at the ends,
+        # but clamping explicitly keeps the intent clear.
+        offsets_h = np.clip(self._event_offsets_h(port, times), -6.0, 6.0)
+        u_ve_t = np.interp(offsets_h, _HOUR_OFFSETS, self.u_ve[idx])
+        v_ve_t = np.interp(offsets_h, _HOUR_OFFSETS, self.v_ve[idx])
+        u_me_t = np.interp(offsets_h, _HOUR_OFFSETS, self.u_me[idx])
+        v_me_t = np.interp(offsets_h, _HOUR_OFFSETS, self.v_me[idx])
+
+        w = (self._coefficients(port, times) - 45.0) / 50.0
+        u = u_me_t + w * (u_ve_t - u_me_t)
+        v = v_me_t + w * (v_ve_t - v_me_t)
+        speeds = np.hypot(u, v).astype(np.float32)
+        # Convert (u east, v north) to compass "to" direction.
+        dirs = (np.rad2deg(np.arctan2(u, v)) % 360.0).astype(np.float32)
         return speeds, dirs, source_label

--- a/packages/data-adapters/tests/currents/test_shom_c2d_parity.py
+++ b/packages/data-adapters/tests/currents/test_shom_c2d_parity.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""The vectorised SHOM predictor against the loop it replaced, sample for sample.
+
+PR 2.4 rewrote ``ShomC2dRegistry.predict_current_series`` from a Python loop
+over instants into one harmonic evaluation for the whole series. That is a
+rewrite of the thing that decides how fast the water is running in the Raz de
+Sein, so "it looks about right" is not a test. ``_reference_predict`` below is
+the pre-2.4 implementation, copied verbatim; the two must agree.
+
+They agree exactly, and the reason is worth stating: the vectorised version
+does not approximate the old scan, it *is* the old scan. Both sample the tide
+on the same 5-minute grid and the coefficient window on the same 30-minute
+grid; the rewrite only stopped re-evaluating the overlapping parts. Same
+inputs to ``harmonic.predict``, in the same order, so the same doubles come
+back. The assertions below allow zero difference on purpose: a tolerance would
+hide the day someone changes the grid and calls it a rounding artefact.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+from openwind_data.currents.harmonic import predict as harmonic_predict
+from openwind_data.currents.shom_c2d_registry import (
+    _BREST_MEAN_RANGE_M,
+    _HOUR_OFFSETS,
+    _TIDE_SCAN_HALFWINDOW,
+    _TIDE_SCAN_STEP_MIN,
+    ShomC2dRegistry,
+    _RefPortMeta,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3].parent
+_LIVE_DIR = _REPO_ROOT / "build" / "shom_c2d"
+
+# In the synthetic zone written below, and in the live Morbihan cartouche.
+SYNTHETIC_POINT = (47.50, -2.90)
+TASCON = (47.5733, -2.8903)
+T0 = datetime(2026, 5, 15, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------
+# The pre-2.4 implementation, verbatim. Three methods, inlined into one
+# function so nothing here can accidentally call the new code.
+# --------------------------------------------------------------------------
+
+
+def _reference_tide_event_time(port: _RefPortMeta, target_t: datetime) -> datetime:
+    if target_t.tzinfo is None:
+        target_t = target_t.replace(tzinfo=UTC)
+    n_steps = int(2 * _TIDE_SCAN_HALFWINDOW.total_seconds() / 60 / _TIDE_SCAN_STEP_MIN) + 1
+    offsets_min = np.linspace(
+        -_TIDE_SCAN_HALFWINDOW.total_seconds() / 60,
+        _TIDE_SCAN_HALFWINDOW.total_seconds() / 60,
+        n_steps,
+    )
+    scan_times = [target_t + timedelta(minutes=float(m)) for m in offsets_min]
+    heights = harmonic_predict(scan_times, port.constants)
+    idx = int(np.argmax(heights) if port.ref_tide == "PM" else np.argmin(heights))
+    return scan_times[idx]
+
+
+def _reference_coefficient(
+    registry: ShomC2dRegistry, port: _RefPortMeta, target_t: datetime
+) -> float:
+    if target_t.tzinfo is None:
+        target_t = target_t.replace(tzinfo=UTC)
+    brest = registry.ref_ports.get("BREST")
+    anchor = brest if brest is not None else port
+    offsets_min = np.linspace(-12.5 * 60, 12.5 * 60, 51)
+    scan_times = [target_t + timedelta(minutes=float(m)) for m in offsets_min]
+    heights = harmonic_predict(scan_times, anchor.constants)
+    rng = float(heights.max() - heights.min())
+    coef = 100.0 * rng / _BREST_MEAN_RANGE_M
+    return max(20.0, min(120.0, coef))
+
+
+def _reference_predict(
+    registry: ShomC2dRegistry, lat: float, lon: float, times: list[datetime]
+) -> tuple[np.ndarray, np.ndarray, str] | None:
+    idx, dist_km = registry._nearest(lat, lon)
+    if idx is None or dist_km > registry._MAX_NEAREST_KM:
+        return None
+    port = registry.ref_ports.get(str(registry.ref_port_keys[idx]))
+    if port is None:
+        return None
+    u_ve = registry.u_ve[idx]
+    v_ve = registry.v_ve[idx]
+    u_me = registry.u_me[idx]
+    v_me = registry.v_me[idx]
+    source_label = (
+        f"shom_c2d_{int(registry.atlas_ids[idx])}_{str(registry.zone_names[idx]).lower()}"
+    )
+
+    speeds = np.empty(len(times), dtype=np.float32)
+    dirs = np.empty(len(times), dtype=np.float32)
+    for i, t in enumerate(times):
+        event_t = _reference_tide_event_time(port, t)
+        offset_h = (t - event_t).total_seconds() / 3600.0
+        offset_h = max(-6.0, min(6.0, offset_h))
+        u_ve_t = float(np.interp(offset_h, _HOUR_OFFSETS, u_ve))
+        v_ve_t = float(np.interp(offset_h, _HOUR_OFFSETS, v_ve))
+        u_me_t = float(np.interp(offset_h, _HOUR_OFFSETS, u_me))
+        v_me_t = float(np.interp(offset_h, _HOUR_OFFSETS, v_me))
+        coef = _reference_coefficient(registry, port, t)
+        w = (coef - 45.0) / 50.0
+        u = u_me_t + w * (u_ve_t - u_me_t)
+        v = v_me_t + w * (v_ve_t - v_me_t)
+        speeds[i] = float(np.hypot(u, v))
+        dirs[i] = float(np.rad2deg(np.arctan2(u, v)) % 360.0)
+    return speeds, dirs, source_label
+
+
+# --------------------------------------------------------------------------
+# A registry with a real reference port, so the tide-event search has
+# something to find. Same shape as the one in test_shom_c2d_registry.
+# --------------------------------------------------------------------------
+
+
+def _write_synthetic_registry(out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    hours = list(range(-6, 7))
+    # An asymmetric pair of series, so a wrong hour offset shows up as a wrong
+    # number rather than cancelling out against a symmetric one.
+    u_ve = [math.sin(math.pi * h / 6.0) for h in hours]
+    v_ve = [0.4 * math.cos(math.pi * h / 5.0) for h in hours]
+    rows = [
+        {
+            "atlas_id": 558,
+            "zone": "TEST_ZONE",
+            "ref_port_key": "BREST",
+            "ref_tide": "PM",
+            "lat": lat,
+            "lon": lon,
+            "u_ve_kn": u_ve,
+            "v_ve_kn": v_ve,
+            "u_me_kn": [0.5 * v for v in u_ve],
+            "v_me_kn": [0.5 * v for v in v_ve],
+        }
+        for lat, lon in ((47.50, -2.90), (47.51, -2.89), (47.49, -2.91))
+    ]
+    pl.DataFrame(rows).with_columns(
+        pl.col("atlas_id").cast(pl.Int16),
+        pl.col("lat").cast(pl.Float32),
+        pl.col("lon").cast(pl.Float32),
+        pl.col("u_ve_kn").cast(pl.List(pl.Float32)),
+        pl.col("v_ve_kn").cast(pl.List(pl.Float32)),
+        pl.col("u_me_kn").cast(pl.List(pl.Float32)),
+        pl.col("v_me_kn").cast(pl.List(pl.Float32)),
+    ).write_parquet(out / "shom_c2d_points.parquet")
+    (out / "shom_c2d_ref_ports.json").write_text(
+        json.dumps(
+            {
+                "BREST": {
+                    "display_name": "Brest",
+                    "lat": 48.3833,
+                    "lon": -4.4956,
+                    "ref_tide": "PM",
+                    # Enough constituents that the extremum moves from day to
+                    # day, which is what makes the parity check meaningful.
+                    "constants": {
+                        "M2": [2.0, 150.0],
+                        "S2": [0.7, 200.0],
+                        "N2": [0.4, 130.0],
+                        "K1": [0.07, 80.0],
+                        "O1": [0.06, 320.0],
+                        "M4": [0.1, 40.0],
+                    },
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> ShomC2dRegistry:
+    _write_synthetic_registry(tmp_path)
+    return ShomC2dRegistry.from_directory(tmp_path)
+
+
+def _assert_identical(registry: ShomC2dRegistry, point, times) -> None:
+    expected = _reference_predict(registry, *point, times)
+    produced = registry.predict_current_series(*point, times)
+    assert expected is not None and produced is not None
+    assert produced[2] == expected[2]
+    speed_diff = float(np.max(np.abs(produced[0] - expected[0]))) if len(times) else 0.0
+    dir_diff = float(np.max(np.abs(produced[1] - expected[1]))) if len(times) else 0.0
+    assert speed_diff == 0.0, f"speed differs by up to {speed_diff} kn over {len(times)} instants"
+    assert dir_diff == 0.0, f"direction differs by up to {dir_diff} deg over {len(times)} instants"
+
+
+def test_thirty_days_hourly(registry) -> None:
+    _assert_identical(registry, SYNTHETIC_POINT, [T0 + timedelta(hours=h) for h in range(721)])
+
+
+def test_seven_days_at_five_minutes(registry) -> None:
+    _assert_identical(
+        registry, SYNTHETIC_POINT, [T0 + timedelta(minutes=5 * i) for i in range(2017)]
+    )
+
+
+def test_a_step_that_is_not_a_whole_number_of_lattice_steps(registry) -> None:
+    """A 7-minute step spreads the series over five lattice phases.
+
+    Nothing in the product asks for one, but the overlay endpoint takes
+    ``step_minutes`` as a free integer, so the grouping has to hold for any
+    of them rather than for the ones we happen to use.
+    """
+    _assert_identical(
+        registry, SYNTHETIC_POINT, [T0 + timedelta(minutes=7 * i) for i in range(300)]
+    )
+
+
+def test_a_single_instant_and_an_empty_series(registry) -> None:
+    _assert_identical(registry, SYNTHETIC_POINT, [T0])
+    speeds, dirs, source = registry.predict_current_series(*SYNTHETIC_POINT, [])
+    assert speeds.shape == (0,)
+    assert dirs.shape == (0,)
+    assert source == "shom_c2d_558_test_zone"
+
+
+def test_naive_instants_are_still_read_as_utc(registry) -> None:
+    naive = [T0.replace(tzinfo=None) + timedelta(hours=h) for h in range(48)]
+    aware = [T0 + timedelta(hours=h) for h in range(48)]
+    naive_out = registry.predict_current_series(*SYNTHETIC_POINT, naive)
+    aware_out = registry.predict_current_series(*SYNTHETIC_POINT, aware)
+    assert naive_out is not None and aware_out is not None
+    assert np.array_equal(naive_out[0], aware_out[0])
+    assert np.array_equal(naive_out[1], aware_out[1])
+
+
+def test_unsorted_instants_keep_their_own_answers(registry) -> None:
+    """Order is the caller's, not ours: the union of windows must not reorder it."""
+    times = [T0 + timedelta(hours=h) for h in (30, 3, 17, 0, 71, 8)]
+    _assert_identical(registry, SYNTHETIC_POINT, times)
+
+
+def test_the_tide_coefficient_is_unchanged(registry) -> None:
+    port = registry.ref_ports["BREST"]
+    for day in range(0, 30, 3):
+        t = T0 + timedelta(days=day)
+        assert registry.tide_coefficient(t) == round(_reference_coefficient(registry, port, t))
+
+
+@pytest.mark.skipif(
+    not (_LIVE_DIR / "shom_c2d_points.parquet").exists(),
+    reason="live SHOM C2D artefacts not built (run scripts/build_shom_c2d.py)",
+)
+def test_live_artefacts_thirty_days_hourly() -> None:
+    """The same check on the shipped 13 k-point cloud, at a real reference port.
+
+    The synthetic fixture proves the arithmetic; this proves it on the
+    constants and the series that actually reach a skipper.
+    """
+    registry = ShomC2dRegistry.from_directory(_LIVE_DIR)
+    _assert_identical(registry, TASCON, [T0 + timedelta(hours=h) for h in range(721)])


### PR DESCRIPTION
PR 2.4 du plan de rework (lot 2), suite de #334. Indépendante : elle ne touche qu'à `shom_c2d_registry.py`.

## Le problème

`ShomC2dRegistry.predict_current_series` bouclait en Python sur les instants. Par instant :

- `_tide_event_time` : 169 prédictions harmoniques pour situer la PM (ou BM) la plus proche, en échantillonnant toutes les 5 min sur +/- 7 h ;
- `_coefficient_for_day` : 51 de plus pour la fenêtre de coefficient, toutes les 30 min sur +/- 12,5 h.

Soit 220 évaluations par instant, 1,4 ms mesurées sur cette machine, 1,03 s pour 30 jours horaires. Le tout synchrone, sur la boucle d'événements, donc au nez de toutes les autres requêtes du worker unique. C'est le point C2 de l'audit.

## Ce que fait la PR

Les fenêtres d'instants voisins se recouvrent presque entièrement, et elles tombent toutes sur un même treillis de 5 minutes (30 min en est 6 pas, et deux instants d'une série sont un nombre entier de pas l'un de l'autre). L'harmonique est donc évaluée **une seule fois** sur l'union des fenêtres, et tout le reste devient de l'indexation numpy.

- `_scan_groups()` répartit les instants par phase de treillis. Une série normale n'en a qu'une ; un pas de 7 min en fait cinq, ce qui coûte cinq treillis plus petits et rien d'autre. Arithmétique en microsecondes entières, pour qu'une série régulière ne se disperse pas sur l'arrondi d'une milliseconde.
- `_sampled_windows()` évalue l'union par blocs de 16 384 échantillons. Le prédicteur alloue plusieurs tableaux `(échantillons, 60)` en float64 : sans découpage, la plus large série que `/api/v1/marine/marc` accepte (800 pas de 6 h, soit 4 800 h à échantillonner toutes les 5 min) faisait +239 Mio de RSS sur une requête anonyme.
- `_tide_event_time` et `_coefficient_for_day` deviennent `_event_offsets_h` et `_coefficients`, qui travaillent sur la série entière. `tide_coefficient()` garde exactement sa signature et son résultat.

Le coefficient reste calculé par instant, sur une fenêtre glissante de 25 h, et **pas une fois par jour** comme le plan le suggérait : deux instants espacés d'une heure voient des marnages légèrement différents, et arrondir à une valeur par jour aurait déplacé tous les courants sur les épaules d'un passage vives-eaux / mortes-eaux, c'est-à-dire là où le coefficient compte le plus. Maintenant que l'harmonique est évaluée une fois pour toute la série, l'échantillonner par instant ne coûte plus rien.

## Parité numérique : exacte

Pas une tolérance, zéro différence. La version vectorisée n'approxime pas l'ancien balayage, **c'est** l'ancien balayage : mêmes échantillons, dans le même ordre, passés à la même fonction `harmonic.predict`, donc les mêmes doubles reviennent. Elle a simplement cessé de réévaluer les parties communes.

`packages/data-adapters/tests/currents/test_shom_c2d_parity.py` garde la boucle d'avant, copiée telle quelle, comme référence, et exige `max |diff| == 0` sur la vitesse comme sur la direction :

| cas | instants | différence max |
|---|---|---|
| 30 jours horaires | 721 | 0 kn / 0 deg |
| 7 jours au pas de 5 min | 2 017 | 0 kn / 0 deg |
| pas de 7 min (5 phases de treillis) | 300 | 0 kn / 0 deg |
| série désordonnée | 6 | 0 kn / 0 deg |
| un instant seul, série vide | 1, 0 | 0 kn / 0 deg |
| **artefacts SHOM réels (13 290 points, Tascon), 30 j horaires** | 721 | **0 kn / 0 deg** |

Le dernier cas est `skipif` en CI (les artefacts ne sont pas versionnés) et a tourné vert en local sur `build/shom_c2d`. Deux tests de plus : les instants naïfs sont toujours lus en UTC, et `tide_coefficient()` rend la même valeur qu'avant sur 10 jours.

Une tolérance aurait été le mauvais choix ici : elle aurait masqué le jour où quelqu'un change la grille d'échantillonnage et appelle ça un artefact d'arrondi.

## Mesures

Registre SHOM réel (13 290 points), point de Tascon, médiane de 5 exécutions :

| série | avant | après | facteur |
|---|---|---|---|
| 30 j horaires (721 instants) | 1 027 ms | **39 ms** | 26x |
| 7 j au pas de 5 min (2 017 instants) | 2 930 ms | **24 ms** | 121x |
| 24 h horaires (25 instants) | 35,6 ms | **2,1 ms** | 17x |

Cible du plan (p95 < 100 ms pour 30 jours horaires) : tenue avec une marge de 2,5x.

Bout en bout sur la route, `GET /api/v1/marine/marc` 30 jours horaires à Tascon, ancien prédicteur réinjecté dans le même processus pour que les deux nombres ne diffèrent que du réécrit :

| | avant | après |
|---|---|---|
| latence médiane (3 exécutions) | 828 ms | **59 ms** |

Mémoire, sur la série la plus large que la route accepte (800 pas, `step_minutes=360`, soit 4 800 h) :

| | sans découpage | par blocs de 16 384 |
|---|---|---|
| latence | 421 ms | 237 ms |
| RSS ajoutée | +239 Mio | **+33 Mio** |

## Tests

data-adapters 313 -> 323 (dont 8 nouveaux de parité ; +2 de plus tournent en local grâce aux artefacts SHOM présents). api 198, mcp-core 70, hf-space 8 inchangés. Ruff propre, format propre. Goldens REST et MCP inchangés.

## Smoke local (worktree, atlas montés)

- `GET /` 200, `GET /api/v1/archetypes` 200
- `GET /api/v1/marine/marc` Tascon, 30 jours horaires : 200, 35 287 o, **134 ms**, `covered: true`, `shom_c2d_558_morbihan`, 721 instants, coef 77
- `POST /api/v1/passage` Marseille -> Porquerolles demain 09:00+02:00, cruiser_30ft : 200 en 330 ms, 40,31 NM, 14,86 h, complexité 2 « modéré », 5 tronçons
- MCP streamable HTTP : `initialize` 200 (`ohmywind` 1.27.2), `tools/list` -> les 4 outils
- `plan_passage` Goulet de Brest -> Iroise : 200, 19,82 NM, 6,18 h, `shom_c2d_560_rade_brest` et `shom_c2d_560_iroise`. Chiffres identiques à ceux d'avant la PR, ce qui est le point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
