### PR TITLE
fix(api): clé de rate limit normalisée par réseau, pas par adresse

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -40,6 +40,8 @@ test asserts it by importing the package with the name `mcp` blocked.
 - `errors.py`: one mapping from exception to `(status, message, code)`.
 - `services.py`: the tidal atlases, loaded once, on `app.state.services`.
 - `security.py`: rate limiting, body ceiling, security headers, client IP.
+  The limiter counts per network, `/32` for IPv4 and `/64` for IPv6, because a
+  phone picks its own address inside the prefix its carrier assigned.
 - `static/landing.html`: the landing page. Its media ship with the deployment.
 
 Serialising a passage is not here: that is `openwind_data.views`, shared with

--- a/packages/api/src/openwind_api/security.py
+++ b/packages/api/src/openwind_api/security.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import logging
 import math
 import os
@@ -173,6 +174,43 @@ def forwarded_hop_count(scope: Scope) -> int:
     return 0
 
 
+# A single address is not what a caller controls. A phone on IPv6 gets a /64
+# from its carrier and picks its own interface identifier inside it, rotating
+# it on a timer (RFC 8981 temporary addresses) or on demand. Keying the
+# limiter on the full address therefore hands one subscriber 2^64 buckets:
+# the quota is unenforceable, and worse, the LRU store that tracks at most
+# 5 000 addresses is evicted out from under every legitimate caller by one
+# client cycling through its own prefix.
+#
+# The prefix is the unit an operator actually assigns, so it is the unit the
+# limiter counts. /64 for IPv6, which is the smallest allocation any carrier
+# or ISP hands to a customer site and the smallest that cannot be picked by
+# the customer. /32 for IPv4, i.e. the address itself: NAT already collapses
+# a household or a marina onto one address, and grouping further would put a
+# whole carrier behind one bucket.
+IPV6_PREFIX_BITS = 64
+IPV4_PREFIX_BITS = 32
+
+
+def rate_limit_key(scope: Scope) -> str:
+    """The network this caller counts against, as a stable string.
+
+    ``"203.0.113.7/32"`` or ``"2001:db8:dead:beef::/64"``. An address the
+    stdlib cannot parse is used verbatim: that covers ``"unknown"`` (no
+    header, no transport address) and any malformed entry a client managed to
+    place at the trusted position, and both must still be counted rather than
+    waved through. Grouping every unparseable value into one bucket is the
+    safe direction: it can throttle unfairly, never exempt.
+    """
+    raw = resolve_client_ip(scope)
+    try:
+        address = ipaddress.ip_address(raw)
+    except ValueError:
+        return raw
+    bits = IPV4_PREFIX_BITS if address.version == 4 else IPV6_PREFIX_BITS
+    return str(ipaddress.ip_network(f"{address}/{bits}", strict=False))
+
+
 def bucket_id(scope: Scope) -> str:
     """Short, stable fingerprint of the rate-limit key for this caller.
 
@@ -181,11 +219,16 @@ def bucket_id(scope: Scope) -> str:
     all callers collapse into a single bucket? Two clients on different
     networks comparing this value settle it in one request each.
 
+    Hashes the *key*, not the address, so what it reports is the bucket that
+    actually exists: two devices sharing an IPv6 /64 do share a quota, and a
+    fingerprint that said otherwise would send the next diagnosis down the
+    wrong path.
+
     Only ever reports the caller's own bucket, and never the address itself.
     Unsalted on purpose: a salt would change on every process restart and
     would make two clients' readings incomparable, which is the whole point.
     """
-    return hashlib.sha256(resolve_client_ip(scope).encode()).hexdigest()[:8]
+    return hashlib.sha256(rate_limit_key(scope).encode()).hexdigest()[:8]
 
 
 # -------------------------------------------------------------- rate limiter
@@ -368,7 +411,7 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        retry_after = counter.check(resolve_client_ip(scope))
+        retry_after = counter.check(rate_limit_key(scope))
         if retry_after is None:
             await self.app(scope, receive, send)
             return

--- a/packages/api/tests/test_security.py
+++ b/packages/api/tests/test_security.py
@@ -74,6 +74,83 @@ def test_client_ip_unknown_when_no_header_and_no_peer() -> None:
     assert security.resolve_client_ip(scope) == "unknown"
 
 
+# ----------------------------------------------------- rate-limit key
+
+# The address is not the unit an operator assigns. A phone on IPv6 picks its
+# own interface identifier inside the /64 its carrier gave it and rotates it
+# (RFC 8981), so keying on the full address hands one subscriber 2^64 buckets
+# and lets it walk the 5 000-entry LRU store out from under everyone else.
+
+
+def test_ipv4_counts_as_itself() -> None:
+    # /32 is the address: NAT already collapses a marina or a household onto
+    # one, and grouping further would put a whole carrier in one bucket.
+    key = security.rate_limit_key(_scope(**{"x-forwarded-for": "203.0.113.7"}))
+    assert key == "203.0.113.7/32"
+
+
+def test_two_ipv4_addresses_never_share_a_bucket() -> None:
+    neighbour = security.rate_limit_key(_scope(**{"x-forwarded-for": "203.0.113.8"}))
+    assert security.rate_limit_key(_scope(**{"x-forwarded-for": "203.0.113.7"})) != neighbour
+
+
+def test_ipv6_counts_by_prefix() -> None:
+    key = security.rate_limit_key(_scope(**{"x-forwarded-for": "2001:db8:dead:beef:1:2:3:4"}))
+    assert key == "2001:db8:dead:beef::/64"
+
+
+def test_an_ipv6_client_cannot_mint_buckets_inside_its_own_prefix() -> None:
+    """The bug this fixes, stated as the property it broke.
+
+    Four addresses a single handset produces over an afternoon of privacy
+    rotation. Before, four quotas; now, one.
+    """
+    keys = {
+        security.rate_limit_key(_scope(**{"x-forwarded-for": suffix}))
+        for suffix in (
+            "2001:db8:dead:beef::1",
+            "2001:db8:dead:beef:abcd:ef01:2345:6789",
+            "2001:db8:dead:beef:ffff:ffff:ffff:ffff",
+            "2001:db8:dead:beef:0:0:0:2",
+        )
+    }
+    assert len(keys) == 1
+
+
+def test_a_neighbouring_ipv6_prefix_is_a_different_bucket() -> None:
+    # /64 is the smallest allocation a customer site gets, so two of them are
+    # two customers and must not share a quota.
+    here = security.rate_limit_key(_scope(**{"x-forwarded-for": "2001:db8:dead:beef::1"}))
+    next_door = security.rate_limit_key(_scope(**{"x-forwarded-for": "2001:db8:dead:bef0::1"}))
+    assert here != next_door
+
+
+def test_an_ipv4_mapped_ipv6_address_stays_one_client() -> None:
+    # ::ffff:203.0.113.7 is how a dual-stack proxy sometimes writes an IPv4
+    # caller. Python parses it as IPv6, so it lands on a /64 of its own
+    # rather than merging with the whole mapped range.
+    key = security.rate_limit_key(_scope(**{"x-forwarded-for": "::ffff:203.0.113.7"}))
+    assert key.endswith("/64")
+
+
+@pytest.mark.parametrize("unparseable", ["unknown", "not-an-address", "203.0.113.999", ""])
+def test_an_unparseable_address_is_still_counted(unparseable) -> None:
+    """Never an exemption. Grouping the unreadable together can only throttle."""
+    scope = _scope(**{"x-forwarded-for": unparseable}) if unparseable else _scope()
+    if not unparseable:
+        scope["client"] = None
+    key = security.rate_limit_key(scope)
+    assert key
+    assert "/" not in key
+
+
+def test_the_bucket_fingerprint_reports_the_bucket_that_exists() -> None:
+    """Two devices on one /64 do share a quota; the diagnostic must say so."""
+    a = security.bucket_id(_scope(**{"x-forwarded-for": "2001:db8:dead:beef::1"}))
+    b = security.bucket_id(_scope(**{"x-forwarded-for": "2001:db8:dead:beef::2"}))
+    assert a == b
+
+
 # --------------------------------------------------------- sliding window
 
 
@@ -482,3 +559,36 @@ def test_single_hop_deployment_is_unaffected(monkeypatch) -> None:
     monkeypatch.setattr(security, "TRUSTED_PROXY_HOPS", 1)
     scope = _edge_scope(None, "1.1.1.1, 203.0.113.7")
     assert security.resolve_client_ip(scope) == "203.0.113.7"
+
+
+def test_the_limiter_uses_the_normalised_key(monkeypatch) -> None:
+    """End to end: a rotating IPv6 client fills one bucket, not four."""
+    from starlette.testclient import TestClient
+
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(2))
+    client = TestClient(create_app(Settings(), _StubMcpApp()))
+    statuses = [
+        client.post(
+            "/api/v1/passage",
+            json={},
+            headers={"X-Forwarded-For": f"2001:db8:dead:beef::{n}"},
+        ).status_code
+        for n in range(1, 5)
+    ]
+    assert statuses == [422, 422, 429, 429]
+
+
+def test_two_prefixes_still_get_their_own_quota(monkeypatch) -> None:
+    from starlette.testclient import TestClient
+
+    monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _init_with_limit(1))
+    client = TestClient(create_app(Settings(), _StubMcpApp()))
+
+    def post(prefix: str) -> int:
+        return client.post(
+            "/api/v1/passage", json={}, headers={"X-Forwarded-For": f"{prefix}::1"}
+        ).status_code
+
+    assert post("2001:db8:1:1") == 422
+    assert post("2001:db8:1:1") == 429
+    assert post("2001:db8:1:2") == 422

--- a/packages/edge-proxy/README.md
+++ b/packages/edge-proxy/README.md
@@ -100,6 +100,18 @@ curl -s https://qdonnars-openwind-mcp.hf.space/api/v1/_client -H 'X-Forwarded-Fo
 curl -s https://mcp.ohmywind.fr/api/v1/_client
 ```
 
+The `bucket` value is a hash of the *network* the origin counts against, not
+of the address: `/32` for an IPv4 caller, `/64` for an IPv6 one. Two devices on
+one IPv6 prefix therefore report the same bucket and share one quota, which is
+correct and deliberate (a handset rotates its address inside its prefix, so
+counting addresses would count nothing). Nothing about the hop chain changed
+with it: the origin still reads the same entry of `X-Forwarded-For` it always
+did, and a direct caller still cannot buy an extra hop.
+
+Note for anyone comparing against a reading taken before 2026-09: the hashes
+changed once, when the key became the network. Two readings are comparable
+only if both were taken on the same side of that change.
+
 `TRUSTED_PROXY_HOPS` is 2 because the chain reaching the app is
 `<client>, <cloudflare egress>`: Cloudflare adds one hop in front of Hugging
 Face. The Worker overwrites `X-Forwarded-For` with `CF-Connecting-IP` so that


### PR DESCRIPTION
PR 2.6 du plan de rework (lot 2), la dernière. Indépendante de #334, #335 et #337 : elle ne touche que `security.py` et ses tests.

## Le problème

La clé de la fenêtre glissante était la chaîne d'adresse brute. Une adresse n'est pas ce qu'un appelant contrôle : un téléphone en IPv6 reçoit un `/64` de son opérateur et choisit lui-même les 64 bits d'identifiant d'interface à l'intérieur, en les faisant tourner sur minuterie (adresses temporaires, RFC 8981) ou à la demande.

Deux conséquences, la seconde pire que la première :

1. **Le quota est inapplicable.** Un seul abonné dispose de 2^64 seaux et ne voit jamais un 429.
2. **Le magasin LRU est expulsable.** `_SlidingWindowCounter` suit au plus 5 000 clés et évince la moins récemment active. Un client qui parcourt son propre préfixe vide le magasin en 5 000 requêtes et fait perdre son compteur à tous les appelants légitimes. Le limiteur cesse alors de limiter qui que ce soit.

## Ce que fait la PR

`rate_limit_key(scope)` normalise avec `ipaddress` :

- **IPv4 en /32**, c'est-à-dire l'adresse elle-même. Le NAT regroupe déjà un foyer, un bureau ou un port de plaisance sur une adresse ; agréger plus mettrait un opérateur entier dans un seau.
- **IPv6 en /64**, la plus petite allocation qu'un opérateur ou un FAI attribue à un site client, et la plus petite que le client ne peut pas choisir.
- **Adresse illisible : comptée telle quelle.** Cela couvre `"unknown"` (ni en-tête, ni adresse de transport) et toute entrée malformée qu'un client aurait réussi à placer à la position de confiance. Regrouper l'illisible ne peut que sur-limiter, jamais exempter, et c'est le bon sens de l'erreur.

`bucket_id()` hache désormais la clé et non l'adresse, pour que le diagnostic décrive le seau qui existe réellement : deux appareils sur un même `/64` partagent bien un quota, et une empreinte qui prétendrait le contraire enverrait le prochain diagnostic dans le mur.

Rien d'autre ne bouge : fenêtre, seuils, seaux séparés planificateurs / `marc`, attestation de bord, `Retry-After`, `X-RateLimit-Bucket`, et surtout **ce que l'origine lit dans `X-Forwarded-For`** (même entrée, même comptage de sauts, un appelant direct ne peut toujours pas s'acheter un saut).

Le second niveau par jeton client reste **reporté** : le GO 6 le conditionne à la mesure des 429 réels, que #337 rend enfin possible.

## Effet de bord assumé

Les empreintes `bucket` changent une fois, y compris en IPv4, puisque la clé hachée est maintenant `"203.0.113.7/32"` et non `"203.0.113.7"`. C'est un diagnostic, pas un contrat, mais deux relevés ne sont comparables que du même côté du changement. Noté dans `packages/edge-proxy/README.md`, à côté de la procédure qui dit justement de comparer des `bucket`.

## Tests

api 198 -> 211. Ruff propre, format propre, goldens REST et MCP inchangés.

Dans `packages/api/tests/test_security.py` :

- IPv4 compté comme lui-même, deux adresses IPv4 voisines ne partagent jamais un seau ;
- IPv6 compté par préfixe ; **quatre adresses qu'un même combiné produit en une après-midi de rotation donnent une seule clé** ;
- un `/64` voisin reste un seau distinct ;
- une adresse IPv4 mappée en IPv6 (`::ffff:203.0.113.7`, ce qu'écrit parfois un proxy double pile) ne fusionne pas avec toute la plage mappée ;
- quatre formes illisibles restent comptées (`unknown`, texte, `203.0.113.999`, aucune adresse du tout) ;
- de bout en bout à travers l'application : avec un plafond de 2, quatre requêtes depuis quatre adresses d'un même `/64` donnent `[422, 422, 429, 429]` (avant : quatre 422, un seau chacune) ;
- deux préfixes distincts gardent chacun leur quota ;
- l'empreinte de seau rapporte le seau qui existe.

## Smoke local (worktree, atlas montés)

`GET /api/v1/_client` avec un `X-Forwarded-For` forgé, ce que la procédure de l'edge proxy fait déjà :

```
203.0.113.7             -> bucket 03e9b066
203.0.113.8             -> bucket 5036b4d0   (voisine IPv4 : seau distinct)
2001:db8:dead:beef::1   -> bucket a806d034
2001:db8:dead:beef::abcd-> bucket a806d034   (même /64 : même seau)
2001:db8:dead:bef0::1   -> bucket ac4adc6c   (/64 voisin : seau distinct)
```

- `GET /` 200, `GET /api/v1/archetypes` 200
- `POST /api/v1/passage` Marseille -> Porquerolles demain 09:00+02:00, cruiser_30ft : 200 en 329 ms, 40,31 NM, 14,86 h, complexité 2 « modéré », 5 tronçons
- MCP streamable HTTP : `initialize` 200 (`ohmywind` 1.27.2), `tools/list` -> les 4 outils, `plan_passage` 200 avec les mêmes 40,31 NM / 14,86 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)
