### PR TITLE
fix(currents): tuiles voisines au bord d'une tuile MARC, target_eta naïf refusé

### DIFF
--- a/packages/api/src/openwind_api/parsing.py
+++ b/packages/api/src/openwind_api/parsing.py
@@ -125,16 +125,28 @@ def parse_passage_request(body: Any, *, timestamp_field: str) -> tuple[datetime,
     )
 
 
-def parse_timestamp(raw: Any, field: str) -> datetime:
-    """ISO-8601, or a refusal naming the field the caller sent."""
+def parse_timestamp(raw: Any, field: str, *, require_aware: bool = False) -> datetime:
+    """ISO-8601, or a refusal naming the field the caller sent.
+
+    ``require_aware`` refuses a value without an offset. The engine already
+    does that for ``departure``, ``latest_departure`` and ``target_arrival``,
+    and answers the same 422 ``naive_datetime``; the fields the engine never
+    sees have to be checked here or they get read in the container's local
+    time instead (audit Mo5).
+    """
     try:
-        return datetime.fromisoformat(raw)
+        parsed = datetime.fromisoformat(raw)
     except (ValueError, TypeError) as exc:
         raise RequestError(f"invalid {field}: {exc}", "invalid_datetime") from exc
+    if require_aware and parsed.tzinfo is None:
+        raise RequestError(f"{field} must be timezone-aware", "naive_datetime")
+    return parsed
 
 
-def parse_optional_timestamp(raw: Any, field: str) -> datetime | None:
-    return None if raw is None else parse_timestamp(raw, field)
+def parse_optional_timestamp(
+    raw: Any, field: str, *, require_aware: bool = False
+) -> datetime | None:
+    return None if raw is None else parse_timestamp(raw, field, require_aware=require_aware)
 
 
 def parse_sweep_interval(raw: Any) -> int:

--- a/packages/api/src/openwind_api/routes/passage.py
+++ b/packages/api/src/openwind_api/routes/passage.py
@@ -180,7 +180,7 @@ async def _sweep(
     latest_departure = parse_timestamp(latest_raw, "latest_departure")
     sweep_interval = parse_sweep_interval(body.get("sweep_interval_hours"))
     target_eta_raw = body.get("target_eta")
-    target_eta_dt = parse_optional_timestamp(target_eta_raw, "target_eta")
+    target_eta_dt = parse_optional_timestamp(target_eta_raw, "target_eta", require_aware=True)
 
     try:
         reports = await estimate_passage_windows(

--- a/packages/api/tests/test_api_sweep.py
+++ b/packages/api/tests/test_api_sweep.py
@@ -79,6 +79,31 @@ async def test_invalid_target_eta_returns_422() -> None:
 
 
 @pytest.mark.asyncio
+async def test_naive_target_eta_is_refused_like_a_naive_departure() -> None:
+    """Audit Mo5: it used to be read in the container's local time.
+
+    Every other timestamp of this request is already refused without an
+    offset, so accepting this one meant the same body filtered differently
+    depending on where the process ran, silently.
+    """
+    resp = await passage_routes.api_passage(
+        FakeRequest(_sweep_body(target_eta="2026-05-01T16:30:00"))
+    )
+    assert resp.status_code == 422
+    body = _payload(resp)
+    assert body["error"] == "target_eta must be timezone-aware"
+    assert body["code"] == "naive_datetime"
+
+
+@pytest.mark.asyncio
+async def test_aware_target_eta_is_still_accepted(no_windows) -> None:
+    resp = await passage_routes.api_passage(
+        FakeRequest(_sweep_body(target_eta="2026-05-01T16:30:00+02:00"))
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_skipped_windows_surface_a_meta_warning(monkeypatch) -> None:
     # estimate_passage_windows is partial-tolerant: it drops windows past the
     # forecast horizon. The shell must tell the user some were dropped.

--- a/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
+++ b/packages/data-adapters/src/openwind_data/currents/marc_atlas.py
@@ -35,6 +35,11 @@ from openwind_data.currents.harmonic import predict as schureman_predict
 _TILE_SIZE_DEG = 0.5
 # m/s to knots — conversion shared with the runtime adapters layer.
 _MS_TO_KN = 1.0 / 0.514444
+# Metres per degree of latitude, the flat-earth constant the cell-distance
+# check has always used. Named here because the tile-edge search compares
+# distances to tile boundaries against distances to cells and the two have to
+# be measured with the same ruler.
+_M_PER_DEG = 111_000.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,12 +109,57 @@ def _read_tile(parquet_path: str) -> pl.DataFrame | None:
     return pl.read_parquet(parquet_path)
 
 
-def _tile_path(atlas: AtlasMeta, lat: float, lon: float) -> Path:
-    tile_lat = np.floor(lat / _TILE_SIZE_DEG) * _TILE_SIZE_DEG
-    tile_lon = np.floor(lon / _TILE_SIZE_DEG) * _TILE_SIZE_DEG
+def _tile_origin_of(lat: float, lon: float) -> tuple[float, float]:
+    """South-west corner of the tile a point falls in, in degrees."""
+    return (
+        float(np.floor(lat / _TILE_SIZE_DEG) * _TILE_SIZE_DEG),
+        float(np.floor(lon / _TILE_SIZE_DEG) * _TILE_SIZE_DEG),
+    )
+
+
+def _tile_path_at(atlas: AtlasMeta, tile_lat: float, tile_lon: float) -> Path:
     return (
         atlas.parquet_dir / f"tile_lat={tile_lat:.1f}" / f"tile_lon={tile_lon:.1f}" / "data.parquet"
     )
+
+
+def _neighbour_tiles(lat: float, lon: float) -> list[tuple[float, float, float]]:
+    """The eight tiles around the one holding ``(lat, lon)``, nearest first.
+
+    Each entry is ``(tile_lat, tile_lon, floor_distance_m)`` where the floor is
+    the shortest possible distance from the query point to *any* point of that
+    tile: the distance to the shared edge for a side neighbour, the diagonal
+    to the shared corner for a diagonal one. That floor is what makes the
+    search exact and cheap at the same time. A cell in a neighbour cannot be
+    nearer than the floor, so a caller holding a cell closer than the floor
+    can skip the tile without opening it, and a caller holding nothing has a
+    sound order to try them in.
+
+    Distances use the same flat-earth ruler as the cell-distance check, so a
+    tile is never opened for a cell the threshold would then reject.
+    """
+    tile_lat, tile_lon = _tile_origin_of(lat, lon)
+    m_per_deg_lon = _M_PER_DEG * float(np.cos(np.deg2rad(lat)))
+    to_south = (lat - tile_lat) * _M_PER_DEG
+    to_north = (tile_lat + _TILE_SIZE_DEG - lat) * _M_PER_DEG
+    to_west = (lon - tile_lon) * m_per_deg_lon
+    to_east = (tile_lon + _TILE_SIZE_DEG - lon) * m_per_deg_lon
+
+    out: list[tuple[float, float, float]] = []
+    for di, d_lat_m in ((-1, to_south), (0, 0.0), (1, to_north)):
+        for dj, d_lon_m in ((-1, to_west), (0, 0.0), (1, to_east)):
+            if di == 0 and dj == 0:
+                continue
+            floor_m = float(np.hypot(d_lat_m if di else 0.0, d_lon_m if dj else 0.0))
+            out.append(
+                (
+                    tile_lat + di * _TILE_SIZE_DEG,
+                    tile_lon + dj * _TILE_SIZE_DEG,
+                    floor_m,
+                )
+            )
+    out.sort(key=lambda t: t[2])
+    return out
 
 
 # One rectangle in degrees, ``(lat_min, lon_min, lat_max, lon_max)``, same
@@ -205,10 +255,10 @@ def _atlas_coverage_cells(parquet_dir: str) -> _Boxes:
     return _merge_tiles_into_rectangles(tiles)
 
 
-def _nearest_cell_in_tile(
+def _nearest_cell_with_distance(
     df: pl.DataFrame, lat: float, lon: float, required_col: str | None = None
-) -> int | None:
-    """Return index of metric-nearest cell, or None if no valid cell qualifies.
+) -> tuple[int, float] | None:
+    """Metric-nearest cell of one tile and its distance in metres, or None.
 
     Uses local-tangent-plane distance: degrees-lon are scaled by cos(lat) so
     we don't bias toward longitudinal neighbours at high latitude. When
@@ -218,6 +268,11 @@ def _nearest_cell_in_tile(
     have an on-land U face (NaN) even when XE itself is valid sea. ~50 cells
     in FINIS exhibit this; routing through a slightly further cell with
     finite U/V is a sub-resolution shift, well within harmonic precision.
+
+    Selection is exactly what it always was. The distance is the same
+    flat-earth hypotenuse the caller used to recompute on the winning row,
+    returned here so the tile-edge search can rank candidates coming from
+    different tiles without redoing the trigonometry each time.
     """
     lats = df["lat"].to_numpy()
     lons = df["lon"].to_numpy()
@@ -230,7 +285,10 @@ def _nearest_cell_in_tile(
         if not valid.any():
             return None
         d2 = np.where(valid, d2, np.inf)
-    return int(np.argmin(d2))
+    idx = int(np.argmin(d2))
+    dlat_m = (float(lats[idx]) - lat) * _M_PER_DEG
+    dlon_m = (float(lons[idx]) - lon) * _M_PER_DEG * cos_lat
+    return idx, float(np.hypot(dlat_m, dlon_m))
 
 
 def _extract_constants(df: pl.DataFrame, idx: int, suffix: str) -> dict[str, tuple[float, float]]:
@@ -310,28 +368,84 @@ class MarcAtlasRegistry:
     # the model has no valid cells).
     _MAX_CELL_DISTANCE_M = 5000.0  # 5 km, generous
 
-    def _cell_with_finite(
+    def _cell_threshold_m(self, atlas: AtlasMeta) -> float:
+        """How far a cell may sit from the query and still answer for it."""
+        return max(self._MAX_CELL_DISTANCE_M, 5.0 * atlas.resolution_m)
+
+    def _best_cell(
         self,
         atlas: AtlasMeta,
-        df: pl.DataFrame,
         lat: float,
         lon: float,
         required_col: str | None = None,
-    ) -> int | None:
-        """Return idx of the nearest cell within distance threshold whose
-        ``required_col`` is finite (when given). Returns None if the closest
-        valid cell is beyond max(5 km, 5x atlas resolution) of the query.
+        *,
+        neighbours: bool = False,
+    ) -> tuple[pl.DataFrame, int] | None:
+        """Nearest qualifying cell of ``atlas``, optionally across tile seams.
+
+        Returns the frame it was found in and its row index, or ``None`` when
+        no cell with a finite ``required_col`` sits within
+        ``max(5 km, 5x atlas resolution)`` of the query.
+
+        Tiles are 0.5 degrees, so a point can sit a few hundred metres inside
+        one and have its true nearest cell in the next: reading only the
+        containing tile, which is what this did everywhere until now, handed
+        such a point a cell further away than the one it should have got,
+        precisely along the coastlines where the 250 m atlases are worth
+        having. The audit filed this as Mo4.
+
+        ``neighbours`` is what fixes it, and it is deliberately off by
+        default. Two invariants would break if the seam search also decided
+        *whether* a point is covered:
+
+        - :meth:`coverage_cells` publishes whole non-empty tiles and promises
+          that a point outside all of them is a point :meth:`covers` refuses.
+          The web client skips its request on that promise, so a neighbour
+          rescuing a point standing in an empty tile would make the server
+          answer where the client has already been told not to ask.
+        - the cascade picks the finest atlas that covers, so letting a
+          neighbour tile establish coverage would promote a fine atlas whose
+          nearest cell is kilometres away over a coarser one with a cell a few
+          hundred metres away. Measured on the real atlases: 40 points of an
+          Iroise grid would have moved from MANGA at 160 to 280 m to FINIS at
+          3 to 5 km. Finer grid, worse answer.
+
+        So coverage stays decided by the containing tile alone, exactly as
+        before, and the seam search only changes *which* cell answers inside
+        coverage. That makes the effect provably one-directional: the search
+        starts from the containing tile's own candidate and replaces it only
+        with something strictly nearer, so a cell can never come out further
+        than it used to be.
+
+        When it does look around, neighbours are visited in order of their
+        floor distance (see `_neighbour_tiles`) and the loop stops as soon as
+        the best cell held is nearer than the next tile could possibly offer.
+        The usual case, a dense grid with a cell a few dozen metres away,
+        opens exactly one tile.
         """
-        idx = _nearest_cell_in_tile(df, lat, lon, required_col=required_col)
-        if idx is None:
+        threshold = self._cell_threshold_m(atlas)
+        tile_lat, tile_lon = _tile_origin_of(lat, lon)
+        df = _read_tile(str(_tile_path_at(atlas, tile_lat, tile_lon)))
+        if df is None or df.height == 0:
             return None
-        cell_lat = float(df["lat"].to_numpy()[idx])
-        cell_lon = float(df["lon"].to_numpy()[idx])
-        dlat_m = (cell_lat - lat) * 111_000
-        dlon_m = (cell_lon - lon) * 111_000 * np.cos(np.deg2rad(lat))
-        d_m = np.hypot(dlat_m, dlon_m)
-        threshold = max(self._MAX_CELL_DISTANCE_M, 5.0 * atlas.resolution_m)
-        return idx if d_m <= threshold else None
+        best: tuple[pl.DataFrame, int] | None = None
+        best_d = threshold
+        found = _nearest_cell_with_distance(df, lat, lon, required_col=required_col)
+        if found is not None and found[1] <= best_d:
+            best, best_d = (df, found[0]), found[1]
+        if not neighbours:
+            return best
+        for n_lat, n_lon, floor_m in _neighbour_tiles(lat, lon):
+            if floor_m >= best_d:
+                # Sorted by floor distance, so nothing further can win either.
+                break
+            n_df = _read_tile(str(_tile_path_at(atlas, n_lat, n_lon)))
+            if n_df is None or n_df.height == 0:
+                continue
+            found = _nearest_cell_with_distance(n_df, lat, lon, required_col=required_col)
+            if found is not None and found[1] < best_d:
+                best, best_d = (n_df, found[0]), found[1]
+        return best
 
     def covers(self, lat: float, lon: float) -> AtlasMeta | None:
         """Return the finest atlas with actual data near (lat, lon), or None.
@@ -339,18 +453,18 @@ class MarcAtlasRegistry:
         Filters by bbox first, then verifies the nearest cell in the matching
         tile is within distance threshold. This catches false bbox matches
         (e.g. ATLNE bbox spuriously covering the Mediterranean).
+
+        Reads the containing tile only, on purpose: see `_best_cell` for why
+        the seam search must not reach the coverage decision.
         """
         candidates = [a for a in self.atlases if _bbox_contains(a.bbox, lat, lon)]
         if not candidates:
             return None
         candidates.sort(key=lambda a: (-a.rank, a.resolution_m))
         for atlas in candidates:
-            df = _read_tile(str(_tile_path(atlas, lat, lon)))
-            if df is None or df.height == 0:
-                continue
             # Use the unfiltered metric-nearest as the coverage signal; the
             # variable-specific lookup happens at predict time.
-            if self._cell_with_finite(atlas, df, lat, lon, required_col=None) is not None:
+            if self._best_cell(atlas, lat, lon, required_col=None) is not None:
                 return atlas
         return None
 
@@ -361,25 +475,36 @@ class MarcAtlasRegistry:
         The metric-nearest XE cell may have an on-land U or V face (NaN);
         in that case we fall back to the nearest cell whose U / V is finite.
         Anchor lat/lon and z0 come from the height cell.
+
+        Memoised per ``(atlas registry, lat, lon)``: one overlay request calls
+        this three times for the same point (once directly, once through each
+        of the height and current series), and the tidal router twice more.
+        The key is the exact pair of floats the caller passed, never a rounded
+        one, so the memo can only return what a recomputation would.
         """
+        return _cell_at_cached(self, lat, lon)
+
+    def _cell_at_uncached(self, lat: float, lon: float) -> CellPrediction | None:
         atlas = self.covers(lat, lon)
         if atlas is None:
             return None
-        df = _read_tile(str(_tile_path(atlas, lat, lon)))
-        if df is None or df.height == 0:
-            return None
         # Per-variable nearest cell with finite data. M2 is the canonical
-        # proxy (always present in every MARC atlas).
-        h_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_h_amp")
-        u_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_u_amp")
-        v_idx = self._cell_with_finite(atlas, df, lat, lon, required_col="M2_v_amp")
-        anchor = h_idx if h_idx is not None else (u_idx if u_idx is not None else v_idx)
+        # proxy (always present in every MARC atlas). Each may land in a
+        # different tile when the query sits near a boundary, so each carries
+        # the frame it was found in.
+        h_found = self._best_cell(atlas, lat, lon, required_col="M2_h_amp", neighbours=True)
+        u_found = self._best_cell(atlas, lat, lon, required_col="M2_u_amp", neighbours=True)
+        v_found = self._best_cell(atlas, lat, lon, required_col="M2_v_amp", neighbours=True)
+        anchor = h_found if h_found is not None else (u_found or v_found)
         if anchor is None:
             return None
-        cell_lat = float(df["lat"].to_numpy()[anchor])
-        cell_lon = float(df["lon"].to_numpy()[anchor])
+        anchor_df, anchor_idx = anchor
+        cell_lat = float(anchor_df["lat"].to_numpy()[anchor_idx])
+        cell_lon = float(anchor_df["lon"].to_numpy()[anchor_idx])
         z0_hydro = (
-            df.get_column("z0_hydro_m").to_numpy()[anchor] if "z0_hydro_m" in df.columns else None
+            anchor_df.get_column("z0_hydro_m").to_numpy()[anchor_idx]
+            if "z0_hydro_m" in anchor_df.columns
+            else None
         )
         return CellPrediction(
             atlas_name=atlas.name,
@@ -388,9 +513,9 @@ class MarcAtlasRegistry:
             z0_hydro_m=(
                 float(z0_hydro) if z0_hydro is not None and np.isfinite(z0_hydro) else None
             ),
-            h_constants=_extract_constants(df, h_idx, "h") if h_idx is not None else {},
-            u_constants=_extract_constants(df, u_idx, "u") if u_idx is not None else {},
-            v_constants=_extract_constants(df, v_idx, "v") if v_idx is not None else {},
+            h_constants=_extract_constants(h_found[0], h_found[1], "h") if h_found else {},
+            u_constants=_extract_constants(u_found[0], u_found[1], "u") if u_found else {},
+            v_constants=_extract_constants(v_found[0], v_found[1], "v") if v_found else {},
         )
 
     def predict_height(self, lat: float, lon: float, t: datetime) -> tuple[float, str] | None:
@@ -447,3 +572,16 @@ class MarcAtlasRegistry:
         speeds_kn = np.hypot(u_ms, v_ms) * _MS_TO_KN
         dirs_to_deg = (np.rad2deg(np.arctan2(u_ms, v_ms))) % 360.0
         return speeds_kn, dirs_to_deg, cell.atlas_name
+
+
+@lru_cache(maxsize=512)
+def _cell_at_cached(registry: MarcAtlasRegistry, lat: float, lon: float) -> CellPrediction | None:
+    """Process-wide memo behind :meth:`MarcAtlasRegistry.cell_at`.
+
+    Module-level rather than per-instance because the registry is a frozen
+    dataclass and because the same atlas directory is opened by both shells:
+    keying on the registry itself lets the two share one answer. Bounded at
+    512 points, roughly twenty corridors' worth, and never keyed on anything
+    the caller did not pass verbatim.
+    """
+    return registry._cell_at_uncached(lat, lon)

--- a/packages/data-adapters/src/openwind_data/views.py
+++ b/packages/data-adapters/src/openwind_data/views.py
@@ -162,7 +162,20 @@ def filter_windows_by_target_eta(
 
     ``target_eta_label`` is echoed verbatim into that warning, so the user
     reads back the string they sent rather than a normalised rewrite of it.
+
+    Raises:
+        ValueError: when ``target_eta`` carries no offset. ``astimezone``
+            would otherwise read a naive value in the *server's* local time,
+            so the same request would filter differently depending on the
+            container's clock, silently and only by a few hours. Every other
+            timestamp on this request is already refused when naive
+            (``departure``, ``latest_departure``, ``target_arrival``); this
+            one used to slip through, which the 2026-09 audit filed as Mo5.
+            The guard lives here rather than in each shell so a third one
+            cannot reintroduce it.
     """
+    if target_eta.tzinfo is None:
+        raise ValueError("target_eta must be timezone-aware")
     target_utc = target_eta.astimezone(UTC)
     tolerance_s = TARGET_ETA_TOLERANCE.total_seconds()
     filtered = [

--- a/packages/data-adapters/tests/currents/test_marc_atlas.py
+++ b/packages/data-adapters/tests/currents/test_marc_atlas.py
@@ -417,3 +417,189 @@ def test_coverage_cells_is_memoised_per_directory(tmp_path: Path) -> None:
     _write_tile(atlas_dir, 48.0, -4.5, rows=1)
     second = MarcAtlasRegistry.from_directory(tmp_path).coverage_cells()
     assert first == second
+
+
+# ------------------------------------------------------------ tile-edge search
+
+
+def _write_cells(
+    atlas_dir: Path, tile_lat: float, tile_lon: float, cells: list[tuple[float, float]]
+) -> None:
+    """Write a tile holding exactly the cells given, in decimal degrees."""
+    tile_dir = atlas_dir / f"tile_lat={tile_lat:.1f}" / f"tile_lon={tile_lon:.1f}"
+    tile_dir.mkdir(parents=True, exist_ok=True)
+    n = len(cells)
+    pl.DataFrame(
+        {
+            "lat": pl.Series([c[0] for c in cells], dtype=pl.Float64),
+            "lon": pl.Series([c[1] for c in cells], dtype=pl.Float64),
+            "z0_hydro_m": pl.Series([0.0] * n, dtype=pl.Float64),
+            "M2_h_amp": pl.Series([1.0] * n, dtype=pl.Float64),
+            "M2_h_g": pl.Series([0.0] * n, dtype=pl.Float64),
+            "M2_u_amp": pl.Series([0.5] * n, dtype=pl.Float64),
+            "M2_u_g": pl.Series([0.0] * n, dtype=pl.Float64),
+            "M2_v_amp": pl.Series([0.3] * n, dtype=pl.Float64),
+            "M2_v_g": pl.Series([0.0] * n, dtype=pl.Float64),
+        }
+    ).write_parquet(tile_dir / "data.parquet", compression="zstd")
+
+
+# 0.0134 deg of longitude at 48 N is about 1 km, so this query sits inside the
+# western tile, a kilometre short of the seam at -4.5.
+SEAM_QUERY = (48.25, -4.5134)
+
+
+def _two_tile_atlas(tmp_path: Path) -> MarcAtlasRegistry:
+    """Two adjacent tiles, seam at longitude -4.5.
+
+    Tile A, west of the seam, holds one cell about 2 km from the query: near
+    enough to establish coverage on its own, which is what keeps the atlas
+    cascade out of this. Tile B, just past the seam, holds one about 1 km
+    away. A query inside A is therefore nearer to B's cell than to A's own,
+    the arrangement the single-tile lookup used to get wrong.
+    """
+    atlas_dir = _write_atlas(tmp_path, "SEAM", (47.5, -5.5, 49.0, -4.0))
+    _write_cells(atlas_dir, 48.0, -5.0, [(48.25, -4.54)])
+    _write_cells(atlas_dir, 48.0, -4.5, [(48.25, -4.499)])
+    return MarcAtlasRegistry.from_directory(tmp_path)
+
+
+def test_nearest_cell_is_found_across_a_tile_seam(tmp_path: Path) -> None:
+    """A point 1 km inside tile A gets tile B's cell when B's is nearer."""
+    registry = _two_tile_atlas(tmp_path)
+    query_lat, query_lon = SEAM_QUERY
+    assert query_lon < -4.5, "the query must sit in the western tile"
+
+    cell = registry.cell_at(query_lat, query_lon)
+    assert cell is not None
+    # Tile B's cell is about 1.1 km away, tile A's own about 2.0 km.
+    assert cell.lon == pytest.approx(-4.499)
+    assert cell.lat == pytest.approx(48.25)
+
+
+def test_the_seam_search_does_not_widen_coverage(tmp_path: Path) -> None:
+    """Coverage stays decided by the containing tile, cell choice does not.
+
+    Letting a neighbour establish coverage would break two things at once:
+    the promise ``coverage_cells`` makes to the web client, and the atlas
+    cascade, which would promote a fine atlas whose nearest cell is
+    kilometres away over a coarser one with a cell next door.
+    """
+    registry = _two_tile_atlas(tmp_path)
+    atlas = registry.covers(*SEAM_QUERY)
+    assert atlas is not None
+    assert atlas.name == "SEAM"
+    # Same answer with the containing tile's own cell removed: no coverage,
+    # even though the neighbour still holds one a kilometre away.
+    empty_root = tmp_path / "empty"
+    empty_dir = _write_atlas(empty_root, "SEAM", (47.5, -5.5, 49.0, -4.0))
+    _write_tile(empty_dir, 48.0, -5.0, rows=0)
+    _write_cells(empty_dir, 48.0, -4.5, [(48.25, -4.499)])
+    assert MarcAtlasRegistry.from_directory(empty_root).covers(*SEAM_QUERY) is None
+
+
+def test_the_closer_cell_of_the_containing_tile_still_wins(tmp_path: Path) -> None:
+    """No regression for the ordinary case: the local cell is the answer."""
+    atlas_dir = _write_atlas(tmp_path, "LOCAL", (47.5, -5.5, 49.0, -4.0))
+    _write_cells(atlas_dir, 48.0, -5.0, [(48.25, -4.51)])
+    _write_cells(atlas_dir, 48.0, -4.5, [(48.25, -4.49)])
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+
+    cell = registry.cell_at(48.25, -4.505)
+    assert cell is not None
+    assert cell.lon == pytest.approx(-4.51)
+
+
+def test_a_corner_query_reaches_the_diagonal_tile(tmp_path: Path) -> None:
+    """Four tiles meet: the nearest cell sits in the diagonal one.
+
+    The containing tile carries a cell 6.5 km away, enough to cover the query
+    on its own, while the diagonal tile has one 466 m away. Only a search that
+    walks the corner finds it.
+    """
+    atlas_dir = _write_atlas(tmp_path, "CORNER", (47.5, -5.5, 49.0, -4.0))
+    _write_cells(atlas_dir, 48.0, -5.0, [(48.45, -4.55)])
+    _write_cells(atlas_dir, 48.5, -4.5, [(48.502, -4.498)])
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+
+    cell = registry.cell_at(48.4985, -4.5015)
+    assert cell is not None
+    assert cell.lat == pytest.approx(48.502)
+    assert cell.lon == pytest.approx(-4.498)
+
+
+def test_an_empty_containing_tile_is_still_not_covered(tmp_path: Path) -> None:
+    """The promise coverage_cells makes to the web client, kept.
+
+    The neighbour search improves which cell answers inside coverage; it must
+    never extend coverage past the published rectangles, or the client would
+    skip a request the server would have honoured.
+    """
+    atlas_dir = _write_atlas(tmp_path, "HALO", (47.5, -5.5, 49.0, -4.0))
+    _write_tile(atlas_dir, 48.0, -5.0, rows=0)
+    _write_cells(atlas_dir, 48.0, -4.5, [(48.25, -4.49)])
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+
+    boxes = registry.coverage_cells()[0][1]
+    query_lat, query_lon = 48.25, -4.5134
+    assert not any(
+        lat_min <= query_lat <= lat_max and lon_min <= query_lon <= lon_max
+        for lat_min, lon_min, lat_max, lon_max in boxes
+    )
+    assert registry.covers(query_lat, query_lon) is None
+    assert registry.cell_at(query_lat, query_lon) is None
+
+
+def test_no_point_outside_the_cells_is_covered_with_neighbour_search(tmp_path: Path) -> None:
+    """The sweep of the coverage invariant, rerun against seams and corners.
+
+    Same contract as ``test_no_point_outside_the_cells_is_ever_covered``, on a
+    layout built to put queries a few hundred metres from every kind of tile
+    boundary: side seams, the corner where four tiles meet, and the empty
+    tile that must stay a hole.
+    """
+    atlas_dir = _write_atlas(tmp_path, "SWEEP2", (47.0, -6.0, 49.5, -3.0))
+    for tile_lat, tile_lon in ((48.0, -5.0), (48.0, -4.5), (48.5, -4.5)):
+        _write_cells(
+            atlas_dir,
+            tile_lat,
+            tile_lon,
+            [(tile_lat + 0.01, tile_lon + 0.01), (tile_lat + 0.49, tile_lon + 0.49)],
+        )
+    _write_tile(atlas_dir, 48.5, -5.0, rows=0)
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+    boxes = registry.coverage_cells()[0][1]
+
+    covered_seen = 0
+    for i in range(51):
+        for j in range(61):
+            lat = 47.75 + i * 0.02
+            lon = -5.25 + j * 0.02
+            if registry.covers(lat, lon) is None:
+                continue
+            covered_seen += 1
+            assert any(
+                lat_min <= lat <= lat_max and lon_min <= lon <= lon_max
+                for lat_min, lon_min, lat_max, lon_max in boxes
+            ), (lat, lon)
+    assert covered_seen > 0
+
+
+def test_cell_at_is_memoised_for_a_repeated_point(tmp_path: Path) -> None:
+    """One overlay request asks for the same point three times.
+
+    Asserted through the tile reader rather than a call counter on the method,
+    because the memo is only worth anything if it also spares the numpy scan
+    behind it.
+    """
+    atlas_dir = _write_atlas(tmp_path, "MEMOCELL", (47.5, -5.5, 49.0, -4.0))
+    _write_cells(atlas_dir, 48.0, -5.0, [(48.25, -4.75)])
+    registry = MarcAtlasRegistry.from_directory(tmp_path)
+
+    first = registry.cell_at(48.25, -4.75)
+    assert first is not None
+    # Rewrite the tile with a different cell behind the memo's back: a cached
+    # answer must not see it.
+    _write_cells(atlas_dir, 48.0, -5.0, [(48.26, -4.76)])
+    again = registry.cell_at(48.25, -4.75)
+    assert again is first

--- a/packages/data-adapters/tests/test_views.py
+++ b/packages/data-adapters/tests/test_views.py
@@ -125,6 +125,15 @@ class TestTargetEtaFilter:
         assert len(kept) == 1
         assert warning is None
 
+    def test_a_naive_target_is_refused_rather_than_read_locally(self) -> None:
+        # Audit Mo5. ``astimezone`` on a naive value silently adopts the
+        # server's own offset, so the same request filtered differently on a
+        # developer's machine and in the container. The guard sits here, in
+        # the shared view, so neither shell can lose it.
+        naive = (DEPARTURE + timedelta(hours=8)).replace(tzinfo=None)
+        with pytest.raises(ValueError, match="target_eta must be timezone-aware"):
+            filter_windows_by_target_eta([_window(DEPARTURE)], naive, "T")
+
 
 class TestSweepEnvelope:
     def test_counts_the_windows_it_actually_carries(self) -> None:


### PR DESCRIPTION
Lot 3, PR 3.3. Deux points de l'annexe C, **Mo4** (bord de tuile MARC) et **Mo5** (datetimes naïfs). Indépendante de la PR 3.1 : fichiers disjoints, mergeable dans n'importe quel ordre.

## Mo4, bord de tuile MARC

`covers()` et `cell_at()` ne lisaient que la tuile contenant le point. Les tuiles font 0,5 degré, donc un point posé à quelques centaines de mètres d'une couture recevait une cellule plus lointaine que celle qu'il aurait dû avoir, précisément le long des côtes où les atlas à 250 m valent le coup.

`_best_cell()` cherche maintenant dans les tuiles voisines, jusqu'à quatre à un coin. Les voisines sont visitées par distance plancher croissante (la distance à la couture partagée, la diagonale au coin partagé) et la boucle s'arrête dès que la meilleure cellule tenue est plus proche que ce que la tuile suivante pourrait offrir. Le cas courant, une grille dense avec une cellule à quelques dizaines de mètres, n'ouvre donc toujours qu'une seule tuile.

### La recherche ne touche pas à la décision de couverture, et c'est délibéré

J'ai d'abord branché la recherche aussi dans `covers()`. Mesure faite : **ça régresse**. Deux invariants tombaient.

1. `coverage_cells()` publie des tuiles entières non vides et promet qu'un point hors de tous ses rectangles est un point que `covers()` refuse. Le client web saute sa requête sur cette promesse (PR #322). Laisser une voisine sauver un point posé dans une tuile vide, c'est répondre là où on a déjà dit au client de ne pas demander.
2. La cascade choisit l'atlas le plus fin qui couvre. Sur les atlas réels, **40 points** d'une grille d'Iroise passaient de MANGA à 160-280 m à FINIS à 3-5 km. Grille plus fine, réponse moins bonne.

Donc la couverture reste décidée par la tuile contenante, exactement comme avant, et la recherche ne change que **quelle cellule répond** à l'intérieur de la couverture. L'effet devient à sens unique et démontrable : on part de la cellule de la tuile contenante et on ne la remplace que par strictement plus proche.

### Mesure sur les atlas réels

Grille d'Iroise, 101 x 101 points au pas de 0,01 degré (47,95 à 48,95 N, -5,05 à -4,05 E), 10 201 points, comparaison variable par variable contre `origin/dev` :

| Variable | Identique | Cellule plus proche | Plus loin | Couverture gagnée | Couverture perdue |
|---|---|---|---|---|---|
| `M2_h_amp` | 9 912 | **289** (médiane 197 m, max 1 252 m gagnés) | **0** | 0 | 0 |
| `M2_u_amp` | 9 908 | **291** (médiane 196 m, max 1 215 m) | **0** | 0 | 0 |
| `M2_v_amp` | 9 911 | **288** (médiane 197 m, max 1 215 m) | **0** | 0 | 0 |

2,8 % des points gagnent une cellule plus proche, aucun ne recule.

### Coût

Tuiles ouvertes en plus, atlas réels (5,3 Go, FINIS 250 m) :

| Point | Tuiles ouvertes en plus |
|---|---|
| Bien à l'intérieur d'une tuile (48,35 / -4,80) | 0 |
| À 1 km d'une couture (48,33 / -4,55) | 1 |
| Exactement sur un coin (48,50 / -5,00) | 3 |

Zéro pour un point qui a déjà une cellule plus proche que la couture, ce qui est le cas général en mer ouverte.

### Mémoïsation

`cell_at()` est mémoïsé par `(registre, lat, lon)` **exacts**, jamais arrondis, donc le memo ne peut rendre que ce qu'un recalcul rendrait. Une requête overlay l'appelle trois fois pour le même point (`marine.py:109, 128, 129`) et le routeur de marées deux fois de plus.

| Mesure | Avant | Après |
|---|---|---|
| Goulet de Brest, 3 appels `cell_at` | 56 ms + 56 ms + 56 ms | 56 ms + 0,013 ms |
| `GET /api/v1/marine/marc` 24 h, second appel même point | 68 ms | **5,7 ms** |

## Mo5, `target_eta` naïf

`departure`, `latest_departure` et `target_arrival` sont déjà refusés sans fuseau (422 `naive_datetime`). `target_eta` traversait et finissait dans un `astimezone()` qui l'interprétait **dans l'heure locale du conteneur** : le même corps de requête filtrait différemment selon l'endroit où tourne le processus, en silence et de quelques heures.

Aligné sur le refus, pas sur l'UTC implicite : c'est le même corps de requête que `departure`, il aurait été incohérent d'accepter l'un et de refuser l'autre. Le garde-fou est posé dans la vue partagée `filter_windows_by_target_eta`, donc les deux shells l'héritent et un troisième ne pourra pas le reperdre, et doublé au parsing REST pour que la réponse soit un 422 et non un 500.

**Aucun code d'erreur nouveau** et **aucun golden touché** : le message et le code existants sont réutilisés, `target_eta must be timezone-aware` / `naive_datetime`, du même moule que `departure_time must be timezone-aware` déjà figé par `error_naive_departure.json`.

`/api/v1/marine/marc` garde son `start`/`end` naïf traité en UTC : c'est explicite, testé, et ce sont des bornes de série, pas un instant métier.

## Nettoyage

`_tile_path()` et `_nearest_cell_in_tile()` n'avaient plus d'appelant après la refonte, retirés.

## Contrat

| Suite | Avant | Après |
|---|---|---|
| `data-adapters` | 339 (+1 skip) | **347** (+1 skip) |
| `api` | 235 | **237** |
| `mcp-core` | 70 | 70 |
| `hf-space` | 12 | 12 |

- 22 goldens REST et 3 goldens MCP intacts, aucune régénération.
- Les 2 tests de couture (`test_nearest_cell_is_found_across_a_tile_seam`, `test_a_corner_query_reaches_the_diagonal_tile`) échouent bien si on neutralise la recherche des voisines : vérifié.
- `test_the_seam_search_does_not_widen_coverage` et le balayage `test_no_point_outside_the_cells_is_covered_with_neighbour_search` (3 111 points sur coutures, coin et tuile vide) tiennent l'invariant publié au client.
- `uvx ruff check` et `format --check` verts sur les quatre paquets.

## Smoke local

Application complète avec les atlas réels (`MARC_ATLAS_DIR` 5,3 Go, `SHOM_C2D_DIR`).

- `GET /api/v1/archetypes` : 200.
- `POST /api/v1/passage` réel Marseille (43.29, 5.37) vers Porquerolles (43.00, 6.20), demain 09:00+02:00, `cruiser_30ft` : 200 en 289 ms, 40,31 nm, 5 tronçons, AROME.
- `GET /api/v1/marine/marc` Goulet de Brest 24 h : 200, `covered: true`, `shom_c2d_560_rade_brest`, coefficient 77, 24 valeurs. 68 ms à froid, 5,7 ms au second appel.
- `target_eta` naïf : 422 `{"error":"target_eta must be timezone-aware","code":"naive_datetime"}`. `target_eta` avec offset : 200 multi_window. `target_arrival` naïf : 422, inchangé.
- MCP `plan_passage` avec `target_eta` naïf : `isError`, `target_eta must be timezone-aware`, même formulation que le REST.

## Divergence relevée, non corrigée

Un point posé dans une tuile **vide** dont la voisine a une cellule à moins de 5 km reste non couvert et bascule sur SMOC, comme aujourd'hui. C'est le second membre du constat Mo4 (« ou SMOC »). Le corriger demanderait d'élargir les rectangles de `coverage_cells()`, donc de changer le contrat que le client web utilise pour sauter des requêtes. Hors périmètre de cette PR, à trancher séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
