### PR TITLE
refacto(web): découpe SpotMap, dialogues en français, lint bloquant (lot 4.2)

### DIFF
--- a/packages/web/scripts/lint-budget.mjs
+++ b/packages/web/scripts/lint-budget.mjs
@@ -1,54 +1,43 @@
 #!/usr/bin/env node
 /**
- * Lint ratchet.
+ * Lint gate.
  *
- * `npm run lint` reports 6 pre-existing errors, all of one kind now: refs
- * written during render, in SpotMap. They change when a Leaflet handler sees
- * a fresh callback, so clearing them means splitting that component up, which
- * is lot 4 of the rework plan. It is not a lint chore.
+ * This script used to be a ratchet: `npm run lint` reported errors the code
+ * had carried for a while, so CI enforced a ceiling that could only go down.
+ * The ceiling is now zero, and the script is a plain blocking lint.
  *
- * The five others were setState called straight from an effect body, in App
- * and PlanPage: derived state pushed back into React instead of computed. They
- * went with the /plan reducer (lot 1), which turned them into transitions, plus
- * one view fallback on the explore page now derived while rendering.
+ * How the budget was spent down, newest first:
  *
- * The fourteen before that were: `any` reaching into Leaflet internals, empty
- * catch blocks, a raw NBSP, a dead local, a component declared inside a
- * render, and two modules mixing components with plain exports. All cleared,
- * none of them touching behaviour.
+ * - 6, refs written during render in SpotMap. Cleared by splitting the
+ *   component up (lot 4.2): the six callback mirrors are written from one
+ *   effect, and the two that mirrored `useState` setters are gone, React
+ *   keeping setter identity stable on its own.
+ * - 5, setState called straight from an effect body, in App and PlanPage:
+ *   derived state pushed back into React instead of computed. They went with
+ *   the /plan reducer (lot 1), which turned them into transitions, plus one
+ *   view fallback on the explore page now derived while rendering.
+ * - 14 before that: `any` reaching into Leaflet internals, empty catch
+ *   blocks, a raw NBSP, a dead local, a component declared inside a render,
+ *   and two modules mixing components with plain exports.
  *
- * Making lint blocking today would therefore mean either a red CI forever or
- * a rushed rewrite of the components. Neither is acceptable, so CI enforces a
- * ceiling instead: the count may go down, never up. New code has to be clean
- * without holding it hostage to the existing debt.
+ * None of them touched behaviour.
  *
- * Lower BUDGET whenever the count drops. The script tells you when to.
+ * The name is kept so CI, the contributing guide and muscle memory keep
+ * working. Warnings stay warnings: `react-hooks/exhaustive-deps` on the map
+ * init effects is deliberate and documented at each site.
  */
 import { ESLint } from "eslint";
-
-const BUDGET = 6;
 
 const eslint = new ESLint();
 const results = await eslint.lintFiles(["."]);
 const errors = results.reduce((total, r) => total + r.errorCount, 0);
 const warnings = results.reduce((total, r) => total + r.warningCount, 0);
 
-console.log(`ESLint: ${errors} error(s), ${warnings} warning(s). Budget: ${BUDGET}.`);
+console.log(`ESLint: ${errors} error(s), ${warnings} warning(s).`);
 
-if (errors > BUDGET) {
+if (errors > 0) {
   const formatter = await eslint.loadFormatter("stylish");
   console.error(await formatter.format(results));
-  console.error(
-    `\nLint budget exceeded: ${errors} errors for a budget of ${BUDGET}.\n` +
-      `Fix what this branch introduced rather than raising the budget.`,
-  );
+  console.error(`\nLint is blocking: fix the ${errors} error(s) above.`);
   process.exit(1);
-}
-
-if (errors < BUDGET) {
-  // Deliberately not a failure: an unrelated branch should not break because
-  // it happened to improve things.
-  console.log(
-    `Budget can be lowered to ${errors} in packages/web/scripts/lint-budget.mjs.`,
-  );
 }

--- a/packages/web/src/api/reverseGeocode.test.ts
+++ b/packages/web/src/api/reverseGeocode.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearReverseGeocodeCache, coordinateName, reverseGeocode } from "./reverseGeocode";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  clearReverseGeocodeCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("reverseGeocode", () => {
+  it("identifies the application, as the Nominatim policy asks", async () => {
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => jsonResponse({ address: { city: "Marseille" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await reverseGeocode(43.29, 5.37);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("nominatim.openstreetmap.org/reverse");
+    expect(url).toContain("email=contact%40ohmywind.fr");
+  });
+
+  it("prefers the most specific place name available", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ address: { village: "Le Brusc", county: "Var" } })),
+    );
+    expect(await reverseGeocode(43.06, 5.8)).toBe("Le Brusc");
+  });
+
+  it("falls back down the address ladder, then to the display name", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ display_name: "Rade de Toulon, Var, France" })),
+    );
+    expect(await reverseGeocode(43.1, 5.9)).toBe("Rade de Toulon");
+  });
+
+  it("falls back to the coordinates when the answer names nothing", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({})));
+    expect(await reverseGeocode(42.5, 6.25)).toBe(coordinateName(42.5, 6.25));
+  });
+
+  it("falls back to the coordinates on a network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("offline"); }));
+    expect(await reverseGeocode(42.5, 6.25)).toBe("42.500, 6.250");
+  });
+
+  it("falls back to the coordinates on an HTTP error", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({}, false)));
+    expect(await reverseGeocode(42.5, 6.25)).toBe("42.500, 6.250");
+  });
+
+  it("caches a hit, so pressing around the same bay costs one request", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ address: { city: "Marseille" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await reverseGeocode(43.2900, 5.3700)).toBe("Marseille");
+    // Same point to within the cache resolution (~100 m).
+    expect(await reverseGeocode(43.29004, 5.37002)).toBe("Marseille");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failure: the next press retries", async () => {
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); });
+    vi.stubGlobal("fetch", fetchMock);
+    await reverseGeocode(43.29, 5.37);
+    await reverseGeocode(43.29, 5.37);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves to the coordinates when the caller aborts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        init?.signal?.throwIfAborted();
+        return jsonResponse({ address: { city: "Marseille" } });
+      }),
+    );
+    const controller = new AbortController();
+    controller.abort();
+    expect(await reverseGeocode(43.29, 5.37, controller.signal)).toBe("43.290, 5.370");
+  });
+});
+
+describe("coordinateName", () => {
+  it("keeps three decimals, about 100 m", () => {
+    expect(coordinateName(43.296123, 5.369987)).toBe("43.296, 5.370");
+  });
+});

--- a/packages/web/src/api/reverseGeocode.ts
+++ b/packages/web/src/api/reverseGeocode.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Naming a point on the water, from Nominatim.
+ *
+ * Used once per spot creation: a long press on the map opens the "new spot"
+ * dialog pre-filled with the nearest place name, so the user validates a name
+ * instead of typing coordinates.
+ *
+ * ## Nominatim usage policy
+ *
+ * The public instance at nominatim.openstreetmap.org is free and asks three
+ * things of us (https://operations.osmfoundation.org/policies/nominatim/):
+ *
+ * 1. **Identify the application.** A browser refuses to let a page set
+ *    `User-Agent`, so the two levers we have are the `Referer` header, which
+ *    Chrome, Firefox and Safari all send by default from `ohmywind.fr`, and
+ *    the officially supported `email` parameter. We send both: the parameter
+ *    carries the project's published contact address, which already ships in
+ *    the privacy page, and survives a `Referrer-Policy` stricter than ours.
+ * 2. **At most one request per second.** One long press cannot beat that, and
+ *    the cache below removes the repeat lookups that a user pressing around
+ *    the same bay would otherwise generate.
+ * 3. **Cache results.** Hence the in-memory map. It is per tab and per
+ *    session on purpose: the answer is a place name, cheap to refetch, and
+ *    persisting it would mean one more storage key to version.
+ *
+ * A failure of any kind falls back to the coordinates. Naming a spot is a
+ * convenience; a network hiccup must not stop the user from saving a point.
+ */
+
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse";
+
+/** Published project address, per the "identify your application" clause. */
+const CONTACT_EMAIL = "contact@ohmywind.fr";
+
+/** Past this, a slow answer is worse than the coordinates it would replace:
+    the dialog is already open and waiting on it. */
+const TIMEOUT_MS = 4000;
+
+/** Rounding the cache key to ~100 m: two presses that close deserve the same
+    name, and it is the resolution `zoom=10` answers at anyway. */
+const KEY_DECIMALS = 3;
+
+/** One entry per distinct place looked up in this tab. A few dozen at most in
+    a long session, so no eviction beyond the cap. */
+const CACHE_MAX = 200;
+const cache = new Map<string, string>();
+
+function cacheKey(lat: number, lon: number): string {
+  return `${lat.toFixed(KEY_DECIMALS)},${lon.toFixed(KEY_DECIMALS)}`;
+}
+
+/** What we fall back to, and what a cacheless caller sees on failure. */
+export function coordinateName(lat: number, lon: number): string {
+  return `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+}
+
+interface NominatimAddress {
+  city?: string;
+  town?: string;
+  village?: string;
+  municipality?: string;
+  county?: string;
+}
+
+interface NominatimReverse {
+  address?: NominatimAddress;
+  display_name?: string;
+}
+
+/** The most specific place name the answer carries, largest-scale first. */
+function pickName(data: NominatimReverse, lat: number, lon: number): string {
+  const addr = data.address ?? {};
+  return (
+    addr.city ||
+    addr.town ||
+    addr.village ||
+    addr.municipality ||
+    addr.county ||
+    data.display_name?.split(",")[0] ||
+    coordinateName(lat, lon)
+  );
+}
+
+/**
+ * Nearest place name for a point, or its coordinates if none can be had.
+ *
+ * `signal` lets the caller drop a lookup whose dialog has been dismissed. An
+ * abort resolves to the coordinates rather than throwing: every caller wants
+ * a name, and none of them wants to handle two failure modes.
+ */
+export async function reverseGeocode(
+  lat: number,
+  lon: number,
+  signal?: AbortSignal,
+): Promise<string> {
+  const key = cacheKey(lat, lon);
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+
+  // The timeout is ours; the caller's signal is theirs. `AbortSignal.any`
+  // gives the fetch a single signal that both can trip.
+  const timeout = AbortSignal.timeout(TIMEOUT_MS);
+  const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
+
+  try {
+    const res = await fetch(
+      `${NOMINATIM_URL}?format=json&lat=${lat}&lon=${lon}&zoom=10` +
+        `&email=${encodeURIComponent(CONTACT_EMAIL)}`,
+      { headers: { "Accept-Language": "fr" }, signal: combined },
+    );
+    if (!res.ok) return coordinateName(lat, lon);
+    const name = pickName((await res.json()) as NominatimReverse, lat, lon);
+    if (cache.size >= CACHE_MAX) cache.clear();
+    cache.set(key, name);
+    return name;
+  } catch {
+    // Network error, abort, timeout or malformed JSON: same answer.
+    return coordinateName(lat, lon);
+  }
+}
+
+/** Test seam: the module-level cache would otherwise leak between cases. */
+export function clearReverseGeocodeCache(): void {
+  cache.clear();
+}

--- a/packages/web/src/components/SpotDialogs.test.tsx
+++ b/packages/web/src/components/SpotDialogs.test.tsx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SpotEditDialog, SpotNameDialog } from "./SpotDialogs";
+import type { Spot } from "../types";
+
+const SPOT: Spot = { name: "Porquerolles", latitude: 43.0034, longitude: 6.2015 };
+
+describe("SpotEditDialog", () => {
+  it("names the spot and shows its position to four decimals", () => {
+    render(
+      <SpotEditDialog spot={SPOT} onRename={vi.fn()} onDelete={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText("Porquerolles")).toBeDefined();
+    expect(screen.getByText("43.0034, 6.2015")).toBeDefined();
+  });
+
+  it("offers its three choices in French", () => {
+    render(
+      <SpotEditDialog spot={SPOT} onRename={vi.fn()} onDelete={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByRole("dialog", { name: "Options du spot" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Renommer" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Supprimer" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Annuler" })).toBeDefined();
+  });
+
+  it("routes each button to its own callback", async () => {
+    const onRename = vi.fn();
+    const onDelete = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <SpotEditDialog spot={SPOT} onRename={onRename} onDelete={onDelete} onCancel={onCancel} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Renommer" }));
+    await user.click(screen.getByRole("button", { name: "Supprimer" }));
+    await user.click(screen.getByRole("button", { name: "Annuler" }));
+    expect(onRename).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SpotNameDialog", () => {
+  const pending = { lat: 43.0034, lng: 6.2015, name: "Porquerolles" };
+
+  it("creates when no spot is being edited", () => {
+    render(
+      <SpotNameDialog
+        pending={pending}
+        onNameChange={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("dialog", { name: "Nouveau spot" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Créer" })).toBeDefined();
+  });
+
+  it("renames when one is", () => {
+    render(
+      <SpotNameDialog
+        pending={{ ...pending, editingSpot: SPOT }}
+        onNameChange={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("dialog", { name: "Renommer le spot" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Renommer" })).toBeDefined();
+  });
+
+  it("reports every keystroke to the caller, which owns the value", async () => {
+    const onNameChange = vi.fn();
+    render(
+      <SpotNameDialog
+        pending={pending}
+        onNameChange={onNameChange}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const field = screen.getByRole("textbox", { name: "Nom du spot" });
+    expect((field as HTMLInputElement).value).toBe("Porquerolles");
+    await userEvent.setup().type(field, "!");
+    expect(onNameChange).toHaveBeenCalledWith("Porquerolles!");
+  });
+
+  it("routes confirm and cancel", async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <SpotNameDialog
+        pending={pending}
+        onNameChange={vi.fn()}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Créer" }));
+    await user.click(screen.getByRole("button", { name: "Annuler" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/SpotDialogs.tsx
+++ b/packages/web/src/components/SpotDialogs.tsx
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import type { Spot } from "../types";
+
+/**
+ * The two modals a press on the spot map opens.
+ *
+ * `SpotEditDialog` follows a long press on a spot the user saved: rename, or
+ * delete. `SpotNameDialog` follows a press on open water (create) and the
+ * rename branch of the first (edit), which is why one component covers both:
+ * the surface is identical down to the button, only the wording changes.
+ *
+ * Lifted out of `SpotMap` with their state left behind: the map owns what is
+ * pending, these only render it. That is also how their copy finally got
+ * translated, the markup having sat in English inside a 940-line component.
+ */
+
+/** What the name dialog is editing: a point on the water, plus the spot it
+    replaces when the user came in through "Renommer". */
+export interface PendingSpot {
+  lat: number;
+  lng: number;
+  name: string;
+  editingSpot?: Spot;
+}
+
+function DialogShell({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="absolute inset-0 flex items-center justify-center z-[1000] bg-black/50 backdrop-blur-sm animate-fade-in"
+      role="dialog"
+      aria-label={label}
+    >
+      <div className="ow-modal-surface backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs animate-modal-in">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function SpotEditDialog({
+  spot,
+  onRename,
+  onDelete,
+  onCancel,
+}: {
+  spot: Spot;
+  onRename: () => void;
+  onDelete: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <DialogShell label="Options du spot">
+      <p className="text-sm font-semibold mb-1" style={{ color: "var(--ow-fg-0)" }}>
+        {spot.name}
+      </p>
+      <p className="text-xs mb-4" style={{ color: "var(--ow-fg-1)" }}>
+        {spot.latitude.toFixed(4)}, {spot.longitude.toFixed(4)}
+      </p>
+      <div className="flex flex-col gap-2">
+        <button
+          className="ow-modal-btn w-full min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
+          onClick={onRename}
+        >
+          Renommer
+        </button>
+        <button
+          className="w-full min-h-[44px] py-2.5 rounded-lg bg-red-700/80 text-white text-sm font-medium hover:bg-red-600 active:bg-red-500 active:scale-[0.98] transition-all"
+          onClick={onDelete}
+        >
+          Supprimer
+        </button>
+        <button
+          className="ow-modal-btn-outline w-full min-h-[44px] py-2.5 rounded-lg text-sm transition-all"
+          onClick={onCancel}
+        >
+          Annuler
+        </button>
+      </div>
+    </DialogShell>
+  );
+}
+
+export function SpotNameDialog({
+  pending,
+  onNameChange,
+  onConfirm,
+  onCancel,
+}: {
+  pending: PendingSpot;
+  onNameChange: (name: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const renaming = pending.editingSpot != null;
+  const title = renaming ? "Renommer le spot" : "Nouveau spot";
+  return (
+    <DialogShell label={title}>
+      <p className="text-sm font-semibold mb-1" style={{ color: "var(--ow-fg-0)" }}>
+        {title}
+      </p>
+      <p className="text-xs mb-3" style={{ color: "var(--ow-fg-1)" }}>
+        {pending.lat.toFixed(4)}, {pending.lng.toFixed(4)}
+      </p>
+      <input
+        className="ow-modal-input w-full text-sm rounded-lg px-3 py-2.5 mb-4 transition-colors"
+        value={pending.name}
+        onChange={(e) => onNameChange(e.target.value)}
+        autoFocus
+        aria-label="Nom du spot"
+      />
+      <div className="flex gap-2">
+        <button
+          className="ow-modal-btn-outline flex-1 min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
+          onClick={onCancel}
+        >
+          Annuler
+        </button>
+        <button
+          className="flex-1 min-h-[44px] py-2.5 rounded-lg bg-teal-600 text-white text-sm font-semibold hover:bg-teal-500 active:scale-[0.98] transition-all"
+          onClick={onConfirm}
+        >
+          {renaming ? "Renommer" : "Créer"}
+        </button>
+      </div>
+    </DialogShell>
+  );
+}

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -5,160 +5,18 @@ import { useEffect, useRef, useCallback, useState, type RefObject } from "react"
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "../types";
-import { QUICK_SPOTS } from "../spots";
 import { useTheme } from "../design/useTheme";
+import { reverseGeocode } from "../api/reverseGeocode";
+import { useLongPress, type LongPressDetail } from "../hooks/useLongPress";
+import { SpotEditDialog, SpotNameDialog, type PendingSpot } from "./SpotDialogs";
+import { ARROW_PANE, syncSpotArrowLayer } from "../utils/spotArrowLayer";
 import type { UserPosition } from "../hooks/useGeolocation";
 import { syncUserPositionLayer } from "../utils/userPositionLayer";
 import { syncSeamarkLayer } from "../utils/seamarkLayer";
+import { syncPreviewMarker, syncSpotMarkers } from "../utils/spotMarkerLayer";
 import { addBasemap, BASEMAP_MAX_ZOOM, type Basemap } from "../utils/basemapLayer";
-import { centerForBottomInset } from "../utils/visibleCenter";
+import { useMapAutoCenter } from "../hooks/useMapAutoCenter";
 import type { MapView } from "../utils/mapViewParams";
-
-// Leaflet renders a CircleMarker into an SVG node it keeps to itself: there is
-// no public accessor, only the internal ``_path``. Hit-testing needs that node
-// to map an element back to its spot, so the field is declared here instead of
-// being reached through ``any`` — same escape hatch, but one that still type
-// checks the property and its type.
-type WithSvgPath = { _path?: Element };
-
-// Spot-map arrows are drawn into a single 300×300 SVG anchored at the spot
-// (centre = 150,150). For ``wind``, each forecast contributes one arrow + label.
-// For ``waves`` and ``currents``, a single arrow is drawn from the Open-Meteo
-// Marine source. ``tides`` is scalar — no arrow.
-//
-// Labels naturally sit just past each arrow tip, in the arrow's direction. When
-// two arrows predict similar directions their tips (and labels) collide. We run
-// a small force-based relaxation pass: each pair of overlapping labels pushes
-// the other away until none overlap (or we hit max iterations). Labels that
-// drift away from their tip get a thin leader line back to it.
-type ArrowItem = {
-  rad: number;
-  tipX: number;
-  tipY: number;
-  // label centre (relaxed)
-  lblX: number;
-  lblY: number;
-  // natural label centre (before relaxation) — used to decide if a leader line is needed
-  natLblX: number;
-  natLblY: number;
-  // top label, e.g. "15" (wind kn), "0.5" (Hs m), "1.5" (current kn)
-  displayText: string;
-  // bottom caption, e.g. "AROME", "Hs m", "kn"
-  caption: string;
-  color: string;
-};
-
-const SPOT_CX = 150;
-const SPOT_CY = 150;
-// Zoom and duration of the "fly to the user" camera move.
-const FLY_ZOOM = 10;
-const FLY_MS = 1200;
-// Approximate label half-width and half-height (speed text 18px + model text 13px stacked).
-const LABEL_HW = 32;
-const LABEL_HH = 22;
-// Don't let labels slide back over the spot marker itself.
-const MIN_FROM_SPOT = 60;
-
-function relaxLabels(items: ArrowItem[]): void {
-  const ITERATIONS = 40;
-  for (let iter = 0; iter < ITERATIONS; iter++) {
-    let moved = false;
-    for (let i = 0; i < items.length; i++) {
-      for (let j = i + 1; j < items.length; j++) {
-        const a = items[i];
-        const b = items[j];
-        const dx = b.lblX - a.lblX;
-        const dy = b.lblY - a.lblY;
-        // AABB overlap on each axis
-        const overlapX = LABEL_HW * 2 - Math.abs(dx);
-        const overlapY = LABEL_HH * 2 - Math.abs(dy);
-        if (overlapX > 0 && overlapY > 0) {
-          // push along the smaller-overlap axis (minimum-translation vector)
-          if (overlapX < overlapY) {
-            const push = overlapX * 0.5 * Math.sign(dx || 1);
-            a.lblX -= push;
-            b.lblX += push;
-          } else {
-            const push = overlapY * 0.5 * Math.sign(dy || 1);
-            a.lblY -= push;
-            b.lblY += push;
-          }
-          moved = true;
-        }
-      }
-    }
-    // After each pass, project labels out of the spot-marker keep-out radius.
-    for (const it of items) {
-      const dx = it.lblX - SPOT_CX;
-      const dy = it.lblY - SPOT_CY;
-      const dist = Math.hypot(dx, dy);
-      if (dist < MIN_FROM_SPOT && dist > 0.001) {
-        const scale = MIN_FROM_SPOT / dist;
-        it.lblX = SPOT_CX + dx * scale;
-        it.lblY = SPOT_CY + dy * scale;
-        moved = true;
-      }
-    }
-    if (!moved) break;
-  }
-}
-
-function arrowMarkup(it: ArrowItem): string {
-  // Thin shaft + narrow arrowhead. Shaft stops at the base of the head so the
-  // two strokes don't pile up under the tip — gives a sharp, single-pointed look.
-  const headLen = 13;
-  const headAng = 0.3;
-  const lx = it.tipX - headLen * Math.sin(it.rad - headAng);
-  const ly = it.tipY + headLen * Math.cos(it.rad - headAng);
-  const rx = it.tipX - headLen * Math.sin(it.rad + headAng);
-  const ry = it.tipY + headLen * Math.cos(it.rad + headAng);
-  // Where the shaft should end (midpoint of the arrowhead base, along the shaft axis).
-  const baseDist = headLen * Math.cos(headAng);
-  const shaftX = it.tipX - baseDist * Math.sin(it.rad);
-  const shaftY = it.tipY + baseDist * Math.cos(it.rad);
-  const dropColor = it.color === "#ffffff" ? "#000" : "#fff";
-  return `<line x1="${SPOT_CX}" y1="${SPOT_CY}" x2="${shaftX}" y2="${shaftY}" stroke="${it.color}" stroke-width="3" stroke-linecap="round" style="filter:drop-shadow(0 0 1.5px ${dropColor})"/>
-    <polygon points="${it.tipX},${it.tipY} ${lx},${ly} ${rx},${ry}" fill="${it.color}" style="filter:drop-shadow(0 0 1.5px ${dropColor})"/>`;
-}
-
-function leaderMarkup(it: ArrowItem): string {
-  // Only draw a leader if the label has been displaced from its natural position.
-  const drift = Math.hypot(it.lblX - it.natLblX, it.lblY - it.natLblY);
-  if (drift < 6) return "";
-  return `<line x1="${it.tipX}" y1="${it.tipY}" x2="${it.lblX}" y2="${it.lblY}" stroke="${it.color}" stroke-width="1.5" stroke-dasharray="3 3" opacity="0.55"/>`;
-}
-
-function labelMarkup(it: ArrowItem): string {
-  const shadow = it.color === "#ffffff"
-    ? "0 0 3px #000,0 0 6px #000"
-    : "0 0 3px #fff,0 0 5px #fff";
-  const caption = it.caption
-    ? `<text x="${it.lblX}" y="${it.lblY + 20}" text-anchor="middle" dominant-baseline="middle" font-size="13" fill="#fff" style="text-shadow:0 0 3px #000,0 0 5px #000">${it.caption}</text>`
-    : "";
-  return `<text x="${it.lblX}" y="${it.lblY}" text-anchor="middle" dominant-baseline="middle" font-size="18" font-weight="700" fill="${it.color}" style="text-shadow:${shadow}">${it.displayText}</text>${caption}`;
-}
-
-async function reverseGeocode(lat: number, lon: number): Promise<string> {
-  try {
-    const res = await fetch(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&zoom=10`,
-      { headers: { "Accept-Language": "fr" } }
-    );
-    const data = await res.json();
-    const addr = data.address || {};
-    return (
-      addr.city ||
-      addr.town ||
-      addr.village ||
-      addr.municipality ||
-      addr.county ||
-      data.display_name?.split(",")[0] ||
-      `${lat.toFixed(3)}, ${lon.toFixed(3)}`
-    );
-  } catch {
-    return `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
-  }
-}
 
 interface SpotMapProps {
   // null when the user has just removed their active spot — keep the map
@@ -210,10 +68,6 @@ interface SpotMapProps {
   showSeamarks?: boolean;
 }
 
-function spotKey(s: Spot) {
-  return `${s.latitude},${s.longitude}`;
-}
-
 export function SpotMap({
   current,
   customSpots,
@@ -240,44 +94,34 @@ export function SpotMap({
   const arrowLayerRef = useRef<L.Marker | null>(null);
   const userLayerRef = useRef<L.LayerGroup | null>(null);
   const previewLayerRef = useRef<L.CircleMarker | null>(null);
+  // The map is built once and lives outside React, so its Leaflet handlers
+  // cannot close over a prop: they would freeze on the value of the render
+  // that built them. Each callback is mirrored into a ref instead, written
+  // from an effect (after commit) rather than during render, which is the
+  // only order React guarantees for a ref.
   const onViewChangeRef = useRef(onViewChange);
+  const onSelectRef = useRef(onSelectSpot);
+  const onPreviewRef = useRef(onPreviewSpot);
+  const onAddRef = useRef(onAddSpot);
+  const onRemoveRef = useRef(onRemoveSpot);
+  const onRenameRef = useRef(onRenameSpot);
   useEffect(() => {
     onViewChangeRef.current = onViewChange;
-  }, [onViewChange]);
-  const onSelectRef = useRef(onSelectSpot);
-  onSelectRef.current = onSelectSpot;
-  const onPreviewRef = useRef(onPreviewSpot);
-  useEffect(() => {
+    onSelectRef.current = onSelectSpot;
     onPreviewRef.current = onPreviewSpot;
-  }, [onPreviewSpot]);
-  /** A long press ends with a pointerup, which the browser follows with a
-      click. Without this the press that opened the "new spot" dialog would
-      also drop a preview underneath it. */
-  const suppressClickRef = useRef(false);
-  const onAddRef = useRef(onAddSpot);
-  onAddRef.current = onAddSpot;
-  const onRemoveRef = useRef(onRemoveSpot);
-  onRemoveRef.current = onRemoveSpot;
-  const onRenameRef = useRef(onRenameSpot);
-  onRenameRef.current = onRenameSpot;
+    onAddRef.current = onAddSpot;
+    onRemoveRef.current = onRemoveSpot;
+    onRenameRef.current = onRenameSpot;
+  }, [onViewChange, onSelectSpot, onPreviewSpot, onAddSpot, onRemoveSpot, onRenameSpot]);
 
-  // pendingSpot: creating a new spot or renaming an existing one
-  const [pendingSpot, setPendingSpot] = useState<{
-    lat: number;
-    lng: number;
-    name: string;
-    editingSpot?: Spot;
-  } | null>(null);
-  const setPendingRef = useRef(setPendingSpot);
-  setPendingRef.current = setPendingSpot;
+  // pendingSpot: creating a new spot or renaming an existing one. The state
+  // setters need no ref of their own: React keeps their identity stable for
+  // the life of the component, so the handlers can close over them directly.
+  const [pendingSpot, setPendingSpot] = useState<PendingSpot | null>(null);
 
   // pendingEdit: long-pressed an existing marker → show rename/delete choice
   const [pendingEdit, setPendingEdit] = useState<Spot | null>(null);
-  const setPendingEditRef = useRef(setPendingEdit);
-  setPendingEditRef.current = setPendingEdit;
 
-  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelPressRef = useRef<() => void>(() => {});
   // Maps each marker's SVG element → its spot (for native long-press detection)
   const elementToSpotRef = useRef<Map<Element, Spot>>(new Map());
   const basemapRef = useRef<Basemap | null>(null);
@@ -285,34 +129,49 @@ export function SpotMap({
 
   const { resolvedTheme } = useTheme();
 
+  /**
+   * Press and hold, on a marker or on open water.
+   *
+   * On a marker the user saved: the rename/delete dialog, which is why only
+   * those markers are in `elementToSpotRef`. On the water: the "new spot"
+   * dialog, pre-filled with the nearest place name. On any other marker
+   * (Leaflet draws them as `circle` or `path` too) nothing is armed at all,
+   * so a plain tap still selects the spot.
+   */
+  const shouldPress = useCallback((target: Element) => {
+    if (elementToSpotRef.current.has(target)) return true;
+    const tag = target.tagName.toLowerCase();
+    return tag !== "circle" && tag !== "path";
+  }, []);
+
+  const onPress = useCallback(async ({ clientX, clientY, target }: LongPressDetail) => {
+    const map = mapRef.current;
+    const el = containerRef.current;
+    if (!map || !el) return;
+    const editSpot = elementToSpotRef.current.get(target);
+    if (editSpot) {
+      setPendingEdit(editSpot);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const latlng = map.containerPointToLatLng(
+      L.point(clientX - rect.left, clientY - rect.top),
+    );
+    const name = await reverseGeocode(latlng.lat, latlng.lng);
+    setPendingSpot({ lat: latlng.lat, lng: latlng.lng, name });
+  }, []);
+
+  const clickSuppressedRef = useLongPress(containerRef, { shouldPress, onPress });
+
   // Switch the basemap style when the theme changes
   useEffect(() => {
     basemapRef.current?.setTheme(resolvedTheme);
   }, [resolvedTheme]);
 
-  // A previewed point is not in customSpots, so the saved-spot markers never
-  // draw it. Without its own marker the panel would switch to a location the
-  // map does not show. Dashed and hollow, to read as provisional next to the
-  // solid saved spots.
+  // The hollow marker for a point being previewed but not saved.
   useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
-    previewLayerRef.current?.remove();
-    previewLayerRef.current = null;
-    if (!current) return;
-    const saved = customSpots.some(
-      (s) => s.latitude === current.latitude && s.longitude === current.longitude,
-    );
-    if (saved) return;
-    previewLayerRef.current = L.circleMarker([current.latitude, current.longitude], {
-      radius: 9,
-      color: "#2dd4bf",
-      weight: 2.5,
-      dashArray: "4 3",
-      fillColor: "#2dd4bf",
-      fillOpacity: 0.25,
-      interactive: false,
-    }).addTo(map);
+    if (!mapRef.current) return;
+    syncPreviewMarker(mapRef.current, previewLayerRef, current, customSpots);
   }, [current, customSpots]);
 
   // Draw the "you are here" dot whenever a fix is known.
@@ -321,69 +180,10 @@ export function SpotMap({
     syncUserPositionLayer(mapRef.current, userLayerRef, userPosition ?? null);
   }, [userPosition]);
 
-  // Centring a point means aiming for the middle of the strip the bottom
-  // data panel leaves visible — and the panel height at the moment a camera
-  // move starts is not final: the skeleton is swapped for tables of varying
-  // height once the forecast lands. So every auto-centre records its target
-  // here, and a ResizeObserver on the panel re-aims the camera when the
-  // height settles. A drag ends the intent: the viewport is the user's.
-  const autoCenterRef = useRef<{
-    lat: number;
-    lon: number;
-    zoom: number;
-    insetPx: number;
-    // Epoch ms when the flyTo animation lands; 0 for plain pans. A panel
-    // resize during the flight re-issues the fly with the remaining
-    // duration, so the correction reads as one continuous camera move.
-    flyEndsAt: number;
-  } | null>(null);
-
-  const visibleCenter = useCallback(
-    (lat: number, lon: number, zoom: number): [number, number] => {
-      const inset = bottomInsetRef?.current?.offsetHeight ?? 0;
-      const c = centerForBottomInset(lat, lon, zoom, inset);
-      return [c.lat, c.lon];
-    },
-    [bottomInsetRef],
-  );
-
-  // The observer wants the element, but the data area is unmounted while no
-  // spot is active — so each auto-centre re-points it at whichever node
-  // currently renders the panel, instead of observing once at mount.
-  const insetRoRef = useRef<ResizeObserver | null>(null);
-  const observedInsetElRef = useRef<Element | null>(null);
-  const ensureInsetObserved = useCallback(() => {
-    const el = bottomInsetRef?.current ?? null;
-    const ro = insetRoRef.current;
-    if (!ro || el === observedInsetElRef.current) return;
-    if (observedInsetElRef.current) ro.unobserve(observedInsetElRef.current);
-    observedInsetElRef.current = el;
-    if (el) ro.observe(el);
-  }, [bottomInsetRef]);
-
-  const autoCenter = useCallback(
-    (lat: number, lon: number, mode: "pan" | "fly") => {
-      const map = mapRef.current;
-      if (!map) return;
-      ensureInsetObserved();
-      const inset = bottomInsetRef?.current?.offsetHeight ?? 0;
-      const zoom = mode === "fly" ? FLY_ZOOM : map.getZoom();
-      const c = centerForBottomInset(lat, lon, zoom, inset);
-      autoCenterRef.current = {
-        lat,
-        lon,
-        zoom,
-        insetPx: inset,
-        flyEndsAt: mode === "fly" ? Date.now() + FLY_MS : 0,
-      };
-      if (mode === "fly") {
-        map.flyTo([c.lat, c.lon], zoom, { duration: FLY_MS / 1000 });
-      } else {
-        map.panTo([c.lat, c.lon], { animate: true });
-      }
-    },
-    [bottomInsetRef, ensureInsetObserved],
-  );
+  // Camera moves that account for the data panel covering the bottom of the
+  // map, and re-aim when the panel's height settles. See the hook.
+  const { visibleCenter, autoCenter, seed: seedAutoCenter, clear: clearAutoCenter, observe: observePanel } =
+    useMapAutoCenter(bottomInsetRef);
 
   // Init map once
   useEffect(() => {
@@ -416,13 +216,11 @@ export function SpotMap({
     // A point-centred initial view is an auto-centre like any other: seed
     // the intent so the panel settling (skeleton → loaded table) re-aims it.
     if (!initialView && (current || userPosition)) {
-      autoCenterRef.current = {
-        lat: current ? current.latitude : userPosition!.lat,
-        lon: current ? current.longitude : userPosition!.lon,
-        zoom: initialZoom,
-        insetPx: bottomInsetRef?.current?.offsetHeight ?? 0,
-        flyEndsAt: 0,
-      };
+      seedAutoCenter(
+        current ? current.latitude : userPosition!.lat,
+        current ? current.longitude : userPosition!.lon,
+        initialZoom,
+      );
     }
 
     basemapRef.current = addBasemap(map, resolvedTheme);
@@ -432,8 +230,8 @@ export function SpotMap({
     // button, which is where they now are, alongside the other sources.
 
     // Custom pane for wind arrows (below markers)
-    map.createPane("windArrows");
-    map.getPane("windArrows")!.style.zIndex = "450";
+    map.createPane(ARROW_PANE);
+    map.getPane(ARROW_PANE)!.style.zIndex = "450";
 
     mapRef.current = map;
 
@@ -442,8 +240,8 @@ export function SpotMap({
     // bubblingMouseEvents: false, so selecting a saved spot stays distinct
     // from previewing open water.
     map.on("click", (e: L.LeafletMouseEvent) => {
-      if (suppressClickRef.current) {
-        suppressClickRef.current = false;
+      if (clickSuppressedRef.current) {
+        clickSuppressedRef.current = false;
         return;
       }
       onPreviewRef.current?.(e.latlng.lat, e.latlng.lng);
@@ -457,125 +255,12 @@ export function SpotMap({
       onViewChangeRef.current?.({ lat: c.lat, lon: c.lng, zoom: map.getZoom() });
     });
 
-    // Long press detection via Pointer Events (covers mouse + touch, one event stream)
     const el = containerRef.current!;
-    let startX = 0;
-    let startY = 0;
 
-    const cancelPress = () => {
-      if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
-    };
-    cancelPressRef.current = cancelPress;
-
-    let activePointers = 0;
-
-    const handlePointerDown = (e: PointerEvent) => {
-      if (e.pointerType === "mouse" && e.button !== 0) return;
-      activePointers++;
-      if (activePointers > 1) { cancelPress(); return; }
-
-      startX = e.clientX;
-      startY = e.clientY;
-      const target = e.target as Element;
-
-      // Check if pressing on a known custom marker
-      const editSpot = elementToSpotRef.current.get(target);
-      if (editSpot) {
-        pressTimerRef.current = setTimeout(() => {
-          suppressClickRef.current = true;
-          setPendingEditRef.current(editSpot);
-        }, 400);
-        return;
-      }
-
-      // If pressing on any other SVG marker (non-custom), just skip
-      const tag = target.tagName.toLowerCase();
-      if (tag === "circle" || tag === "path") return;
-
-      // Press on the map background → add new spot
-      pressTimerRef.current = setTimeout(async () => {
-        suppressClickRef.current = true;
-        const rect = el.getBoundingClientRect();
-        const point = L.point(startX - rect.left, startY - rect.top);
-        const latlng = map.containerPointToLatLng(point);
-        const name = await reverseGeocode(latlng.lat, latlng.lng);
-        setPendingRef.current({ lat: latlng.lat, lng: latlng.lng, name });
-      }, 400);
-    };
-
-    const handlePointerUp = () => {
-      activePointers = Math.max(0, activePointers - 1);
-      cancelPress();
-      // The click that follows this pointerup runs first; clearing on the
-      // next tick means one press swallows exactly one click, and a later
-      // tap on the map is honoured normally.
-      setTimeout(() => {
-        suppressClickRef.current = false;
-      }, 0);
-    };
-
-    const handlePointerMove = (e: PointerEvent) => {
-      if (Math.abs(e.clientX - startX) > 10 || Math.abs(e.clientY - startY) > 10) {
-        cancelPress();
-      }
-    };
-
-    // Right-click (desktop) — same outcomes as long-press but instant. We
-    // suppress the browser context menu so the rename/add dialog is the only
-    // surface the user has to interact with.
-    const handleContextMenu = async (e: MouseEvent) => {
-      e.preventDefault();
-      cancelPress();
-      const target = e.target as Element;
-      const editSpot = elementToSpotRef.current.get(target);
-      if (editSpot) {
-        setPendingEditRef.current(editSpot);
-        return;
-      }
-      const tag = target.tagName.toLowerCase();
-      if (tag === "circle" || tag === "path") return;
-      const rect = el.getBoundingClientRect();
-      const point = L.point(e.clientX - rect.left, e.clientY - rect.top);
-      const latlng = map.containerPointToLatLng(point);
-      const name = await reverseGeocode(latlng.lat, latlng.lng);
-      setPendingRef.current({ lat: latlng.lat, lng: latlng.lng, name });
-    };
-
-    el.addEventListener("pointerdown", handlePointerDown);
-    el.addEventListener("contextmenu", handleContextMenu);
-    window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", handlePointerUp);
-    window.addEventListener("pointercancel", handlePointerUp);
-
-    // Create initial markers immediately + fix size after layout
-    for (const spot of [...QUICK_SPOTS, ...customSpots]) {
-      const key = spotKey(spot);
-      const active =
-        current != null &&
-        spot.latitude === current.latitude &&
-        spot.longitude === current.longitude;
-      const isCustom = customSpots.some((s) => spotKey(s) === key);
-      const marker = L.circleMarker([spot.latitude, spot.longitude], {
-        radius: active ? 10 : 7,
-        color: active ? "#ffffff" : "#9ca3af",
-        fillColor: active ? "#2dd4bf" : "#6b7280",
-        fillOpacity: active ? 0.9 : 0.6,
-        weight: active ? 2.5 : 1,
-        bubblingMouseEvents: false,
-      })
-        .bindTooltip(spot.name, {
-          direction: "top",
-          offset: [0, -10],
-          className: "spot-tooltip",
-        })
-        .on("click", () => onSelectRef.current(spot))
-        .addTo(map);
-      if (isCustom) {
-        const svgEl = (marker as unknown as WithSvgPath)._path;
-        if (svgEl) elementToSpotRef.current.set(svgEl, spot);
-      }
-      markersRef.current.set(key, marker);
-    }
+    // Markers are not created here: the sync effect below is declared
+    // after this one, so it runs in the same commit and draws them before
+    // the browser paints. Creating them twice was one copy of the marker
+    // style too many.
 
     setTimeout(() => map.invalidateSize(), 200);
 
@@ -583,55 +268,11 @@ export function SpotMap({
     const ro = new ResizeObserver(() => map.invalidateSize());
     ro.observe(el);
 
-    // The user dragging the map ends any auto-centre intent: from then on
-    // the viewport is theirs, panel resizes must not move it. (A manual
-    // zoom keeps the intent — zooming around the centred point is still
-    // "looking at the point".)
-    map.on("dragstart", () => {
-      autoCenterRef.current = null;
-    });
-
-    // Re-aim the camera when the data panel's height settles: the height
-    // measured when an auto-centre started (often the loading skeleton) is
-    // not the height of the loaded tables, and the difference shifts the
-    // point off the visible-strip centre by half of it. The observed node
-    // is (re-)chosen by ensureInsetObserved at each auto-centre, because
-    // the panel unmounts while no spot is active.
-    insetRoRef.current = new ResizeObserver(() => {
-      const target = autoCenterRef.current;
-      if (!target || !mapRef.current) return;
-      // Measure through the ref, not the observed entry: after a remount
-      // the observer may still deliver for the old node.
-      const inset = bottomInsetRef?.current?.offsetHeight ?? 0;
-      if (inset === target.insetPx) return;
-      target.insetPx = inset;
-      const flyRemainingMs = target.flyEndsAt - Date.now();
-      // Mid-flight the interpolated getZoom() is meaningless — keep the
-      // fly's destination zoom. At rest, follow the user's current zoom.
-      const zoom = flyRemainingMs > 0 ? target.zoom : mapRef.current.getZoom();
-      target.zoom = zoom;
-      const c = centerForBottomInset(target.lat, target.lon, zoom, inset);
-      if (flyRemainingMs > 0) {
-        mapRef.current.flyTo([c.lat, c.lon], zoom, {
-          duration: Math.max(flyRemainingMs, 300) / 1000,
-        });
-      } else {
-        mapRef.current.panTo([c.lat, c.lon], { animate: true });
-      }
-    });
-    ensureInsetObserved();
+    const detachPanelWatch = observePanel(map);
 
     return () => {
-      cancelPress();
       ro.disconnect();
-      insetRoRef.current?.disconnect();
-      insetRoRef.current = null;
-      observedInsetElRef.current = null;
-      el.removeEventListener("pointerdown", handlePointerDown);
-      el.removeEventListener("contextmenu", handleContextMenu);
-      window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", handlePointerUp);
-      window.removeEventListener("pointercancel", handlePointerUp);
+      detachPanelWatch();
       map.remove();
       mapRef.current = null;
     };
@@ -647,61 +288,15 @@ export function SpotMap({
   }, [showSeamarks]);
 
   const syncMarkers = useCallback(() => {
-    const map = mapRef.current;
-    if (!map) return;
-
-    const allSpots = [...QUICK_SPOTS, ...customSpots];
-    const desiredKeys = new Set(allSpots.map(spotKey));
-
-    // Remove old markers
-    for (const [key, marker] of markersRef.current) {
-      if (!desiredKeys.has(key)) {
-        const svgEl = (marker as unknown as WithSvgPath)._path;
-        if (svgEl) elementToSpotRef.current.delete(svgEl);
-        marker.remove();
-        markersRef.current.delete(key);
-      }
-    }
-
-    // Add or update
-    for (const spot of allSpots) {
-      const key = spotKey(spot);
-      const active =
-        current != null &&
-        spot.latitude === current.latitude &&
-        spot.longitude === current.longitude;
-      const style = {
-        radius: active ? 10 : 7,
-        color: active ? "#ffffff" : "#9ca3af",
-        fillColor: active ? "#2dd4bf" : "#6b7280",
-        fillOpacity: active ? 0.9 : 0.6,
-        weight: active ? 2.5 : 1,
-      };
-
-      const isCustom = customSpots.some((cs) => spotKey(cs) === key);
-      let marker = markersRef.current.get(key);
-      if (!marker) {
-        const s = spot;
-        marker = L.circleMarker([s.latitude, s.longitude], {
-          ...style,
-          bubblingMouseEvents: false,
-        })
-          .bindTooltip(s.name, {
-            direction: "top",
-            offset: [0, -10],
-            className: "spot-tooltip",
-          })
-          .on("click", () => onSelectRef.current(s))
-          .addTo(map);
-        if (isCustom) {
-          const svgEl = (marker as unknown as WithSvgPath)._path;
-          if (svgEl) elementToSpotRef.current.set(svgEl, s);
-        }
-        markersRef.current.set(key, marker);
-      } else {
-        marker.setStyle(style);
-      }
-    }
+    if (!mapRef.current) return;
+    syncSpotMarkers({
+      map: mapRef.current,
+      markers: markersRef.current,
+      elementToSpot: elementToSpotRef.current,
+      spots: customSpots,
+      current,
+      onSelect: (spot) => onSelectRef.current(spot),
+    });
   }, [current, customSpots]);
 
   // Sync markers on changes
@@ -713,11 +308,11 @@ export function SpotMap({
     // If the user just removed their active spot (current == null), don't
     // pan at all — preserve their viewport instead of reverting to a default.
     if (current) {
-      autoCenter(current.latitude, current.longitude, "pan");
+      autoCenter(mapRef.current, current.latitude, current.longitude, "pan");
     } else {
-      autoCenterRef.current = null;
+      clearAutoCenter();
     }
-  }, [current, customSpots, syncMarkers, autoCenter]);
+  }, [current, customSpots, syncMarkers, autoCenter, clearAutoCenter]);
 
   // Fly to the user only when the page asks for it (first visit with no
   // saved spot, or an explicit tap on the locate button). Keying on the
@@ -732,7 +327,7 @@ export function SpotMap({
   useEffect(() => {
     if (!mapRef.current) return;
     if (!flyToStamp || !userPosition) return;
-    autoCenter(userPosition.lat, userPosition.lon, "fly");
+    autoCenter(mapRef.current, userPosition.lat, userPosition.lon, "fly");
     // userPosition is intentionally not a dependency: the stamp is what
     // expresses "a move was requested", and a fresh fix alone must not
     // steal the viewport.
@@ -740,202 +335,59 @@ export function SpotMap({
   }, [flyToStamp]);
 
   // Metric-aware arrows: wind = one per model, waves/currents = one (single
-  // Open-Meteo Marine source), tides = none (scalar).
+  // Open-Meteo Marine source), tides = none (scalar). The geometry, the
+  // per-metric scales and the label-collision pass live in utils/spotArrows.
   useEffect(() => {
-    const map = mapRef.current;
-    if (!map) return;
-
-    if (arrowLayerRef.current) {
-      arrowLayerRef.current.remove();
-      arrowLayerRef.current = null;
-    }
-
-    if (!selectedHour || !current) return;
-
-    const color = resolvedTheme === "light" ? "#64748b" : "#ffffff";
-
-    // (rad, length) → tip + natural label position. Builds a fully-positioned
-    // ArrowItem so the relaxation step can move the label without recomputing
-    // geometry.
-    const buildItem = (
-      rad: number,
-      length: number,
-      displayText: string,
-      caption: string,
-    ): ArrowItem => {
-      const tipX = SPOT_CX + Math.sin(rad) * length;
-      const tipY = SPOT_CY - Math.cos(rad) * length;
-      const natLblX = tipX + Math.sin(rad) * 26;
-      const natLblY = tipY - Math.cos(rad) * 26;
-      return {
-        rad, tipX, tipY,
-        lblX: natLblX, lblY: natLblY,
-        natLblX, natLblY,
-        displayText, caption, color,
-      };
-    };
-
-    const items: ArrowItem[] = [];
-    if (metric === "wind") {
-      // One arrow per model. Direction is "from" → +180 to point downwind.
-      for (const forecast of forecasts) {
-        const timeIdx = forecast.hourly.time.indexOf(selectedHour);
-        if (timeIdx === -1) continue;
-        const dir = forecast.hourly.wind_direction_10m[timeIdx];
-        const spd = forecast.hourly.wind_speed_10m[timeIdx];
-        if (dir == null || spd == null) continue;
-        const rad = ((dir + 180) * Math.PI) / 180;
-        const length = Math.min(72 + spd * 4.8, 240);
-        items.push(buildItem(rad, length, String(Math.round(spd)), forecast.modelName));
-      }
-    } else if (metric === "waves" && marine) {
-      const timeIdx = marine.time.indexOf(selectedHour);
-      if (timeIdx !== -1) {
-        const dir = marine.wave_direction_deg[timeIdx];
-        const hs = marine.wave_height_m[timeIdx];
-        if (dir != null && hs != null) {
-          // wave_direction is "from" (Open-Meteo convention) → +180 downwave.
-          const rad = ((dir + 180) * Math.PI) / 180;
-          // Hs typically 0–4 m; scale so a 2 m sea reads visually like a 20 kn
-          // wind on the wind layer.
-          const length = Math.min(72 + hs * 50, 240);
-          // Top label: Hs with unit attached so the number reads as a height
-          // ("0.2m") rather than an abstract value. Caption: dominant period
-          // in seconds — sailors read this together to gauge swell vs chop.
-          const period = marine.wave_period_s[timeIdx];
-          const caption = period != null ? `${period.toFixed(0)}s` : "Hs";
-          items.push(buildItem(rad, length, `${hs.toFixed(1)}m`, caption));
-        }
-      }
-    } else if (metric === "currents" && marine) {
-      const timeIdx = marine.time.indexOf(selectedHour);
-      if (timeIdx !== -1) {
-        const spd = marine.current_speed_kn[timeIdx];
-        const dir = marine.current_direction_to_deg[timeIdx];
-        if (spd != null && dir != null) {
-          // current_direction is already "to" — no flip.
-          const rad = (dir * Math.PI) / 180;
-          // Visual scale tuned to nav impact: 1 kn = 5 kn-of-wind length,
-          // 4 kn = 20 kn-of-wind length. Avoids over-dramatising the
-          // sub-1-knot values that are typical Mediterranean baseline.
-          const length = Math.min(60 + spd * 25, 180);
-          // Single-line label "0.8 kn" — currents have no secondary axis
-          // to show below (unlike waves with period), so collapse to one line.
-          items.push(buildItem(rad, length, `${spd.toFixed(1)} kn`, ""));
-        }
-      }
-    }
-    // metric === "tides": no arrow (scalar), fall through to no-render.
-
-    if (items.length === 0) return;
-    relaxLabels(items);
-
-    // Render order: arrows (back) → leader lines → labels (front, on top of arrows)
-    let svgContent = "";
-    for (const it of items) svgContent += arrowMarkup(it);
-    for (const it of items) svgContent += leaderMarkup(it);
-    for (const it of items) svgContent += labelMarkup(it);
-
-    const icon = L.divIcon({
-      html: `<svg width="300" height="300" viewBox="0 0 300 300" style="overflow:visible;pointer-events:none">${svgContent}</svg>`,
-      className: "",
-      iconSize: [300, 300],
-      iconAnchor: [150, 150],
+    if (!mapRef.current) return;
+    syncSpotArrowLayer(mapRef.current, arrowLayerRef, {
+      current,
+      selectedHour,
+      metric,
+      forecasts,
+      marine,
+      color: resolvedTheme === "light" ? "#64748b" : "#ffffff",
     });
-
-    arrowLayerRef.current = L.marker([current.latitude, current.longitude], {
-      icon,
-      interactive: false,
-      pane: "windArrows",
-    }).addTo(map);
   }, [selectedHour, forecasts, marine, metric, current, resolvedTheme]);
 
   return (
     <div className="w-full h-full relative">
       <div ref={containerRef} className="w-full h-full overflow-hidden" />
-      {/* Marker long-press: rename or delete */}
+      {/* Long press on a saved marker: rename or delete. */}
       {pendingEdit && (
-        <div className="absolute inset-0 flex items-center justify-center z-[1000] bg-black/50 backdrop-blur-sm animate-fade-in" role="dialog" aria-label="Spot options">
-          <div className="ow-modal-surface backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs animate-modal-in">
-            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--ow-fg-0)' }}>{pendingEdit.name}</p>
-            <p className="text-xs mb-4" style={{ color: 'var(--ow-fg-1)' }}>
-              {pendingEdit.latitude.toFixed(4)}, {pendingEdit.longitude.toFixed(4)}
-            </p>
-            <div className="flex flex-col gap-2">
-              <button
-                className="ow-modal-btn w-full min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
-                onClick={() => {
-                  const s = pendingEdit;
-                  setPendingEdit(null);
-                  setPendingSpot({ lat: s.latitude, lng: s.longitude, name: s.name, editingSpot: s });
-                }}
-              >
-                Rename
-              </button>
-              <button
-                className="w-full min-h-[44px] py-2.5 rounded-lg bg-red-700/80 text-white text-sm font-medium hover:bg-red-600 active:bg-red-500 active:scale-[0.98] transition-all"
-                onClick={() => {
-                  onRemoveRef.current(pendingEdit);
-                  setPendingEdit(null);
-                }}
-              >
-                Delete
-              </button>
-              <button
-                className="ow-modal-btn-outline w-full min-h-[44px] py-2.5 rounded-lg text-sm transition-all"
-                onClick={() => setPendingEdit(null)}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
+        <SpotEditDialog
+          spot={pendingEdit}
+          onRename={() => {
+            const s = pendingEdit;
+            setPendingEdit(null);
+            setPendingSpot({ lat: s.latitude, lng: s.longitude, name: s.name, editingSpot: s });
+          }}
+          onDelete={() => {
+            onRemoveRef.current(pendingEdit);
+            setPendingEdit(null);
+          }}
+          onCancel={() => setPendingEdit(null)}
+        />
       )}
 
-      {/* New spot / rename spot */}
+      {/* Press on open water (create), or the rename branch above (edit). */}
       {pendingSpot && (
-        <div className="absolute inset-0 flex items-center justify-center z-[1000] bg-black/50 backdrop-blur-sm animate-fade-in" role="dialog" aria-label={pendingSpot.editingSpot ? "Rename spot" : "New spot"}>
-          <div className="ow-modal-surface backdrop-blur rounded-xl p-5 mx-4 w-full max-w-xs animate-modal-in">
-            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--ow-fg-0)' }}>
-              {pendingSpot.editingSpot ? "Rename spot" : "New spot"}
-            </p>
-            <p className="text-xs mb-3" style={{ color: 'var(--ow-fg-1)' }}>
-              {pendingSpot.lat.toFixed(4)}, {pendingSpot.lng.toFixed(4)}
-            </p>
-            <input
-              className="ow-modal-input w-full text-sm rounded-lg px-3 py-2.5 mb-4 transition-colors"
-              value={pendingSpot.name}
-              onChange={(e) => setPendingSpot({ ...pendingSpot, name: e.target.value })}
-              autoFocus
-              aria-label="Spot name"
-            />
-            <div className="flex gap-2">
-              <button
-                className="ow-modal-btn-outline flex-1 min-h-[44px] py-2.5 rounded-lg text-sm font-medium transition-all"
-                onClick={() => setPendingSpot(null)}
-              >
-                Cancel
-              </button>
-              <button
-                className="flex-1 min-h-[44px] py-2.5 rounded-lg bg-teal-600 text-white text-sm font-semibold hover:bg-teal-500 active:scale-[0.98] transition-all"
-                onClick={() => {
-                  if (pendingSpot.editingSpot) {
-                    onRenameRef.current(pendingSpot.editingSpot, pendingSpot.name);
-                  } else {
-                    onAddRef.current({
-                      name: pendingSpot.name,
-                      latitude: pendingSpot.lat,
-                      longitude: pendingSpot.lng,
-                    });
-                  }
-                  setPendingSpot(null);
-                }}
-              >
-                {pendingSpot.editingSpot ? "Rename" : "Create"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <SpotNameDialog
+          pending={pendingSpot}
+          onNameChange={(name) => setPendingSpot({ ...pendingSpot, name })}
+          onConfirm={() => {
+            if (pendingSpot.editingSpot) {
+              onRenameRef.current(pendingSpot.editingSpot, pendingSpot.name);
+            } else {
+              onAddRef.current({
+                name: pendingSpot.name,
+                latitude: pendingSpot.lat,
+                longitude: pendingSpot.lng,
+              });
+            }
+            setPendingSpot(null);
+          }}
+          onCancel={() => setPendingSpot(null)}
+        />
       )}
     </div>
   );

--- a/packages/web/src/hooks/useLongPress.test.tsx
+++ b/packages/web/src/hooks/useLongPress.test.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { useLongPress, type LongPressDetail } from "./useLongPress";
+
+// jsdom ships no PointerEvent, and Testing Library's fireEvent would not carry
+// `pointerType` or `button` anyway. A minimal stand-in built on MouseEvent is
+// enough: the hook only reads clientX/clientY, target, pointerType and button.
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerType?: string; button?: number } = {},
+): Event {
+  const e = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    button: init.button ?? 0,
+  });
+  Object.defineProperty(e, "pointerType", { value: init.pointerType ?? "touch" });
+  return e;
+}
+
+function Harness({
+  onPress,
+  shouldPress,
+}: {
+  onPress: (d: LongPressDetail) => void;
+  shouldPress?: (t: Element) => boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const clickSuppressedRef = useLongPress(ref, { onPress, shouldPress });
+  return (
+    <div
+      ref={ref}
+      data-testid="surface"
+      onClick={() => {
+        if (clickSuppressedRef.current) {
+          clickSuppressedRef.current = false;
+          return;
+        }
+        onPress({ clientX: -1, clientY: -1, target: document.body });
+      }}
+    >
+      <span data-testid="child">enfant</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function press(el: Element, at = { clientX: 10, clientY: 20 }) {
+  act(() => {
+    el.dispatchEvent(pointerEvent("pointerdown", at));
+  });
+}
+
+function hold(ms = 400) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+function release() {
+  act(() => {
+    window.dispatchEvent(pointerEvent("pointerup"));
+  });
+}
+
+describe("useLongPress", () => {
+  it("fires after the hold, with the coordinates of the press", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    press(getByTestId("child"), { clientX: 120, clientY: 240 });
+    expect(onPress).not.toHaveBeenCalled();
+    hold();
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress.mock.calls[0][0]).toMatchObject({ clientX: 120, clientY: 240 });
+    expect((onPress.mock.calls[0][0] as LongPressDetail).target).toBe(getByTestId("child"));
+  });
+
+  it("does not fire when the press is released early", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    press(getByTestId("surface"));
+    hold(200);
+    release();
+    hold(400);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the pointer travels: that is a drag", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    press(getByTestId("surface"), { clientX: 100, clientY: 100 });
+    act(() => {
+      window.dispatchEvent(pointerEvent("pointermove", { clientX: 140, clientY: 100 }));
+    });
+    hold();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a few pixels of tremor", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    press(getByTestId("surface"), { clientX: 100, clientY: 100 });
+    act(() => {
+      window.dispatchEvent(pointerEvent("pointermove", { clientX: 105, clientY: 103 }));
+    });
+    hold();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire on a second finger: a pinch is not a hold", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    const el = getByTestId("surface");
+    press(el);
+    press(el, { clientX: 200, clientY: 200 });
+    hold();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("ignores a right button press", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    press(getByTestId("surface"), { clientX: 10, clientY: 10 });
+    act(() => {
+      getByTestId("surface").dispatchEvent(
+        pointerEvent("pointerdown", { pointerType: "mouse", button: 2 }),
+      );
+    });
+    hold();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours shouldPress, so a press on an excluded target arms nothing", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(
+      <Harness onPress={onPress} shouldPress={(t) => t.tagName.toLowerCase() !== "span"} />,
+    );
+    press(getByTestId("child"));
+    hold();
+    expect(onPress).not.toHaveBeenCalled();
+    release();
+    press(getByTestId("surface"));
+    hold();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows the click the press produces, and only that one", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    const el = getByTestId("surface");
+    press(el);
+    hold();
+    expect(onPress).toHaveBeenCalledTimes(1);
+    // The browser fires the click right after pointerup; the harness's click
+    // handler would call onPress again if the flag were not raised.
+    release();
+    act(() => {
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onPress).toHaveBeenCalledTimes(1);
+    // A later, ordinary tap goes through.
+    act(() => {
+      vi.advanceTimersByTime(1);
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onPress).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires straight away on a right click, and suppresses the native menu", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(<Harness onPress={onPress} />);
+    const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 55, clientY: 66 });
+    act(() => {
+      getByTestId("surface").dispatchEvent(event);
+    });
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress.mock.calls[0][0]).toMatchObject({ clientX: 55, clientY: 66 });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("honours shouldPress on a right click too", () => {
+    const onPress = vi.fn();
+    const { getByTestId } = render(
+      <Harness onPress={onPress} shouldPress={() => false} />,
+    );
+    act(() => {
+      getByTestId("surface").dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+      );
+    });
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("drops its listeners on unmount", () => {
+    const onPress = vi.fn();
+    const { getByTestId, unmount } = render(<Harness onPress={onPress} />);
+    const el = getByTestId("surface");
+    press(el);
+    unmount();
+    hold();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/useLongPress.ts
+++ b/packages/web/src/hooks/useLongPress.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { useEffect, useRef, type RefObject } from "react";
+
+/**
+ * "Press and hold here", over an element that also handles clicks and drags.
+ *
+ * The gesture the spot map is built around: hold a finger on the water for a
+ * moment and a spot dialog opens there. Written on Pointer Events, one stream
+ * for mouse and touch alike, because the touch-only APIs and the HTML5 drag
+ * API each miss half the devices (see the Firefox Android drag regression in
+ * `docs/qa/user-journeys.md`, J10).
+ *
+ * Three details carry the behaviour, and all three came from bugs:
+ *
+ * - **A second finger cancels.** A pinch-zoom starts as a press; without the
+ *   pointer count, zooming into a bay dropped a dialog on it.
+ * - **Movement cancels.** Panning the map is a press that travels; past a few
+ *   pixels of travel it is a drag, not a hold.
+ * - **The press swallows the click that follows it.** A pointerup is followed
+ *   by a click, so the hold that opened the dialog would immediately fire the
+ *   element's own click handler underneath it. The returned ref is raised the
+ *   moment the press fires and lowered on the tick after pointerup, which is
+ *   exactly one click later.
+ *
+ * A right click takes the same exit, immediately, and the browser context menu
+ * is suppressed so the dialog is the only surface offered.
+ */
+
+export interface LongPressDetail {
+  /** Viewport coordinates of the press, i.e. of the initial pointerdown. */
+  clientX: number;
+  clientY: number;
+  /** What was under the pointer. Callers map it back to their own model. */
+  target: Element;
+}
+
+interface UseLongPressOptions {
+  /** Fires after `delayMs` of a still press, or straight away on right click. */
+  onPress: (detail: LongPressDetail) => void;
+  /**
+   * Consulted at pointerdown, and again on right click, before anything is
+   * armed. Return false to let this press through untouched: the spot map uses
+   * it to leave taps on markers it does not own alone.
+   */
+  shouldPress?: (target: Element) => boolean;
+  /** How long the press has to be held. 400 ms reads as deliberate without
+      feeling slow, and sits under the ~500 ms of the native context menu. */
+  delayMs?: number;
+  /** Past this much travel, the gesture is a drag. */
+  moveTolerancePx?: number;
+}
+
+/**
+ * Returns the click-suppression flag: true between the press firing and the
+ * click it produces. A click handler on the same element reads it, ignores
+ * that one click, and lowers it. The ref keeps its identity for the life of
+ * the component, so a handler wired once can hold on to it.
+ */
+export function useLongPress(
+  targetRef: RefObject<HTMLElement | null>,
+  options: UseLongPressOptions,
+): RefObject<boolean> {
+  const { delayMs = 400, moveTolerancePx = 10 } = options;
+
+  // The callbacks are read at event time, never at effect time: re-arming the
+  // listeners on every render of the parent would drop a press in flight.
+  const onPressRef = useRef(options.onPress);
+  const shouldPressRef = useRef(options.shouldPress);
+  useEffect(() => {
+    onPressRef.current = options.onPress;
+    shouldPressRef.current = options.shouldPress;
+  }, [options.onPress, options.shouldPress]);
+
+  const clickSuppressedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const el = targetRef.current;
+    if (!el) return;
+
+    let startX = 0;
+    let startY = 0;
+    let activePointers = 0;
+
+    const cancel = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      activePointers++;
+      if (activePointers > 1) {
+        cancel();
+        return;
+      }
+
+      startX = e.clientX;
+      startY = e.clientY;
+      const target = e.target as Element;
+      if (shouldPressRef.current && !shouldPressRef.current(target)) return;
+
+      // Captured, not read from the closure at fire time: the press that
+      // fires is the one whose coordinates the caller is owed.
+      const pressX = startX;
+      const pressY = startY;
+      timerRef.current = setTimeout(() => {
+        clickSuppressedRef.current = true;
+        onPressRef.current({ clientX: pressX, clientY: pressY, target });
+      }, delayMs);
+    };
+
+    const handlePointerUp = () => {
+      activePointers = Math.max(0, activePointers - 1);
+      cancel();
+      // The click that follows this pointerup runs first; clearing on the
+      // next tick means one press swallows exactly one click, and a later
+      // tap is honoured normally.
+      setTimeout(() => {
+        clickSuppressedRef.current = false;
+      }, 0);
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (
+        Math.abs(e.clientX - startX) > moveTolerancePx ||
+        Math.abs(e.clientY - startY) > moveTolerancePx
+      ) {
+        cancel();
+      }
+    };
+
+    // Right click, desktop: same outcome as a hold, without the wait.
+    const handleContextMenu = (e: MouseEvent) => {
+      e.preventDefault();
+      cancel();
+      const target = e.target as Element;
+      if (shouldPressRef.current && !shouldPressRef.current(target)) return;
+      onPressRef.current({ clientX: e.clientX, clientY: e.clientY, target });
+    };
+
+    el.addEventListener("pointerdown", handlePointerDown);
+    el.addEventListener("contextmenu", handleContextMenu);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+
+    return () => {
+      cancel();
+      el.removeEventListener("pointerdown", handlePointerDown);
+      el.removeEventListener("contextmenu", handleContextMenu);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+  }, [targetRef, delayMs, moveTolerancePx]);
+
+  return clickSuppressedRef;
+}

--- a/packages/web/src/hooks/useMapAutoCenter.ts
+++ b/packages/web/src/hooks/useMapAutoCenter.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { useCallback, useRef, type RefObject } from "react";
+import type L from "leaflet";
+import { centerForBottomInset } from "../utils/visibleCenter";
+
+/**
+ * Centring a point on a map whose bottom edge is covered by a data panel.
+ *
+ * The forecast tables sit over the bottom of the map. Centring a spot on the
+ * container therefore hides it behind them: what has to be centred is the
+ * strip left visible above the panel (issue #218).
+ *
+ * The hard part is that the panel's height at the moment a camera move starts
+ * is not its final height. The loading skeleton gives way to tables of varying
+ * height once the forecast lands, and the difference pushes the point off the
+ * strip's centre by half of it. So every auto-centre records its intent here,
+ * and a ResizeObserver on the panel re-aims the camera once the height
+ * settles. Mid-flight, the correction re-issues the fly with the time it has
+ * left, so it reads as one continuous move rather than two.
+ *
+ * A drag ends the intent: from then on the viewport belongs to the user, and a
+ * panel resize must not take it back. A zoom does not, because zooming around
+ * a centred point is still looking at that point.
+ */
+
+/** Zoom and duration of a "fly to this point" camera move. */
+export const FLY_ZOOM = 10;
+export const FLY_MS = 1200;
+
+interface AutoCenterIntent {
+  lat: number;
+  lon: number;
+  zoom: number;
+  insetPx: number;
+  /** Epoch ms when the flyTo animation lands; 0 for plain pans. */
+  flyEndsAt: number;
+}
+
+interface MapAutoCenter {
+  /** Where the map centre has to be for `(lat, lon)` to land in the visible
+      strip. For the initial `setView`, before any map exists. */
+  visibleCenter: (lat: number, lon: number, zoom: number) => [number, number];
+  /** Move the camera onto a point, and remember that we did. */
+  autoCenter: (map: L.Map, lat: number, lon: number, mode: "pan" | "fly") => void;
+  /** Record an intent for a camera position that was set directly, so a panel
+      resize still re-aims it. Used for the map's initial view. */
+  seed: (lat: number, lon: number, zoom: number) => void;
+  /** Forget the intent: the viewport is the user's now. */
+  clear: () => void;
+  /** Start watching the panel for the given map. Returns the teardown. */
+  observe: (map: L.Map) => () => void;
+}
+
+export function useMapAutoCenter(
+  bottomInsetRef: RefObject<HTMLElement | null> | undefined,
+): MapAutoCenter {
+  const intentRef = useRef<AutoCenterIntent | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
+  const observedElRef = useRef<Element | null>(null);
+
+  const insetPx = useCallback(
+    () => bottomInsetRef?.current?.offsetHeight ?? 0,
+    [bottomInsetRef],
+  );
+
+  // The observer wants the element, but the data area is unmounted while no
+  // spot is active, so each auto-centre re-points it at whichever node
+  // currently renders the panel instead of observing once at mount.
+  const ensureObserved = useCallback(() => {
+    const el = bottomInsetRef?.current ?? null;
+    const ro = roRef.current;
+    if (!ro || el === observedElRef.current) return;
+    if (observedElRef.current) ro.unobserve(observedElRef.current);
+    observedElRef.current = el;
+    if (el) ro.observe(el);
+  }, [bottomInsetRef]);
+
+  const visibleCenter = useCallback(
+    (lat: number, lon: number, zoom: number): [number, number] => {
+      const c = centerForBottomInset(lat, lon, zoom, insetPx());
+      return [c.lat, c.lon];
+    },
+    [insetPx],
+  );
+
+  const autoCenter = useCallback(
+    (map: L.Map, lat: number, lon: number, mode: "pan" | "fly") => {
+      ensureObserved();
+      const inset = insetPx();
+      const zoom = mode === "fly" ? FLY_ZOOM : map.getZoom();
+      const c = centerForBottomInset(lat, lon, zoom, inset);
+      intentRef.current = {
+        lat,
+        lon,
+        zoom,
+        insetPx: inset,
+        flyEndsAt: mode === "fly" ? Date.now() + FLY_MS : 0,
+      };
+      if (mode === "fly") {
+        map.flyTo([c.lat, c.lon], zoom, { duration: FLY_MS / 1000 });
+      } else {
+        map.panTo([c.lat, c.lon], { animate: true });
+      }
+    },
+    [ensureObserved, insetPx],
+  );
+
+  const seed = useCallback(
+    (lat: number, lon: number, zoom: number) => {
+      intentRef.current = { lat, lon, zoom, insetPx: insetPx(), flyEndsAt: 0 };
+    },
+    [insetPx],
+  );
+
+  const clear = useCallback(() => {
+    intentRef.current = null;
+  }, []);
+
+  const observe = useCallback(
+    (map: L.Map) => {
+      roRef.current = new ResizeObserver(() => {
+        const target = intentRef.current;
+        if (!target) return;
+        // Measure through the ref, not the observed entry: after a remount
+        // the observer may still deliver for the old node.
+        const inset = insetPx();
+        if (inset === target.insetPx) return;
+        target.insetPx = inset;
+        const flyRemainingMs = target.flyEndsAt - Date.now();
+        // Mid-flight the interpolated getZoom() is meaningless, so keep the
+        // fly's destination zoom. At rest, follow the user's current zoom.
+        const zoom = flyRemainingMs > 0 ? target.zoom : map.getZoom();
+        target.zoom = zoom;
+        const c = centerForBottomInset(target.lat, target.lon, zoom, inset);
+        if (flyRemainingMs > 0) {
+          map.flyTo([c.lat, c.lon], zoom, {
+            duration: Math.max(flyRemainingMs, 300) / 1000,
+          });
+        } else {
+          map.panTo([c.lat, c.lon], { animate: true });
+        }
+      });
+      // The user dragging the map ends any auto-centre intent.
+      map.on("dragstart", clear);
+      ensureObserved();
+      return () => {
+        roRef.current?.disconnect();
+        roRef.current = null;
+        observedElRef.current = null;
+      };
+    },
+    [clear, ensureObserved, insetPx],
+  );
+
+  return { visibleCenter, autoCenter, seed, clear, observe };
+}

--- a/packages/web/src/utils/spotArrowLayer.ts
+++ b/packages/web/src/utils/spotArrowLayer.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The arrow overlay as a Leaflet layer.
+ *
+ * Split from `spotArrows.ts`, which stays free of Leaflet: the geometry and
+ * the label relaxation are pure functions of numbers, and their tests run in
+ * Node without a DOM. Only this file needs a map.
+ */
+
+import L from "leaflet";
+import type { MarineHourly, MetricView, ModelForecast, Spot } from "../types";
+import {
+  arrowsSvg,
+  currentArrowItems,
+  SPOT_CX,
+  SPOT_CY,
+  waveArrowItems,
+  windArrowItems,
+  type ArrowItem,
+} from "./spotArrows";
+
+/** Name of the Leaflet pane the arrows live in, created by the map owner. */
+export const ARROW_PANE = "windArrows";
+
+/**
+ * Reconcile the arrow overlay with what should be drawn, in the shape the
+ * other map layers use (`syncUserPositionLayer`, `syncSeamarkLayer`).
+ *
+ * The arrows ride in their own pane, below the markers and above the basemap,
+ * and are never interactive: they are a reading of the hour, not a target.
+ */
+export function syncSpotArrowLayer(
+  map: L.Map,
+  layerRef: { current: L.Marker | null },
+  opts: {
+    current: Spot | null;
+    selectedHour: string | null;
+    metric: MetricView;
+    forecasts: ModelForecast[];
+    marine: MarineHourly | null;
+    color: string;
+  },
+): void {
+  layerRef.current?.remove();
+  layerRef.current = null;
+
+  const { current, selectedHour, metric, forecasts, marine, color } = opts;
+  if (!selectedHour || !current) return;
+
+  let items: ArrowItem[] = [];
+  if (metric === "wind") {
+    items = windArrowItems(forecasts, selectedHour, color);
+  } else if (metric === "waves" && marine) {
+    items = waveArrowItems(marine, selectedHour, color);
+  } else if (metric === "currents" && marine) {
+    items = currentArrowItems(marine, selectedHour, color);
+  }
+  // metric === "tides": scalar, no arrow.
+
+  const html = arrowsSvg(items);
+  if (!html) return;
+
+  layerRef.current = L.marker([current.latitude, current.longitude], {
+    icon: L.divIcon({
+      html,
+      className: "",
+      iconSize: [300, 300],
+      iconAnchor: [SPOT_CX, SPOT_CY],
+    }),
+    interactive: false,
+    pane: ARROW_PANE,
+  }).addTo(map);
+}

--- a/packages/web/src/utils/spotArrows.test.ts
+++ b/packages/web/src/utils/spotArrows.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it } from "vitest";
+import {
+  arrowsSvg,
+  buildArrowItem,
+  currentArrowItems,
+  relaxLabels,
+  SPOT_CX,
+  SPOT_CY,
+  waveArrowItems,
+  windArrowItems,
+  type ArrowItem,
+} from "./spotArrows";
+import type { MarineHourly, ModelForecast } from "../types";
+
+const COLOR = "#ffffff";
+const HOUR = "2026-09-03T12:00";
+
+function forecast(name: string, dirDeg: number | null, speedKn: number | null): ModelForecast {
+  return {
+    modelName: name,
+    hourly: {
+      time: ["2026-09-03T11:00", HOUR],
+      wind_speed_10m: [0, speedKn],
+      wind_direction_10m: [0, dirDeg],
+      wind_gusts_10m: [0, 0],
+      weather_code: [0, 0],
+    },
+  };
+}
+
+function marine(over: Partial<MarineHourly> = {}): MarineHourly {
+  return {
+    time: ["2026-09-03T11:00", HOUR],
+    wave_height_m: [0, 1.4],
+    wave_period_s: [0, 7.6],
+    wave_direction_deg: [0, 270],
+    current_speed_kn: [0, 0.8],
+    current_direction_to_deg: [0, 90],
+    tide_height_m: [0, 0],
+    ...over,
+  };
+}
+
+describe("buildArrowItem", () => {
+  it("points north for angle zero, screen y growing downwards", () => {
+    const it = buildArrowItem(0, 100, "10", "AROME", COLOR);
+    expect(it.tipX).toBeCloseTo(SPOT_CX);
+    expect(it.tipY).toBeCloseTo(SPOT_CY - 100);
+  });
+
+  it("points east for a quarter turn", () => {
+    const it = buildArrowItem(Math.PI / 2, 100, "10", "", COLOR);
+    expect(it.tipX).toBeCloseTo(SPOT_CX + 100);
+    expect(it.tipY).toBeCloseTo(SPOT_CY);
+  });
+
+  it("puts the label past the tip, on the same axis", () => {
+    const it = buildArrowItem(Math.PI / 2, 100, "10", "", COLOR);
+    expect(it.natLblX).toBeCloseTo(SPOT_CX + 126);
+    expect(it.lblX).toBe(it.natLblX);
+    expect(it.lblY).toBe(it.natLblY);
+  });
+});
+
+describe("relaxLabels", () => {
+  it("separates two labels that land on top of each other", () => {
+    // Two models predicting the same wind: identical arrows, identical labels.
+    const items: ArrowItem[] = [
+      buildArrowItem(0, 120, "15", "AROME", COLOR),
+      buildArrowItem(0, 120, "15", "ICON", COLOR),
+    ];
+    relaxLabels(items);
+    const dx = Math.abs(items[0].lblX - items[1].lblX);
+    const dy = Math.abs(items[0].lblY - items[1].lblY);
+    // No AABB overlap left: apart on at least one axis.
+    expect(dx >= 64 || dy >= 44).toBe(true);
+  });
+
+  it("pushes a label off the spot marker", () => {
+    // A very short arrow puts its label inside the keep-out radius.
+    const items = [buildArrowItem(0, 5, "2", "AROME", COLOR)];
+    relaxLabels(items);
+    const dist = Math.hypot(items[0].lblX - SPOT_CX, items[0].lblY - SPOT_CY);
+    expect(dist).toBeGreaterThanOrEqual(59.9);
+  });
+
+  it("leaves a lone, well-placed label where it is", () => {
+    const items = [buildArrowItem(Math.PI / 2, 150, "20", "AROME", COLOR)];
+    const before = { x: items[0].lblX, y: items[0].lblY };
+    relaxLabels(items);
+    expect(items[0].lblX).toBe(before.x);
+    expect(items[0].lblY).toBe(before.y);
+  });
+});
+
+describe("windArrowItems", () => {
+  it("draws one arrow per model, pointing downwind", () => {
+    // A north wind (from 000) blows towards the south: the arrow points down
+    // the screen, i.e. tipY below the centre.
+    const items = windArrowItems([forecast("AROME", 0, 12)], HOUR, COLOR);
+    expect(items).toHaveLength(1);
+    expect(items[0].tipY).toBeGreaterThan(SPOT_CY);
+    expect(items[0].displayText).toBe("12");
+    expect(items[0].caption).toBe("AROME");
+  });
+
+  it("skips a model with no value at that hour", () => {
+    expect(windArrowItems([forecast("AROME", null, 12)], HOUR, COLOR)).toEqual([]);
+    expect(windArrowItems([forecast("AROME", 0, null)], HOUR, COLOR)).toEqual([]);
+  });
+
+  it("skips a model whose series does not cover that hour", () => {
+    expect(windArrowItems([forecast("AROME", 0, 12)], "2030-01-01T00:00", COLOR)).toEqual([]);
+  });
+
+  it("caps the arrow length so a gale stays on the canvas", () => {
+    const gale = windArrowItems([forecast("AROME", 90, 60)], HOUR, COLOR)[0];
+    const length = Math.hypot(gale.tipX - SPOT_CX, gale.tipY - SPOT_CY);
+    expect(length).toBeCloseTo(240);
+  });
+});
+
+describe("waveArrowItems", () => {
+  it("labels the height and captions the period", () => {
+    const items = waveArrowItems(marine(), HOUR, COLOR);
+    expect(items[0].displayText).toBe("1.4m");
+    expect(items[0].caption).toBe("8s");
+  });
+
+  it("falls back to Hs when the period is missing", () => {
+    const items = waveArrowItems(marine({ wave_period_s: [0, null] }), HOUR, COLOR);
+    expect(items[0].caption).toBe("Hs");
+  });
+
+  it("points downwave: a westerly swell runs east", () => {
+    // wave_direction is "from" (270 = from the west), so the arrow goes east.
+    const items = waveArrowItems(marine(), HOUR, COLOR);
+    expect(items[0].tipX).toBeGreaterThan(SPOT_CX);
+  });
+
+  it("draws nothing without a height or a direction", () => {
+    expect(waveArrowItems(marine({ wave_height_m: [0, null] }), HOUR, COLOR)).toEqual([]);
+    expect(waveArrowItems(marine({ wave_direction_deg: [0, null] }), HOUR, COLOR)).toEqual([]);
+  });
+});
+
+describe("currentArrowItems", () => {
+  it("points where the current sets, with no flip", () => {
+    // current_direction is already a "to": 90 sets east.
+    const items = currentArrowItems(marine(), HOUR, COLOR);
+    expect(items[0].tipX).toBeGreaterThan(SPOT_CX);
+    expect(items[0].tipY).toBeCloseTo(SPOT_CY);
+  });
+
+  it("labels one line only, in knots", () => {
+    const items = currentArrowItems(marine(), HOUR, COLOR);
+    expect(items[0].displayText).toBe("0.8 kn");
+    expect(items[0].caption).toBe("");
+  });
+
+  it("draws nothing without a speed or a direction", () => {
+    expect(currentArrowItems(marine({ current_speed_kn: [0, null] }), HOUR, COLOR)).toEqual([]);
+    expect(
+      currentArrowItems(marine({ current_direction_to_deg: [0, null] }), HOUR, COLOR),
+    ).toEqual([]);
+  });
+});
+
+describe("arrowsSvg", () => {
+  it("is empty when there is nothing to draw", () => {
+    expect(arrowsSvg([])).toBe("");
+  });
+
+  it("renders arrows behind, then leaders, then labels", () => {
+    const items = [
+      buildArrowItem(0, 120, "15", "AROME", COLOR),
+      buildArrowItem(0, 120, "15", "ICON", COLOR),
+    ];
+    const svg = arrowsSvg(items);
+    expect(svg.startsWith("<svg width=\"300\" height=\"300\"")).toBe(true);
+    expect(svg.indexOf("<polygon")).toBeLessThan(svg.indexOf("<text"));
+    // The two labels were pushed apart, so at least one leader is drawn.
+    expect(svg).toContain("stroke-dasharray");
+    expect(svg.match(/<text/g)).toHaveLength(4); // 2 values + 2 captions
+  });
+});

--- a/packages/web/src/utils/spotArrows.ts
+++ b/packages/web/src/utils/spotArrows.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The arrows drawn over the active spot, as pure geometry.
+ *
+ * Everything here is a function of numbers to numbers, or of numbers to an SVG
+ * string. Nothing touches Leaflet, React or the DOM: `SpotMap` builds the items,
+ * relaxes them, renders them to a string and hands that string to a `divIcon`.
+ * Extracted from the component so the label-collision pass and the per-metric
+ * scales can be read, and tested, without a map.
+ *
+ * ## What is drawn
+ *
+ * A single 300x300 SVG anchored on the spot, centre (150, 150). For `wind`,
+ * one arrow and one label per forecast model. For `waves` and `currents`, a
+ * single arrow from the Open-Meteo Marine series. `tides` is scalar and gets
+ * no arrow at all.
+ *
+ * ## Conventions, which differ by metric
+ *
+ * Wind and wave directions come "from" (meteorological convention), so their
+ * arrows are flipped 180 degrees to point where the wind blows and where the
+ * waves run. A current direction is already a "to", and is drawn as-is. This
+ * is the asymmetry behind issue #269, and the legend in the marine table says
+ * so in words.
+ */
+
+import type { MarineHourly, ModelForecast } from "../types";
+
+/** Centre of the arrow canvas, i.e. the spot itself. */
+export const SPOT_CX = 150;
+export const SPOT_CY = 150;
+
+/** Approximate label half-width and half-height (18 px value over 13 px caption). */
+const LABEL_HW = 32;
+const LABEL_HH = 22;
+/** Labels never slide back over the spot marker itself. */
+const MIN_FROM_SPOT = 60;
+
+export type ArrowItem = {
+  rad: number;
+  tipX: number;
+  tipY: number;
+  /** Label centre, after relaxation. */
+  lblX: number;
+  lblY: number;
+  /** Label centre before relaxation, used to decide whether a leader is needed. */
+  natLblX: number;
+  natLblY: number;
+  /** Top label, e.g. "15" (wind kn), "0.5m" (Hs), "1.5 kn" (current). */
+  displayText: string;
+  /** Bottom caption, e.g. "AROME", "8s". Empty for a single-line label. */
+  caption: string;
+  color: string;
+};
+
+/**
+ * (angle, length) to a fully positioned item. The label sits just past the
+ * tip, along the arrow, which is where it would naturally go before any
+ * neighbour pushes it aside.
+ */
+export function buildArrowItem(
+  rad: number,
+  length: number,
+  displayText: string,
+  caption: string,
+  color: string,
+): ArrowItem {
+  const tipX = SPOT_CX + Math.sin(rad) * length;
+  const tipY = SPOT_CY - Math.cos(rad) * length;
+  const natLblX = tipX + Math.sin(rad) * 26;
+  const natLblY = tipY - Math.cos(rad) * 26;
+  return {
+    rad, tipX, tipY,
+    lblX: natLblX, lblY: natLblY,
+    natLblX, natLblY,
+    displayText, caption, color,
+  };
+}
+
+/**
+ * Push overlapping labels apart, in place.
+ *
+ * Labels naturally sit past their arrow tip, in the arrow's direction, so two
+ * models predicting a similar direction stack their numbers on top of each
+ * other. A few passes of a minimum-translation push separate them; whatever
+ * has drifted from its tip gets a leader line back, drawn by `leaderMarkup`.
+ */
+export function relaxLabels(items: ArrowItem[]): void {
+  const ITERATIONS = 40;
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    let moved = false;
+    for (let i = 0; i < items.length; i++) {
+      for (let j = i + 1; j < items.length; j++) {
+        const a = items[i];
+        const b = items[j];
+        const dx = b.lblX - a.lblX;
+        const dy = b.lblY - a.lblY;
+        // AABB overlap on each axis
+        const overlapX = LABEL_HW * 2 - Math.abs(dx);
+        const overlapY = LABEL_HH * 2 - Math.abs(dy);
+        if (overlapX > 0 && overlapY > 0) {
+          // push along the smaller-overlap axis (minimum-translation vector)
+          if (overlapX < overlapY) {
+            const push = overlapX * 0.5 * Math.sign(dx || 1);
+            a.lblX -= push;
+            b.lblX += push;
+          } else {
+            const push = overlapY * 0.5 * Math.sign(dy || 1);
+            a.lblY -= push;
+            b.lblY += push;
+          }
+          moved = true;
+        }
+      }
+    }
+    // After each pass, project labels out of the spot-marker keep-out radius.
+    for (const it of items) {
+      const dx = it.lblX - SPOT_CX;
+      const dy = it.lblY - SPOT_CY;
+      const dist = Math.hypot(dx, dy);
+      if (dist < MIN_FROM_SPOT && dist > 0.001) {
+        const scale = MIN_FROM_SPOT / dist;
+        it.lblX = SPOT_CX + dx * scale;
+        it.lblY = SPOT_CY + dy * scale;
+        moved = true;
+      }
+    }
+    if (!moved) break;
+  }
+}
+
+function arrowMarkup(it: ArrowItem): string {
+  // Thin shaft + narrow arrowhead. Shaft stops at the base of the head so the
+  // two strokes don't pile up under the tip — gives a sharp, single-pointed look.
+  const headLen = 13;
+  const headAng = 0.3;
+  const lx = it.tipX - headLen * Math.sin(it.rad - headAng);
+  const ly = it.tipY + headLen * Math.cos(it.rad - headAng);
+  const rx = it.tipX - headLen * Math.sin(it.rad + headAng);
+  const ry = it.tipY + headLen * Math.cos(it.rad + headAng);
+  // Where the shaft should end (midpoint of the arrowhead base, along the shaft axis).
+  const baseDist = headLen * Math.cos(headAng);
+  const shaftX = it.tipX - baseDist * Math.sin(it.rad);
+  const shaftY = it.tipY + baseDist * Math.cos(it.rad);
+  const dropColor = it.color === "#ffffff" ? "#000" : "#fff";
+  return `<line x1="${SPOT_CX}" y1="${SPOT_CY}" x2="${shaftX}" y2="${shaftY}" stroke="${it.color}" stroke-width="3" stroke-linecap="round" style="filter:drop-shadow(0 0 1.5px ${dropColor})"/>
+    <polygon points="${it.tipX},${it.tipY} ${lx},${ly} ${rx},${ry}" fill="${it.color}" style="filter:drop-shadow(0 0 1.5px ${dropColor})"/>`;
+}
+
+function leaderMarkup(it: ArrowItem): string {
+  // Only draw a leader if the label has been displaced from its natural position.
+  const drift = Math.hypot(it.lblX - it.natLblX, it.lblY - it.natLblY);
+  if (drift < 6) return "";
+  return `<line x1="${it.tipX}" y1="${it.tipY}" x2="${it.lblX}" y2="${it.lblY}" stroke="${it.color}" stroke-width="1.5" stroke-dasharray="3 3" opacity="0.55"/>`;
+}
+
+function labelMarkup(it: ArrowItem): string {
+  const shadow = it.color === "#ffffff"
+    ? "0 0 3px #000,0 0 6px #000"
+    : "0 0 3px #fff,0 0 5px #fff";
+  const caption = it.caption
+    ? `<text x="${it.lblX}" y="${it.lblY + 20}" text-anchor="middle" dominant-baseline="middle" font-size="13" fill="#fff" style="text-shadow:0 0 3px #000,0 0 5px #000">${it.caption}</text>`
+    : "";
+  return `<text x="${it.lblX}" y="${it.lblY}" text-anchor="middle" dominant-baseline="middle" font-size="18" font-weight="700" fill="${it.color}" style="text-shadow:${shadow}">${it.displayText}</text>${caption}`;
+}
+
+// ── Per-metric builders ──────────────────────────────────────────────────────
+
+/** One arrow per model, length growing with the wind, capped so a gale does
+    not draw off the canvas. Direction is "from", hence the 180 degree flip. */
+export function windArrowItems(
+  forecasts: ModelForecast[],
+  selectedHour: string,
+  color: string,
+): ArrowItem[] {
+  const items: ArrowItem[] = [];
+  for (const forecast of forecasts) {
+    const timeIdx = forecast.hourly.time.indexOf(selectedHour);
+    if (timeIdx === -1) continue;
+    const dir = forecast.hourly.wind_direction_10m[timeIdx];
+    const spd = forecast.hourly.wind_speed_10m[timeIdx];
+    if (dir == null || spd == null) continue;
+    const rad = ((dir + 180) * Math.PI) / 180;
+    const length = Math.min(72 + spd * 4.8, 240);
+    items.push(buildArrowItem(rad, length, String(Math.round(spd)), forecast.modelName, color));
+  }
+  return items;
+}
+
+/** A single arrow from the Marine series. Hs is scaled so a 2 m sea reads
+    visually like a 20 kn wind on the wind layer; the caption is the dominant
+    period, which is what separates swell from chop. Direction is "from". */
+export function waveArrowItems(
+  marine: MarineHourly,
+  selectedHour: string,
+  color: string,
+): ArrowItem[] {
+  const timeIdx = marine.time.indexOf(selectedHour);
+  if (timeIdx === -1) return [];
+  const dir = marine.wave_direction_deg[timeIdx];
+  const hs = marine.wave_height_m[timeIdx];
+  if (dir == null || hs == null) return [];
+  const rad = ((dir + 180) * Math.PI) / 180;
+  const length = Math.min(72 + hs * 50, 240);
+  const period = marine.wave_period_s[timeIdx];
+  const caption = period != null ? `${period.toFixed(0)}s` : "Hs";
+  return [buildArrowItem(rad, length, `${hs.toFixed(1)}m`, caption, color)];
+}
+
+/** A single arrow, drawn where the current sets: the Marine direction is
+    already a "to", so no flip. The scale is tuned to navigational impact
+    (1 kn reads like 5 kn of wind, 4 kn like 20) rather than to the raw value,
+    so a typical Mediterranean sub-knot drift is not over-dramatised. One line
+    only: a current has no second axis to caption. */
+export function currentArrowItems(
+  marine: MarineHourly,
+  selectedHour: string,
+  color: string,
+): ArrowItem[] {
+  const timeIdx = marine.time.indexOf(selectedHour);
+  if (timeIdx === -1) return [];
+  const spd = marine.current_speed_kn[timeIdx];
+  const dir = marine.current_direction_to_deg[timeIdx];
+  if (spd == null || dir == null) return [];
+  const rad = (dir * Math.PI) / 180;
+  const length = Math.min(60 + spd * 25, 180);
+  return [buildArrowItem(rad, length, `${spd.toFixed(1)} kn`, "", color)];
+}
+
+/**
+ * The finished `<svg>` for a set of items, or an empty string when there is
+ * nothing to draw. Relaxes the labels on the way, since no caller wants the
+ * unrelaxed form. Render order matters: arrows behind, then leader lines,
+ * then labels on top.
+ */
+export function arrowsSvg(items: ArrowItem[]): string {
+  if (items.length === 0) return "";
+  relaxLabels(items);
+  let content = "";
+  for (const it of items) content += arrowMarkup(it);
+  for (const it of items) content += leaderMarkup(it);
+  for (const it of items) content += labelMarkup(it);
+  return `<svg width="300" height="300" viewBox="0 0 300 300" style="overflow:visible;pointer-events:none">${content}</svg>`;
+}

--- a/packages/web/src/utils/spotMarkerLayer.ts
+++ b/packages/web/src/utils/spotMarkerLayer.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The spot markers on the explore map, and the hollow one that marks a point
+ * merely being previewed.
+ *
+ * Same shape as `userPositionLayer` and `seamarkLayer`: a plain function that
+ * takes the map and the refs holding the current layers, and reconciles them
+ * with what should be drawn. React owns the data; Leaflet owns the nodes.
+ *
+ * The element-to-spot map is the other half of the long-press menu: a press
+ * lands on an SVG node, and this is what turns that node back into the spot it
+ * draws. Only markers registered here open the rename/delete dialog.
+ */
+
+import L from "leaflet";
+import type { Spot } from "../types";
+
+// Leaflet renders a CircleMarker into an SVG node it keeps to itself: there is
+// no public accessor, only the internal ``_path``. Hit-testing needs that node
+// to map an element back to its spot, so the field is declared here instead of
+// being reached through ``any`` — same escape hatch, but one that still type
+// checks the property and its type.
+type WithSvgPath = { _path?: Element };
+
+/** Identity of a spot on the map: two spots at the same point are one marker. */
+export function spotKey(s: Spot): string {
+  return `${s.latitude},${s.longitude}`;
+}
+
+function isAt(spot: Spot, at: Spot | null): boolean {
+  return at != null && spot.latitude === at.latitude && spot.longitude === at.longitude;
+}
+
+/** Bigger, brighter and ringed when the spot is the one being read. */
+function styleFor(active: boolean) {
+  return {
+    radius: active ? 10 : 7,
+    color: active ? "#ffffff" : "#9ca3af",
+    fillColor: active ? "#2dd4bf" : "#6b7280",
+    fillOpacity: active ? 0.9 : 0.6,
+    weight: active ? 2.5 : 1,
+  };
+}
+
+interface SyncSpotMarkersArgs {
+  map: L.Map;
+  /** Live markers, keyed by `spotKey`. Mutated in place. */
+  markers: Map<string, L.CircleMarker>;
+  /** SVG node to spot, for the long-press menu. Mutated in place. */
+  elementToSpot: Map<Element, Spot>;
+  spots: Spot[];
+  /** The spot currently being read, or null. Drives the active style. */
+  current: Spot | null;
+  onSelect: (spot: Spot) => void;
+}
+
+/** Reconcile the saved-spot markers with `spots`, restyling what stays. */
+export function syncSpotMarkers({
+  map,
+  markers,
+  elementToSpot,
+  spots,
+  current,
+  onSelect,
+}: SyncSpotMarkersArgs): void {
+  const desiredKeys = new Set(spots.map(spotKey));
+
+  for (const [key, marker] of markers) {
+    if (!desiredKeys.has(key)) {
+      const svgEl = (marker as unknown as WithSvgPath)._path;
+      if (svgEl) elementToSpot.delete(svgEl);
+      marker.remove();
+      markers.delete(key);
+    }
+  }
+
+  for (const spot of spots) {
+    const key = spotKey(spot);
+    const style = styleFor(isAt(spot, current));
+    const existing = markers.get(key);
+    if (existing) {
+      existing.setStyle(style);
+      continue;
+    }
+    const marker = L.circleMarker([spot.latitude, spot.longitude], {
+      ...style,
+      // Leaflet paths default to this anyway; spelled out because it is what
+      // keeps a marker click from also reaching the map's own click handler,
+      // which would preview open water on top of selecting the spot.
+      bubblingMouseEvents: false,
+    })
+      .bindTooltip(spot.name, {
+        direction: "top",
+        offset: [0, -10],
+        className: "spot-tooltip",
+      })
+      .on("click", () => onSelect(spot))
+      .addTo(map);
+    const svgEl = (marker as unknown as WithSvgPath)._path;
+    if (svgEl) elementToSpot.set(svgEl, spot);
+    markers.set(key, marker);
+  }
+}
+
+/**
+ * The marker for a point being previewed but not saved.
+ *
+ * A previewed point is not in the spot list, so the markers above never draw
+ * it, and the panel would be reading conditions at a place the map does not
+ * show. Dashed and hollow, to read as provisional next to the solid saved
+ * spots, and non-interactive: there is nothing to select, it is already open.
+ */
+export function syncPreviewMarker(
+  map: L.Map,
+  layerRef: { current: L.CircleMarker | null },
+  current: Spot | null,
+  savedSpots: Spot[],
+): void {
+  layerRef.current?.remove();
+  layerRef.current = null;
+  if (!current) return;
+  if (savedSpots.some((s) => isAt(s, current))) return;
+  layerRef.current = L.circleMarker([current.latitude, current.longitude], {
+    radius: 9,
+    color: "#2dd4bf",
+    weight: 2.5,
+    dashArray: "4 3",
+    fillColor: "#2dd4bf",
+    fillOpacity: 0.25,
+    interactive: false,
+  }).addTo(map);
+}


### PR DESCRIPTION
Lot 4, PR 4.2. `SpotMap.tsx` faisait 942 lignes et mélangeait sept sujets. Chacun sort dans son module, testable seul. Aucun changement de comportement voulu, sauf la traduction des deux modales, annoncée plus bas.

## Ce qui sort

| Module | Lignes | Ce qu'il porte |
|---|---|---|
| `utils/spotArrows.ts` | 246 | géométrie pure : `relaxLabels`, les trois markups, un constructeur par métrique. Aucun import Leaflet, donc les tests tournent dans le projet vitest `unit`, sans DOM |
| `utils/spotArrowLayer.ts` | 75 | la couche Leaflet correspondante, sur le modèle de `syncUserPositionLayer` et `syncSeamarkLayer` |
| `utils/spotMarkerLayer.ts` | 134 | marqueurs de spots et marqueur de prévisualisation |
| `api/reverseGeocode.ts` | 128 | le seul `fetch` qui vivait hors de `src/api` |
| `hooks/useLongPress.ts` | 163 | l'appui long en Pointer Events |
| `hooks/useMapAutoCenter.ts` | 158 | le recentrage sous le panneau de données |
| `components/SpotDialogs.tsx` | 135 | les deux modales |

`SpotMap.tsx` : **942 → 394 lignes**, sous la cible de 400.

## Nominatim, politique d'usage

Le geocodage inverse partait sans identification d'aucune sorte. La [politique de l'instance publique](https://operations.osmfoundation.org/policies/nominatim/) en demande trois choses, et le module les documente et les tient :

1. **Identifier l'application.** Un navigateur refuse qu'une page pose `User-Agent`. Restent le `Referer`, que Chrome, Firefox et Safari envoient seuls depuis `ohmywind.fr`, et le paramètre `email`, officiellement supporté. Les deux sont là : le paramètre porte l'adresse publique du projet, déjà présente dans la page de confidentialité, et survit à une `Referrer-Policy` plus stricte que la nôtre.
2. **Une requête par seconde au plus.** Un appui long ne peut pas la dépasser, et le cache mémoire supprime les répétitions d'un utilisateur qui tâtonne dans la même baie (clé arrondie à ~100 m).
3. **Mettre les réponses en cache.** D'où ce cache, par onglet et par session : la réponse est un nom de lieu, peu coûteux à refaire, et le persister ajouterait une clé de stockage à versionner.

Un `AbortSignal` du appelant s'ajoute au délai de garde de 4 s via `AbortSignal.any`. Tout échec, abandon compris, retombe sur les coordonnées : nommer un spot est un confort, un hoquet réseau ne doit pas empêcher d'enregistrer un point.

## Les six refs écrites en rendu, et le lint qui devient bloquant

Les six erreurs `react-hooks/refs` disparaissent, sans `eslint-disable` :

- quatre miroirs de callbacks (`onSelectSpot`, `onAddSpot`, `onRemoveSpot`, `onRenameSpot`) sont écrits depuis un effet, comme le faisaient déjà `onViewChange` et `onPreviewSpot`. Un seul effet pour les six.
- les deux autres doublaient des setters `useState`. React garantit leur identité pour la vie du composant : le ref ne servait à rien, les handlers les capturent directement.

Le budget lint passe donc de 6 à 0, et `scripts/lint-budget.mjs` devient un lint bloquant. Le nom du script est conservé pour que la CI, le guide de contribution et les habitudes continuent de marcher ; l'en-tête raconte comment le budget a été dépensé, de 14 à 0. Les avertissements restent des avertissements : l'`exhaustive-deps` de l'effet d'init de la carte est délibéré et documenté sur place.

## Nettoyages de dédoublonnage

- Le style de marqueur n'est plus écrit deux fois. L'effet d'init recréait les marqueurs que l'effet de synchro, déclaré juste après, recrée de toute façon dans le même commit, avant peinture. La boucle d'init part.
- `QUICK_SPOTS`, tableau vide diffusé dans deux boucles (`[...QUICK_SPOTS, ...customSpots]`), et le drapeau `isCustom` qui en découlait et valait toujours vrai, disparaissent. `spots.ts` et `QuickSpots.tsx`, morts tous les deux, restent en place pour knip (PR 4.4).

## Traduction des modales, changement visible assumé

Les deux modales étaient en anglais dans une application dont tout le reste est en français :

| Avant | Après |
|---|---|
| `Rename` / `Delete` / `Cancel` | `Renommer` / `Supprimer` / `Annuler` |
| `New spot` / `Create` | `Nouveau spot` / `Créer` |
| `Rename spot` / `Rename` | `Renommer le spot` / `Renommer` |
| `aria-label="Spot options"` | `aria-label="Options du spot"` |
| `aria-label="Spot name"` | `aria-label="Nom du spot"` |

**À mettre à jour hors périmètre** : `docs/qa/user-journeys.md`, parcours J2, attend encore « dialogue "New spot" ... "Create" ». Non touché ici, le lot 4 se limitant à `packages/web`.

## Ce qui n'est pas fait ici, volontairement

Les hexadécimaux d'accent en dur de `SpotMap` (`#2dd4bf` pour le marqueur de prévisualisation et le spot actif) restent. Les remplacer par `--ow-accent` changerait le rendu en thème clair, où le jeton vaut `#0f766e` précisément parce que `#2dd4bf` a 1,7:1 de contraste sur blanc. C'est le périmètre de la PR 4.5, avec ses captures avant/après dans les deux thèmes.

## Vérifications

- `npm run typecheck`, `npm run lint:budget` (0 erreur, 1 avertissement), `npm run test`, `npm run build` : verts.
- Tests 541 → 598 (+57) : flèches 19, appui long 11, geocodage inverse 10, dialogues 7, plus les 10 du lot 4.1 si celui-ci est mergé avant.
- Aperçu de production (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`), parcours J2 et J3 sur un spot :
  - appui long en mer : dialogue « Nouveau spot » avec « 43.0689, 5.3613 » et le nom rempli par le geocodage ; « Créer » pose le marqueur et ouvre les prévisions ;
  - appui long en pleine mer loin de toute côte : le nom retombe sur les coordonnées, sans erreur ;
  - appui long sur le marqueur : « Options du spot » avec « Renommer / Supprimer / Annuler » ; « Renommer » ouvre « Renommer le spot » pré-rempli ; « Annuler » referme ;
  - tableau horaire : AROME HD en premier, quatre modèles, vitesses en nœuds ;
  - flèches : `Wind` 9/AROME, 10/ICON, 5/ECMWF, 11/GFS avec étiquettes écartées et lignes de rappel ; `Waves` `0.3m` / `3s` ; `Currents` `0.3 kn` ;
  - console vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
