### PR TITLE
refacto(routing): un seul moteur d'échantillonnage et de tronçon pour l'aller et le retour

### DIFF
--- a/packages/data-adapters/src/openwind_data/routing/passage.py
+++ b/packages/data-adapters/src/openwind_data/routing/passage.py
@@ -53,6 +53,7 @@ from openwind_data.routing.archetypes import (
 )
 from openwind_data.routing.geometry import (
     Point,
+    Segment,
     haversine_distance,
     midpoint,
     normalize_twa,
@@ -550,6 +551,7 @@ async def estimate_passage(
                     use_wave_correction=use_wave_correction,
                     polar_override=polar_override,
                     model_chain=chain[idx:],
+                    backward=False,
                 )
             except ForecastHorizonError as exc:
                 last_err = exc
@@ -568,35 +570,94 @@ async def estimate_passage(
         use_wave_correction=use_wave_correction,
         polar_override=polar_override,
         model_chain=model_chain,
+        backward=False,
     )
 
 
-async def _estimate_with_model(
+@dataclass(frozen=True, slots=True)
+class RouteSampling:
+    """Everything the engine needs to know about the route and its weather.
+
+    Produced by `_sample_route`, consumed by the walk. Holds five parallel
+    lists, all in route order whichever direction the walk will take: a
+    segment, the mid-time its weather was sampled at, its mid-point, the
+    bundle that came back, and the model that bundle's wind actually came
+    from (the primary for most segments, a fallback for the ones the primary
+    could not cover).
+    """
+
+    segments: list[Segment]
+    mid_times: list[datetime]
+    mid_points: list[Point]
+    bundles: list[ForecastBundle]
+    models: list[str]
+    effective_length_nm: float
+    # Route length in nm when `_resolve_segment_length` stretched the spacing,
+    # `None` when the requested spacing was kept. Feeds the sampling warning.
+    capped_route_nm: float | None
+
+
+def _layout_mid_times(
+    segments: list[Segment], anchor_utc: datetime, layout_speed_kn: float, *, backward: bool
+) -> list[datetime]:
+    """Lay out one weather-sampling mid-time per segment from a fixed anchor.
+
+    Forward the anchor is the departure and the walk accumulates into the
+    future; backward it is the target arrival and the walk accumulates into
+    the past. Both use the same boat-aware cruising estimate, so the same
+    temporal-correlation argument covers them (see the module docstring).
+    """
+    out: list[datetime] = []
+    cumulative = timedelta(0)
+    order = range(len(segments) - 1, -1, -1) if backward else range(len(segments))
+    for idx in order:
+        seg_h = segments[idx].distance_nm / layout_speed_kn
+        half = timedelta(hours=seg_h / 2)
+        if backward:
+            out.append(anchor_utc - cumulative - half)
+        else:
+            out.append(anchor_utc + cumulative + half)
+        cumulative += timedelta(hours=seg_h)
+    return list(reversed(out)) if backward else out
+
+
+async def _sample_route(
     waypoints: list[Point],
-    departure_time: datetime,
-    boat_archetype: str,
+    anchor_utc: datetime,
+    polar: BoatPolar,
     *,
     efficiency: float,
     segment_length_nm: float,
     adapter: MarineDataAdapter | None,
     model: str,
     heuristic_speed_kn: float | None,
-    use_wave_correction: bool,
-    polar_override: BoatPolar | None = None,
-    model_chain: tuple[str, ...] | None = None,
-) -> PassageReport:
-    """Estimate a passage using a single primary ``model`` for wind sampling.
+    model_chain: tuple[str, ...] | None,
+    backward: bool,
+) -> RouteSampling:
+    """Split the route, lay out sampling times, and fetch the weather.
 
-    When ``model_chain`` is provided, segments where the primary model
-    returns null wind (typical: waypoint outside the model's geographic
-    coverage — AROME France queried in the North Sea) fall back to the next
-    model in the chain, one segment at a time. The primary model is used
-    when it works, so routes fully covered by it pay zero extra cost.
+    The single I/O phase of a passage estimate, shared by both directions:
+    everything after it is arithmetic. Three steps, in order:
+
+    1. Resolve the effective segment spacing (stretched on long routes) and
+       cut the polyline, then lay out one mid-time per segment from
+       ``anchor_utc`` in the direction the walk will take.
+    2. Warm the cache for every mid-point in one batched multi-coordinate
+       call when the adapter supports it, then gather the primary model for
+       all segments at once. Routes fully covered by the primary pay exactly
+       one batched gather, as before the per-segment fallback existed.
+    3. For the segments where the primary returned null wind (typically an
+       off-coverage waypoint: AROME asked outside France), walk the rest of
+       the chain point by point. Border legs cost one call per fallback step,
+       covered routes cost nothing.
+
+    ``model_chain`` empty or ``None`` disables step 3 entirely: a segment the
+    primary cannot serve then surfaces as ``ForecastHorizonError`` from the
+    walk, which is what lets the ``model="auto"`` loop in ``estimate_passage``
+    advance to the next candidate.
     """
-    polar = polar_override if polar_override is not None else get_polar(boat_archetype)
     effective_length_nm, capped_route_nm = _resolve_segment_length(waypoints, segment_length_nm)
     segments = segment_route(waypoints, effective_length_nm)
-    departure_utc = departure_time.astimezone(UTC)
 
     # An explicit heuristic_speed_kn wins (caller pin / test hook); otherwise
     # the layout speed comes from the boat itself.
@@ -605,20 +666,12 @@ async def _estimate_with_model(
         if heuristic_speed_kn is not None
         else _layout_speed_kn(polar, efficiency)
     )
-    seg_mid_times: list[datetime] = []
-    cumulative = timedelta(0)
-    for seg in segments:
-        seg_h = seg.distance_nm / layout_speed_kn
-        seg_mid_times.append(departure_utc + cumulative + timedelta(hours=seg_h / 2))
-        cumulative += timedelta(hours=seg_h)
-
-    seg_mid_points = [midpoint(s.start, s.end) for s in segments]
+    mid_times = _layout_mid_times(segments, anchor_utc, layout_speed_kn, backward=backward)
+    mid_points = [midpoint(s.start, s.end) for s in segments]
 
     # When a chain is provided, drop the primary so we don't redundantly try
     # it twice in the per-segment fallback. Empty tuple (no fallback) is the
-    # back-compat path: segments where primary returns null raise
-    # ForecastHorizonError exactly as before, so the outer ``estimate_passage``
-    # AUTO loop can advance to the next model.
+    # back-compat path described in the docstring.
     chain_tail: tuple[str, ...] = ()
     if model_chain:
         chain_tail = tuple(m for m in model_chain if m != model)
@@ -626,20 +679,16 @@ async def _estimate_with_model(
     own_adapter = adapter is None
     fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
     try:
-        # Warm the cache for every segment point in one batched multi-coordinate
-        # call (adapters that support it), so the per-segment gather below is
-        # served from cache instead of one HTTP call per point. Pure speedup;
-        # adapters without prewarm_batch (cache-backed, stubs) skip it.
+        # Adapters without prewarm_batch (cache-backed, stubs) skip straight to
+        # the gather; for the others this is a pure speedup, one HTTP call for
+        # all points instead of one per point.
         if hasattr(fetch_adapter, "prewarm_batch"):
             await fetch_adapter.prewarm_batch(
-                [(pt.lat, pt.lon) for pt in seg_mid_points],
-                min(seg_mid_times) - WIND_FETCH_WINDOW / 2,
-                max(seg_mid_times) + WIND_FETCH_WINDOW / 2,
+                [(pt.lat, pt.lon) for pt in mid_points],
+                min(mid_times) - WIND_FETCH_WINDOW / 2,
+                max(mid_times) + WIND_FETCH_WINDOW / 2,
                 [model],
             )
-        # First pass: batch-fetch all segments with the primary model. Same
-        # request shape as before — routes 100% covered by the primary see
-        # exactly one batched gather (preserves cache prewarm behaviour).
         bundles = await asyncio.gather(
             *[
                 fetch_adapter.fetch(
@@ -649,22 +698,17 @@ async def _estimate_with_model(
                     mid + WIND_FETCH_WINDOW / 2,
                     models=[model],
                 )
-                for pt, mid in zip(seg_mid_points, seg_mid_times, strict=True)
+                for pt, mid in zip(mid_points, mid_times, strict=True)
             ]
         )
 
-        # Per-segment models default to the primary; fallback may overwrite
-        # individual entries below.
+        # Per-segment models default to the primary; the fallback below may
+        # overwrite individual entries.
         seg_models: list[str] = [model] * len(segments)
-
-        # Identify segments where the primary model returned null wind and
-        # walk the rest of the chain for those points only. The chain_tail
-        # is empty in single-model mode (no fallback), so this loop is a
-        # no-op for the existing behaviour.
         if chain_tail:
             fallback_indices = [
                 i
-                for i, (b, mid) in enumerate(zip(bundles, seg_mid_times, strict=True))
+                for i, (b, mid) in enumerate(zip(bundles, mid_times, strict=True))
                 if not _segment_has_wind(b, model, mid)
             ]
             if fallback_indices:
@@ -672,9 +716,9 @@ async def _estimate_with_model(
                     *[
                         _fetch_segment_with_fallback(
                             fetch_adapter,
-                            seg_mid_points[i].lat,
-                            seg_mid_points[i].lon,
-                            seg_mid_times[i],
+                            mid_points[i].lat,
+                            mid_points[i].lon,
+                            mid_times[i],
                             primary_model=chain_tail[0],
                             chain=chain_tail,
                         )
@@ -690,102 +734,141 @@ async def _estimate_with_model(
         if own_adapter and hasattr(fetch_adapter, "aclose"):
             await fetch_adapter.aclose()  # pragma: no cover
 
-    reports: list[SegmentReport] = []
-    cumulative_actual = timedelta(0)
-    min_boat_speed = float("inf")
-    max_drift_h = 0.0
-    for seg, mid_time, mid_pt, bundle, seg_model in zip(
-        segments, seg_mid_times, seg_mid_points, bundles, seg_models, strict=True
-    ):
-        wind_series = bundle.wind_by_model.get(seg_model)
-        if wind_series is None or not wind_series.points:
-            # Primary returned null AND no fallback chain or chain exhausted:
-            # preserve the existing horizon-error semantics so the outer
-            # AUTO loop in ``estimate_passage`` can advance to the next
-            # candidate model.
-            raise ForecastHorizonError(seg_model, mid_time)
-        wp = _closest_wind_point(wind_series.points, mid_time)
-        twa = normalize_twa(twd=wp.direction_deg, course=seg.bearing_deg)
-        polar_speed = lookup_polar(polar, wp.speed_kn, twa)
-        opt_twa, opt_polar_speed = best_vmg_upwind(polar, wp.speed_kn)
-        if twa < opt_twa:
-            # Sailor tacks at optimal VMG angle; effective speed toward destination:
-            #   v_eff = polar(opt) * cos(opt - twa)
-            # At twa=0 reduces to VMG_pure_upwind; at twa->opt transitions smoothly.
-            effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
-        else:
-            effective_polar = polar_speed
-        # Always surface Hs and currents from the bundle so callers see sea
-        # state and ground-track corrections, even if wave correction is off.
-        sea_pt = _closest_sea_point(bundle.sea.points, mid_time)
-        hs_m = sea_pt.wave_height_m if sea_pt else None
-        tp_s = sea_pt.wave_period_s if sea_pt else None
-        cur_kn = sea_pt.current_speed_kn if sea_pt else None
-        cur_to = sea_pt.current_direction_to_deg if sea_pt else None
-        cur_src = sea_pt.current_source if sea_pt else None
-        cur_conf = confidence_for_point(mid_pt.lat, mid_pt.lon, cur_src)
-        derate = 1.0
-        if use_wave_correction and hs_m is not None:
-            derate = wave_derate(hs_m, twa)
-        sail_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
-        # Motor kicks in when the user configured a threshold AND the polar
-        # estimate falls below it. The check happens on the post-efficiency /
-        # post-derate sail speed — that's the value the user actually sees in
-        # the UI, so it's the one the threshold should refer to.
-        boat_speed, motor_used = _apply_motor(polar, sail_speed)
-        sog = _apply_current(boat_speed, seg.bearing_deg, cur_kn, cur_to)
-        ground_speed = sog if sog is not None else boat_speed
-        seg_duration = timedelta(hours=seg.distance_nm / ground_speed)
-        seg_start = departure_utc + cumulative_actual
-        seg_end = seg_start + seg_duration
-        cumulative_actual += seg_duration
-        min_boat_speed = min(min_boat_speed, boat_speed)
-        actual_mid = seg_start + seg_duration / 2
-        max_drift_h = max(max_drift_h, abs((actual_mid - mid_time).total_seconds()) / 3600.0)
-        reports.append(
-            SegmentReport(
-                start=seg.start,
-                end=seg.end,
-                distance_nm=seg.distance_nm,
-                bearing_deg=seg.bearing_deg,
-                start_time=seg_start,
-                end_time=seg_end,
-                tws_kn=wp.speed_kn,
-                twd_deg=wp.direction_deg,
-                twa_deg=twa,
-                polar_speed_kn=polar_speed,
-                boat_speed_kn=boat_speed,
-                duration_h=seg_duration.total_seconds() / 3600.0,
-                hs_m=hs_m,
-                wave_derate_factor=derate,
-                current_speed_kn=cur_kn,
-                current_direction_to_deg=cur_to,
-                sog_kn=sog,
-                current_source=cur_src,
-                current_confidence=cur_conf,
-                gust_kn=wp.gust_kn,
-                wave_period_s=tp_s,
-                model_used=seg_model,
-                motor_used=motor_used,
-            )
-        )
+    return RouteSampling(
+        segments=segments,
+        mid_times=mid_times,
+        mid_points=mid_points,
+        bundles=list(bundles),
+        models=seg_models,
+        effective_length_nm=effective_length_nm,
+        capped_route_nm=capped_route_nm,
+    )
 
+
+def _segment_report(
+    seg: Segment,
+    *,
+    mid_time: datetime,
+    mid_point: Point,
+    bundle: ForecastBundle,
+    model: str,
+    polar: BoatPolar,
+    efficiency: float,
+    use_wave_correction: bool,
+    anchor: datetime,
+    backward: bool,
+) -> SegmentReport:
+    """Compute one segment: wind, sail geometry, sea, current, duration.
+
+    Pure. ``anchor`` is the end of the segment when walking backward and its
+    start when walking forward, which is the only way the direction of the
+    walk reaches this function: everything else, from the tacking correction
+    to the motor rule, is the same physics either way.
+
+    Raises:
+        ForecastHorizonError: when ``bundle`` carries no wind for ``model``.
+            The primary returned null and either no chain was supplied or the
+            chain was exhausted; re-raising here preserves the semantics the
+            ``model="auto"`` loop relies on to advance to the next candidate.
+    """
+    wind_series = bundle.wind_by_model.get(model)
+    if wind_series is None or not wind_series.points:
+        raise ForecastHorizonError(model, mid_time)
+    wp = _closest_wind_point(wind_series.points, mid_time)
+    twa = normalize_twa(twd=wp.direction_deg, course=seg.bearing_deg)
+    polar_speed = lookup_polar(polar, wp.speed_kn, twa)
+    opt_twa, opt_polar_speed = best_vmg_upwind(polar, wp.speed_kn)
+    if twa < opt_twa:
+        # Sailor tacks at optimal VMG angle; effective speed toward destination:
+        #   v_eff = polar(opt) * cos(opt - twa)
+        # At twa=0 reduces to VMG_pure_upwind; at twa->opt transitions smoothly.
+        effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
+    else:
+        effective_polar = polar_speed
+
+    # Always surface Hs and currents from the bundle so callers see sea state
+    # and ground-track corrections, even if wave correction is off.
+    sea_pt = _closest_sea_point(bundle.sea.points, mid_time)
+    hs_m = sea_pt.wave_height_m if sea_pt else None
+    tp_s = sea_pt.wave_period_s if sea_pt else None
+    cur_kn = sea_pt.current_speed_kn if sea_pt else None
+    cur_to = sea_pt.current_direction_to_deg if sea_pt else None
+    cur_src = sea_pt.current_source if sea_pt else None
+    cur_conf = confidence_for_point(mid_point.lat, mid_point.lon, cur_src)
+
+    derate = 1.0
+    if use_wave_correction and hs_m is not None:
+        derate = wave_derate(hs_m, twa)
+    sail_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
+    # Motor kicks in when the user configured a threshold AND the polar
+    # estimate falls below it. The check happens on the post-efficiency /
+    # post-derate sail speed, the value the user actually sees in the UI, so
+    # it is the one the threshold should refer to.
+    boat_speed, motor_used = _apply_motor(polar, sail_speed)
+    sog = _apply_current(boat_speed, seg.bearing_deg, cur_kn, cur_to)
+    ground_speed = sog if sog is not None else boat_speed
+    seg_duration = timedelta(hours=seg.distance_nm / ground_speed)
+
+    start_time = anchor - seg_duration if backward else anchor
+    end_time = anchor if backward else anchor + seg_duration
+    return SegmentReport(
+        start=seg.start,
+        end=seg.end,
+        distance_nm=seg.distance_nm,
+        bearing_deg=seg.bearing_deg,
+        start_time=start_time,
+        end_time=end_time,
+        tws_kn=wp.speed_kn,
+        twd_deg=wp.direction_deg,
+        twa_deg=twa,
+        polar_speed_kn=polar_speed,
+        boat_speed_kn=boat_speed,
+        duration_h=seg_duration.total_seconds() / 3600.0,
+        hs_m=hs_m,
+        wave_derate_factor=derate,
+        current_speed_kn=cur_kn,
+        current_direction_to_deg=cur_to,
+        sog_kn=sog,
+        current_source=cur_src,
+        current_confidence=cur_conf,
+        gust_kn=wp.gust_kn,
+        wave_period_s=tp_s,
+        model_used=model,
+        motor_used=motor_used,
+    )
+
+
+def _collect_warnings(
+    sampling: RouteSampling,
+    *,
+    requested_length_nm: float,
+    min_boat_speed_kn: float,
+    model: str,
+) -> tuple[list[str], str]:
+    """Return the route-level warnings and the model to report.
+
+    Three sources, in the order they are appended to the report: the sampling
+    cap, the light-wind stall, and the per-segment model fallback.
+
+    The fallback has two outcomes. When every segment ended up on the *same*
+    alternative model, it is promoted to ``report.model`` with no warning:
+    that is one coherent label for the whole route, and it matches what the
+    outer AUTO loop did before the per-segment fallback existed. When the
+    route is split across models, the primary stays the reported one and a
+    warning names how many points fell through and to what.
+    """
     warnings: list[str] = []
-    if capped_route_nm is not None:
+    if sampling.capped_route_nm is not None:
         warnings.append(
-            f"trajet long ({capped_route_nm:.0f} nm) : {len(segments)} points météo "
-            f"échantillonnés (~{effective_length_nm:.0f} nm entre points) au lieu de "
-            f"{segment_length_nm:.0f} nm pour limiter les requêtes API."
+            f"trajet long ({sampling.capped_route_nm:.0f} nm) : "
+            f"{len(sampling.segments)} points météo "
+            f"échantillonnés (~{sampling.effective_length_nm:.0f} nm entre points) au lieu de "
+            f"{requested_length_nm:.0f} nm pour limiter les requêtes API."
         )
-    if min_boat_speed < LIGHT_WIND_THRESHOLD_KN:
-        warnings.append(f"vent faible : vitesse mini {min_boat_speed:.1f} kn, passage très lent")
-    # Per-segment fallback bookkeeping. Two cases:
-    # 1) every segment fell back to the SAME alternative model — promote it
-    #    to ``report.model`` so the UI / LLM sees a single coherent label
-    #    (matches the pre-fallback behaviour of the outer AUTO loop, which
-    #    used to swap the whole route when the primary couldn't deliver).
-    # 2) mixed — keep the primary as ``report.model`` and warn that the
-    #    route is split across models.
+    if min_boat_speed_kn < LIGHT_WIND_THRESHOLD_KN:
+        warnings.append(f"vent faible : vitesse mini {min_boat_speed_kn:.1f} kn, passage très lent")
+
+    seg_models = sampling.models
     used_distinct: list[str] = []
     for m in seg_models:
         if m not in used_distinct:
@@ -793,9 +876,6 @@ async def _estimate_with_model(
     resolved_model = model
     if used_distinct and used_distinct != [model]:
         if len(used_distinct) == 1 and used_distinct[0] != model:
-            # Full route swap — promote, no warning needed (this matches the
-            # outer AUTO loop's behaviour before the per-segment fallback
-            # was introduced).
             resolved_model = used_distinct[0]
         else:
             fallback_count = sum(1 for m in seg_models if m != model)
@@ -805,26 +885,12 @@ async def _estimate_with_model(
                 f"points (probable hors zone de couverture) ; fallback automatique sur "
                 f"{', '.join(others)}"
             )
-
-    arrival = departure_utc + cumulative_actual
-    total_distance = sum(s.distance_nm for s in segments)
-    return PassageReport(
-        archetype=boat_archetype,
-        departure_time=departure_utc,
-        arrival_time=arrival,
-        duration_h=cumulative_actual.total_seconds() / 3600.0,
-        distance_nm=total_distance,
-        efficiency=efficiency,
-        model=resolved_model,
-        segments=tuple(reports),
-        warnings=tuple(warnings),
-        max_sampling_drift_h=round(max_drift_h, 2),
-    )
+    return warnings, resolved_model
 
 
-async def _estimate_backward_with_model(
+async def _estimate_with_model(
     waypoints: list[Point],
-    target_arrival: datetime,
+    anchor_time: datetime,
     boat_archetype: str,
     *,
     efficiency: float,
@@ -833,208 +899,86 @@ async def _estimate_backward_with_model(
     model: str,
     heuristic_speed_kn: float | None,
     use_wave_correction: bool,
-    polar_override: BoatPolar | None = None,
-    model_chain: tuple[str, ...] | None = None,
+    polar_override: BoatPolar | None,
+    model_chain: tuple[str, ...] | None,
+    backward: bool,
 ) -> PassageReport:
-    """Mirror of `_estimate_with_model` anchored at arrival, solving backward.
+    """The one passage engine, run in either direction.
 
-    Walks segments from last to first: each segment's end_time is fixed (the
-    next segment's start_time, or `target_arrival` for the last segment), and
-    its actual duration is computed from the wind sampled at a mid-time guess.
-    By construction, the resulting report has `arrival_time == target_arrival`
-    exactly (modulo timedelta microsecond drift), so no fixed-point iteration
-    is needed. Mid-time guesses use the same boat-aware layout speed as the
-    forward path, same temporal-correlation argument applies.
+    ``anchor_time`` is the departure when ``backward`` is false and the target
+    arrival when it is true. Sampling, per-segment physics and warnings are
+    the same code either way (see `_sample_route`, `_segment_report`,
+    `_collect_warnings`); what differs is which end of the passage is known,
+    and therefore which way the walk chains segment times together. Forward,
+    each segment starts where the previous one ended, from the departure.
+    Backward, each segment ends where the next one started, from the arrival,
+    so ``report.arrival_time == target_arrival`` exactly by construction and
+    no fixed-point iteration is needed.
     """
     polar = polar_override if polar_override is not None else get_polar(boat_archetype)
-    effective_length_nm, capped_route_nm = _resolve_segment_length(waypoints, segment_length_nm)
-    segments = segment_route(waypoints, effective_length_nm)
-    target_utc = target_arrival.astimezone(UTC)
-
-    # Same layout-speed resolution as the forward path.
-    layout_speed_kn = (
-        max(heuristic_speed_kn, MIN_BOAT_SPEED_KN)
-        if heuristic_speed_kn is not None
-        else _layout_speed_kn(polar, efficiency)
+    anchor_utc = anchor_time.astimezone(UTC)
+    sampling = await _sample_route(
+        waypoints,
+        anchor_utc,
+        polar,
+        efficiency=efficiency,
+        segment_length_nm=segment_length_nm,
+        adapter=adapter,
+        model=model,
+        heuristic_speed_kn=heuristic_speed_kn,
+        model_chain=model_chain,
+        backward=backward,
     )
-    seg_mid_times: list[datetime] = [target_utc] * len(segments)
-    cumulative_back = timedelta(0)
-    for idx in range(len(segments) - 1, -1, -1):
-        seg_h = segments[idx].distance_nm / layout_speed_kn
-        seg_mid_times[idx] = target_utc - cumulative_back - timedelta(hours=seg_h / 2)
-        cumulative_back += timedelta(hours=seg_h)
 
-    seg_mid_points = [midpoint(s.start, s.end) for s in segments]
-
-    chain_tail: tuple[str, ...] = ()
-    if model_chain:
-        chain_tail = tuple(m for m in model_chain if m != model)
-
-    own_adapter = adapter is None
-    fetch_adapter: MarineDataAdapter = adapter or OpenMeteoAdapter()
-    try:
-        # Batched multi-coordinate prewarm so the per-segment gather is cache-
-        # served (one HTTP call for all points instead of one per point).
-        if hasattr(fetch_adapter, "prewarm_batch"):
-            await fetch_adapter.prewarm_batch(
-                [(pt.lat, pt.lon) for pt in seg_mid_points],
-                min(seg_mid_times) - WIND_FETCH_WINDOW / 2,
-                max(seg_mid_times) + WIND_FETCH_WINDOW / 2,
-                [model],
-            )
-        bundles = await asyncio.gather(
-            *[
-                fetch_adapter.fetch(
-                    pt.lat,
-                    pt.lon,
-                    mid - WIND_FETCH_WINDOW / 2,
-                    mid + WIND_FETCH_WINDOW / 2,
-                    models=[model],
-                )
-                for pt, mid in zip(seg_mid_points, seg_mid_times, strict=True)
-            ]
+    # The walk. Forward it runs in route order anchored at the departure,
+    # backward in reverse order anchored at the arrival; either way each
+    # segment's free end becomes the next anchor, so the chain of times is
+    # exact rather than a sum of rounded hours.
+    order = list(range(len(sampling.segments)))
+    if backward:
+        order.reverse()
+    walked: list[SegmentReport] = []
+    anchor = anchor_utc
+    for i in order:
+        seg_report = _segment_report(
+            sampling.segments[i],
+            mid_time=sampling.mid_times[i],
+            mid_point=sampling.mid_points[i],
+            bundle=sampling.bundles[i],
+            model=sampling.models[i],
+            polar=polar,
+            efficiency=efficiency,
+            use_wave_correction=use_wave_correction,
+            anchor=anchor,
+            backward=backward,
         )
+        walked.append(seg_report)
+        anchor = seg_report.start_time if backward else seg_report.end_time
+    reports = list(reversed(walked)) if backward else walked
 
-        seg_models: list[str] = [model] * len(segments)
-        if chain_tail:
-            fallback_indices = [
-                i
-                for i, (b, mid) in enumerate(zip(bundles, seg_mid_times, strict=True))
-                if not _segment_has_wind(b, model, mid)
-            ]
-            if fallback_indices:
-                fallback_results = await asyncio.gather(
-                    *[
-                        _fetch_segment_with_fallback(
-                            fetch_adapter,
-                            seg_mid_points[i].lat,
-                            seg_mid_points[i].lon,
-                            seg_mid_times[i],
-                            primary_model=chain_tail[0],
-                            chain=chain_tail,
-                        )
-                        for i in fallback_indices
-                    ]
-                )
-                for idx, (used_model, used_bundle) in zip(
-                    fallback_indices, fallback_results, strict=True
-                ):
-                    seg_models[idx] = used_model
-                    bundles[idx] = used_bundle
-    finally:
-        if own_adapter and hasattr(fetch_adapter, "aclose"):
-            await fetch_adapter.aclose()  # pragma: no cover
+    min_boat_speed = min((r.boat_speed_kn for r in reports), default=float("inf"))
+    max_drift_h = max(
+        (
+            abs(((r.start_time + (r.end_time - r.start_time) / 2) - mid).total_seconds()) / 3600.0
+            for r, mid in zip(reports, sampling.mid_times, strict=True)
+        ),
+        default=0.0,
+    )
+    warnings, resolved_model = _collect_warnings(
+        sampling,
+        requested_length_nm=segment_length_nm,
+        min_boat_speed_kn=min_boat_speed,
+        model=model,
+    )
 
-    # Backward pass: walk segments in reverse, anchoring end_time at arrival.
-    reverse_reports: list[SegmentReport] = []
-    end_time = target_utc
-    min_boat_speed = float("inf")
-    max_drift_h = 0.0
-    for seg, mid_time, mid_pt, bundle, seg_model in zip(
-        reversed(segments),
-        reversed(seg_mid_times),
-        reversed(seg_mid_points),
-        reversed(bundles),
-        reversed(seg_models),
-        strict=True,
-    ):
-        wind_series = bundle.wind_by_model.get(seg_model)
-        if wind_series is None or not wind_series.points:
-            raise ForecastHorizonError(seg_model, mid_time)
-        wp = _closest_wind_point(wind_series.points, mid_time)
-        twa = normalize_twa(twd=wp.direction_deg, course=seg.bearing_deg)
-        polar_speed = lookup_polar(polar, wp.speed_kn, twa)
-        opt_twa, opt_polar_speed = best_vmg_upwind(polar, wp.speed_kn)
-        if twa < opt_twa:
-            effective_polar = opt_polar_speed * math.cos(math.radians(opt_twa - twa))
-        else:
-            effective_polar = polar_speed
-        sea_pt = _closest_sea_point(bundle.sea.points, mid_time)
-        hs_m = sea_pt.wave_height_m if sea_pt else None
-        tp_s = sea_pt.wave_period_s if sea_pt else None
-        cur_kn = sea_pt.current_speed_kn if sea_pt else None
-        cur_to = sea_pt.current_direction_to_deg if sea_pt else None
-        cur_src = sea_pt.current_source if sea_pt else None
-        cur_conf = confidence_for_point(mid_pt.lat, mid_pt.lon, cur_src)
-        derate = 1.0
-        if use_wave_correction and hs_m is not None:
-            derate = wave_derate(hs_m, twa)
-        sail_speed = max(effective_polar * efficiency * derate, MIN_BOAT_SPEED_KN)
-        boat_speed, motor_used = _apply_motor(polar, sail_speed)
-        sog = _apply_current(boat_speed, seg.bearing_deg, cur_kn, cur_to)
-        ground_speed = sog if sog is not None else boat_speed
-        seg_duration = timedelta(hours=seg.distance_nm / ground_speed)
-        seg_start = end_time - seg_duration
-        min_boat_speed = min(min_boat_speed, boat_speed)
-        actual_mid = seg_start + seg_duration / 2
-        max_drift_h = max(max_drift_h, abs((actual_mid - mid_time).total_seconds()) / 3600.0)
-        reverse_reports.append(
-            SegmentReport(
-                start=seg.start,
-                end=seg.end,
-                distance_nm=seg.distance_nm,
-                bearing_deg=seg.bearing_deg,
-                start_time=seg_start,
-                end_time=end_time,
-                tws_kn=wp.speed_kn,
-                twd_deg=wp.direction_deg,
-                twa_deg=twa,
-                polar_speed_kn=polar_speed,
-                boat_speed_kn=boat_speed,
-                duration_h=seg_duration.total_seconds() / 3600.0,
-                hs_m=hs_m,
-                wave_derate_factor=derate,
-                current_speed_kn=cur_kn,
-                current_source=cur_src,
-                current_direction_to_deg=cur_to,
-                sog_kn=sog,
-                current_confidence=cur_conf,
-                gust_kn=wp.gust_kn,
-                wave_period_s=tp_s,
-                model_used=seg_model,
-                motor_used=motor_used,
-            )
-        )
-        end_time = seg_start
-
-    reports = list(reversed(reverse_reports))
-    departure = reports[0].start_time
-    duration = target_utc - departure
-
-    warnings: list[str] = []
-    if capped_route_nm is not None:
-        warnings.append(
-            f"trajet long ({capped_route_nm:.0f} nm) : {len(segments)} points météo "
-            f"échantillonnés (~{effective_length_nm:.0f} nm entre points) au lieu de "
-            f"{segment_length_nm:.0f} nm pour limiter les requêtes API."
-        )
-    if min_boat_speed < LIGHT_WIND_THRESHOLD_KN:
-        warnings.append(f"vent faible : vitesse mini {min_boat_speed:.1f} kn, passage très lent")
-    # See forward path for rationale.
-    used_distinct: list[str] = []
-    for m in seg_models:
-        if m not in used_distinct:
-            used_distinct.append(m)
-    resolved_model = model
-    if used_distinct and used_distinct != [model]:
-        if len(used_distinct) == 1 and used_distinct[0] != model:
-            resolved_model = used_distinct[0]
-        else:
-            fallback_count = sum(1 for m in seg_models if m != model)
-            others = [m for m in used_distinct if m != model]
-            warnings.append(
-                f"modèle {model} sans données sur {fallback_count}/{len(seg_models)} "
-                f"points (probable hors zone de couverture) ; fallback automatique sur "
-                f"{', '.join(others)}"
-            )
-
-    total_distance = sum(s.distance_nm for s in segments)
+    departure = anchor if backward else anchor_utc
+    arrival = anchor_utc if backward else anchor
     return PassageReport(
         archetype=boat_archetype,
         departure_time=departure,
-        arrival_time=target_utc,
-        duration_h=duration.total_seconds() / 3600.0,
-        distance_nm=total_distance,
+        arrival_time=arrival,
+        duration_h=(arrival - departure).total_seconds() / 3600.0,
+        distance_nm=sum(s.distance_nm for s in sampling.segments),
         efficiency=efficiency,
         model=resolved_model,
         segments=tuple(reports),
@@ -1281,7 +1225,7 @@ async def estimate_passage_for_arrival(
         last_err: ForecastHorizonError | None = None
         for idx, candidate in enumerate(chain):
             try:
-                report = await _estimate_backward_with_model(
+                report = await _estimate_with_model(
                     waypoints,
                     target_utc,
                     boat_archetype,
@@ -1293,6 +1237,7 @@ async def estimate_passage_for_arrival(
                     use_wave_correction=use_wave_correction,
                     polar_override=polar_override,
                     model_chain=chain[idx:],
+                    backward=True,
                 )
                 return EtaPassagePlan(report=report, target_arrival=target_utc)
             except ForecastHorizonError as exc:
@@ -1301,7 +1246,7 @@ async def estimate_passage_for_arrival(
         assert last_err is not None
         raise last_err
 
-    report = await _estimate_backward_with_model(
+    report = await _estimate_with_model(
         waypoints,
         target_utc,
         boat_archetype,
@@ -1313,5 +1258,6 @@ async def estimate_passage_for_arrival(
         use_wave_correction=use_wave_correction,
         polar_override=polar_override,
         model_chain=model_chain,
+        backward=True,
     )
     return EtaPassagePlan(report=report, target_arrival=target_utc)

--- a/packages/data-adapters/tests/goldens/passage_auto_chain_arome_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_auto_chain_arome_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T05:03:05.276688+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 12.948534253333333,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T05:03:05.276688+00:00",
+      "end_time": "2026-05-14T07:04:38.371278+00:00",
+      "tws_kn": 11.373,
+      "twd_deg": 75.144,
+      "twa_deg": 40.160267441373776,
+      "polar_speed_kn": 4.653368484911133,
+      "boat_speed_kn": 3.7059333071552185,
+      "duration_h": 2.025859608333333,
+      "hs_m": 0.84,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2818574514038877,
+      "current_direction_to_deg": 101.715,
+      "sog_kn": 3.979900167660109,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.922,
+      "wave_period_s": 3.916,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:04:38.371278+00:00",
+      "end_time": "2026-05-14T09:19:21.583068+00:00",
+      "tws_kn": 9.93,
+      "twd_deg": 78.47,
+      "twa_deg": 36.94846329946506,
+      "polar_speed_kn": 4.278999999999999,
+      "boat_speed_kn": 3.4375271689195257,
+      "duration_h": 2.2453366083333335,
+      "hs_m": 1.067,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.15712742980561553,
+      "current_direction_to_deg": 102.823,
+      "sog_kn": 3.590873174955266,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.902,
+      "wave_period_s": 4.266,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:19:21.583068+00:00",
+      "end_time": "2026-05-14T12:03:24.296006+00:00",
+      "tws_kn": 7.528,
+      "twd_deg": 84.795,
+      "twa_deg": 30.73732145313346,
+      "polar_speed_kn": 3.5348,
+      "boat_speed_kn": 2.8152151960876926,
+      "duration_h": 2.7340869272222226,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13606911447084233,
+      "current_direction_to_deg": 104.932,
+      "sog_kn": 2.9489621981972074,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.539,
+      "wave_period_s": 4.979,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:03:24.296006+00:00",
+      "end_time": "2026-05-14T14:59:52.880657+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 3.05495,
+      "boat_speed_kn": 2.3867402883053463,
+      "duration_h": 2.9412735141666664,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 2.7412340118196563,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T14:59:52.880657+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.2908259721385407,
+      "duration_h": 3.001977595277778,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.6858025216436867,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.3 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.49
+}

--- a/packages/data-adapters/tests/goldens/passage_auto_chain_arome_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_auto_chain_arome_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:15:27.202559+00:00",
+  "duration_h": 10.257556266388889,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:43:52.001758+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 5.936910697654952,
+      "boat_speed_kn": 4.452683023241214,
+      "duration_h": 1.7311115994444446,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 4.657538542482453,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:43:52.001758+00:00",
+      "end_time": "2026-05-14T09:28:54.705812+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 5.706407797967904,
+      "boat_speed_kn": 4.279805848475927,
+      "duration_h": 1.750751126111111,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 4.605291337676915,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:28:54.705812+00:00",
+      "end_time": "2026-05-14T11:23:43.010842+00:00",
+      "tws_kn": 12.38,
+      "twd_deg": 72.795,
+      "twa_deg": 42.73732145313346,
+      "polar_speed_kn": 5.021239287188008,
+      "boat_speed_kn": 3.8647344091990448,
+      "duration_h": 1.913418063888889,
+      "hs_m": 0.688,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.36069114470842334,
+      "current_direction_to_deg": 100.932,
+      "sog_kn": 4.2137780275451195,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.332,
+      "wave_period_s": 3.719,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T11:23:43.010842+00:00",
+      "end_time": "2026-05-14T13:41:37.690663+00:00",
+      "tws_kn": 9.656,
+      "twd_deg": 79.118,
+      "twa_deg": 36.527841684338625,
+      "polar_speed_kn": 4.1968,
+      "boat_speed_kn": 3.3728875275065096,
+      "duration_h": 2.2985221725,
+      "hs_m": 1.107,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1382289416846652,
+      "current_direction_to_deg": 103.039,
+      "sog_kn": 3.507783867067917,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.518,
+      "wave_period_s": 4.34,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T13:41:37.690663+00:00",
+      "end_time": "2026-05-14T16:15:27.202559+00:00",
+      "tws_kn": 8.336,
+      "twd_deg": 82.44,
+      "twa_deg": 33.31902378937997,
+      "polar_speed_kn": 3.8008000000000006,
+      "boat_speed_kn": 3.0486279718824845,
+      "duration_h": 2.5637533044444445,
+      "hs_m": 1.261,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 104.147,
+      "sog_kn": 3.1448887772929788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.67,
+      "wave_period_s": 4.724,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.53
+}

--- a/packages/data-adapters/tests/goldens/passage_coastal_four_waypoints_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_coastal_four_waypoints_backward.json
@@ -1,0 +1,201 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-14T05:45:22.087441+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 12.24386459972222,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T05:45:22.087441+00:00",
+      "end_time": "2026-05-14T07:42:52.994912+00:00",
+      "tws_kn": 11.392,
+      "twd_deg": 75.1,
+      "twa_deg": 50.850793370973065,
+      "polar_speed_kn": 5.912431734838922,
+      "boat_speed_kn": 4.4343238011291914,
+      "duration_h": 1.9585854086111112,
+      "hs_m": 0.837,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.28347732181425483,
+      "current_direction_to_deg": 101.7,
+      "sog_kn": 4.692786051158014,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.949,
+      "wave_period_s": 3.912,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:42:52.994912+00:00",
+      "end_time": "2026-05-14T09:08:47.340014+00:00",
+      "tws_kn": 8.762,
+      "twd_deg": 81.318,
+      "twa_deg": 36.185901863961135,
+      "polar_speed_kn": 4.4667,
+      "boat_speed_kn": 3.52696809044363,
+      "duration_h": 1.4317625283333335,
+      "hs_m": 1.22,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09935205183585312,
+      "current_direction_to_deg": 103.773,
+      "sog_kn": 3.6234807840914174,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.267,
+      "wave_period_s": 4.595,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T09:08:47.340014+00:00",
+      "end_time": "2026-05-14T10:42:56.373815+00:00",
+      "tws_kn": 7.618,
+      "twd_deg": 84.513,
+      "twa_deg": 33.06279967356022,
+      "polar_speed_kn": 4.0472,
+      "boat_speed_kn": 3.180823766144938,
+      "duration_h": 1.5691760558333332,
+      "hs_m": 1.299,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.12850971922246218,
+      "current_direction_to_deg": 104.838,
+      "sog_kn": 3.3061707702947247,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.665,
+      "wave_period_s": 4.95,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:42:56.373815+00:00",
+      "end_time": "2026-05-14T13:03:49.974509+00:00",
+      "tws_kn": 6.72,
+      "twd_deg": 87.776,
+      "twa_deg": 22.121212137782322,
+      "polar_speed_kn": 3.6879999999999997,
+      "boat_speed_kn": 2.743834346550374,
+      "duration_h": 2.3482224150000004,
+      "hs_m": 1.254,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.23974082073434125,
+      "current_direction_to_deg": 105.925,
+      "sog_kn": 2.9829992532803478,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.408,
+      "wave_period_s": 5.249,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T13:03:49.974509+00:00",
+      "end_time": "2026-05-14T15:30:01.306587+00:00",
+      "tws_kn": 6.159,
+      "twd_deg": 91.106,
+      "twa_deg": 18.893837108224147,
+      "polar_speed_kn": 3.4635999999999996,
+      "boat_speed_kn": 2.5174313701565754,
+      "duration_h": 2.436481132777778,
+      "hs_m": 1.094,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3579913606911447,
+      "current_direction_to_deg": 107.035,
+      "sog_kn": 2.8749435471320215,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.623,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T15:30:01.306587+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.436,
+      "twa_deg": 15.666252196774622,
+      "polar_speed_kn": 3.4015999999999997,
+      "boat_speed_kn": 2.4040494746644545,
+      "duration_h": 2.499637059166667,
+      "hs_m": 0.87,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.145,
+      "sog_kn": 2.8023051124741003,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.4 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.6
+}

--- a/packages/data-adapters/tests/goldens/passage_coastal_four_waypoints_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_coastal_four_waypoints_forward.json
@@ -1,0 +1,199 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T15:09:37.335152+00:00",
+  "duration_h": 9.160370875555556,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:42:10.180619+00:00",
+      "tws_kn": 15.513,
+      "twd_deg": 63.1,
+      "twa_deg": 62.85079337097301,
+      "polar_speed_kn": 6.946326445699101,
+      "boat_speed_kn": 5.209744834274326,
+      "duration_h": 1.702827949722222,
+      "hs_m": 0.589,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2132829373650108,
+      "current_direction_to_deg": 97.7,
+      "sog_kn": 5.397622400536265,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.718,
+      "wave_period_s": 3.601,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:42:10.180619+00:00",
+      "end_time": "2026-05-14T08:42:48.644424+00:00",
+      "tws_kn": 14.74,
+      "twd_deg": 66.318,
+      "twa_deg": 51.185901863961135,
+      "polar_speed_kn": 6.421436074558445,
+      "boat_speed_kn": 4.816077055918834,
+      "duration_h": 1.0106843902777778,
+      "hs_m": 0.503,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.33477321814254857,
+      "current_direction_to_deg": 98.773,
+      "sog_kn": 5.133119754030927,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.636,
+      "wave_period_s": 3.503,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:42:48.644424+00:00",
+      "end_time": "2026-05-14T09:45:17.778881+00:00",
+      "tws_kn": 13.682,
+      "twd_deg": 69.513,
+      "twa_deg": 48.06279967356022,
+      "polar_speed_kn": 6.136067980413613,
+      "boat_speed_kn": 4.60205098531021,
+      "duration_h": 1.0414262380555557,
+      "hs_m": 0.538,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 99.838,
+      "sog_kn": 4.981595257778315,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.155,
+      "wave_period_s": 3.542,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T09:45:17.778881+00:00",
+      "end_time": "2026-05-14T11:16:40.113336+00:00",
+      "tws_kn": 12.388,
+      "twd_deg": 72.776,
+      "twa_deg": 37.121212137782265,
+      "polar_speed_kn": 5.4582,
+      "boat_speed_kn": 4.242887203806181,
+      "duration_h": 1.5228706819444444,
+      "hs_m": 0.687,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.36123110151187904,
+      "current_direction_to_deg": 100.925,
+      "sog_kn": 4.599698315347701,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.343,
+      "wave_period_s": 3.717,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T11:16:40.113336+00:00",
+      "end_time": "2026-05-14T13:06:15.834742+00:00",
+      "tws_kn": 9.661,
+      "twd_deg": 79.106,
+      "twa_deg": 30.893837108224147,
+      "polar_speed_kn": 4.78135,
+      "boat_speed_kn": 3.697132381208669,
+      "duration_h": 1.8265892794444443,
+      "hs_m": 1.106,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13876889848812093,
+      "current_direction_to_deg": 103.035,
+      "sog_kn": 3.834877270265844,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.525,
+      "wave_period_s": 4.339,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T13:06:15.834742+00:00",
+      "end_time": "2026-05-14T15:09:37.335152+00:00",
+      "tws_kn": 8.337,
+      "twd_deg": 82.436,
+      "twa_deg": 27.66625219677462,
+      "polar_speed_kn": 4.31795,
+      "boat_speed_kn": 3.3092818979934044,
+      "duration_h": 2.055972336111111,
+      "hs_m": 1.261,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 104.145,
+      "sog_kn": 3.4070233279756406,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.672,
+      "wave_period_s": 4.723,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.27
+}

--- a/packages/data-adapters/tests/goldens/passage_efficiency_low_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_efficiency_low_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T02:23:30.537026+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 15.608184159444445,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.55,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T02:23:30.537026+00:00",
+      "end_time": "2026-05-14T04:43:05.248526+00:00",
+      "tws_kn": 14.79,
+      "twd_deg": 66.144,
+      "twa_deg": 49.160267441373776,
+      "polar_speed_kn": 5.728616046482427,
+      "boat_speed_kn": 3.1507388255653352,
+      "duration_h": 2.32630875,
+      "hs_m": 0.504,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3288336933045356,
+      "current_direction_to_deg": 98.715,
+      "sog_kn": 3.4658851690155252,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.706,
+      "wave_period_s": 3.505,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T04:43:05.248526+00:00",
+      "end_time": "2026-05-14T07:14:08.347045+00:00",
+      "tws_kn": 12.516,
+      "twd_deg": 72.47,
+      "twa_deg": 42.94846329946506,
+      "polar_speed_kn": 5.054307797967904,
+      "boat_speed_kn": 2.8457447963472644,
+      "duration_h": 2.517527366388889,
+      "hs_m": 0.669,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.36879049676025916,
+      "current_direction_to_deg": 100.823,
+      "sog_kn": 3.202634101598491,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.522,
+      "wave_period_s": 3.696,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T07:14:08.347045+00:00",
+      "end_time": "2026-05-14T10:17:19.440179+00:00",
+      "tws_kn": 9.792,
+      "twd_deg": 78.795,
+      "twa_deg": 36.73732145313346,
+      "polar_speed_kn": 4.2376,
+      "boat_speed_kn": 2.4969884080654667,
+      "duration_h": 3.0530814261111114,
+      "hs_m": 1.087,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.14740820734341253,
+      "current_direction_to_deg": 102.932,
+      "sog_kn": 2.6408463680478738,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.709,
+      "wave_period_s": 4.303,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T10:17:19.440179+00:00",
+      "end_time": "2026-05-14T14:06:51.099226+00:00",
+      "tws_kn": 6.644,
+      "twd_deg": 88.118,
+      "twa_deg": 27.527841684338682,
+      "polar_speed_kn": 3.2254,
+      "boat_speed_kn": 1.8579581197310377,
+      "duration_h": 3.825460846388889,
+      "hs_m": 1.242,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2532397408207343,
+      "current_direction_to_deg": 106.039,
+      "sog_kn": 2.107646455852616,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.302,
+      "wave_period_s": 5.275,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T14:06:51.099226+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 1.67993904623493,
+      "duration_h": 3.8858057705555553,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.0749155957400762,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 1.7 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.3
+}

--- a/packages/data-adapters/tests/goldens/passage_efficiency_low_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_efficiency_low_forward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T21:17:56.894103+00:00",
+  "duration_h": 15.299137250833333,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.55,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T08:19:24.403506+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 5.936910697654952,
+      "boat_speed_kn": 3.2653008837102235,
+      "duration_h": 2.3234454183333333,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 3.4701564029514635,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T08:19:24.403506+00:00",
+      "end_time": "2026-05-14T10:43:24.062009+00:00",
+      "tws_kn": 13.697,
+      "twd_deg": 69.47,
+      "twa_deg": 45.94846329946506,
+      "polar_speed_kn": 5.411457797967904,
+      "boat_speed_kn": 2.9763017888823473,
+      "duration_h": 2.399905139722222,
+      "hs_m": 0.537,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39794816414686823,
+      "current_direction_to_deg": 99.823,
+      "sog_kn": 3.3595990364902906,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.176,
+      "wave_period_s": 3.541,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T10:43:24.062009+00:00",
+      "end_time": "2026-05-14T13:46:35.155143+00:00",
+      "tws_kn": 9.792,
+      "twd_deg": 78.795,
+      "twa_deg": 36.73732145313346,
+      "polar_speed_kn": 4.2376,
+      "boat_speed_kn": 2.4969884080654667,
+      "duration_h": 3.0530814261111114,
+      "hs_m": 1.087,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.14740820734341253,
+      "current_direction_to_deg": 102.932,
+      "sog_kn": 2.6408463680478738,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.709,
+      "wave_period_s": 4.303,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T13:46:35.155143+00:00",
+      "end_time": "2026-05-14T17:28:00.339451+00:00",
+      "tws_kn": 7.428,
+      "twd_deg": 85.118,
+      "twa_deg": 30.527841684338625,
+      "polar_speed_kn": 3.4998,
+      "boat_speed_kn": 2.04258806934363,
+      "duration_h": 3.6903289744444443,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1447084233261339,
+      "current_direction_to_deg": 105.039,
+      "sog_kn": 2.184823914326902,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.399,
+      "wave_period_s": 5.012,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T17:28:00.339451+00:00",
+      "end_time": "2026-05-14T21:17:56.894103+00:00",
+      "tws_kn": 6.124,
+      "twd_deg": 91.44,
+      "twa_deg": 24.319023789380026,
+      "polar_speed_kn": 3.0434,
+      "boat_speed_kn": 1.7413463494659212,
+      "duration_h": 3.8323762922222224,
+      "hs_m": 1.073,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3666306695464363,
+      "current_direction_to_deg": 107.147,
+      "sog_kn": 2.1038432503595144,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.574,
+      "wave_period_s": 5.456,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 1.7 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 3.23
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_full_route_swap_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_full_route_swap_backward.json
@@ -1,0 +1,201 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T04:59:24.602251+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 13.009832708055557,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "icon_eu",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T04:59:24.602251+00:00",
+      "end_time": "2026-05-14T07:09:23.345772+00:00",
+      "tws_kn": 11.392,
+      "twd_deg": 75.1,
+      "twa_deg": 50.850793370973065,
+      "polar_speed_kn": 5.312431734838923,
+      "boat_speed_kn": 3.984323801129192,
+      "duration_h": 2.166317644722222,
+      "hs_m": 0.837,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.28347732181425483,
+      "current_direction_to_deg": 101.7,
+      "sog_kn": 4.242786051158014,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.949,
+      "wave_period_s": 3.912,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:09:23.345772+00:00",
+      "end_time": "2026-05-14T08:35:15.066103+00:00",
+      "tws_kn": 9.996,
+      "twd_deg": 78.318,
+      "twa_deg": 39.185901863961135,
+      "polar_speed_kn": 4.2988,
+      "boat_speed_kn": 3.4686642772954293,
+      "duration_h": 1.4310334252777779,
+      "hs_m": 1.057,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16198704103671704,
+      "current_direction_to_deg": 102.773,
+      "sog_kn": 3.6253269258604788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.994,
+      "wave_period_s": 4.249,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:35:15.066103+00:00",
+      "end_time": "2026-05-14T10:11:04.282600+00:00",
+      "tws_kn": 8.686,
+      "twd_deg": 81.513,
+      "twa_deg": 36.06279967356022,
+      "polar_speed_kn": 3.9058,
+      "boat_speed_kn": 3.1530984162747684,
+      "duration_h": 1.5970045825,
+      "hs_m": 1.228,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 103.838,
+      "sog_kn": 3.2485592499977947,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.16,
+      "wave_period_s": 4.618,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:11:04.282600+00:00",
+      "end_time": "2026-05-14T12:37:36.010857+00:00",
+      "tws_kn": 7.534,
+      "twd_deg": 84.776,
+      "twa_deg": 25.121212137782322,
+      "polar_speed_kn": 3.5369,
+      "boat_speed_kn": 2.733254743120263,
+      "duration_h": 2.442146738055556,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1355291576673866,
+      "current_direction_to_deg": 104.925,
+      "sog_kn": 2.868273884314763,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.548,
+      "wave_period_s": 4.977,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T12:37:36.010857+00:00",
+      "end_time": "2026-05-14T15:16:44.093270+00:00",
+      "tws_kn": 6.159,
+      "twd_deg": 91.106,
+      "twa_deg": 18.893837108224147,
+      "polar_speed_kn": 3.05565,
+      "boat_speed_kn": 2.283550548076617,
+      "duration_h": 2.652245114722222,
+      "hs_m": 1.094,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3579913606911447,
+      "current_direction_to_deg": 107.035,
+      "sog_kn": 2.641062725052063,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.623,
+      "wave_period_s": 5.444,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T15:16:44.093270+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.436,
+      "twa_deg": 15.666252196774622,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.175991468798683,
+      "duration_h": 2.721085202777778,
+      "hs_m": 0.87,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.145,
+      "sog_kn": 2.574247106608329,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "icon_eu",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.2 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.54
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_full_route_swap_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_full_route_swap_forward.json
@@ -1,0 +1,201 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:26:42.248972+00:00",
+  "duration_h": 10.44506915888889,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "icon_eu",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:52:01.752526+00:00",
+      "tws_kn": 15.513,
+      "twd_deg": 63.1,
+      "twa_deg": 62.85079337097301,
+      "polar_speed_kn": 6.312943655325006,
+      "boat_speed_kn": 4.734707741493754,
+      "duration_h": 1.8671534794444444,
+      "hs_m": 0.589,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2132829373650108,
+      "current_direction_to_deg": 97.7,
+      "sog_kn": 4.922585307755693,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.718,
+      "wave_period_s": 3.601,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:52:01.752526+00:00",
+      "end_time": "2026-05-14T08:58:29.835559+00:00",
+      "tws_kn": 14.74,
+      "twd_deg": 66.318,
+      "twa_deg": 51.185901863961135,
+      "polar_speed_kn": 5.821436074558445,
+      "boat_speed_kn": 4.366077055918834,
+      "duration_h": 1.1078008424999999,
+      "hs_m": 0.503,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.33477321814254857,
+      "current_direction_to_deg": 98.773,
+      "sog_kn": 4.683119754030927,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.636,
+      "wave_period_s": 3.503,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:58:29.835559+00:00",
+      "end_time": "2026-05-14T10:07:11.269485+00:00",
+      "tws_kn": 13.682,
+      "twd_deg": 69.513,
+      "twa_deg": 48.06279967356022,
+      "polar_speed_kn": 5.536067980413613,
+      "boat_speed_kn": 4.152050985310209,
+      "duration_h": 1.1448427572222222,
+      "hs_m": 0.538,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 99.838,
+      "sog_kn": 4.5315952577783145,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.155,
+      "wave_period_s": 3.542,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:07:11.269485+00:00",
+      "end_time": "2026-05-14T11:56:01.962999+00:00",
+      "tws_kn": 11.098,
+      "twd_deg": 75.776,
+      "twa_deg": 34.121212137782265,
+      "polar_speed_kn": 4.5745,
+      "boat_speed_kn": 3.6067825600040937,
+      "duration_h": 1.8140815316666665,
+      "hs_m": 0.884,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.25701943844492436,
+      "current_direction_to_deg": 101.925,
+      "sog_kn": 3.8613180211824445,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.537,
+      "wave_period_s": 3.978,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T11:56:01.962999+00:00",
+      "end_time": "2026-05-14T13:57:59.519731+00:00",
+      "tws_kn": 9.661,
+      "twd_deg": 79.106,
+      "twa_deg": 30.893837108224147,
+      "polar_speed_kn": 4.1983,
+      "boat_speed_kn": 3.3083622587976187,
+      "duration_h": 2.0326546477777776,
+      "hs_m": 1.106,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13876889848812093,
+      "current_direction_to_deg": 103.035,
+      "sog_kn": 3.4461071478547938,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.525,
+      "wave_period_s": 4.339,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T13:57:59.519731+00:00",
+      "end_time": "2026-05-14T16:26:42.248972+00:00",
+      "tws_kn": 7.333,
+      "twd_deg": 85.436,
+      "twa_deg": 24.66625219677462,
+      "polar_speed_kn": 3.4665500000000002,
+      "boat_speed_kn": 2.6723126983920666,
+      "duration_h": 2.4785359002777776,
+      "hs_m": 1.299,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1544276457883369,
+      "current_direction_to_deg": 105.145,
+      "sog_kn": 2.826162699362019,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.266,
+      "wave_period_s": 5.043,
+      "model_used": "icon_eu",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.7 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 1.6
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_mixed_route_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_mixed_route_backward.json
@@ -1,0 +1,202 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T04:59:24.602251+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 13.009832708055557,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T04:59:24.602251+00:00",
+      "end_time": "2026-05-14T07:09:23.345772+00:00",
+      "tws_kn": 11.392,
+      "twd_deg": 75.1,
+      "twa_deg": 50.850793370973065,
+      "polar_speed_kn": 5.312431734838923,
+      "boat_speed_kn": 3.984323801129192,
+      "duration_h": 2.166317644722222,
+      "hs_m": 0.837,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.28347732181425483,
+      "current_direction_to_deg": 101.7,
+      "sog_kn": 4.242786051158014,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.949,
+      "wave_period_s": 3.912,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:09:23.345772+00:00",
+      "end_time": "2026-05-14T08:35:15.066103+00:00",
+      "tws_kn": 9.996,
+      "twd_deg": 78.318,
+      "twa_deg": 39.185901863961135,
+      "polar_speed_kn": 4.2988,
+      "boat_speed_kn": 3.4686642772954293,
+      "duration_h": 1.4310334252777779,
+      "hs_m": 1.057,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16198704103671704,
+      "current_direction_to_deg": 102.773,
+      "sog_kn": 3.6253269258604788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.994,
+      "wave_period_s": 4.249,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:35:15.066103+00:00",
+      "end_time": "2026-05-14T10:11:04.282600+00:00",
+      "tws_kn": 8.686,
+      "twd_deg": 81.513,
+      "twa_deg": 36.06279967356022,
+      "polar_speed_kn": 3.9058,
+      "boat_speed_kn": 3.1530984162747684,
+      "duration_h": 1.5970045825,
+      "hs_m": 1.228,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 103.838,
+      "sog_kn": 3.2485592499977947,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.16,
+      "wave_period_s": 4.618,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:11:04.282600+00:00",
+      "end_time": "2026-05-14T12:37:36.010857+00:00",
+      "tws_kn": 7.534,
+      "twd_deg": 84.776,
+      "twa_deg": 25.121212137782322,
+      "polar_speed_kn": 3.5369,
+      "boat_speed_kn": 2.733254743120263,
+      "duration_h": 2.442146738055556,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1355291576673866,
+      "current_direction_to_deg": 104.925,
+      "sog_kn": 2.868273884314763,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.548,
+      "wave_period_s": 4.977,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T12:37:36.010857+00:00",
+      "end_time": "2026-05-14T15:16:44.093270+00:00",
+      "tws_kn": 6.159,
+      "twd_deg": 91.106,
+      "twa_deg": 18.893837108224147,
+      "polar_speed_kn": 3.05565,
+      "boat_speed_kn": 2.283550548076617,
+      "duration_h": 2.652245114722222,
+      "hs_m": 1.094,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3579913606911447,
+      "current_direction_to_deg": 107.035,
+      "sog_kn": 2.641062725052063,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.623,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T15:16:44.093270+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.436,
+      "twa_deg": 15.666252196774622,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.175991468798683,
+      "duration_h": 2.721085202777778,
+      "hs_m": 0.87,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.145,
+      "sog_kn": 2.574247106608329,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.2 kn, passage très lent",
+    "modèle meteofrance_arome_france sans données sur 2/6 points (probable hors zone de couverture) ; fallback automatique sur icon_eu"
+  ],
+  "max_sampling_drift_h": 4.54
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_mixed_route_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_mixed_route_forward.json
@@ -1,0 +1,202 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:26:42.248972+00:00",
+  "duration_h": 10.44506915888889,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:52:01.752526+00:00",
+      "tws_kn": 15.513,
+      "twd_deg": 63.1,
+      "twa_deg": 62.85079337097301,
+      "polar_speed_kn": 6.312943655325006,
+      "boat_speed_kn": 4.734707741493754,
+      "duration_h": 1.8671534794444444,
+      "hs_m": 0.589,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2132829373650108,
+      "current_direction_to_deg": 97.7,
+      "sog_kn": 4.922585307755693,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.718,
+      "wave_period_s": 3.601,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:52:01.752526+00:00",
+      "end_time": "2026-05-14T08:58:29.835559+00:00",
+      "tws_kn": 14.74,
+      "twd_deg": 66.318,
+      "twa_deg": 51.185901863961135,
+      "polar_speed_kn": 5.821436074558445,
+      "boat_speed_kn": 4.366077055918834,
+      "duration_h": 1.1078008424999999,
+      "hs_m": 0.503,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.33477321814254857,
+      "current_direction_to_deg": 98.773,
+      "sog_kn": 4.683119754030927,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.636,
+      "wave_period_s": 3.503,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:58:29.835559+00:00",
+      "end_time": "2026-05-14T10:07:11.269485+00:00",
+      "tws_kn": 13.682,
+      "twd_deg": 69.513,
+      "twa_deg": 48.06279967356022,
+      "polar_speed_kn": 5.536067980413613,
+      "boat_speed_kn": 4.152050985310209,
+      "duration_h": 1.1448427572222222,
+      "hs_m": 0.538,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 99.838,
+      "sog_kn": 4.5315952577783145,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.155,
+      "wave_period_s": 3.542,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:07:11.269485+00:00",
+      "end_time": "2026-05-14T11:56:01.962999+00:00",
+      "tws_kn": 11.098,
+      "twd_deg": 75.776,
+      "twa_deg": 34.121212137782265,
+      "polar_speed_kn": 4.5745,
+      "boat_speed_kn": 3.6067825600040937,
+      "duration_h": 1.8140815316666665,
+      "hs_m": 0.884,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.25701943844492436,
+      "current_direction_to_deg": 101.925,
+      "sog_kn": 3.8613180211824445,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.537,
+      "wave_period_s": 3.978,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T11:56:01.962999+00:00",
+      "end_time": "2026-05-14T13:57:59.519731+00:00",
+      "tws_kn": 9.661,
+      "twd_deg": 79.106,
+      "twa_deg": 30.893837108224147,
+      "polar_speed_kn": 4.1983,
+      "boat_speed_kn": 3.3083622587976187,
+      "duration_h": 2.0326546477777776,
+      "hs_m": 1.106,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13876889848812093,
+      "current_direction_to_deg": 103.035,
+      "sog_kn": 3.4461071478547938,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.525,
+      "wave_period_s": 4.339,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T13:57:59.519731+00:00",
+      "end_time": "2026-05-14T16:26:42.248972+00:00",
+      "tws_kn": 7.333,
+      "twd_deg": 85.436,
+      "twa_deg": 24.66625219677462,
+      "polar_speed_kn": 3.4665500000000002,
+      "boat_speed_kn": 2.6723126983920666,
+      "duration_h": 2.4785359002777776,
+      "hs_m": 1.299,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1544276457883369,
+      "current_direction_to_deg": 105.145,
+      "sog_kn": 2.826162699362019,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.266,
+      "wave_period_s": 5.043,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.7 kn, passage très lent",
+    "modèle meteofrance_arome_france sans données sur 2/6 points (probable hors zone de couverture) ; fallback automatique sur icon_eu"
+  ],
+  "max_sampling_drift_h": 1.6
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_two_models_deep_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_two_models_deep_backward.json
@@ -1,0 +1,202 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T04:59:24.602251+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 13.009832708055557,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T04:59:24.602251+00:00",
+      "end_time": "2026-05-14T07:09:23.345772+00:00",
+      "tws_kn": 11.392,
+      "twd_deg": 75.1,
+      "twa_deg": 50.850793370973065,
+      "polar_speed_kn": 5.312431734838923,
+      "boat_speed_kn": 3.984323801129192,
+      "duration_h": 2.166317644722222,
+      "hs_m": 0.837,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.28347732181425483,
+      "current_direction_to_deg": 101.7,
+      "sog_kn": 4.242786051158014,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.949,
+      "wave_period_s": 3.912,
+      "model_used": "ecmwf_ifs025",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:09:23.345772+00:00",
+      "end_time": "2026-05-14T08:35:15.066103+00:00",
+      "tws_kn": 9.996,
+      "twd_deg": 78.318,
+      "twa_deg": 39.185901863961135,
+      "polar_speed_kn": 4.2988,
+      "boat_speed_kn": 3.4686642772954293,
+      "duration_h": 1.4310334252777779,
+      "hs_m": 1.057,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16198704103671704,
+      "current_direction_to_deg": 102.773,
+      "sog_kn": 3.6253269258604788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.994,
+      "wave_period_s": 4.249,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:35:15.066103+00:00",
+      "end_time": "2026-05-14T10:11:04.282600+00:00",
+      "tws_kn": 8.686,
+      "twd_deg": 81.513,
+      "twa_deg": 36.06279967356022,
+      "polar_speed_kn": 3.9058,
+      "boat_speed_kn": 3.1530984162747684,
+      "duration_h": 1.5970045825,
+      "hs_m": 1.228,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 103.838,
+      "sog_kn": 3.2485592499977947,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.16,
+      "wave_period_s": 4.618,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:11:04.282600+00:00",
+      "end_time": "2026-05-14T12:37:36.010857+00:00",
+      "tws_kn": 7.534,
+      "twd_deg": 84.776,
+      "twa_deg": 25.121212137782322,
+      "polar_speed_kn": 3.5369,
+      "boat_speed_kn": 2.733254743120263,
+      "duration_h": 2.442146738055556,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1355291576673866,
+      "current_direction_to_deg": 104.925,
+      "sog_kn": 2.868273884314763,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.548,
+      "wave_period_s": 4.977,
+      "model_used": "ecmwf_ifs025",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T12:37:36.010857+00:00",
+      "end_time": "2026-05-14T15:16:44.093270+00:00",
+      "tws_kn": 6.159,
+      "twd_deg": 91.106,
+      "twa_deg": 18.893837108224147,
+      "polar_speed_kn": 3.05565,
+      "boat_speed_kn": 2.283550548076617,
+      "duration_h": 2.652245114722222,
+      "hs_m": 1.094,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3579913606911447,
+      "current_direction_to_deg": 107.035,
+      "sog_kn": 2.641062725052063,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.623,
+      "wave_period_s": 5.444,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T15:16:44.093270+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.436,
+      "twa_deg": 15.666252196774622,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.175991468798683,
+      "duration_h": 2.721085202777778,
+      "hs_m": 0.87,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.145,
+      "sog_kn": 2.574247106608329,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "icon_eu",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.2 kn, passage très lent",
+    "modèle meteofrance_arome_france sans données sur 6/6 points (probable hors zone de couverture) ; fallback automatique sur ecmwf_ifs025, icon_eu"
+  ],
+  "max_sampling_drift_h": 4.54
+}

--- a/packages/data-adapters/tests/goldens/passage_fallback_two_models_deep_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_fallback_two_models_deep_forward.json
@@ -1,0 +1,202 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:26:42.248972+00:00",
+  "duration_h": 10.44506915888889,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:52:01.752526+00:00",
+      "tws_kn": 15.513,
+      "twd_deg": 63.1,
+      "twa_deg": 62.85079337097301,
+      "polar_speed_kn": 6.312943655325006,
+      "boat_speed_kn": 4.734707741493754,
+      "duration_h": 1.8671534794444444,
+      "hs_m": 0.589,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2132829373650108,
+      "current_direction_to_deg": 97.7,
+      "sog_kn": 4.922585307755693,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.718,
+      "wave_period_s": 3.601,
+      "model_used": "ecmwf_ifs025",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:52:01.752526+00:00",
+      "end_time": "2026-05-14T08:58:29.835559+00:00",
+      "tws_kn": 14.74,
+      "twd_deg": 66.318,
+      "twa_deg": 51.185901863961135,
+      "polar_speed_kn": 5.821436074558445,
+      "boat_speed_kn": 4.366077055918834,
+      "duration_h": 1.1078008424999999,
+      "hs_m": 0.503,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.33477321814254857,
+      "current_direction_to_deg": 98.773,
+      "sog_kn": 4.683119754030927,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.636,
+      "wave_period_s": 3.503,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:58:29.835559+00:00",
+      "end_time": "2026-05-14T10:07:11.269485+00:00",
+      "tws_kn": 13.682,
+      "twd_deg": 69.513,
+      "twa_deg": 48.06279967356022,
+      "polar_speed_kn": 5.536067980413613,
+      "boat_speed_kn": 4.152050985310209,
+      "duration_h": 1.1448427572222222,
+      "hs_m": 0.538,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 99.838,
+      "sog_kn": 4.5315952577783145,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.155,
+      "wave_period_s": 3.542,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:07:11.269485+00:00",
+      "end_time": "2026-05-14T11:56:01.962999+00:00",
+      "tws_kn": 11.098,
+      "twd_deg": 75.776,
+      "twa_deg": 34.121212137782265,
+      "polar_speed_kn": 4.5745,
+      "boat_speed_kn": 3.6067825600040937,
+      "duration_h": 1.8140815316666665,
+      "hs_m": 0.884,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.25701943844492436,
+      "current_direction_to_deg": 101.925,
+      "sog_kn": 3.8613180211824445,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.537,
+      "wave_period_s": 3.978,
+      "model_used": "ecmwf_ifs025",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T11:56:01.962999+00:00",
+      "end_time": "2026-05-14T13:57:59.519731+00:00",
+      "tws_kn": 9.661,
+      "twd_deg": 79.106,
+      "twa_deg": 30.893837108224147,
+      "polar_speed_kn": 4.1983,
+      "boat_speed_kn": 3.3083622587976187,
+      "duration_h": 2.0326546477777776,
+      "hs_m": 1.106,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13876889848812093,
+      "current_direction_to_deg": 103.035,
+      "sog_kn": 3.4461071478547938,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.525,
+      "wave_period_s": 4.339,
+      "model_used": "icon_eu",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T13:57:59.519731+00:00",
+      "end_time": "2026-05-14T16:26:42.248972+00:00",
+      "tws_kn": 7.333,
+      "twd_deg": 85.436,
+      "twa_deg": 24.66625219677462,
+      "polar_speed_kn": 3.4665500000000002,
+      "boat_speed_kn": 2.6723126983920666,
+      "duration_h": 2.4785359002777776,
+      "hs_m": 1.299,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1544276457883369,
+      "current_direction_to_deg": 105.145,
+      "sog_kn": 2.826162699362019,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.266,
+      "wave_period_s": 5.043,
+      "model_used": "icon_eu",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.7 kn, passage très lent",
+    "modèle meteofrance_arome_france sans données sur 6/6 points (probable hors zone de couverture) ; fallback automatique sur ecmwf_ifs025, icon_eu"
+  ],
+  "max_sampling_drift_h": 1.6
+}

--- a/packages/data-adapters/tests/goldens/passage_light_wind_warning_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_light_wind_warning_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-12T07:59:33.993095+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 58.00722414027778,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-12T07:59:33.993095+00:00",
+      "end_time": "2026-05-12T20:38:39.567980+00:00",
+      "tws_kn": 15.72,
+      "twd_deg": 270.144,
+      "twa_deg": 154.83973255862622,
+      "polar_speed_kn": 0.7679857116247922,
+      "boat_speed_kn": 0.5759892837185941,
+      "duration_h": 12.651548579166667,
+      "hs_m": 1.149,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16792656587473,
+      "current_direction_to_deg": 46.715,
+      "sog_kn": 0.6372910750636092,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 22.008,
+      "wave_period_s": 3.674,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-12T20:38:39.567980+00:00",
+      "end_time": "2026-05-13T07:56:31.460116+00:00",
+      "tws_kn": 6.116,
+      "twd_deg": 312.47,
+      "twa_deg": 162.94846329946506,
+      "polar_speed_kn": 0.32252225554675634,
+      "boat_speed_kn": 0.5,
+      "duration_h": 11.297747815555557,
+      "hs_m": 0.733,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.36879049676025916,
+      "current_direction_to_deg": 60.823,
+      "sog_kn": 0.7136571931605222,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.562,
+      "wave_period_s": 3.775,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-13T07:56:31.460116+00:00",
+      "end_time": "2026-05-13T17:07:01.542236+00:00",
+      "tws_kn": 14.598,
+      "twd_deg": 354.795,
+      "twa_deg": 120.73732145313352,
+      "polar_speed_kn": 0.8180220857024958,
+      "boat_speed_kn": 0.6135165642768718,
+      "duration_h": 9.175022811111111,
+      "hs_m": 0.5,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3493520518358531,
+      "current_direction_to_deg": 74.932,
+      "sog_kn": 0.8787682778661305,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.437,
+      "wave_period_s": 5.02,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-13T17:07:01.542236+00:00",
+      "end_time": "2026-05-14T06:52:22.895555+00:00",
+      "tws_kn": 8.545,
+      "twd_deg": 34.118,
+      "twa_deg": 81.52784168433863,
+      "polar_speed_kn": 0.6627945466949419,
+      "boat_speed_kn": 0.5,
+      "duration_h": 13.7559314775,
+      "hs_m": 0.558,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09719222462203023,
+      "current_direction_to_deg": 88.039,
+      "sog_kn": 0.5861267198374196,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.963,
+      "wave_period_s": 5.275,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T06:52:22.895555+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 10.808,
+      "twd_deg": 76.44,
+      "twa_deg": 39.31902378937997,
+      "polar_speed_kn": 0.5402399999999999,
+      "boat_speed_kn": 0.5,
+      "duration_h": 11.126973456944445,
+      "hs_m": 0.931,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.23110151187904965,
+      "current_direction_to_deg": 102.147,
+      "sog_kn": 0.7246102479137845,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.131,
+      "wave_period_s": 4.045,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 0.5 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 10.34
+}

--- a/packages/data-adapters/tests/goldens/passage_light_wind_warning_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_light_wind_warning_forward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-16T16:05:07.707499+00:00",
+  "duration_h": 58.08547430527778,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T19:27:44.082637+00:00",
+      "tws_kn": 8.83,
+      "twd_deg": 81.144,
+      "twa_deg": 34.160267441373776,
+      "polar_speed_kn": 0.47387999999999997,
+      "boat_speed_kn": 0.5,
+      "duration_h": 13.462245176944444,
+      "hs_m": 1.213,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1009719222462203,
+      "current_direction_to_deg": 103.715,
+      "sog_kn": 0.5989133973707692,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.362,
+      "wave_period_s": 4.575,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T19:27:44.082637+00:00",
+      "end_time": "2026-05-15T05:56:39.057704+00:00",
+      "tws_kn": 15.21,
+      "twd_deg": 123.47,
+      "twa_deg": 8.051536700534939,
+      "polar_speed_kn": 0.62652,
+      "boat_speed_kn": 0.5,
+      "duration_h": 10.481937518611112,
+      "hs_m": 1.263,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.26943844492440605,
+      "current_direction_to_deg": 117.823,
+      "sog_kn": 0.76920120740145,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.294,
+      "wave_period_s": 3.541,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-15T05:56:39.057704+00:00",
+      "end_time": "2026-05-15T15:34:45.324785+00:00",
+      "tws_kn": 6.194,
+      "twd_deg": 162.795,
+      "twa_deg": 47.26267854686648,
+      "polar_speed_kn": 0.42128466132029396,
+      "boat_speed_kn": 0.5,
+      "duration_h": 9.635074189166666,
+      "hs_m": 1.112,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3493520518358531,
+      "current_direction_to_deg": 130.932,
+      "sog_kn": 0.8368092281220983,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.672,
+      "wave_period_s": 4.35,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-15T15:34:45.324785+00:00",
+      "end_time": "2026-05-16T02:31:29.394547+00:00",
+      "tws_kn": 15.816,
+      "twd_deg": 205.118,
+      "twa_deg": 89.47215831566132,
+      "polar_speed_kn": 0.814051453305058,
+      "boat_speed_kn": 0.6105385899787935,
+      "duration_h": 10.945574933888889,
+      "hs_m": 0.693,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1447084233261339,
+      "current_direction_to_deg": 145.039,
+      "sog_kn": 0.7366190486979136,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 22.142,
+      "wave_period_s": 5.435,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-16T02:31:29.394547+00:00",
+      "end_time": "2026-05-16T16:05:07.707499+00:00",
+      "tws_kn": 7.603,
+      "twd_deg": 247.44,
+      "twa_deg": 131.68097621061997,
+      "polar_speed_kn": 0.5924867622622617,
+      "boat_speed_kn": 0.5,
+      "duration_h": 13.560642486666667,
+      "hs_m": 0.501,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13012958963282936,
+      "current_direction_to_deg": 159.147,
+      "sog_kn": 0.5945676248861784,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.644,
+      "wave_period_s": 5.044,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 0.5 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 10.72
+}

--- a/packages/data-adapters/tests/goldens/passage_med_catamaran_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_catamaran_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "catamaran_40ft",
+  "departure_time": "2026-05-14T04:54:19.733624+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 13.094518437777777,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T04:54:19.733624+00:00",
+      "end_time": "2026-05-14T07:08:14.588026+00:00",
+      "tws_kn": 8.83,
+      "twd_deg": 81.144,
+      "twa_deg": 34.160267441373776,
+      "polar_speed_kn": 3.4075,
+      "boat_speed_kn": 3.513571276463726,
+      "duration_h": 2.2319040005555557,
+      "hs_m": 1.213,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1009719222462203,
+      "current_direction_to_deg": 103.715,
+      "sog_kn": 3.612484673834495,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.362,
+      "wave_period_s": 4.575,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:08:14.588026+00:00",
+      "end_time": "2026-05-14T09:37:12.749091+00:00",
+      "tws_kn": 7.632,
+      "twd_deg": 84.47,
+      "twa_deg": 30.94846329946506,
+      "polar_speed_kn": 3.0896000000000003,
+      "boat_speed_kn": 3.1216125967344914,
+      "duration_h": 2.4828225180555554,
+      "hs_m": 1.298,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.12796976241900646,
+      "current_direction_to_deg": 104.823,
+      "sog_kn": 3.2474004633664797,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.685,
+      "wave_period_s": 4.946,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:37:12.749091+00:00",
+      "end_time": "2026-05-14T12:18:30.723231+00:00",
+      "tws_kn": 6.715,
+      "twd_deg": 87.795,
+      "twa_deg": 27.737321453133518,
+      "polar_speed_kn": 2.8145000000000002,
+      "boat_speed_kn": 2.7622438614933387,
+      "duration_h": 2.68832615,
+      "hs_m": 1.253,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.24028077753779697,
+      "current_direction_to_deg": 105.932,
+      "sog_kn": 2.9991595311093167,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.401,
+      "wave_period_s": 5.251,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:18:30.723231+00:00",
+      "end_time": "2026-05-14T15:06:51.580416+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 2.6471,
+      "boat_speed_kn": 2.5191028289699364,
+      "duration_h": 2.8057936625,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 2.8735965524842464,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T15:06:51.580416+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 2.6012,
+      "boat_speed_kn": 2.3990758227834905,
+      "duration_h": 2.8856721066666666,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.7940523722886366,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.4 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 6.6
+}

--- a/packages/data-adapters/tests/goldens/passage_med_catamaran_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_catamaran_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "catamaran_40ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T14:23:33.963604+00:00",
+  "duration_h": 8.392767667777777,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:34:34.032372+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 6.547590779874929,
+      "boat_speed_kn": 4.910693084906196,
+      "duration_h": 1.5761201033333332,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 5.115548604147436,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:34:34.032372+00:00",
+      "end_time": "2026-05-14T09:10:22.069810+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 5.9907387609090605,
+      "boat_speed_kn": 4.724201242047666,
+      "duration_h": 1.5966770661111112,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 5.049686731248654,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:10:22.069810+00:00",
+      "end_time": "2026-05-14T10:47:37.021171+00:00",
+      "tws_kn": 13.577,
+      "twd_deg": 69.795,
+      "twa_deg": 45.73732145313346,
+      "polar_speed_kn": 5.2997602121593115,
+      "boat_speed_kn": 4.589621266422955,
+      "duration_h": 1.6208198225000001,
+      "hs_m": 0.547,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3995680345572354,
+      "current_direction_to_deg": 99.932,
+      "sog_kn": 4.974469637342289,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.008,
+      "wave_period_s": 3.552,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T10:47:37.021171+00:00",
+      "end_time": "2026-05-14T12:30:30.541440+00:00",
+      "tws_kn": 12.244,
+      "twd_deg": 73.118,
+      "twa_deg": 42.527841684338625,
+      "polar_speed_kn": 4.544138636349073,
+      "boat_speed_kn": 4.360986011415779,
+      "duration_h": 1.7148667413888887,
+      "hs_m": 0.707,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3520518358531317,
+      "current_direction_to_deg": 101.039,
+      "sog_kn": 4.701659202414137,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.142,
+      "wave_period_s": 3.743,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T12:30:30.541440+00:00",
+      "end_time": "2026-05-14T14:23:33.963604+00:00",
+      "tws_kn": 10.808,
+      "twd_deg": 76.44,
+      "twa_deg": 39.31902378937997,
+      "polar_speed_kn": 3.8616,
+      "boat_speed_kn": 4.0543197203018835,
+      "duration_h": 1.8842839344444444,
+      "hs_m": 0.931,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.23110151187904965,
+      "current_direction_to_deg": 102.147,
+      "sog_kn": 4.278929968215668,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.131,
+      "wave_period_s": 4.045,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 2.08
+}

--- a/packages/data-adapters/tests/goldens/passage_med_cruiser30_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_cruiser30_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T05:03:05.276688+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 12.948534253333333,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T05:03:05.276688+00:00",
+      "end_time": "2026-05-14T07:04:38.371278+00:00",
+      "tws_kn": 11.373,
+      "twd_deg": 75.144,
+      "twa_deg": 40.160267441373776,
+      "polar_speed_kn": 4.653368484911133,
+      "boat_speed_kn": 3.7059333071552185,
+      "duration_h": 2.025859608333333,
+      "hs_m": 0.84,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2818574514038877,
+      "current_direction_to_deg": 101.715,
+      "sog_kn": 3.979900167660109,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.922,
+      "wave_period_s": 3.916,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:04:38.371278+00:00",
+      "end_time": "2026-05-14T09:19:21.583068+00:00",
+      "tws_kn": 9.93,
+      "twd_deg": 78.47,
+      "twa_deg": 36.94846329946506,
+      "polar_speed_kn": 4.278999999999999,
+      "boat_speed_kn": 3.4375271689195257,
+      "duration_h": 2.2453366083333335,
+      "hs_m": 1.067,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.15712742980561553,
+      "current_direction_to_deg": 102.823,
+      "sog_kn": 3.590873174955266,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.902,
+      "wave_period_s": 4.266,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:19:21.583068+00:00",
+      "end_time": "2026-05-14T12:03:24.296006+00:00",
+      "tws_kn": 7.528,
+      "twd_deg": 84.795,
+      "twa_deg": 30.73732145313346,
+      "polar_speed_kn": 3.5348,
+      "boat_speed_kn": 2.8152151960876926,
+      "duration_h": 2.7340869272222226,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13606911447084233,
+      "current_direction_to_deg": 104.932,
+      "sog_kn": 2.9489621981972074,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.539,
+      "wave_period_s": 4.979,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:03:24.296006+00:00",
+      "end_time": "2026-05-14T14:59:52.880657+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 3.05495,
+      "boat_speed_kn": 2.3867402883053463,
+      "duration_h": 2.9412735141666664,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 2.7412340118196563,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T14:59:52.880657+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.2908259721385407,
+      "duration_h": 3.001977595277778,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.6858025216436867,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.3 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.49
+}

--- a/packages/data-adapters/tests/goldens/passage_med_cruiser30_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_cruiser30_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:15:27.202559+00:00",
+  "duration_h": 10.257556266388889,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:43:52.001758+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 5.936910697654952,
+      "boat_speed_kn": 4.452683023241214,
+      "duration_h": 1.7311115994444446,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 4.657538542482453,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:43:52.001758+00:00",
+      "end_time": "2026-05-14T09:28:54.705812+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 5.706407797967904,
+      "boat_speed_kn": 4.279805848475927,
+      "duration_h": 1.750751126111111,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 4.605291337676915,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:28:54.705812+00:00",
+      "end_time": "2026-05-14T11:23:43.010842+00:00",
+      "tws_kn": 12.38,
+      "twd_deg": 72.795,
+      "twa_deg": 42.73732145313346,
+      "polar_speed_kn": 5.021239287188008,
+      "boat_speed_kn": 3.8647344091990448,
+      "duration_h": 1.913418063888889,
+      "hs_m": 0.688,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.36069114470842334,
+      "current_direction_to_deg": 100.932,
+      "sog_kn": 4.2137780275451195,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.332,
+      "wave_period_s": 3.719,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T11:23:43.010842+00:00",
+      "end_time": "2026-05-14T13:41:37.690663+00:00",
+      "tws_kn": 9.656,
+      "twd_deg": 79.118,
+      "twa_deg": 36.527841684338625,
+      "polar_speed_kn": 4.1968,
+      "boat_speed_kn": 3.3728875275065096,
+      "duration_h": 2.2985221725,
+      "hs_m": 1.107,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1382289416846652,
+      "current_direction_to_deg": 103.039,
+      "sog_kn": 3.507783867067917,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.518,
+      "wave_period_s": 4.34,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T13:41:37.690663+00:00",
+      "end_time": "2026-05-14T16:15:27.202559+00:00",
+      "tws_kn": 8.336,
+      "twd_deg": 82.44,
+      "twa_deg": 33.31902378937997,
+      "polar_speed_kn": 3.8008000000000006,
+      "boat_speed_kn": 3.0486279718824845,
+      "duration_h": 2.5637533044444445,
+      "hs_m": 1.261,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 104.147,
+      "sog_kn": 3.1448887772929788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.67,
+      "wave_period_s": 4.724,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.53
+}

--- a/packages/data-adapters/tests/goldens/passage_med_cruiser50_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_cruiser50_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_50ft",
+  "departure_time": "2026-05-14T06:41:24.879318+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 11.309755745,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:41:24.879318+00:00",
+      "end_time": "2026-05-14T08:31:13.323203+00:00",
+      "tws_kn": 10.07,
+      "twd_deg": 78.144,
+      "twa_deg": 37.160267441373776,
+      "polar_speed_kn": 5.4175,
+      "boat_speed_kn": 4.241671327776348,
+      "duration_h": 1.830123301388889,
+      "hs_m": 1.046,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16792656587473,
+      "current_direction_to_deg": 102.715,
+      "sog_kn": 4.405560537172351,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 14.098,
+      "wave_period_s": 4.229,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T08:31:13.323203+00:00",
+      "end_time": "2026-05-14T10:34:23.837890+00:00",
+      "tws_kn": 8.703,
+      "twd_deg": 81.47,
+      "twa_deg": 33.94846329946506,
+      "polar_speed_kn": 4.8812,
+      "boat_speed_kn": 3.8306425662547277,
+      "duration_h": 2.0529207463888888,
+      "hs_m": 1.226,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09881209503239739,
+      "current_direction_to_deg": 103.823,
+      "sog_kn": 3.9274380218352065,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.184,
+      "wave_period_s": 4.613,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T10:34:23.837890+00:00",
+      "end_time": "2026-05-14T12:59:02.675959+00:00",
+      "tws_kn": 6.715,
+      "twd_deg": 87.795,
+      "twa_deg": 27.737321453133518,
+      "polar_speed_kn": 4.02175,
+      "boat_speed_kn": 3.1075168630815733,
+      "duration_h": 2.4107883525,
+      "hs_m": 1.253,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.24028077753779697,
+      "current_direction_to_deg": 105.932,
+      "sog_kn": 3.3444325326975513,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.401,
+      "wave_period_s": 5.251,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:59:02.675959+00:00",
+      "end_time": "2026-05-14T15:27:46.683576+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 3.7706500000000003,
+      "boat_speed_kn": 2.8980571066964322,
+      "duration_h": 2.478891004722222,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 3.252550830210742,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T15:27:46.683576+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.7018,
+      "boat_speed_kn": 2.783035361381511,
+      "duration_h": 2.53703234,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 3.178011910886657,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.8 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.27
+}

--- a/packages/data-adapters/tests/goldens/passage_med_cruiser50_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_cruiser50_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_50ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T14:08:12.123828+00:00",
+  "duration_h": 8.136701063333334,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:27:58.624828+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 7.058513372068689,
+      "boat_speed_kn": 5.293885029051517,
+      "duration_h": 1.4662846744444444,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 5.498740548292757,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:27:58.624828+00:00",
+      "end_time": "2026-05-14T08:57:03.787100+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 6.806407797967903,
+      "boat_speed_kn": 5.1048058484759276,
+      "duration_h": 1.4847672977777777,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 5.430291337676915,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T08:57:03.787100+00:00",
+      "end_time": "2026-05-14T10:29:17.314606+00:00",
+      "tws_kn": 13.577,
+      "twd_deg": 69.795,
+      "twa_deg": 45.73732145313346,
+      "polar_speed_kn": 6.480789287188008,
+      "boat_speed_kn": 4.860591965391006,
+      "duration_h": 1.537090973888889,
+      "hs_m": 0.547,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3995680345572354,
+      "current_direction_to_deg": 99.932,
+      "sog_kn": 5.24544033631034,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.008,
+      "wave_period_s": 3.552,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T10:29:17.314606+00:00",
+      "end_time": "2026-05-14T12:13:23.788849+00:00",
+      "tws_kn": 10.948,
+      "twd_deg": 76.118,
+      "twa_deg": 39.527841684338625,
+      "polar_speed_kn": 5.6370000000000005,
+      "boat_speed_kn": 4.41006186216932,
+      "duration_h": 1.7351317341666666,
+      "hs_m": 0.908,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2435205183585313,
+      "current_direction_to_deg": 102.039,
+      "sog_kn": 4.646747469524749,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.327,
+      "wave_period_s": 4.012,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T12:13:23.788849+00:00",
+      "end_time": "2026-05-14T14:08:12.123828+00:00",
+      "tws_kn": 9.522,
+      "twd_deg": 79.44,
+      "twa_deg": 36.31902378937997,
+      "polar_speed_kn": 5.2088,
+      "boat_speed_kn": 4.086770018932049,
+      "duration_h": 1.9134263830555556,
+      "hs_m": 1.126,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13012958963282936,
+      "current_direction_to_deg": 103.147,
+      "sog_kn": 4.213759706759839,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.331,
+      "wave_period_s": 4.377,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.06
+}

--- a/packages/data-adapters/tests/goldens/passage_med_racer_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_racer_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "racer_cruiser",
+  "departure_time": "2026-05-14T06:54:51.796372+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 11.08561211888889,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:54:51.796372+00:00",
+      "end_time": "2026-05-14T08:43:10.177524+00:00",
+      "tws_kn": 10.07,
+      "twd_deg": 78.144,
+      "twa_deg": 37.160267441373776,
+      "polar_speed_kn": 5.6175,
+      "boat_speed_kn": 4.302729122934138,
+      "duration_h": 1.8051058755555556,
+      "hs_m": 1.046,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16792656587473,
+      "current_direction_to_deg": 102.715,
+      "sog_kn": 4.466618332330142,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 14.098,
+      "wave_period_s": 4.229,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T08:43:10.177524+00:00",
+      "end_time": "2026-05-14T10:53:25.852524+00:00",
+      "tws_kn": 7.632,
+      "twd_deg": 84.47,
+      "twa_deg": 30.94846329946506,
+      "polar_speed_kn": 4.7344,
+      "boat_speed_kn": 3.588003761192642,
+      "duration_h": 2.1710208333333334,
+      "hs_m": 1.298,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.12796976241900646,
+      "current_direction_to_deg": 104.823,
+      "sog_kn": 3.71379162782463,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.685,
+      "wave_period_s": 4.946,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T10:53:25.852524+00:00",
+      "end_time": "2026-05-14T13:12:26.397800+00:00",
+      "tws_kn": 6.715,
+      "twd_deg": 87.795,
+      "twa_deg": 27.737321453133518,
+      "polar_speed_kn": 4.32175,
+      "boat_speed_kn": 3.2431671575378944,
+      "duration_h": 2.3168181322222225,
+      "hs_m": 1.253,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.24028077753779697,
+      "current_direction_to_deg": 105.932,
+      "sog_kn": 3.4800828271538724,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.401,
+      "wave_period_s": 5.251,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T13:12:26.397800+00:00",
+      "end_time": "2026-05-14T15:34:44.475147+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 4.07065,
+      "boat_speed_kn": 3.045075898734284,
+      "duration_h": 2.3716881519444444,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 3.399569622248594,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T15:34:44.475147+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 4.001799999999999,
+      "boat_speed_kn": 2.935378061775674,
+      "duration_h": 2.4209791258333335,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 3.33035461128082,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.9 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.56
+}

--- a/packages/data-adapters/tests/goldens/passage_med_racer_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_med_racer_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "racer_cruiser",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T13:47:18.594041+00:00",
+  "duration_h": 7.788498344722222,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:24:31.122309+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 7.358513372068689,
+      "boat_speed_kn": 5.518885029051517,
+      "duration_h": 1.4086450858333335,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 5.723740548292756,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:24:31.122309+00:00",
+      "end_time": "2026-05-14T08:50:10.790767+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 7.095892430962554,
+      "boat_speed_kn": 5.321919323221915,
+      "duration_h": 1.4276856827777777,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 5.647404812422903,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T08:50:10.790767+00:00",
+      "end_time": "2026-05-14T10:19:07.914455+00:00",
+      "tws_kn": 13.577,
+      "twd_deg": 69.795,
+      "twa_deg": 45.73732145313346,
+      "polar_speed_kn": 6.7381625017193425,
+      "boat_speed_kn": 5.053621876289506,
+      "duration_h": 1.4825343577777776,
+      "hs_m": 0.547,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3995680345572354,
+      "current_direction_to_deg": 99.932,
+      "sog_kn": 5.438470247208841,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.008,
+      "wave_period_s": 3.552,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T10:19:07.914455+00:00",
+      "end_time": "2026-05-14T11:54:26.340896+00:00",
+      "tws_kn": 12.244,
+      "twd_deg": 73.118,
+      "twa_deg": 42.527841684338625,
+      "polar_speed_kn": 6.313548917903704,
+      "boat_speed_kn": 4.7351616884277785,
+      "duration_h": 1.5884517891666665,
+      "hs_m": 0.707,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3520518358531317,
+      "current_direction_to_deg": 101.039,
+      "sog_kn": 5.075834879426137,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.142,
+      "wave_period_s": 3.743,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T11:54:26.340896+00:00",
+      "end_time": "2026-05-14T13:47:18.594041+00:00",
+      "tws_kn": 9.522,
+      "twd_deg": 79.44,
+      "twa_deg": 36.31902378937997,
+      "polar_speed_kn": 5.4327000000000005,
+      "boat_speed_kn": 4.1589972296352435,
+      "duration_h": 1.8811814291666666,
+      "hs_m": 1.126,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13012958963282936,
+      "current_direction_to_deg": 103.147,
+      "sog_kn": 4.285986917463033,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.331,
+      "wave_period_s": 4.377,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.22
+}

--- a/packages/data-adapters/tests/goldens/passage_motor_polar_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_motor_polar_backward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T12:01:50.854330+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 5.969207130555556,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.55,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T12:01:50.854330+00:00",
+      "end_time": "2026-05-14T13:14:26.537246+00:00",
+      "tws_kn": 10.07,
+      "twd_deg": 78.144,
+      "twa_deg": 37.160267441373776,
+      "polar_speed_kn": 4.3175,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.2099119211111111,
+      "hs_m": 1.046,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16792656587473,
+      "current_direction_to_deg": 102.715,
+      "sog_kn": 6.663889209396004,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 14.098,
+      "wave_period_s": 4.229,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T13:14:26.537246+00:00",
+      "end_time": "2026-05-14T14:27:27.267352+00:00",
+      "tws_kn": 7.632,
+      "twd_deg": 84.47,
+      "twa_deg": 30.94846329946506,
+      "polar_speed_kn": 3.5712,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.2168694738888888,
+      "hs_m": 1.298,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.12796976241900646,
+      "current_direction_to_deg": 104.823,
+      "sog_kn": 6.625787866631988,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.685,
+      "wave_period_s": 4.946,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T14:27:27.267352+00:00",
+      "end_time": "2026-05-14T15:39:15.735768+00:00",
+      "tws_kn": 6.715,
+      "twd_deg": 87.795,
+      "twa_deg": 27.737321453133518,
+      "polar_speed_kn": 3.2502500000000003,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.196796782222222,
+      "hs_m": 1.253,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.24028077753779697,
+      "current_direction_to_deg": 105.932,
+      "sog_kn": 6.7369156696159775,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.401,
+      "wave_period_s": 5.251,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T15:39:15.735768+00:00",
+      "end_time": "2026-05-14T16:49:50.299188+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 3.05495,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.1762676166666668,
+      "hs_m": 1.093,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 6.8544937235143095,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T16:49:50.299188+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.1693613366666666,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 6.894976549505146,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 0.22
+}

--- a/packages/data-adapters/tests/goldens/passage_motor_polar_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_motor_polar_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T11:57:00.578175+00:00",
+  "duration_h": 5.950160604166666,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.55,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:12:09.069925+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 5.936910697654952,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.202519423611111,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 6.70485551924124,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:12:09.069925+00:00",
+      "end_time": "2026-05-14T08:23:01.630190+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 5.706407797967904,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.181266740277778,
+      "hs_m": 0.502,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 6.825485489200988,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T08:23:01.630190+00:00",
+      "end_time": "2026-05-14T09:33:17.523819+00:00",
+      "tws_kn": 13.577,
+      "twd_deg": 69.795,
+      "twa_deg": 45.73732145313346,
+      "polar_speed_kn": 5.380789287188008,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.1710815636111112,
+      "hs_m": 0.547,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3995680345572354,
+      "current_direction_to_deg": 99.932,
+      "sog_kn": 6.884848370919334,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.008,
+      "wave_period_s": 3.552,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T09:33:17.523819+00:00",
+      "end_time": "2026-05-14T10:44:00.642526+00:00",
+      "tws_kn": 12.244,
+      "twd_deg": 73.118,
+      "twa_deg": 42.527841684338625,
+      "polar_speed_kn": 4.988270501060318,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.1786440852777778,
+      "hs_m": 0.707,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3520518358531317,
+      "current_direction_to_deg": 101.039,
+      "sog_kn": 6.840673190998358,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.142,
+      "wave_period_s": 3.743,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T10:44:00.642526+00:00",
+      "end_time": "2026-05-14T11:57:00.578175+00:00",
+      "tws_kn": 9.522,
+      "twd_deg": 79.44,
+      "twa_deg": 36.31902378937997,
+      "polar_speed_kn": 4.1566,
+      "boat_speed_kn": 6.5,
+      "duration_h": 1.2166487913888888,
+      "hs_m": 1.126,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13012958963282936,
+      "current_direction_to_deg": 103.147,
+      "sog_kn": 6.626989687827789,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.331,
+      "wave_period_s": 4.377,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": true
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 0.24
+}

--- a/packages/data-adapters/tests/goldens/passage_pinned_layout_speed_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_pinned_layout_speed_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T05:43:52.816244+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 12.268662154444444,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T05:43:52.816244+00:00",
+      "end_time": "2026-05-14T07:32:16.844103+00:00",
+      "tws_kn": 13.816,
+      "twd_deg": 69.144,
+      "twa_deg": 46.160267441373776,
+      "polar_speed_kn": 5.442016046482427,
+      "boat_speed_kn": 4.08151203486182,
+      "duration_h": 1.8066744052777777,
+      "hs_m": 0.528,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3957883369330453,
+      "current_direction_to_deg": 99.715,
+      "sog_kn": 4.4627404759872675,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.342,
+      "wave_period_s": 3.531,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:32:16.844103+00:00",
+      "end_time": "2026-05-14T09:34:58.624887+00:00",
+      "tws_kn": 11.231,
+      "twd_deg": 75.47,
+      "twa_deg": 39.94846329946506,
+      "polar_speed_kn": 4.607749999999999,
+      "boat_speed_kn": 3.6808786016077217,
+      "duration_h": 2.0449391066666665,
+      "hs_m": 0.863,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.26943844492440605,
+      "current_direction_to_deg": 101.823,
+      "sog_kn": 3.9427672778865666,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.723,
+      "wave_period_s": 3.948,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:34:58.624887+00:00",
+      "end_time": "2026-05-14T12:06:04.207365+00:00",
+      "tws_kn": 8.578,
+      "twd_deg": 81.795,
+      "twa_deg": 33.73732145313346,
+      "polar_speed_kn": 3.8734,
+      "boat_speed_kn": 3.1065495955827673,
+      "duration_h": 2.518217355,
+      "hs_m": 1.239,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09719222462203023,
+      "current_direction_to_deg": 103.932,
+      "sog_kn": 3.201756583628977,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.009,
+      "wave_period_s": 4.65,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:06:04.207365+00:00",
+      "end_time": "2026-05-14T14:59:52.880657+00:00",
+      "tws_kn": 6.644,
+      "twd_deg": 88.118,
+      "twa_deg": 27.527841684338682,
+      "polar_speed_kn": 3.2254,
+      "boat_speed_kn": 2.5335792541786875,
+      "duration_h": 2.896853692222222,
+      "hs_m": 1.242,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2532397408207343,
+      "current_direction_to_deg": 106.039,
+      "sog_kn": 2.783267590300266,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.302,
+      "wave_period_s": 5.275,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T14:59:52.880657+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.2908259721385407,
+      "duration_h": 3.001977595277778,
+      "hs_m": 0.869,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.6858025216436867,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.3 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 2.38
+}

--- a/packages/data-adapters/tests/goldens/passage_pinned_layout_speed_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_pinned_layout_speed_forward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T17:03:30.136471+00:00",
+  "duration_h": 11.058371241944444,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:43:52.001758+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 5.936910697654952,
+      "boat_speed_kn": 4.452683023241214,
+      "duration_h": 1.7311115994444446,
+      "hs_m": 0.587,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 4.657538542482453,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:43:52.001758+00:00",
+      "end_time": "2026-05-14T09:32:46.559004+00:00",
+      "tws_kn": 13.697,
+      "twd_deg": 69.47,
+      "twa_deg": 45.94846329946506,
+      "polar_speed_kn": 5.411457797967904,
+      "boat_speed_kn": 4.058593348475927,
+      "duration_h": 1.8151547905555556,
+      "hs_m": 0.537,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39794816414686823,
+      "current_direction_to_deg": 99.823,
+      "sog_kn": 4.44189059608387,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.176,
+      "wave_period_s": 3.541,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:32:46.559004+00:00",
+      "end_time": "2026-05-14T11:36:39.385583+00:00",
+      "tws_kn": 11.089,
+      "twd_deg": 75.795,
+      "twa_deg": 39.73732145313346,
+      "polar_speed_kn": 4.57225,
+      "boat_speed_kn": 3.6557930874592417,
+      "duration_h": 2.064674049722222,
+      "hs_m": 0.886,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.25647948164146867,
+      "current_direction_to_deg": 101.932,
+      "sog_kn": 3.9050808027001604,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.525,
+      "wave_period_s": 3.98,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T11:36:39.385583+00:00",
+      "end_time": "2026-05-14T14:09:09.003819+00:00",
+      "tws_kn": 8.455,
+      "twd_deg": 82.118,
+      "twa_deg": 33.527841684338625,
+      "polar_speed_kn": 3.8365,
+      "boat_speed_kn": 3.0771449055705657,
+      "duration_h": 2.541560621111111,
+      "hs_m": 1.25,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09719222462203023,
+      "current_direction_to_deg": 104.039,
+      "sog_kn": 3.1723496689318833,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.837,
+      "wave_period_s": 4.687,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T14:09:09.003819+00:00",
+      "end_time": "2026-05-14T17:03:30.136471+00:00",
+      "tws_kn": 6.577,
+      "twd_deg": 88.44,
+      "twa_deg": 27.319023789380026,
+      "polar_speed_kn": 3.20195,
+      "boat_speed_kn": 2.512702350342527,
+      "duration_h": 2.905870181111111,
+      "hs_m": 1.23,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.26565874730021594,
+      "current_direction_to_deg": 106.147,
+      "sog_kn": 2.7746315193116597,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.208,
+      "wave_period_s": 5.298,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.5 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 0.53
+}

--- a/packages/data-adapters/tests/goldens/passage_prewarming_adapter_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_prewarming_adapter_backward.json
@@ -1,0 +1,201 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T04:59:24.602251+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 13.009832708055557,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T04:59:24.602251+00:00",
+      "end_time": "2026-05-14T07:09:23.345772+00:00",
+      "tws_kn": 11.392,
+      "twd_deg": 75.1,
+      "twa_deg": 50.850793370973065,
+      "polar_speed_kn": 5.312431734838923,
+      "boat_speed_kn": 3.984323801129192,
+      "duration_h": 2.166317644722222,
+      "hs_m": 0.837,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.28347732181425483,
+      "current_direction_to_deg": 101.7,
+      "sog_kn": 4.242786051158014,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.949,
+      "wave_period_s": 3.912,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:09:23.345772+00:00",
+      "end_time": "2026-05-14T08:35:15.066103+00:00",
+      "tws_kn": 9.996,
+      "twd_deg": 78.318,
+      "twa_deg": 39.185901863961135,
+      "polar_speed_kn": 4.2988,
+      "boat_speed_kn": 3.4686642772954293,
+      "duration_h": 1.4310334252777779,
+      "hs_m": 1.057,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.16198704103671704,
+      "current_direction_to_deg": 102.773,
+      "sog_kn": 3.6253269258604788,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.994,
+      "wave_period_s": 4.249,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:35:15.066103+00:00",
+      "end_time": "2026-05-14T10:11:04.282600+00:00",
+      "tws_kn": 8.686,
+      "twd_deg": 81.513,
+      "twa_deg": 36.06279967356022,
+      "polar_speed_kn": 3.9058,
+      "boat_speed_kn": 3.1530984162747684,
+      "duration_h": 1.5970045825,
+      "hs_m": 1.228,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 103.838,
+      "sog_kn": 3.2485592499977947,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.16,
+      "wave_period_s": 4.618,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:11:04.282600+00:00",
+      "end_time": "2026-05-14T12:37:36.010857+00:00",
+      "tws_kn": 7.534,
+      "twd_deg": 84.776,
+      "twa_deg": 25.121212137782322,
+      "polar_speed_kn": 3.5369,
+      "boat_speed_kn": 2.733254743120263,
+      "duration_h": 2.442146738055556,
+      "hs_m": 1.3,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1355291576673866,
+      "current_direction_to_deg": 104.925,
+      "sog_kn": 2.868273884314763,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.548,
+      "wave_period_s": 4.977,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T12:37:36.010857+00:00",
+      "end_time": "2026-05-14T15:16:44.093270+00:00",
+      "tws_kn": 6.159,
+      "twd_deg": 91.106,
+      "twa_deg": 18.893837108224147,
+      "polar_speed_kn": 3.05565,
+      "boat_speed_kn": 2.283550548076617,
+      "duration_h": 2.652245114722222,
+      "hs_m": 1.094,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3579913606911447,
+      "current_direction_to_deg": 107.035,
+      "sog_kn": 2.641062725052063,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.623,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T15:16:44.093270+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.436,
+      "twa_deg": 15.666252196774622,
+      "polar_speed_kn": 3.0014,
+      "boat_speed_kn": 2.175991468798683,
+      "duration_h": 2.721085202777778,
+      "hs_m": 0.87,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.145,
+      "sog_kn": 2.574247106608329,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.2 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 4.54
+}

--- a/packages/data-adapters/tests/goldens/passage_prewarming_adapter_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_prewarming_adapter_forward.json
@@ -1,0 +1,201 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T16:26:42.248972+00:00",
+  "duration_h": 10.44506915888889,
+  "distance_nm": 40.58138743478648,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "distance_nm": 9.191222285835886,
+      "bearing_deg": 125.95079337097303,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:52:01.752526+00:00",
+      "tws_kn": 15.513,
+      "twd_deg": 63.1,
+      "twa_deg": 62.85079337097301,
+      "polar_speed_kn": 6.312943655325006,
+      "boat_speed_kn": 4.734707741493754,
+      "duration_h": 1.8671534794444444,
+      "hs_m": 0.589,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2132829373650108,
+      "current_direction_to_deg": 97.7,
+      "sog_kn": 4.922585307755693,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.718,
+      "wave_period_s": 3.601,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.2,
+        "lon": 5.54
+      },
+      "end": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "distance_nm": 5.187964008911067,
+      "bearing_deg": 117.50390186396112,
+      "start_time": "2026-05-14T07:52:01.752526+00:00",
+      "end_time": "2026-05-14T08:58:29.835559+00:00",
+      "tws_kn": 14.74,
+      "twd_deg": 66.318,
+      "twa_deg": 51.185901863961135,
+      "polar_speed_kn": 5.821436074558445,
+      "boat_speed_kn": 4.366077055918834,
+      "duration_h": 1.1078008424999999,
+      "hs_m": 0.503,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.33477321814254857,
+      "current_direction_to_deg": 98.773,
+      "sog_kn": 4.683119754030927,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.636,
+      "wave_period_s": 3.503,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.160048006456584,
+        "lon": 5.64506874072371
+      },
+      "end": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "distance_nm": 5.187964008910949,
+      "bearing_deg": 117.57579967356025,
+      "start_time": "2026-05-14T08:58:29.835559+00:00",
+      "end_time": "2026-05-14T10:07:11.269485+00:00",
+      "tws_kn": 13.682,
+      "twd_deg": 69.513,
+      "twa_deg": 48.06279967356022,
+      "polar_speed_kn": 5.536067980413613,
+      "boat_speed_kn": 4.152050985310209,
+      "duration_h": 1.1448427572222222,
+      "hs_m": 0.538,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 99.838,
+      "sog_kn": 4.5315952577783145,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.155,
+      "wave_period_s": 3.542,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.12,
+        "lon": 5.75
+      },
+      "end": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "distance_nm": 7.004745710376182,
+      "bearing_deg": 109.89721213778228,
+      "start_time": "2026-05-14T10:07:11.269485+00:00",
+      "end_time": "2026-05-14T11:56:01.962999+00:00",
+      "tws_kn": 11.098,
+      "twd_deg": 75.776,
+      "twa_deg": 34.121212137782265,
+      "polar_speed_kn": 4.5745,
+      "boat_speed_kn": 3.6067825600040937,
+      "duration_h": 1.8140815316666665,
+      "hs_m": 0.884,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.25701943844492436,
+      "current_direction_to_deg": 101.925,
+      "sog_kn": 3.8613180211824445,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.537,
+      "wave_period_s": 3.978,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.08019598814333,
+        "lon": 5.900195645305336
+      },
+      "end": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "distance_nm": 7.004745710376144,
+      "bearing_deg": 109.99983710822414,
+      "start_time": "2026-05-14T11:56:01.962999+00:00",
+      "end_time": "2026-05-14T13:57:59.519731+00:00",
+      "tws_kn": 9.661,
+      "twd_deg": 79.106,
+      "twa_deg": 30.893837108224147,
+      "polar_speed_kn": 4.1983,
+      "boat_speed_kn": 3.3083622587976187,
+      "duration_h": 2.0326546477777776,
+      "hs_m": 1.106,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.13876889848812093,
+      "current_direction_to_deg": 103.035,
+      "sog_kn": 3.4461071478547938,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 13.525,
+      "wave_period_s": 4.339,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.04019581155575,
+        "lon": 6.050195788390582
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 7.004745710376247,
+      "bearing_deg": 110.10225219677466,
+      "start_time": "2026-05-14T13:57:59.519731+00:00",
+      "end_time": "2026-05-14T16:26:42.248972+00:00",
+      "tws_kn": 7.333,
+      "twd_deg": 85.436,
+      "twa_deg": 24.66625219677462,
+      "polar_speed_kn": 3.4665500000000002,
+      "boat_speed_kn": 2.6723126983920666,
+      "duration_h": 2.4785359002777776,
+      "hs_m": 1.299,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.1544276457883369,
+      "current_direction_to_deg": 105.145,
+      "sog_kn": 2.826162699362019,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.266,
+      "wave_period_s": 5.043,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.7 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 1.6
+}

--- a/packages/data-adapters/tests/goldens/passage_reaching_short_legs_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_reaching_short_legs_backward.json
@@ -1,0 +1,137 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T11:51:27.797682+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 6.142278421666666,
+  "distance_nm": 19.553198046245676,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.35505946265184,
+        "lon": 5.302717120847173
+      },
+      "distance_nm": 4.888299511561068,
+      "bearing_deg": 323.066534797691,
+      "start_time": "2026-05-14T11:51:27.797682+00:00",
+      "end_time": "2026-05-14T13:08:12.599015+00:00",
+      "tws_kn": 7.794,
+      "twd_deg": 83.977,
+      "twa_deg": 120.91046520230896,
+      "polar_speed_kn": 5.217937445099705,
+      "boat_speed_kn": 3.9134530838247787,
+      "duration_h": 1.279111481388889,
+      "hs_m": 1.294,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.117170626349892,
+      "current_direction_to_deg": 104.659,
+      "sog_kn": 3.8216368024751985,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.912,
+      "wave_period_s": 4.894,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.35505946265184,
+        "lon": 5.302717120847173
+      },
+      "end": {
+        "lat": 43.42007940036433,
+        "lon": 5.235289862144002
+      },
+      "distance_nm": 4.888299511561522,
+      "bearing_deg": 323.0203717030887,
+      "start_time": "2026-05-14T13:08:12.599015+00:00",
+      "end_time": "2026-05-14T14:35:27.550632+00:00",
+      "tws_kn": 6.912,
+      "twd_deg": 86.97,
+      "twa_deg": 123.94962829691133,
+      "polar_speed_kn": 4.7024515560753395,
+      "boat_speed_kn": 3.526838667056505,
+      "duration_h": 1.4541532269444444,
+      "hs_m": 1.277,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.20788336933045357,
+      "current_direction_to_deg": 105.657,
+      "sog_kn": 3.361612394667406,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.677,
+      "wave_period_s": 5.184,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.42007940036433,
+        "lon": 5.235289862144002
+      },
+      "end": {
+        "lat": 43.48505963810732,
+        "lon": 5.167717672851788
+      },
+      "distance_nm": 4.8882995115619305,
+      "bearing_deg": 322.97405389535726,
+      "start_time": "2026-05-14T14:35:27.550632+00:00",
+      "end_time": "2026-05-14T16:13:47.006888+00:00",
+      "tws_kn": 6.307,
+      "twd_deg": 89.962,
+      "twa_deg": 126.98794610464273,
+      "polar_speed_kn": 4.3241716768153955,
+      "boat_speed_kn": 3.2431287576115464,
+      "duration_h": 1.638737848888889,
+      "hs_m": 1.159,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.32289416846652264,
+      "current_direction_to_deg": 106.654,
+      "sog_kn": 2.982966137413501,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.83,
+      "wave_period_s": 5.392,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.48505963810732,
+        "lon": 5.167717672851788
+      },
+      "end": {
+        "lat": 43.55,
+        "lon": 5.1
+      },
+      "distance_nm": 4.888299511561153,
+      "bearing_deg": 322.9275808508951,
+      "start_time": "2026-05-14T16:13:47.006888+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.021,
+      "twd_deg": 92.954,
+      "twa_deg": 130.02641914910492,
+      "polar_speed_kn": 4.1108127266221635,
+      "boat_speed_kn": 3.0831095449666224,
+      "duration_h": 1.7702758644444445,
+      "hs_m": 0.973,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3941684665226781,
+      "current_direction_to_deg": 107.651,
+      "sog_kn": 2.761320769161884,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.429,
+      "wave_period_s": 5.493,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.99
+}

--- a/packages/data-adapters/tests/goldens/passage_reaching_short_legs_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_reaching_short_legs_forward.json
@@ -1,0 +1,137 @@
+{
+  "archetype": "cruiser_30ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T10:02:38.044484+00:00",
+  "duration_h": 4.043901245555555,
+  "distance_nm": 19.553198046245676,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.35505946265184,
+        "lon": 5.302717120847173
+      },
+      "distance_nm": 4.888299511561068,
+      "bearing_deg": 323.066534797691,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T06:58:38.181867+00:00",
+      "tws_kn": 15.536,
+      "twd_deg": 62.977,
+      "twa_deg": 99.91046520230896,
+      "polar_speed_kn": 6.86440851238841,
+      "boat_speed_kn": 5.148306384291308,
+      "duration_h": 0.9772727408333333,
+      "hs_m": 0.595,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.20842332613390926,
+      "current_direction_to_deg": 97.659,
+      "sog_kn": 5.001980826812415,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.75,
+      "wave_period_s": 3.608,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.35505946265184,
+        "lon": 5.302717120847173
+      },
+      "end": {
+        "lat": 43.42007940036433,
+        "lon": 5.235289862144002
+      },
+      "distance_nm": 4.888299511561522,
+      "bearing_deg": 323.0203717030887,
+      "start_time": "2026-05-14T06:58:38.181867+00:00",
+      "end_time": "2026-05-14T07:58:33.583419+00:00",
+      "tws_kn": 14.839,
+      "twd_deg": 65.97,
+      "twa_deg": 102.94962829691133,
+      "polar_speed_kn": 6.833859986837329,
+      "boat_speed_kn": 5.1253949901279965,
+      "duration_h": 0.9987226533333333,
+      "hs_m": 0.506,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.32289416846652264,
+      "current_direction_to_deg": 98.657,
+      "sog_kn": 4.894551550152054,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.775,
+      "wave_period_s": 3.507,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.42007940036433,
+        "lon": 5.235289862144002
+      },
+      "end": {
+        "lat": 43.48505963810732,
+        "lon": 5.167717672851788
+      },
+      "distance_nm": 4.8882995115619305,
+      "bearing_deg": 322.97405389535726,
+      "start_time": "2026-05-14T07:58:33.583419+00:00",
+      "end_time": "2026-05-14T08:59:51.457058+00:00",
+      "tws_kn": 13.881,
+      "twd_deg": 68.962,
+      "twa_deg": 105.98794610464273,
+      "polar_speed_kn": 6.762089730523213,
+      "boat_speed_kn": 5.071567297892409,
+      "duration_h": 1.0216315663888889,
+      "hs_m": 0.523,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3941684665226781,
+      "current_direction_to_deg": 99.654,
+      "sog_kn": 4.784796860145491,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 19.433,
+      "wave_period_s": 3.526,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.48505963810732,
+        "lon": 5.167717672851788
+      },
+      "end": {
+        "lat": 43.55,
+        "lon": 5.1
+      },
+      "distance_nm": 4.888299511561153,
+      "bearing_deg": 322.9275808508951,
+      "start_time": "2026-05-14T08:59:51.457058+00:00",
+      "end_time": "2026-05-14T10:02:38.044484+00:00",
+      "tws_kn": 12.729,
+      "twd_deg": 71.954,
+      "twa_deg": 109.02641914910492,
+      "polar_speed_kn": 6.604482095745524,
+      "boat_speed_kn": 4.953361571809143,
+      "duration_h": 1.046274285,
+      "hs_m": 0.64,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.38012958963282933,
+      "current_direction_to_deg": 100.651,
+      "sog_kn": 4.6721013616024365,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.821,
+      "wave_period_s": 3.662,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 0.03
+}

--- a/packages/data-adapters/tests/goldens/passage_sampling_cap_warning_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_sampling_cap_warning_backward.json
@@ -1,0 +1,326 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-13T03:00:17.405049+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 38.995165264166666,
+  "distance_nm": 154.2071381402308,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.22550293644618,
+        "lon": 5.711365179421999
+      },
+      "distance_nm": 15.42071381402319,
+      "bearing_deg": 104.42671544236691,
+      "start_time": "2026-05-13T03:00:17.405049+00:00",
+      "end_time": "2026-05-13T06:31:59.983313+00:00",
+      "tws_kn": 6.808,
+      "twd_deg": 15.396,
+      "twa_deg": 89.0307154423669,
+      "polar_speed_kn": 5.550676205898225,
+      "boat_speed_kn": 4.163007154423669,
+      "duration_h": 3.528493962222222,
+      "hs_m": 1.266,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.22462203023758096,
+      "current_direction_to_deg": 81.799,
+      "sog_kn": 4.370338727684848,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.531,
+      "wave_period_s": 3.539,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.22550293644618,
+        "lon": 5.711365179421999
+      },
+      "end": {
+        "lat": 43.15999306225655,
+        "lon": 6.0520031155020515
+      },
+      "distance_nm": 15.420713814022923,
+      "bearing_deg": 104.66064709696485,
+      "start_time": "2026-05-13T06:31:59.983313+00:00",
+      "end_time": "2026-05-13T10:12:50.914854+00:00",
+      "tws_kn": 6.197,
+      "twd_deg": 25.224,
+      "twa_deg": 79.43664709696486,
+      "polar_speed_kn": 5.147805294626197,
+      "boat_speed_kn": 3.860853970969648,
+      "duration_h": 3.6808143169444443,
+      "hs_m": 0.687,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3488120950323974,
+      "current_direction_to_deg": 85.075,
+      "sog_kn": 4.189484305936235,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.676,
+      "wave_period_s": 4.352,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.15999306225655,
+        "lon": 6.0520031155020515
+      },
+      "end": {
+        "lat": 43.09347486235601,
+        "lon": 6.391905772662855
+      },
+      "distance_nm": 15.420713814023209,
+      "bearing_deg": 104.89379878206535,
+      "start_time": "2026-05-13T10:12:50.914854+00:00",
+      "end_time": "2026-05-13T13:34:04.183497+00:00",
+      "tws_kn": 8.905,
+      "twd_deg": 35.047,
+      "twa_deg": 69.84679878206532,
+      "polar_speed_kn": 5.999726626068844,
+      "boat_speed_kn": 4.499794969551633,
+      "duration_h": 3.3536857341666666,
+      "hs_m": 0.596,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.10259179265658747,
+      "current_direction_to_deg": 88.349,
+      "sog_kn": 4.5981391925978095,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.467,
+      "wave_period_s": 5.338,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.09347486235601,
+        "lon": 6.391905772662855
+      },
+      "end": {
+        "lat": 43.02595286568102,
+        "lon": 6.731065298015315
+      },
+      "distance_nm": 15.420713814023037,
+      "bearing_deg": 105.12616153179329,
+      "start_time": "2026-05-13T13:34:04.183497+00:00",
+      "end_time": "2026-05-13T16:33:18.659391+00:00",
+      "tws_kn": 11.81,
+      "twd_deg": 41.864,
+      "twa_deg": 63.26216153179331,
+      "polar_speed_kn": 6.470738717726444,
+      "boat_speed_kn": 4.853054038294833,
+      "duration_h": 2.987354415,
+      "hs_m": 1.028,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3191144708423326,
+      "current_direction_to_deg": 90.621,
+      "sog_kn": 5.161996761158942,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 16.534,
+      "wave_period_s": 5.477,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.02595286568102,
+        "lon": 6.731065298015315
+      },
+      "end": {
+        "lat": 42.9574316439108,
+        "lon": 7.069474021674995
+      },
+      "distance_nm": 15.420713814023125,
+      "bearing_deg": 105.35772656135669,
+      "start_time": "2026-05-13T16:33:18.659391+00:00",
+      "end_time": "2026-05-13T19:31:43.574131+00:00",
+      "tws_kn": 15.258,
+      "twd_deg": 51.677,
+      "twa_deg": 53.680726561356664,
+      "polar_speed_kn": 6.573029062454267,
+      "boat_speed_kn": 4.9297717968407,
+      "duration_h": 2.973587427777778,
+      "hs_m": 1.257,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.2613390928725702,
+      "current_direction_to_deg": 93.892,
+      "sog_kn": 5.185895551390703,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.361,
+      "wave_period_s": 4.711,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.9574316439108,
+        "lon": 7.069474021674995
+      },
+      "end": {
+        "lat": 42.88791581020051,
+        "lon": 7.407124456988099
+      },
+      "distance_nm": 15.42071381402298,
+      "bearing_deg": 105.58848526728798,
+      "start_time": "2026-05-13T19:31:43.574131+00:00",
+      "end_time": "2026-05-13T22:46:38.510615+00:00",
+      "tws_kn": 15.771,
+      "twd_deg": 61.484,
+      "twa_deg": 44.104485267288,
+      "polar_speed_kn": 6.12336911603728,
+      "boat_speed_kn": 4.592526837027959,
+      "duration_h": 3.248593467777778,
+      "hs_m": 0.672,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.15604751619870408,
+      "current_direction_to_deg": 97.161,
+      "sog_kn": 4.746889374287172,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 22.079,
+      "wave_period_s": 3.699,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.88791581020051,
+        "lon": 7.407124456988099
+      },
+      "end": {
+        "lat": 42.81741001791668,
+        "lon": 7.744009300668407
+      },
+      "distance_nm": 15.42071381402318,
+      "bearing_deg": 105.8184292276843,
+      "start_time": "2026-05-13T22:46:38.510615+00:00",
+      "end_time": "2026-05-14T02:04:39.479319+00:00",
+      "tws_kn": 13.0,
+      "twd_deg": 71.285,
+      "twa_deg": 34.53342922768434,
+      "polar_speed_kn": 5.550000000000001,
+      "boat_speed_kn": 4.283362665562429,
+      "duration_h": 3.3002690844444444,
+      "hs_m": 0.607,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3909287257019438,
+      "current_direction_to_deg": 100.428,
+      "sog_kn": 4.672562575708938,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 18.2,
+      "wave_period_s": 3.622,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.81741001791668,
+        "lon": 7.744009300668407
+      },
+      "end": {
+        "lat": 42.74591895937596,
+        "lon": 8.080121432846633
+      },
+      "distance_nm": 15.420713814022989,
+      "bearing_deg": 106.04755020227134,
+      "start_time": "2026-05-14T02:04:39.479319+00:00",
+      "end_time": "2026-05-14T06:29:46.797031+00:00",
+      "tws_kn": 8.855,
+      "twd_deg": 81.082,
+      "twa_deg": 24.965550202271288,
+      "polar_speed_kn": 4.49925,
+      "boat_speed_kn": 3.3884499663384835,
+      "duration_h": 4.4186993644444446,
+      "hs_m": 1.21,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.10151187904967601,
+      "current_direction_to_deg": 103.694,
+      "sog_kn": 3.4898762150869445,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.397,
+      "wave_period_s": 4.568,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.74591895937596,
+        "lon": 8.080121432846633
+      },
+      "end": {
+        "lat": 42.67344736458754,
+        "lon": 8.415453917033778
+      },
+      "distance_nm": 15.420713814023102,
+      "bearing_deg": 106.27584013246224,
+      "start_time": "2026-05-14T06:29:46.797031+00:00",
+      "end_time": "2026-05-14T12:00:16.183200+00:00",
+      "tws_kn": 6.185,
+      "twd_deg": 90.873,
+      "twa_deg": 15.402840132462188,
+      "polar_speed_kn": 3.4739999999999998,
+      "boat_speed_kn": 2.448124139649,
+      "duration_h": 5.5081628247222225,
+      "hs_m": 1.108,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.351511879049676,
+      "current_direction_to_deg": 106.958,
+      "sog_kn": 2.799611105359143,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.659,
+      "wave_period_s": 5.435,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.67344736458754,
+        "lon": 8.415453917033778
+      },
+      "end": {
+        "lat": 42.6,
+        "lon": 8.75
+      },
+      "distance_nm": 15.420713814023072,
+      "bearing_deg": 106.5032911412626,
+      "start_time": "2026-05-14T12:00:16.183200+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.821,
+      "twd_deg": 100.659,
+      "twa_deg": 5.844291141262602,
+      "polar_speed_kn": 3.7283999999999997,
+      "boat_speed_kn": 2.3500516921276113,
+      "duration_h": 5.995504666666667,
+      "hs_m": 0.533,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.22246220302375808,
+      "current_direction_to_deg": 110.22,
+      "sog_kn": 2.572046002997805,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 9.549,
+      "wave_period_s": 5.215,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "trajet long (154 nm) : 10 points météo échantillonnés (~15 nm entre points) au lieu de 10 nm pour limiter les requêtes API.",
+    "vent faible : vitesse mini 2.4 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 10.1
+}

--- a/packages/data-adapters/tests/goldens/passage_sampling_cap_warning_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_sampling_cap_warning_forward.json
@@ -1,0 +1,326 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-15T23:32:26.835254+00:00",
+  "duration_h": 41.54078757055556,
+  "distance_nm": 154.2071381402308,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.22550293644618,
+        "lon": 5.711365179421999
+      },
+      "distance_nm": 15.42071381402319,
+      "bearing_deg": 104.42671544236691,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T09:13:31.028298+00:00",
+      "tws_kn": 15.456,
+      "twd_deg": 63.396,
+      "twa_deg": 41.0307154423669,
+      "polar_speed_kn": 5.907442926542014,
+      "boat_speed_kn": 4.558072323288952,
+      "duration_h": 3.2252856383333333,
+      "hs_m": 0.577,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.22462203023758096,
+      "current_direction_to_deg": 97.799,
+      "sog_kn": 4.7811932160275,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.638,
+      "wave_period_s": 3.587,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.22550293644618,
+        "lon": 5.711365179421999
+      },
+      "end": {
+        "lat": 43.15999306225655,
+        "lon": 6.0520031155020515
+      },
+      "distance_nm": 15.420713814022923,
+      "bearing_deg": 104.66064709696485,
+      "start_time": "2026-05-14T09:13:31.028298+00:00",
+      "end_time": "2026-05-14T12:39:11.169808+00:00",
+      "tws_kn": 12.199,
+      "twd_deg": 73.224,
+      "twa_deg": 31.43664709696486,
+      "polar_speed_kn": 5.429850000000001,
+      "boat_speed_kn": 4.150568714068217,
+      "duration_h": 3.427817086111111,
+      "hs_m": 0.714,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3488120950323974,
+      "current_direction_to_deg": 101.075,
+      "sog_kn": 4.498697983779471,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.079,
+      "wave_period_s": 3.751,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.15999306225655,
+        "lon": 6.0520031155020515
+      },
+      "end": {
+        "lat": 43.09347486235601,
+        "lon": 6.391905772662855
+      },
+      "distance_nm": 15.420713814023209,
+      "bearing_deg": 104.89379878206535,
+      "start_time": "2026-05-14T12:39:11.169808+00:00",
+      "end_time": "2026-05-14T17:24:32.047337+00:00",
+      "tws_kn": 8.115,
+      "twd_deg": 83.047,
+      "twa_deg": 21.84679878206532,
+      "polar_speed_kn": 4.2402500000000005,
+      "boat_speed_kn": 3.1399201077612666,
+      "duration_h": 4.755799313611112,
+      "hs_m": 1.277,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.10259179265658747,
+      "current_direction_to_deg": 104.349,
+      "sog_kn": 3.242507262678448,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.361,
+      "wave_period_s": 4.792,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.09347486235601,
+        "lon": 6.391905772662855
+      },
+      "end": {
+        "lat": 43.02595286568102,
+        "lon": 6.731065298015315
+      },
+      "distance_nm": 15.420713814023037,
+      "bearing_deg": 105.12616153179329,
+      "start_time": "2026-05-14T17:24:32.047337+00:00",
+      "end_time": "2026-05-14T23:04:32.966637+00:00",
+      "tws_kn": 6.025,
+      "twd_deg": 92.864,
+      "twa_deg": 12.262161531793254,
+      "polar_speed_kn": 3.41,
+      "boat_speed_kn": 2.328463848460562,
+      "duration_h": 5.666922027777778,
+      "hs_m": 0.979,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.3930885529157667,
+      "current_direction_to_deg": 107.621,
+      "sog_kn": 2.721179811216937,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.435,
+      "wave_period_s": 5.491,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.02595286568102,
+        "lon": 6.731065298015315
+      },
+      "end": {
+        "lat": 42.9574316439108,
+        "lon": 7.069474021674995
+      },
+      "distance_nm": 15.420713814023125,
+      "bearing_deg": 105.35772656135669,
+      "start_time": "2026-05-14T23:04:32.966637+00:00",
+      "end_time": "2026-05-15T05:11:12.382856+00:00",
+      "tws_kn": 7.366,
+      "twd_deg": 102.677,
+      "twa_deg": 2.680726561356664,
+      "polar_speed_kn": 3.9463999999999997,
+      "boat_speed_kn": 2.3735107635211685,
+      "duration_h": 6.110948949722222,
+      "hs_m": 0.501,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.15064794816414687,
+      "current_direction_to_deg": 110.892,
+      "sog_kn": 2.523456494423942,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.312,
+      "wave_period_s": 5.032,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.9574316439108,
+        "lon": 7.069474021674995
+      },
+      "end": {
+        "lat": 42.88791581020051,
+        "lon": 7.407124456988099
+      },
+      "distance_nm": 15.42071381402298,
+      "bearing_deg": 105.58848526728798,
+      "start_time": "2026-05-15T05:11:12.382856+00:00",
+      "end_time": "2026-05-15T09:33:21.892699+00:00",
+      "tws_kn": 11.211,
+      "twd_deg": 112.484,
+      "twa_deg": 6.8955147327120585,
+      "polar_speed_kn": 5.202750000000001,
+      "boat_speed_kn": 3.265033525387329,
+      "duration_h": 4.369308289722222,
+      "hs_m": 0.934,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.26727861771058314,
+      "current_direction_to_deg": 114.161,
+      "sog_kn": 3.5293261065518293,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.695,
+      "wave_period_s": 3.952,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.88791581020051,
+        "lon": 7.407124456988099
+      },
+      "end": {
+        "lat": 42.81741001791668,
+        "lon": 7.744009300668407
+      },
+      "distance_nm": 15.42071381402318,
+      "bearing_deg": 105.8184292276843,
+      "start_time": "2026-05-15T09:33:21.892699+00:00",
+      "end_time": "2026-05-15T13:07:36.320993+00:00",
+      "tws_kn": 14.909,
+      "twd_deg": 122.285,
+      "twa_deg": 16.466570772315663,
+      "polar_speed_kn": 5.790900000000001,
+      "boat_speed_kn": 4.010885966314462,
+      "duration_h": 3.570674526111111,
+      "hs_m": 1.29,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.31425485961123106,
+      "current_direction_to_deg": 117.428,
+      "sog_kn": 4.318711689257346,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.873,
+      "wave_period_s": 3.511,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.81741001791668,
+        "lon": 7.744009300668407
+      },
+      "end": {
+        "lat": 42.74591895937596,
+        "lon": 8.080121432846633
+      },
+      "distance_nm": 15.420713814022989,
+      "bearing_deg": 106.04755020227134,
+      "start_time": "2026-05-15T13:07:36.320993+00:00",
+      "end_time": "2026-05-15T16:37:59.996533+00:00",
+      "tws_kn": 15.984,
+      "twd_deg": 129.082,
+      "twa_deg": 23.034449797728712,
+      "polar_speed_kn": 5.8984000000000005,
+      "boat_speed_kn": 4.299008785936893,
+      "duration_h": 3.506576538888889,
+      "hs_m": 0.964,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.10151187904967601,
+      "current_direction_to_deg": 119.694,
+      "sog_kn": 4.397654989821679,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 22.378,
+      "wave_period_s": 3.911,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.74591895937596,
+        "lon": 8.080121432846633
+      },
+      "end": {
+        "lat": 42.67344736458754,
+        "lon": 8.415453917033778
+      },
+      "distance_nm": 15.420713814023102,
+      "bearing_deg": 106.27584013246224,
+      "start_time": "2026-05-15T16:37:59.996533+00:00",
+      "end_time": "2026-05-15T19:52:57.168699+00:00",
+      "tws_kn": 14.574,
+      "twd_deg": 138.873,
+      "twa_deg": 32.59715986753781,
+      "polar_speed_kn": 5.7574000000000005,
+      "boat_speed_kn": 4.409264680561229,
+      "duration_h": 3.2492144905555556,
+      "hs_m": 0.5,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.351511879049676,
+      "current_direction_to_deg": 122.958,
+      "sog_kn": 4.745982100784787,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.404,
+      "wave_period_s": 4.987,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 42.67344736458754,
+        "lon": 8.415453917033778
+      },
+      "end": {
+        "lat": 42.6,
+        "lon": 8.75
+      },
+      "distance_nm": 15.420713814023072,
+      "bearing_deg": 106.5032911412626,
+      "start_time": "2026-05-15T19:52:57.168699+00:00",
+      "end_time": "2026-05-15T23:32:26.835254+00:00",
+      "tws_kn": 10.713,
+      "twd_deg": 148.659,
+      "twa_deg": 42.1557088587374,
+      "polar_speed_kn": 5.22146451803022,
+      "boat_speed_kn": 4.005916281286995,
+      "duration_h": 3.658240709722222,
+      "hs_m": 0.946,
+      "wave_derate_factor": 1.0,
+      "current_speed_kn": 0.22246220302375808,
+      "current_direction_to_deg": 126.22,
+      "sog_kn": 4.215336014655345,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 14.998,
+      "wave_period_s": 5.497,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "trajet long (154 nm) : 10 points météo échantillonnés (~15 nm entre points) au lieu de 10 nm pour limiter les requêtes API.",
+    "vent faible : vitesse mini 2.3 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 12.58
+}

--- a/packages/data-adapters/tests/goldens/passage_wave_correction_backward.json
+++ b/packages/data-adapters/tests/goldens/passage_wave_correction_backward.json
@@ -1,0 +1,170 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-14T05:19:58.061538+00:00",
+  "arrival_time": "2026-05-14T18:00:00+00:00",
+  "duration_h": 12.667205128333332,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T05:19:58.061538+00:00",
+      "end_time": "2026-05-14T07:13:43.056710+00:00",
+      "tws_kn": 11.373,
+      "twd_deg": 75.144,
+      "twa_deg": 40.160267441373776,
+      "polar_speed_kn": 5.2533684849111335,
+      "boat_speed_kn": 3.9788989145620213,
+      "duration_h": 1.8958319922222222,
+      "hs_m": 0.84,
+      "wave_derate_factor": 0.9674922229777563,
+      "current_speed_kn": 0.2818574514038877,
+      "current_direction_to_deg": 101.715,
+      "sog_kn": 4.252865775066912,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.922,
+      "wave_period_s": 3.916,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:13:43.056710+00:00",
+      "end_time": "2026-05-14T09:37:44.504189+00:00",
+      "tws_kn": 8.703,
+      "twd_deg": 81.47,
+      "twa_deg": 33.94846329946506,
+      "polar_speed_kn": 4.44605,
+      "boat_speed_kn": 3.2621080676362344,
+      "duration_h": 2.4004020775,
+      "hs_m": 1.226,
+      "wave_derate_factor": 0.9346658427512553,
+      "current_speed_kn": 0.09881209503239739,
+      "current_direction_to_deg": 103.823,
+      "sog_kn": 3.3589035232167133,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 12.184,
+      "wave_period_s": 4.613,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:37:44.504189+00:00",
+      "end_time": "2026-05-14T12:17:25.745611+00:00",
+      "tws_kn": 7.528,
+      "twd_deg": 84.795,
+      "twa_deg": 30.73732145313346,
+      "polar_speed_kn": 4.0112,
+      "boat_speed_kn": 2.895692201425882,
+      "duration_h": 2.6614559505555553,
+      "hs_m": 1.3,
+      "wave_derate_factor": 0.9264230773829987,
+      "current_speed_kn": 0.13606911447084233,
+      "current_direction_to_deg": 104.932,
+      "sog_kn": 3.029439203535397,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 10.539,
+      "wave_period_s": 4.979,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T12:17:25.745611+00:00",
+      "end_time": "2026-05-14T15:08:26.577305+00:00",
+      "tws_kn": 6.157,
+      "twd_deg": 91.118,
+      "twa_deg": 24.527841684338682,
+      "polar_speed_kn": 3.4627999999999997,
+      "boat_speed_kn": 2.4743011781408404,
+      "duration_h": 2.850231026111111,
+      "hs_m": 1.093,
+      "wave_derate_factor": 0.9442167252706024,
+      "current_speed_kn": 0.35853131749460043,
+      "current_direction_to_deg": 107.039,
+      "sog_kn": 2.8287949016551504,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.62,
+      "wave_period_s": 5.444,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T15:08:26.577305+00:00",
+      "end_time": "2026-05-14T18:00:00+00:00",
+      "tws_kn": 6.004,
+      "twd_deg": 94.44,
+      "twa_deg": 21.319023789380026,
+      "polar_speed_kn": 3.4015999999999997,
+      "boat_speed_kn": 2.4248618310960204,
+      "duration_h": 2.8592840819444443,
+      "hs_m": 0.869,
+      "wave_derate_factor": 0.9622310252044362,
+      "current_speed_kn": 0.39848812095032393,
+      "current_direction_to_deg": 108.147,
+      "sog_kn": 2.8198383806011664,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 8.406,
+      "wave_period_s": 5.499,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [
+    "vent faible : vitesse mini 2.4 kn, passage très lent"
+  ],
+  "max_sampling_drift_h": 5.0
+}

--- a/packages/data-adapters/tests/goldens/passage_wave_correction_forward.json
+++ b/packages/data-adapters/tests/goldens/passage_wave_correction_forward.json
@@ -1,0 +1,168 @@
+{
+  "archetype": "cruiser_40ft",
+  "departure_time": "2026-05-14T06:00:00+00:00",
+  "arrival_time": "2026-05-14T15:26:04.219233+00:00",
+  "duration_h": 9.434505342500001,
+  "distance_nm": 40.31359497580557,
+  "efficiency": 0.75,
+  "model": "meteofrance_arome_france",
+  "segments": [
+    {
+      "start": {
+        "lat": 43.29,
+        "lon": 5.37
+      },
+      "end": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "distance_nm": 8.062718995161209,
+      "bearing_deg": 115.30426744137378,
+      "start_time": "2026-05-14T06:00:00+00:00",
+      "end_time": "2026-05-14T07:36:10.889479+00:00",
+      "tws_kn": 15.505,
+      "twd_deg": 63.144,
+      "twa_deg": 52.160267441373776,
+      "polar_speed_kn": 6.536910697654951,
+      "boat_speed_kn": 4.824835048581251,
+      "duration_h": 1.603024855277778,
+      "hs_m": 0.587,
+      "wave_derate_factor": 0.9841213526775191,
+      "current_speed_kn": 0.21490280777537796,
+      "current_direction_to_deg": 97.715,
+      "sog_kn": 5.029690567822491,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 21.707,
+      "wave_period_s": 3.599,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.232480879404,
+        "lon": 5.5366299287276535
+      },
+      "end": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "distance_nm": 8.062718995161038,
+      "bearing_deg": 115.41846329946509,
+      "start_time": "2026-05-14T07:36:10.889479+00:00",
+      "end_time": "2026-05-14T09:12:59.949375+00:00",
+      "tws_kn": 14.695,
+      "twd_deg": 66.47,
+      "twa_deg": 48.94846329946506,
+      "polar_speed_kn": 6.306407797967903,
+      "boat_speed_kn": 4.67115577507956,
+      "duration_h": 1.6136277488888888,
+      "hs_m": 0.502,
+      "wave_derate_factor": 0.9875998983308658,
+      "current_speed_kn": 0.3396328293736501,
+      "current_direction_to_deg": 98.823,
+      "sog_kn": 4.996641264280548,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 20.573,
+      "wave_period_s": 3.502,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.17472037656086,
+        "lon": 5.702944966802751
+      },
+      "end": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "distance_nm": 8.062718995160967,
+      "bearing_deg": 115.53232145313348,
+      "start_time": "2026-05-14T09:12:59.949375+00:00",
+      "end_time": "2026-05-14T10:59:55.216296+00:00",
+      "tws_kn": 12.38,
+      "twd_deg": 72.795,
+      "twa_deg": 42.73732145313346,
+      "polar_speed_kn": 5.621239287188008,
+      "boat_speed_kn": 4.175442851258987,
+      "duration_h": 1.7820185891666667,
+      "hs_m": 0.688,
+      "wave_derate_factor": 0.9774634598221905,
+      "current_speed_kn": 0.36069114470842334,
+      "current_direction_to_deg": 100.932,
+      "sog_kn": 4.524486469605062,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 17.332,
+      "wave_period_s": 3.719,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.11671943433981,
+        "lon": 5.868945033252365
+      },
+      "end": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "distance_nm": 8.062718995161225,
+      "bearing_deg": 115.64584168433862,
+      "start_time": "2026-05-14T10:59:55.216296+00:00",
+      "end_time": "2026-05-14T12:57:17.011607+00:00",
+      "tws_kn": 10.948,
+      "twd_deg": 76.118,
+      "twa_deg": 39.527841684338625,
+      "polar_speed_kn": 5.1370000000000005,
+      "boat_speed_kn": 3.885244539900407,
+      "duration_h": 1.9560542530555556,
+      "hs_m": 0.908,
+      "wave_derate_factor": 0.9625987477850512,
+      "current_speed_kn": 0.2435205183585313,
+      "current_direction_to_deg": 102.039,
+      "sog_kn": 4.121930147255837,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 15.327,
+      "wave_period_s": 4.012,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    },
+    {
+      "start": {
+        "lat": 43.05847899497058,
+        "lon": 6.034630061653228
+      },
+      "end": {
+        "lat": 43.0,
+        "lon": 6.2
+      },
+      "distance_nm": 8.062718995161136,
+      "bearing_deg": 115.75902378937997,
+      "start_time": "2026-05-14T12:57:17.011607+00:00",
+      "end_time": "2026-05-14T15:26:04.219233+00:00",
+      "tws_kn": 8.336,
+      "twd_deg": 82.44,
+      "twa_deg": 33.31902378937997,
+      "polar_speed_kn": 4.3176000000000005,
+      "boat_speed_kn": 3.155124129295251,
+      "duration_h": 2.479779896111111,
+      "hs_m": 1.261,
+      "wave_derate_factor": 0.9311386742265763,
+      "current_speed_kn": 0.09827213822894168,
+      "current_direction_to_deg": 104.147,
+      "sog_kn": 3.2513849347057455,
+      "current_source": "openmeteo_smoc",
+      "current_confidence": "medium",
+      "gust_kn": 11.67,
+      "wave_period_s": 4.724,
+      "model_used": "meteofrance_arome_france",
+      "motor_used": false
+    }
+  ],
+  "warnings": [],
+  "max_sampling_drift_h": 1.48
+}

--- a/packages/data-adapters/tests/test_passage_characterisation.py
+++ b/packages/data-adapters/tests/test_passage_characterisation.py
@@ -1,0 +1,372 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""Recorded reports of both passage engines, forward and backward.
+
+The forward engine and the backward engine were written as mirrors of each
+other and drifted, which is what the 2026-09 audit filed as M1. Merging them
+back into one sampling pass and one segment computation is a refactor with no
+right to change a single number, and the 92 behaviour tests of
+``test_passage.py`` assert properties, not values: they would not catch a
+segment whose ``boat_speed_kn`` moved by a thousandth, nor a field silently
+left at its default.
+
+So this file records the whole ``PassageReport``, serialised exactly as the
+REST and MCP shells serialise it (``views.passage_view``), for a table of
+routes and configurations chosen to reach every branch the two engines share:
+tacking geometry, wave derate, motor rule, current projection, the sampling
+cap and its warning, the light-wind warning, the per-segment model fallback
+(full route swap and mixed route), and an adapter carrying ``prewarm_batch``
+next to one without it.
+
+Weather comes from ``openwind_data.testing``, a closed-form function of
+``(lat, lon, time)``, so the recorded numbers are reproducible without a
+network, a file, or a clock. Departure and arrival instants are fixed dates:
+the deterministic adapter has no horizon, so nothing here expires.
+
+Regenerating is deliberate and visible::
+
+    OPENWIND_REGENERATE_GOLDENS=1 uv run pytest tests/test_passage_characterisation.py
+
+and a PR that moves one of these files without saying so in its description is
+a change to the physics nobody agreed to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import os
+import pathlib
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+import pytest
+
+from openwind_data.adapters.base import ForecastBundle, WindSeries
+from openwind_data.routing.archetypes import get_polar
+from openwind_data.routing.geometry import Point
+from openwind_data.routing.passage import (
+    WIND_FETCH_WINDOW,
+    NoModelCoveredError,
+    PassageReport,
+    estimate_passage,
+    estimate_passage_for_arrival,
+)
+from openwind_data.testing import DeterministicMarineAdapter
+from openwind_data.views import passage_view
+
+GOLDEN_DIR = pathlib.Path(__file__).parent / "goldens"
+REGENERATE = os.environ.get("OPENWIND_REGENERATE_GOLDENS") == "1"
+
+# Fixed instants. The deterministic adapter answers whatever it is asked, so a
+# hard-coded date stays valid; a "tomorrow" would make the recorded bytes
+# depend on the day the suite runs.
+DEPARTURE = datetime(2026, 5, 14, 6, 0, tzinfo=UTC)
+ARRIVAL = datetime(2026, 5, 14, 18, 0, tzinfo=UTC)
+
+MARSEILLE = Point(43.29, 5.37)
+PORQUEROLLES = Point(43.00, 6.20)
+CASSIS = Point(43.20, 5.54)
+BANDOL = Point(43.12, 5.75)
+# A north-westward leg out of Marseille, sailed in short 5 nm hops. The
+# deterministic wind puts it on a reach, so this is the case that pins the
+# plain ``polar_speed`` branch, while the Marseille to Porquerolles routes
+# above run at 21 to 52 deg TWA and pin the tacking-geometry branch.
+REACHING = [Point(43.29, 5.37), Point(43.55, 5.10)]
+# Long enough to trip MAX_SAMPLED_SEGMENTS and raise the sampling warning.
+LONG_ROUTE = [Point(43.29, 5.37), Point(42.60, 8.75)]
+
+MED = [MARSEILLE, PORQUEROLLES]
+COASTAL = [MARSEILLE, CASSIS, BANDOL, PORQUEROLLES]
+
+AROME = "meteofrance_arome_france"
+ICON = "icon_eu"
+ECMWF = "ecmwf_ifs025"
+GFS = "gfs_seamless"
+
+# A boat that motors as soon as the sails drop under 5 kn, and a boat so slow
+# under sail that it trips the light-wind warning. Both derive from a shipped
+# polar so the grid stays realistic.
+MOTOR_POLAR = dataclasses.replace(
+    get_polar("cruiser_30ft"), motor_threshold_kn=5.0, motor_speed_kn=6.5
+)
+_BASE = get_polar("cruiser_30ft")
+SLOW_POLAR = dataclasses.replace(
+    _BASE,
+    boat_speed_kn=tuple(tuple(v * 0.12 for v in row) for row in _BASE.boat_speed_kn),
+)
+
+
+class PrewarmingDeterministicAdapter(DeterministicMarineAdapter):
+    """The deterministic adapter plus the batched prewarm hook.
+
+    The engine probes for ``prewarm_batch`` before its per-segment gather, so
+    that branch is only reached by adapters exposing it. Recording a report
+    through this one proves the prewarm call does not perturb the numbers, and
+    ``prewarm_calls`` lets the merged engine be checked for firing it exactly
+    once per estimate, over the right window.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prewarm_calls: list[tuple[int, datetime, datetime, tuple[str, ...]]] = []
+
+    async def prewarm_batch(
+        self,
+        points: list[tuple[float, float]],
+        start: datetime,
+        end: datetime,
+        models: list[str],
+    ) -> None:
+        self.prewarm_calls.append((len(points), start, end, tuple(models)))
+
+
+class BlindModelAdapter(DeterministicMarineAdapter):
+    """Deterministic weather, except some models see nothing at some points.
+
+    ``blind`` maps a model slug to the indices of the route points where that
+    model answers with an empty wind series, which is the shape of an
+    off-coverage waypoint: AROME asked outside France answers 200 with nulls
+    and ``_parse_wind`` drops those rows. ``blind_everywhere`` blinds a model
+    on the whole route, which is how the full-route promotion branch is
+    reached. Point indices follow the order the engine first asks for them,
+    which is route order in both directions.
+    """
+
+    def __init__(
+        self,
+        blind: dict[str, set[int]] | None = None,
+        blind_everywhere: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__()
+        self._blind = blind or {}
+        self._blind_everywhere = blind_everywhere
+        self._seen: list[tuple[float, float]] = []
+
+    def _index_of(self, lat: float, lon: float) -> int:
+        key = (round(lat, 6), round(lon, 6))
+        if key not in self._seen:
+            self._seen.append(key)
+        return self._seen.index(key)
+
+    async def fetch(
+        self,
+        lat: float,
+        lon: float,
+        start: datetime,
+        end: datetime,
+        models: list[str] | None = None,
+    ) -> ForecastBundle:
+        bundle = await super().fetch(lat, lon, start, end, models)
+        idx = self._index_of(lat, lon)
+        wind = dict(bundle.wind_by_model)
+        for slug in list(wind):
+            if slug in self._blind_everywhere or idx in self._blind.get(slug, set()):
+                wind[slug] = WindSeries(model=slug, points=())
+        return dataclasses.replace(bundle, wind_by_model=wind)
+
+
+AdapterFactory = Callable[[], DeterministicMarineAdapter]
+
+
+async def _forward(adapter_factory: AdapterFactory = DeterministicMarineAdapter, **kwargs):
+    waypoints = kwargs.pop("waypoints")
+    archetype = kwargs.pop("archetype")
+    return await estimate_passage(
+        waypoints, DEPARTURE, archetype, adapter=adapter_factory(), **kwargs
+    )
+
+
+async def _backward(adapter_factory: AdapterFactory = DeterministicMarineAdapter, **kwargs):
+    waypoints = kwargs.pop("waypoints")
+    archetype = kwargs.pop("archetype")
+    plan = await estimate_passage_for_arrival(
+        waypoints, ARRIVAL, archetype, adapter=adapter_factory(), **kwargs
+    )
+    assert plan.target_arrival == ARRIVAL
+    assert plan.report.arrival_time == ARRIVAL
+    return plan.report
+
+
+# Each entry is (golden name, zero-argument coroutine factory). Every
+# configuration runs in both directions so a merged engine cannot get one of
+# the two right by luck.
+CASES: list[tuple[str, Callable[[], object]]] = []
+
+
+def _register(name: str, **kwargs) -> None:
+    """Record the same configuration forward and backward."""
+    frozen = dict(kwargs)
+    CASES.append((f"{name}_forward", lambda: _forward(**frozen)))
+    CASES.append((f"{name}_backward", lambda: _backward(**frozen)))
+
+
+_register("med_cruiser30", waypoints=MED, archetype="cruiser_30ft")
+_register("med_cruiser50", waypoints=MED, archetype="cruiser_50ft")
+_register("med_catamaran", waypoints=MED, archetype="catamaran_40ft")
+_register("med_racer", waypoints=MED, archetype="racer_cruiser")
+_register("coastal_four_waypoints", waypoints=COASTAL, archetype="cruiser_40ft")
+_register(
+    "reaching_short_legs", waypoints=REACHING, archetype="cruiser_30ft", segment_length_nm=5.0
+)
+_register("wave_correction", waypoints=MED, archetype="cruiser_40ft", use_wave_correction=True)
+_register(
+    "motor_polar",
+    waypoints=MED,
+    archetype="cruiser_30ft",
+    polar_override=MOTOR_POLAR,
+    efficiency=0.55,
+)
+_register("light_wind_warning", waypoints=MED, archetype="cruiser_30ft", polar_override=SLOW_POLAR)
+_register("sampling_cap_warning", waypoints=LONG_ROUTE, archetype="cruiser_40ft")
+_register("pinned_layout_speed", waypoints=MED, archetype="cruiser_30ft", heuristic_speed_kn=4.0)
+_register("efficiency_low", waypoints=MED, archetype="cruiser_30ft", efficiency=0.55)
+_register(
+    "prewarming_adapter",
+    waypoints=COASTAL,
+    archetype="cruiser_30ft",
+    adapter_factory=PrewarmingDeterministicAdapter,
+)
+_register("auto_chain_arome", waypoints=MED, archetype="cruiser_30ft", model="auto")
+_register(
+    "fallback_full_route_swap",
+    waypoints=COASTAL,
+    archetype="cruiser_30ft",
+    model="auto",
+    adapter_factory=lambda: BlindModelAdapter(blind_everywhere=(AROME,)),
+)
+_register(
+    "fallback_mixed_route",
+    waypoints=COASTAL,
+    archetype="cruiser_30ft",
+    model="auto",
+    adapter_factory=lambda: BlindModelAdapter(blind={AROME: {1, 2}}),
+)
+_register(
+    "fallback_two_models_deep",
+    waypoints=COASTAL,
+    archetype="cruiser_30ft",
+    model="auto",
+    adapter_factory=lambda: BlindModelAdapter(blind_everywhere=(AROME,), blind={ICON: {0, 3}}),
+)
+
+
+def _serialise(report: PassageReport) -> bytes:
+    """The bytes the shells would ship, plus a trailing newline for diffs."""
+    body = json.dumps(passage_view(report), indent=2, ensure_ascii=False, sort_keys=False)
+    return (body + "\n").encode()
+
+
+def _first_field(want: dict, got: dict) -> str:
+    for key in want:
+        if key not in got:
+            return f"{key} (missing)"
+        if want[key] == got[key]:
+            continue
+        if key == "segments":
+            for i, (a, b) in enumerate(zip(want[key], got[key], strict=False)):
+                if a != b:
+                    diff = {k: (a.get(k), b.get(k)) for k in a if a.get(k) != b.get(k)}
+                    return f"segments[{i}] {diff}"
+            return f"segments (length {len(want[key])} vs {len(got[key])})"
+        return f"{key}: {want[key]!r} vs {got[key]!r}"
+    return "none (extra keys only)"
+
+
+def _assert_golden(name: str, payload: bytes) -> None:
+    path = GOLDEN_DIR / name
+    if REGENERATE:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        return
+    if not path.is_file():
+        raise AssertionError(
+            f"missing golden {name}; run OPENWIND_REGENERATE_GOLDENS=1 pytest to record it"
+        )
+    recorded = path.read_bytes()
+    if recorded == payload:
+        return
+    raise AssertionError(
+        f"{name} differs from the recorded report.\n"
+        f"  first differing field: {_first_field(json.loads(recorded), json.loads(payload))}\n"
+        "The engine merge is a refactor: no number may move. If the change is "
+        "intended, re-record with OPENWIND_REGENERATE_GOLDENS=1 and show the "
+        "diff in the PR."
+    )
+
+
+@pytest.mark.parametrize("name,factory", CASES, ids=[c[0] for c in CASES])
+def test_recorded_passage_report(name: str, factory) -> None:
+    report = asyncio.run(factory())
+    _assert_golden(f"passage_{name}.json", _serialise(report))
+
+
+def test_forward_and_backward_agree_on_geometry() -> None:
+    """The two directions sample the same route, so the geometry must match.
+
+    Not a golden: an invariant the merge has to preserve by construction once
+    both engines share one sampling pass. Durations legitimately differ (the
+    two hit different weather), the route does not.
+    """
+    fwd = asyncio.run(_forward(waypoints=COASTAL, archetype="cruiser_40ft"))
+    bwd = asyncio.run(_backward(waypoints=COASTAL, archetype="cruiser_40ft"))
+    assert fwd.distance_nm == bwd.distance_nm
+    assert [s.distance_nm for s in fwd.segments] == [s.distance_nm for s in bwd.segments]
+    assert [s.bearing_deg for s in fwd.segments] == [s.bearing_deg for s in bwd.segments]
+    assert [(s.start, s.end) for s in fwd.segments] == [(s.start, s.end) for s in bwd.segments]
+
+
+def test_prewarm_fires_once_per_estimate_in_both_directions() -> None:
+    """The batched prewarm is the whole point of the cache warm-up.
+
+    A recorded report would not notice it disappearing (the deterministic
+    adapter answers the same either way), so the call itself is asserted here,
+    including the window it covers: forward it starts at the departure minus
+    half the fetch window, backward it ends at the arrival plus half of it.
+    """
+    fwd_adapter = PrewarmingDeterministicAdapter()
+    asyncio.run(
+        _forward(waypoints=COASTAL, archetype="cruiser_30ft", adapter_factory=lambda: fwd_adapter)
+    )
+    assert len(fwd_adapter.prewarm_calls) == 1
+    n_points, start, end, models = fwd_adapter.prewarm_calls[0]
+    assert n_points >= 3
+    assert models == (AROME,)
+    assert start > DEPARTURE - WIND_FETCH_WINDOW
+    assert start < end
+
+    bwd_adapter = PrewarmingDeterministicAdapter()
+    asyncio.run(
+        _backward(waypoints=COASTAL, archetype="cruiser_30ft", adapter_factory=lambda: bwd_adapter)
+    )
+    assert len(bwd_adapter.prewarm_calls) == 1
+    back_points, back_start, back_end, back_models = bwd_adapter.prewarm_calls[0]
+    assert back_points == n_points
+    assert back_models == (AROME,)
+    assert back_start < back_end
+    assert back_end < ARRIVAL + WIND_FETCH_WINDOW
+
+
+def test_every_model_blind_raises_no_model_covered_in_both_directions() -> None:
+    """Chain exhausted by null data, not by horizon: a 422, never a 500."""
+    blind_all = (AROME, ICON, ECMWF, GFS)
+    with pytest.raises(NoModelCoveredError):
+        asyncio.run(
+            _forward(
+                waypoints=MED,
+                archetype="cruiser_30ft",
+                model="auto",
+                adapter_factory=lambda: BlindModelAdapter(blind_everywhere=blind_all),
+            )
+        )
+    with pytest.raises(NoModelCoveredError):
+        asyncio.run(
+            _backward(
+                waypoints=MED,
+                archetype="cruiser_30ft",
+                model="auto",
+                adapter_factory=lambda: BlindModelAdapter(blind_everywhere=blind_all),
+            )
+        )


### PR DESCRIPTION
Lot 3, PR 3.1 du plan de rework. Point **M1** de l'annexe C : `passage.py` portait deux moteurs en miroir, `_estimate_with_model` (départ connu) et `_estimate_backward_with_model` (arrivée connue), **179 lignes identiques** sur 251 et 221. La dérive était déjà installée : l'ordre des champs `current_*` à la construction du `SegmentReport` diffère entre les deux (ligne 764 contre 988).

GO 4 accordé. Refacto pur : **aucun nombre ne bouge**.

## Filet posé avant de toucher au moteur

Premier commit, `tests/test_passage_characterisation.py` : le `PassageReport` complet de chaque moteur, sérialisé comme les shells le sérialisent (`views.passage_view`), enregistré pour **17 configurations jouées dans les deux sens** (34 goldens). Les 92 tests de comportement existants vérifient des propriétés, pas des valeurs : ils laisseraient passer un `boat_speed_kn` déplacé d'un millième ou un champ resté à son défaut.

Table couvrant les branches partagées : géométrie de louvoyage (TWA 21 à 52 deg) et allure portante, derate de houle, règle moteur, projection du courant, plafond d'échantillonnage et son avertissement, avertissement de vent faible, repli par tronçon (bascule complète de route, route mixte, deux modèles de profondeur), adaptateur avec et sans `prewarm_batch`, quatre archétypes. Météo issue de `openwind_data.testing`, fonction fermée de `(lat, lon, temps)` : ni réseau, ni fichier, ni horloge.

## Ce qui a été extrait

| Bloc | Rôle |
|---|---|
| `_sample_route()` | découpe la route, pose les instants d'échantillonnage depuis l'ancre, préchauffe le cache, lance le gather du modèle primaire puis le repli par tronçon. Retourne un `RouteSampling` (segments, instants, milieux, bundles, modèle par tronçon, longueur effective, plafond) |
| `_segment_report()` | pur. Un `SegmentReport` à partir d'un segment, d'un point de vent, d'un point de mer, de la polaire et des options. **Un seul site de construction**, donc la dérive d'ordre de champs devient impossible |
| `_collect_warnings()` | pur. Plafond d'échantillonnage, vent faible, promotion ou avertissement de modèle |
| `_layout_mid_times()` | pur. La seule fonction où le sens compte pour les instants |

Les deux moteurs deviennent un seul `_estimate_with_model(..., backward: bool)` qui ne garde que sa marche : forward chaque tronçon démarre où le précédent finit, backward chaque tronçon finit où le suivant commence. Le chaînage passe par les `datetime` du rapport et non par une somme d'heures arrondies, donc l'arithmétique reste exacte à la microseconde près (c'est ce qui garantit `arrival_time == target_arrival` exactement).

Les deux enveloppes de délégation ont été supprimées aussi : les quatre sites d'appel publics passent `backward=False/True` directement.

## Mesures

| Mesure | Avant | Après |
|---|---|---|
| `passage.py` | 1 317 lignes | 1 263 lignes |
| Moteurs forward + backward | 251 + 221 = 472 lignes | 413 lignes, **un seul exemplaire** |
| Ratio difflib entre les deux moteurs | 0,7585 (179 lignes identiques) | sans objet, il n'y en a plus qu'un |
| Lignes de code dans une fenêtre dupliquée de 6 lignes ou plus | 362 / 1 054 (34,3 %) | 76 / 1 012 (**7,5 %**) |

Les 76 lignes restantes sont du passage d'arguments nommés aux quatre sites d'appel publics (`estimate_passage` boucle auto contre appel direct, idem `estimate_passage_for_arrival`), pas de la logique.

## Contrat

| Suite | Avant | Après |
|---|---|---|
| `data-adapters` | 339 (+1 skip) | **376** (+1 skip) |
| `api` | 235 | 235 |
| `mcp-core` | 70 | 70 |
| `hf-space` | 12 | 12 |

- **34 goldens de caractérisation rejoués à l'octet près** après la fusion, enregistrés avant.
- **22 goldens REST et 3 goldens MCP intacts**, aucune régénération (`git status` propre hors `passage.py`).
- Test de parité live contre cache navigateur vert.
- `uvx ruff check` et `ruff format --check` verts sur les quatre paquets.

## Smoke local

Application complète lancée avec les atlas (`MARC_ATLAS_DIR`, `SHOM_C2D_DIR`).

- `GET /api/v1/archetypes` : 200.
- `POST /api/v1/passage` réel, Marseille (43.29, 5.37) vers Porquerolles (43.00, 6.20), demain 09:00+02:00, `cruiser_30ft` : 200 en 331 ms, **40,31 nm, 5 tronçons**, modèle `meteofrance_arome_france`, arrivée 21:54:43.880518Z, durée 14,91 h, complexité 2 modéré, courants `openmeteo_smoc` confiance `medium`, avertissement vent faible (journée molle). Somme des durées de tronçon = 14,912189 h = durée totale.
- `POST /api/v1/passage-by-eta` (moteur backward), arrivée visée demain 20:00+02:00 : 200, arrivée **exactement** 18:00:00Z, chaîne de tronçons contiguë, `segments[0].start_time == departure_time`, `segments[-1].end_time == arrival_time`.
- MCP `initialize` (ohmywind 1.27.2), `tools/list` : `read_me`, `list_boat_archetypes`, `get_marine_forecast`, `plan_passage`. Un `plan_passage` réel sur la même route rend **les mêmes chiffres au dernier chiffre** que l'appel REST ci-dessus (arrivée 21:54:43.880518Z, durée 14,91 h), plus `openwind_url` et `disclaimer`.

## Divergence trouvée entre les deux moteurs

Une seule, et elle est cosmétique : l'ordre des arguments nommés `current_speed_kn` / `current_direction_to_deg` / `sog_kn` / `current_source` / `current_confidence` à la construction du `SegmentReport` différait entre les deux moteurs. Comme ce sont des mots-clés, aucun effet observable ; l'ordre du JSON vient de la déclaration de la dataclass. La fusion la fait disparaître par construction. Aucune divergence de calcul n'a été trouvée, et aucun comportement n'a été modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
