### PR TITLE
feat(api): journal structuré, identifiant de requête, amont observable

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -50,10 +50,34 @@ test asserts it by importing the package with the name `mcp` blocked.
 - `security.py`: rate limiting, body ceiling, security headers, client IP.
   The limiter counts per network, `/32` for IPv4 and `/64` for IPv6, because a
   phone picks its own address inside the prefix its carrier assigned.
+- `access.py`: one logfmt line per request, and the `X-Request-Id` header.
 - `static/landing.html`: the landing page. Its media ship with the deployment.
 
 Serialising a passage is not here: that is `openwind_data.views`, shared with
 the MCP shell so the two describe the same sailing.
+
+## Logs
+
+One line per request on the `openwind_api.access` logger, at INFO, in logfmt:
+
+```
+id=9f2c1a4b7e3d5088 method=POST path=/api/v1/passage status=200 dur_ms=263.4 bytes=4267 cache=yes bucket=846488f1
+```
+
+`cache` says whether the caller posted a `forecast_cache`, which is the
+difference between a request that cost an upstream fan-out and one that cost
+only CPU. `bucket` is `sha256(client address)[:8]`: enough to tell whether one
+caller is responsible for a burst, and not an address. **No address is ever
+logged**, in any field, in any shape, and a test greps the whole log to keep
+it that way.
+
+`X-Request-Id` is echoed when the caller sends a usable one (64 chars of
+`[A-Za-z0-9._:-]`) and generated otherwise, returned on every response and
+exposed through CORS so the web app can quote it.
+
+Every upstream Open-Meteo call is logged at DEBUG, by host, with its status,
+its duration and whether the cache answered instead. Never with the query
+string: it carries the waypoints.
 
 ## Errors
 

--- a/packages/api/src/openwind_api/access.py
+++ b/packages/api/src/openwind_api/access.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""One log line per request, and an id to follow it by.
+
+Until now the deployment logged nothing of its own. uvicorn printed a method,
+a path and a status; there was no duration, no response size, no way to tell a
+plan served from the browser's own sampling apart from one that went upstream,
+and no identifier a user could quote when reporting that "the plan failed
+around eleven". The 2026-09 audit filed that as Mo1, and it is the reason
+several of its own findings had to be measured by reading the source rather
+than by reading production.
+
+## Format
+
+logfmt: ``key=value`` pairs, space separated, values quoted only when they
+need it. One format, chosen once, and the reasons are worth writing down
+because the obvious alternative is JSON:
+
+- the logs are read in Hugging Face's plain-text web console, where a JSON
+  line wraps into an unreadable block and a logfmt line stays one line;
+- there is no log collector to parse JSON *for* anyone, so the audience is a
+  human with a browser and, at best, ``grep``;
+- every value here is a scalar, so JSON's one real advantage (structure) buys
+  nothing.
+
+If a collector ever appears, this is the single place to change.
+
+## Fields
+
+``id`` request id, echoed in the ``X-Request-Id`` response header.
+``method`` ``path`` what was asked.
+``status`` what was answered, including a 429 from the limiter or a 413 from
+    the body ceiling: this middleware is the outermost one, so it sees the
+    real answer rather than the one the handler would have given.
+``dur_ms`` wall time for the whole stack, compression included.
+``bytes`` response body bytes as they went on the wire, so *after* gzip.
+``cache`` whether the request carried a ``forecast_cache``, i.e. whether the
+    browser sampled the corridor itself. The single most useful field here:
+    it separates the requests that cost us an upstream fan-out from the ones
+    that cost us only CPU.
+``bucket`` the rate-limit bucket's fingerprint, ``sha256(ip)[:8]``.
+
+## Addresses
+
+Never logged. Not the client address, not ``X-Forwarded-For``, not a
+"truncated" address. ``bucket`` is a one-way hash and is enough for the
+question these logs exist to answer (is one caller responsible for this
+traffic?), while an address in a log file is personal data we would then have
+to hold, protect and expire. The privacy policy says the deployment keeps no
+identifying logs; this module is where that stays true.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import secrets
+import time
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from openwind_api.security import bucket_id
+
+_logger = logging.getLogger("openwind_api.access")
+
+REQUEST_ID_HEADER = "x-request-id"
+
+# A caller-supplied id is untrusted text on its way into a log line. Anything
+# outside this alphabet, or longer than this, gets a generated id instead:
+# a newline in the middle of a request id forges log entries, and that is a
+# real technique, not a theoretical one.
+_SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
+
+# logfmt needs quoting only when a value could break the "key=value key=value"
+# reading. Paths are the realistic source of one.
+_NEEDS_QUOTING = re.compile(r'[\s"=]')
+
+
+def _field(value: object) -> str:
+    text = str(value)
+    if not text:
+        return '""'
+    if _NEEDS_QUOTING.search(text):
+        return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return text
+
+
+def request_id_of(scope: Scope) -> str:
+    """This request's id: the caller's if it is safe to echo, else a fresh one.
+
+    Honouring the caller's id is what lets the edge proxy, the web app and the
+    Space agree on one identifier for one user action. Sixteen hex characters
+    when we generate it: enough that two ids never collide inside a log
+    window, short enough to read aloud over the phone.
+    """
+    for name, value in scope.get("headers", ()):
+        if name == REQUEST_ID_HEADER.encode():
+            candidate = value.decode("latin-1")
+            if _SAFE_REQUEST_ID.match(candidate):
+                return candidate
+            break
+    return secrets.token_hex(8)
+
+
+class AccessLogMiddleware:
+    """Time every request, log one line, and stamp it with its id.
+
+    Outermost in the stack on purpose: it must see the status the client
+    actually receives (a 429 never reaches a handler) and the bytes that
+    actually leave (compression happens inside it).
+
+    The id is written onto ``scope["state"]`` as well as onto the response, so
+    a handler can put it in an error body or carry it into its own logging
+    without re-reading a header.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = request_id_of(scope)
+        state = scope.setdefault("state", {})
+        state["request_id"] = request_id
+
+        started = time.perf_counter()
+        status = 0
+        body_bytes = 0
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status, body_bytes
+            if message["type"] == "http.response.start":
+                status = message["status"]
+                MutableHeaders(scope=message)[REQUEST_ID_HEADER] = request_id
+            elif message["type"] == "http.response.body":
+                body_bytes += len(message.get("body", b""))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except BaseException:
+            # A handler that raised still gets a line, with the 500 the server
+            # is about to send. Losing the slow, failing requests is losing
+            # exactly the ones worth seeing.
+            self._log(scope, request_id, 500, started, body_bytes)
+            raise
+        self._log(scope, request_id, status, started, body_bytes)
+
+    def _log(
+        self, scope: Scope, request_id: str, status: int, started: float, body_bytes: int
+    ) -> None:
+        duration_ms = (time.perf_counter() - started) * 1000
+        cached = scope.get("state", {}).get("forecast_cache")
+        _logger.info(
+            "id=%s method=%s path=%s status=%d dur_ms=%.1f bytes=%d cache=%s bucket=%s",
+            _field(request_id),
+            _field(scope.get("method", "-")),
+            _field(scope.get("path", "-")),
+            status,
+            duration_ms,
+            body_bytes,
+            "-" if cached is None else ("yes" if cached else "no"),
+            _field(bucket_id(scope)),
+        )

--- a/packages/api/src/openwind_api/app.py
+++ b/packages/api/src/openwind_api/app.py
@@ -25,6 +25,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from openwind_api.access import AccessLogMiddleware
 from openwind_api.routes.archetypes import api_archetypes, api_client_debug
 from openwind_api.routes.landing import ICON_REDIRECTS, icon_redirect, index, static_asset_route
 from openwind_api.routes.marine import api_marc_coverage, api_marc_overlay
@@ -157,6 +158,10 @@ def create_app(
         # headers, otherwise the browser reports an opaque CORS failure and
         # the real cause never reaches the user.
         middleware=[
+            # Outermost, so the line it logs carries the status the client
+            # really got (a 429 never reaches a handler) and the byte count
+            # that really left (compression happens inside it).
+            Middleware(AccessLogMiddleware),
             Middleware(
                 CORSMiddleware,
                 allow_origins=ALLOWED_ORIGINS,
@@ -167,7 +172,10 @@ def create_app(
                 # opts the rest in here. Without this the web app cannot tell
                 # the user how long to wait and has to guess, which is how the
                 # copy ended up hard-coding "une minute" for a 5-minute window.
-                expose_headers=["Retry-After"],
+                # X-Request-Id joins it for the same reason: the web app
+                # cannot quote an identifier in a bug report if the browser
+                # will not let it read one.
+                expose_headers=["Retry-After", "X-Request-Id"],
             ),
             # Compression sits inside CORS (so the negotiated headers are
             # never rewritten by the compressor) and outside everything that

--- a/packages/api/src/openwind_api/routes/passage.py
+++ b/packages/api/src/openwind_api/routes/passage.py
@@ -68,6 +68,17 @@ def _adapter(request: Request, parsed: PassageRequest) -> MarineDataAdapter:
     return parsed.adapter or request.app.state.services.marine
 
 
+def _note_forecast_cache(request: Request, parsed: PassageRequest) -> None:
+    """Record which of those two doors this one came through, for the log.
+
+    From outside they are the same POST to the same path, and the ratio
+    between them is what says whether the web app's client-side sampling is
+    working in the field: one costs us CPU only, the other fans out to
+    Open-Meteo.
+    """
+    request.scope.setdefault("state", {})["forecast_cache"] = parsed.adapter is not None
+
+
 async def api_passage(request: Request) -> JSONResponse:
     """Plan a passage from a departure time, or sweep a range of them.
 
@@ -79,6 +90,7 @@ async def api_passage(request: Request) -> JSONResponse:
         body = await _json_body(request)
         departure, parsed = parse_passage_request(body, timestamp_field="departure")
         adapter = _adapter(request, parsed)
+        _note_forecast_cache(request, parsed)
         latest_raw = body.get("latest_departure")
         if latest_raw is not None:
             return await _sweep(body, departure, parsed, latest_raw, adapter)
@@ -100,6 +112,7 @@ async def api_passage_by_eta(request: Request) -> JSONResponse:
         body = await _json_body(request)
         target_arrival, parsed = parse_passage_request(body, timestamp_field="target_arrival")
         adapter = _adapter(request, parsed)
+        _note_forecast_cache(request, parsed)
     except RequestError as exc:
         return exc.response()
 

--- a/packages/api/tests/fake_requests.py
+++ b/packages/api/tests/fake_requests.py
@@ -23,7 +23,7 @@ from openwind_data.testing import DeterministicMarineAdapter
 
 
 class FakeRequest:
-    """A JSON body, and the services a handler resolves its adapter from.
+    """A JSON body, the services a handler resolves its adapter from, a scope.
 
     ``body`` may be an ``Exception``, which ``json()`` then raises: that is how
     a malformed payload is simulated, since Starlette surfaces a decode
@@ -32,6 +32,10 @@ class FakeRequest:
     The default adapter is the deterministic stub rather than a live one, so a
     test that reaches the engine by accident fails on an assertion rather than
     on a network call.
+
+    ``scope`` is where the handler tells the access log which door the request
+    came through; see ``_note_forecast_cache``. The point of having one class
+    was that the next field would cost one edit, and this is the next field.
     """
 
     def __init__(self, body: Any, *, marine: Any = None) -> None:
@@ -41,6 +45,7 @@ class FakeRequest:
                 services=SimpleNamespace(marine=marine or DeterministicMarineAdapter())
             )
         )
+        self.scope: dict = {}
 
     async def json(self) -> Any:
         if isinstance(self._body, Exception):

--- a/packages/api/tests/test_access_log.py
+++ b/packages/api/tests/test_access_log.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""One line per request, an id to follow it by, and no addresses anywhere.
+
+The last of those is the one worth having a test for. "Do not log IPs" is a
+promise made in the privacy policy and kept by a handful of format strings,
+which is exactly the kind of promise a refactor breaks without anyone
+noticing. ``test_no_address_ever_reaches_the_log`` sends recognisable
+addresses through every header the deployment reads and greps the whole log
+for them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+
+import pytest
+from openwind_data.adapters.base import ForecastHorizonError
+from openwind_data.testing import browser_cache_payload, hourly_axis
+from starlette.testclient import TestClient
+
+from openwind_api import security
+from openwind_api.access import AccessLogMiddleware, request_id_of
+from openwind_api.app import create_app
+from openwind_api.routes import passage as passage_routes
+from openwind_api.settings import Settings
+
+ACCESS_LOGGER = "openwind_api.access"
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app(Settings()))
+
+
+@pytest.fixture
+def access_lines(caplog):
+    caplog.set_level(logging.INFO, logger=ACCESS_LOGGER)
+    return lambda: [r.getMessage() for r in caplog.records if r.name == ACCESS_LOGGER]
+
+
+def _fields(line: str) -> dict[str, str]:
+    """Parse one logfmt line back into a dict, quotes included."""
+    return {
+        m.group(1): (m.group(2) or m.group(3))
+        for m in re.finditer(r'(\w+)=(?:"((?:[^"\\]|\\.)*)"|(\S+))', line)
+    }
+
+
+class TestRequestId:
+    def test_a_generated_id_comes_back_in_the_header(self, client) -> None:
+        resp = client.get("/api/v1/archetypes")
+        assert resp.status_code == 200
+        assert re.fullmatch(r"[0-9a-f]{16}", resp.headers["x-request-id"])
+
+    def test_the_callers_id_is_echoed(self, client) -> None:
+        resp = client.get("/api/v1/archetypes", headers={"X-Request-Id": "web-42_abc.1"})
+        assert resp.headers["x-request-id"] == "web-42_abc.1"
+
+    def test_the_echoed_id_is_the_one_that_is_logged(self, client, access_lines) -> None:
+        client.get("/api/v1/archetypes", headers={"X-Request-Id": "traced-once"})
+        assert _fields(access_lines()[-1])["id"] == "traced-once"
+
+    @pytest.mark.parametrize(
+        "forged",
+        [
+            # A newline forges a second log entry; the rest are simply not ids.
+            "ok\nid=other method=GET path=/ status=200",
+            "a" * 65,
+            "",
+            "spaces here",
+            "<script>",
+        ],
+    )
+    def test_an_unusable_id_is_replaced_rather_than_echoed(self, client, forged) -> None:
+        resp = client.get("/api/v1/archetypes", headers={"X-Request-Id": forged})
+        assert re.fullmatch(r"[0-9a-f]{16}", resp.headers["x-request-id"])
+
+    def test_a_forged_id_never_reaches_the_log(self, client, access_lines) -> None:
+        client.get("/api/v1/archetypes", headers={"X-Request-Id": "x\nid=forged status=200"})
+        assert not any("forged" in line for line in access_lines())
+
+    def test_the_browser_is_allowed_to_read_it(self, client) -> None:
+        # A header the browser cannot read is a header the web app cannot put
+        # in a bug report.
+        resp = client.get("/api/v1/archetypes", headers={"Origin": "https://ohmywind.fr"})
+        assert "X-Request-Id" in resp.headers["access-control-expose-headers"]
+
+    def test_two_requests_get_two_ids(self) -> None:
+        assert request_id_of({"type": "http", "headers": []}) != request_id_of(
+            {"type": "http", "headers": []}
+        )
+
+
+class TestOneLinePerRequest:
+    def test_a_get_is_logged_once_with_its_shape(self, client, access_lines) -> None:
+        client.get("/api/v1/archetypes")
+        lines = access_lines()
+        assert len(lines) == 1
+        fields = _fields(lines[0])
+        assert fields["method"] == "GET"
+        assert fields["path"] == "/api/v1/archetypes"
+        assert fields["status"] == "200"
+        assert float(fields["dur_ms"]) >= 0
+        assert int(fields["bytes"]) > 0
+        assert re.fullmatch(r"[0-9a-f]{8}", fields["bucket"])
+
+    def test_three_requests_are_three_lines(self, client, access_lines) -> None:
+        client.get("/api/v1/archetypes")
+        client.get("/api/v1/marine/marc/coverage")
+        client.post("/api/v1/passage", json={})
+        assert len(access_lines()) == 3
+
+    def test_a_refusal_is_logged_with_the_status_the_client_got(self, client, access_lines) -> None:
+        client.post("/api/v1/passage", json={})
+        assert _fields(access_lines()[-1])["status"] == "422"
+
+    def test_the_limiter_s_own_429_is_logged(self, monkeypatch, access_lines) -> None:
+        """The middleware is outside the limiter, so it sees what a handler never does."""
+        original = security.RateLimitMiddleware.__init__
+
+        def _one_request(self, app, **kwargs):
+            original(self, app, **{**kwargs, "max_requests": 1})
+
+        monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _one_request)
+        limited = TestClient(create_app(Settings()))
+        limited.post("/api/v1/passage", json={})
+        limited.post("/api/v1/passage", json={})
+        assert [_fields(line)["status"] for line in access_lines()] == ["422", "429"]
+
+    def test_a_handler_that_raises_is_still_logged(self, access_lines) -> None:
+        async def _boom(scope, receive, send):
+            raise ZeroDivisionError("bug")
+
+        client = TestClient(AccessLogMiddleware(_boom), raise_server_exceptions=False)
+        assert client.get("/api/v1/archetypes").status_code == 500
+        assert _fields(access_lines()[-1])["status"] == "500"
+
+
+class TestForecastCacheField:
+    """Which door the request came through: the field these logs exist for."""
+
+    def _body(self, **extra) -> dict:
+        body = {
+            "waypoints": [[43.29, 5.37], [43.00, 6.20]],
+            "departure": DEPARTURE.isoformat(),
+            "archetype": "cruiser_30ft",
+        }
+        body.update(extra)
+        return body
+
+    def test_a_request_that_never_reached_the_parser_says_nothing(
+        self, client, access_lines
+    ) -> None:
+        client.get("/api/v1/archetypes")
+        assert _fields(access_lines()[-1])["cache"] == "-"
+
+    def test_a_malformed_body_says_nothing_either(self, client, access_lines) -> None:
+        client.post("/api/v1/passage", json={})
+        assert _fields(access_lines()[-1])["cache"] == "-"
+
+    def test_a_live_plan_says_no(self, client, access_lines, monkeypatch) -> None:
+        # Stop at the engine: the field is decided by parsing, before any fetch.
+        async def _stub(*_args, **_kwargs):
+            raise ForecastHorizonError("meteofrance_arome_france", DEPARTURE)
+
+        monkeypatch.setattr(passage_routes, "estimate_passage", _stub)
+        assert client.post("/api/v1/passage", json=self._body()).status_code == 422
+        assert _fields(access_lines()[-1])["cache"] == "no"
+
+    def test_a_plan_off_the_browser_cache_says_yes(self, client, access_lines) -> None:
+        axis = hourly_axis(DEPARTURE, DEPARTURE.replace(hour=20))
+        payload = browser_cache_payload([(43.29, 5.37), (43.00, 6.20)], axis)
+        resp = client.post("/api/v1/passage", json=self._body(forecast_cache=payload))
+        assert resp.status_code == 200
+        assert _fields(access_lines()[-1])["cache"] == "yes"
+
+
+def test_no_address_ever_reaches_the_log(caplog) -> None:
+    """The promise the privacy policy makes, checked against every log line.
+
+    Both address families, through both headers the deployment reads, on a
+    route that answers and on one that refuses. Anything that ends up
+    quoting the caller rather than hashing it fails here.
+    """
+    caplog.set_level(logging.DEBUG)
+    addresses = ["203.0.113.77", "2001:db8:dead:beef::1"]
+    client = TestClient(create_app(Settings()))
+    for address in addresses:
+        client.get("/api/v1/archetypes", headers={"X-Forwarded-For": f"{address}, 10.0.0.1"})
+        client.post("/api/v1/passage", json={}, headers={"X-Real-Ip": address})
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert logged  # the check is worthless if nothing was logged at all
+    for address in addresses:
+        assert address not in logged
+    # Nor the hash's input in any other shape: no dotted quad at all.
+    assert not re.search(r"\b\d{1,3}(\.\d{1,3}){3}\b", logged)

--- a/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
+++ b/packages/data-adapters/src/openwind_data/adapters/openmeteo.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -20,6 +21,15 @@ from openwind_data.adapters.base import (
     WindPoint,
     WindSeries,
 )
+
+# Every upstream call, at DEBUG. The line carries the host, the status and
+# the duration, and never the query string: it holds the coordinates of a
+# passage, which is where a boat is going, and that does not belong in a log
+# file. Cache hits and misses are logged here too, because the ratio between
+# them is the only way to tell a deployment that is warming its cache from one
+# that is paying Open-Meteo for the same point over and over. Refusals (429)
+# and timeouts are WARNING: they change what the user sees.
+_logger = logging.getLogger(__name__)
 
 FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
 MARINE_URL = "https://marine-api.open-meteo.com/v1/marine"
@@ -186,19 +196,48 @@ class OpenMeteoAdapter:
         the caller turns it into ``UpstreamRateLimitError`` so the reason
         reaches the user instead of being slept through.
         """
-        await self._pace_http()
-        resp = await client.get(url, params=params)
+        resp = await self._get_logged(client, url, params)
         if resp.status_code != 429:
             return resp
 
         advertised = _retry_after_seconds(resp)
         wait = RATE_LIMIT_RETRY_DEFAULT_WAIT_S if advertised is None else advertised
+        _logger.warning(
+            "open-meteo refused a request: host=%s reason=%r retry_after=%s retrying=%s",
+            httpx.URL(url).host,
+            _error_reason(resp),
+            "-" if advertised is None else f"{advertised:g}s",
+            wait <= RATE_LIMIT_RETRY_MAX_WAIT_S,
+        )
         if wait > RATE_LIMIT_RETRY_MAX_WAIT_S:
             return resp
 
         await asyncio.sleep(wait)
+        return await self._get_logged(client, url, params)
+
+    async def _get_logged(
+        self, client: httpx.AsyncClient, url: str, params: dict[str, Any]
+    ) -> httpx.Response:
+        """One paced GET, timed and logged. Never logs the query string."""
         await self._pace_http()
-        return await client.get(url, params=params)
+        started = time.perf_counter()
+        host = httpx.URL(url).host
+        try:
+            resp = await client.get(url, params=params)
+        except httpx.TimeoutException:
+            _logger.warning(
+                "open-meteo timed out: host=%s after=%.0fms",
+                host,
+                (time.perf_counter() - started) * 1000,
+            )
+            raise
+        _logger.debug(
+            "open-meteo call: host=%s status=%d dur_ms=%.0f",
+            host,
+            resp.status_code,
+            (time.perf_counter() - started) * 1000,
+        )
+        return resp
 
     async def fetch(
         self,
@@ -236,7 +275,15 @@ class OpenMeteoAdapter:
             and cached.bundle.start <= start_utc
             and cached.bundle.end >= end_utc
         ):
+            _logger.debug("forecast cache hit: lat=%.2f lon=%.2f", key.lat_round, key.lon_round)
             return _slice_bundle(cached.bundle, start_utc, end_utc)
+        _logger.debug(
+            "forecast cache miss: lat=%.2f lon=%.2f models=%d stale=%s",
+            key.lat_round,
+            key.lon_round,
+            len(models),
+            cached is not None,
+        )
 
         # Fetch a wide window so future calls with later `departure` can be served
         # from cache. If a stale-but-narrower entry exists, widen to cover both.
@@ -257,6 +304,12 @@ class OpenMeteoAdapter:
         # not cancel the fetch every other follower is waiting on.
         flight = self._inflight.get(key)
         if flight is not None and flight.start <= start_utc and flight.end >= end_utc:
+            # Logged separately from the miss above: the cache really did not
+            # answer, and what saved the round-trip was the join. Counting the
+            # two together would make the cache look better than it is.
+            _logger.debug(
+                "forecast single-flight join: lat=%.2f lon=%.2f", key.lat_round, key.lon_round
+            )
             joined = await asyncio.shield(flight.future)
             return _slice_bundle(joined, start_utc, end_utc)
 

--- a/packages/data-adapters/tests/test_openmeteo_logging.py
+++ b/packages/data-adapters/tests/test_openmeteo_logging.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""What the adapter says about its upstream, and what it must never say.
+
+Two things are being pinned. The first is that the calls are observable at
+all: before this, a plan that took nine seconds looked exactly like a plan
+that took one, and the only way to tell whether the cache was working was to
+read the source. The second is that the coordinates stay out of the logs: a
+passage's waypoints are where a boat is going, and a query string carrying
+them is not something to leave in a Space's console.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+import respx
+
+from openwind_data.adapters.base import UpstreamRateLimitError
+from openwind_data.adapters.openmeteo import FORECAST_URL, MARINE_URL, OpenMeteoAdapter
+
+LOGGER = "openwind_data.adapters.openmeteo"
+START = datetime(2026, 4, 26, 0, 0, tzinfo=UTC)
+END = datetime(2026, 4, 26, 23, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def lines(caplog):
+    caplog.set_level(logging.DEBUG, logger=LOGGER)
+    return lambda level=None: [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == LOGGER and (not level or r.levelno == level)
+    ]
+
+
+@respx.mock
+async def test_every_upstream_call_is_logged_with_its_host_and_status(
+    lines, forecast_marseille_arome, marine_porquerolles
+):
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+
+    calls = [line for line in lines() if line.startswith("open-meteo call")]
+    assert len(calls) == 2
+    assert any("host=api.open-meteo.com" in line and "status=200" in line for line in calls)
+    assert any("host=marine-api.open-meteo.com" in line for line in calls)
+    assert all("dur_ms=" in line for line in calls)
+
+
+@respx.mock
+async def test_the_cache_says_whether_it_answered(
+    lines, forecast_marseille_arome, marine_porquerolles
+):
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+    await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+
+    assert sum(line.startswith("forecast cache miss") for line in lines()) == 1
+    assert sum(line.startswith("forecast cache hit") for line in lines()) == 1
+
+
+@respx.mock
+async def test_a_refusal_is_a_warning_naming_the_counter_that_tripped(lines, marine_porquerolles):
+    """A 429 changes what the user sees, so it is not a DEBUG detail.
+
+    The reason Open-Meteo returns is the difference between "retry in a
+    moment" and "this address is spent for the day", which is the one thing
+    worth knowing when the Space starts refusing plans.
+    """
+    respx.get(FORECAST_URL).mock(
+        return_value=httpx.Response(
+            429,
+            headers={"Retry-After": "600"},
+            json={"reason": "Daily API request limit exceeded"},
+        )
+    )
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    with pytest.raises(UpstreamRateLimitError):
+        await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+
+    warnings = lines(logging.WARNING)
+    assert len(warnings) == 1
+    assert "Daily API request limit exceeded" in warnings[0]
+    assert "retry_after=600s" in warnings[0]
+    assert "retrying=False" in warnings[0]
+
+
+@respx.mock
+async def test_a_timeout_is_a_warning_too(lines, marine_porquerolles):
+    respx.get(FORECAST_URL).mock(side_effect=httpx.ReadTimeout("upstream is silent"))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    with pytest.raises(httpx.ReadTimeout):
+        await adapter.fetch(lat=43.30, lon=5.35, start=START, end=END)
+
+    warnings = lines(logging.WARNING)
+    assert any(line.startswith("open-meteo timed out") for line in warnings)
+    assert any("host=api.open-meteo.com" in line for line in warnings)
+
+
+@respx.mock
+async def test_no_query_string_and_no_waypoint_ever_reaches_our_log(
+    lines, forecast_marseille_arome, marine_porquerolles
+):
+    """The URL is logged by host, never in full.
+
+    Coordinates rounded to two decimals do appear on the cache lines, and that
+    is the deliberate limit: a ~1 km grid cell is what the cache is keyed on,
+    and the full-precision waypoints the caller sent stay out.
+
+    httpx's own logger does print the whole URL at INFO, query string
+    included. That is why the deployment mutes it below WARNING; see
+    ``configure_logging`` in ``packages/hf-space/app.py`` and its test.
+    """
+    respx.get(FORECAST_URL).mock(return_value=httpx.Response(200, json=forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(return_value=httpx.Response(200, json=marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    await adapter.fetch(lat=43.296431, lon=5.354812, start=START, end=END)
+
+    logged = "\n".join(lines())
+    assert logged
+    assert "43.296431" not in logged
+    assert "?" not in logged
+    assert "latitude=" not in logged
+
+
+@respx.mock
+async def test_a_joined_flight_is_logged_apart_from_a_cache_hit(
+    lines, forecast_marseille_arome, marine_porquerolles
+):
+    """The join is not a cache hit, and the log must not pretend it is.
+
+    A joiner has already missed the cache by the time it finds a request in
+    the air. Reporting both as hits would flatter the cache and hide the fact
+    that the round-trip was saved by the single-flight instead.
+    """
+
+    async def _slow(payload):
+        async def _respond(_request):
+            await asyncio.sleep(0.02)
+            return httpx.Response(200, json=payload)
+
+        return _respond
+
+    respx.get(FORECAST_URL).mock(side_effect=await _slow(forecast_marseille_arome))
+    respx.get(MARINE_URL).mock(side_effect=await _slow(marine_porquerolles))
+
+    adapter = OpenMeteoAdapter(http_min_interval_s=0)
+    await asyncio.gather(
+        *[adapter.fetch(lat=43.30, lon=5.35, start=START, end=END) for _ in range(4)]
+    )
+
+    assert sum(line.startswith("forecast single-flight join") for line in lines()) == 3
+    assert sum(line.startswith("forecast cache miss") for line in lines()) == 4
+    assert not any(line.startswith("forecast cache hit") for line in lines())

--- a/packages/hf-space/app.py
+++ b/packages/hf-space/app.py
@@ -99,8 +99,34 @@ def build_app() -> Any:
     return create_app(settings, mcp_app=build_mcp_app(services.marine), services=services)
 
 
+def configure_logging() -> None:
+    """Set the level, and silence the one library that logs too much.
+
+    INFO carries the API's own access line and the atlas warm-up. DEBUG adds
+    every upstream Open-Meteo call with its status, its duration and whether
+    the cache answered instead: worth turning on from the Space's variables
+    when a slow plan needs explaining, and too chatty to leave on.
+
+    httpx logs every request at INFO **with the full URL**, and an Open-Meteo
+    URL carries the latitude and longitude of a waypoint at full precision.
+    That is where a boat is going, written into a log this deployment
+    promises not to keep. Muted to WARNING, which still surfaces the transport
+    failures worth seeing.
+    """
+    requested = os.environ.get("OPENWIND_LOG_LEVEL", "INFO").upper()
+    # An unreadable value must not be the reason a deployment fails to boot.
+    level = getattr(logging, requested, None)
+    if not isinstance(level, int):
+        level = logging.INFO
+    logging.basicConfig(level=level)
+    # ``basicConfig`` is a no-op once anything has installed a handler, which
+    # uvicorn does, so the level is also set outright.
+    logging.getLogger().setLevel(level)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+    configure_logging()
     warn_if_edge_secret_missing()
     app = build_app()
     # Run uvicorn explicitly (rather than ``server.run(transport=...)``) so we
@@ -113,6 +139,13 @@ def main() -> None:
         port=PORT,
         proxy_headers=True,
         forwarded_allow_ips="*",
+        # One access line per request, not two. uvicorn's own says method,
+        # path and status; ``openwind_api.access`` says those plus a request
+        # id, a duration, a response size, whether the browser supplied the
+        # forecast and which rate-limit bucket the caller is in. Keeping both
+        # would double the volume to add nothing, and uvicorn's logs the
+        # client address, which this deployment deliberately does not keep.
+        access_log=False,
     )
 
 

--- a/packages/hf-space/tests/test_wrapper.py
+++ b/packages/hf-space/tests/test_wrapper.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
+import logging
 import pathlib
 import types
 
@@ -131,3 +132,30 @@ def test_the_shared_client_is_closed_when_the_process_stops(wrapper, monkeypatch
         assert client.get("/api/v1/archetypes").status_code == 200
         assert not app.state.services.http.is_closed
     assert app.state.services.http.is_closed
+
+
+def test_the_transport_library_never_logs_a_waypoint(wrapper, caplog) -> None:
+    """httpx logs the whole URL at INFO, and an Open-Meteo URL is a waypoint.
+
+    Nothing in the API or the adapter can prevent that: it is a third-party
+    logger, and it becomes loud the moment anyone calls ``basicConfig``. The
+    deployment is where the level is set, so the deployment is where it is
+    muted.
+    """
+    logging.getLogger("httpx").setLevel(logging.NOTSET)
+    wrapper.configure_logging()
+    assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
+
+
+def test_the_log_level_is_a_space_variable(wrapper, monkeypatch) -> None:
+    restore = logging.getLogger().level
+    try:
+        monkeypatch.setenv("OPENWIND_LOG_LEVEL", "debug")
+        wrapper.configure_logging()
+        assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+        # A typo in a Space variable must not stop the Space from booting.
+        monkeypatch.setenv("OPENWIND_LOG_LEVEL", "VERBOSE")
+        wrapper.configure_logging()
+        assert logging.getLogger().getEffectiveLevel() == logging.INFO
+    finally:
+        logging.getLogger().setLevel(restore)


### PR DESCRIPTION
PR 2.5 du plan de rework (lot 2). Rebasée sur `dev` après #334, #335 et #338 : les deux réserves annoncées sont levées, voir en bas.

## Le problème

Le déploiement ne journalisait rien qui lui appartienne. uvicorn imprimait une méthode, un chemin, un statut. Pas de durée, pas de taille de réponse, aucun moyen de distinguer un plan servi depuis l'échantillonnage du navigateur d'un plan parti chercher la météo en amont, et aucun identifiant qu'un utilisateur puisse citer en disant « le calcul a échoué vers onze heures ». C'est le point Mo1 de l'audit, et c'est aussi la raison pour laquelle plusieurs de ses constats ont dû être mesurés en lisant le code plutôt que la production.

## Ce que fait la PR

**`openwind_api/access.py`**, un middleware placé en tout premier de la pile. Il voit donc le statut réellement rendu (un 429 du limiteur n'atteint jamais un handler) et les octets réellement sortis (la compression est à l'intérieur). Une ligne par requête, au niveau INFO, sur le logger `openwind_api.access` :

```
id=9f2c1a4b7e3d5088 method=POST path=/api/v1/passage status=200 dur_ms=263.4 bytes=4267 cache=yes bucket=846488f1
```

Format logfmt, choisi une fois et documenté dans le module. Les logs se lisent dans la console web de Hugging Face, où une ligne JSON s'enroule en pavé illisible ; il n'y a aucun collecteur pour parser du JSON à la place de quelqu'un ; et toutes les valeurs sont des scalaires, donc le seul vrai avantage du JSON ne sert à rien. Si un collecteur apparaît un jour, c'est le seul endroit à changer.

`cache` est le champ pour lequel ce journal existe : il sépare les requêtes qui nous coûtent un éventail d'appels amont de celles qui ne coûtent que du CPU. De l'extérieur, ce sont le même POST sur le même chemin.

**Aucune adresse n'est journalisée**, sous aucune forme : ni l'adresse du client, ni `X-Forwarded-For`, ni une version « tronquée ». `bucket` est `sha256(adresse)[:8]`, ce qui suffit à la seule question que ces logs servent à trancher (un seul appelant est-il responsable de ce trafic ?). `test_no_address_ever_reaches_the_log` envoie des adresses IPv4 et IPv6 reconnaissables dans les en-têtes que le déploiement lit, sur une route qui répond et une qui refuse, et cherche leur trace dans tout le journal.

**`X-Request-Id`** est renvoyé sur chaque réponse et exposé via CORS. L'identifiant de l'appelant est repris quand il est sûr à écho (64 caractères de `[A-Za-z0-9._:-]`), remplacé sinon : un saut de ligne dans un identifiant forge une entrée de journal, et c'est une technique réelle, pas théorique. Cinq formes hostiles sont testées.

**Côté `openwind_data`** : chaque appel Open-Meteo au niveau DEBUG, par hôte, avec son statut et sa durée, plus les hits et les miss du cache, plus les jointures de vol du single-flight de #334. Ces dernières sont comptées à part d'un hit, et c'est le point : un joignant a bel et bien manqué le cache, et confondre les deux flatterait le cache en masquant ce qui a réellement économisé l'aller-retour. Les 429 et les délais dépassés passent en WARNING, avec le compteur qui a sauté (« Daily API request limit exceeded » et « Minutely » ne se traitent pas pareil). Jamais la query string : elle porte les coordonnées d'un point de passage.

## Fuite corrigée au passage

httpx journalise chaque requête au niveau INFO **avec l'URL complète**, donc avec la latitude et la longitude d'un waypoint à pleine précision. Le `logging.basicConfig(level=INFO)` du wrapper l'activait déjà en production : la console du Space contient aujourd'hui les coordonnées de chaque point de chaque plan calculé en live. C'est un test de cette PR qui l'a fait apparaître.

`configure_logging()` dans `packages/hf-space/app.py` ramène `httpx` à WARNING, lit `OPENWIND_LOG_LEVEL` pour passer en DEBUG depuis les variables du Space sans redéploiement, et retombe sur INFO si la variable est illisible plutôt que d'empêcher le Space de démarrer.

L'access log d'uvicorn est coupé (`access_log=False`) : le nôtre en dit strictement plus, et celui d'uvicorn écrit l'adresse du client.

## Tests

Sur `dev` rebasée : api 219 -> 235, data-adapters 333 -> 339, hf-space 10 -> 12, mcp-core 70 inchangé. Ruff propre, format propre, goldens REST et MCP inchangés.

- `packages/api/tests/test_access_log.py` (21) : identifiant généré et repris, cinq formes d'identifiant refusées, en-tête exposé via CORS, une ligne par requête et pas deux, le 429 du limiteur journalisé avec son vrai statut, un handler qui lève journalisé quand même, le champ `cache` à `yes` / `no` / `-`, et la vérification « aucune adresse ».
- `packages/data-adapters/tests/test_openmeteo_logging.py` (6) : hôte et statut par appel, hit/miss du cache, jointure de vol journalisée à part d'un hit (4 fetch concurrents = 4 miss, 3 jointures, 0 hit), WARNING sur 429 avec la raison amont, WARNING sur délai dépassé, et aucune query string dans nos lignes.
- `packages/hf-space/tests/test_wrapper.py` : httpx muselé à WARNING, niveau piloté par la variable d'environnement, valeur illisible tolérée.

## Rebase sur dev (réserves levées)

Les deux points annoncés se sont produits exactement comme prévu et sont résolus :

1. **Les six `_FakeRequest`.** #334 les a fusionnés dans `tests/fake_requests.py`. Les six ajouts de `self.scope` sont remplacés par une seule ligne dans la classe partagée, résolue en faveur de `dev` pour les fichiers refactorisés.
2. **La ligne DEBUG du single-flight.** Le code qu'elle décrit est maintenant sur `dev`, donc la ligne est incluse ici avec son test, ce qui referme le périmètre annoncé de 2.5.

`routes/passage.py` garde les deux fonctions (`_adapter` de #334, `_note_forecast_cache` d'ici) et les deux appels ; `hf-space/app.py` garde `build_app()` et `configure_logging()`. `openmeteo.py` s'est fusionné tout seul : le hit/miss du cache reste avant la jointure de vol, et `_get_paced` passe par `_get_logged`.

## Smoke local après rebase

Rejoué avec les deux PR ensemble, atlas montés, `OPENWIND_LOG_LEVEL=DEBUG` :

```
INFO:openwind_api.access:id=fef50a04ab7f8825 method=POST path=/api/v1/passage status=200 dur_ms=339.5 bytes=4267 cache=no bucket=aaf075b7
INFO:openwind_api.access:id=65d8a8b5ddfe0a8d method=POST path=/mcp status=200 dur_ms=6.9 bytes=267 cache=- bucket=aaf075b7
INFO:openwind_api.access:id=94428e19ba6f7c01 method=POST path=/mcp status=200 dur_ms=1.8 bytes=13727 cache=- bucket=aaf075b7
INFO:openwind_api.access:id=fa7c92c6f4d293cd method=POST path=/mcp status=200 dur_ms=3.3 bytes=11693 cache=- bucket=aaf075b7
```

- `X-Request-Id` généré (`1e3f8b35e52cd04e`) et repris (`smoke-rebase`)
- `POST /api/v1/passage` Marseille -> Porquerolles demain 09:00+02:00, cruiser_30ft : 200 en 341 ms, 40,31 NM, 14,86 h, complexité 2 « modéré », 5 tronçons
- MCP `initialize` 200 (`ohmywind` 1.27.2), `tools/list` -> les 4 outils, `plan_passage` 200 avec les mêmes 40,31 NM / 14,86 h
- **0** occurrence de `latitude=`, **0** ligne d'accès uvicorn, **1** seul préchauffage d'atlas
- La dernière ligne dit le gain combiné : `plan_passage` en 3,3 ms sur le cache rempli par la requête REST. Avant #334, la même mesure donnait 1 038 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)