### PR TITLE
fix(web): les écritures d'URL passent par le routeur, et une page 404 (lot 4.6)

### DIFF
--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -5,6 +5,8 @@ import App from "./App";
 import { PlanPage } from "./routes/PlanPage";
 import { ConfigPage } from "./routes/ConfigPage";
 import { LazyPageBoundary } from "./components/LazyPageBoundary";
+import { NotFoundPage } from "./routes/NotFoundPage";
+import { matchRoute } from "./routeTable";
 import { useRouter } from "./router";
 
 // Les deux pages de documentation tirent react-markdown, remark/rehype, KaTeX
@@ -43,20 +45,31 @@ const docFallback = (
  * fast refresh stays happy.
  */
 export function Routes() {
-  const { path, search } = useRouter();
+  const { path } = useRouter();
 
-  // Keyed on the full URL so a navigation remounts the page, which is what
-  // the pages already expect: each reads its query string once, at mount.
-  // What changes versus the previous full document load is everything around
-  // it. The shell, the theme and the parsed script all survive, so switching
-  // mode no longer blanks the app.
-  const key = path + search;
+  // Keyed on the path alone, deliberately not on the full URL. A navigation
+  // still remounts the page, which is what the pages expect: each reads its
+  // query string once, at mount. What must not remount it is a *rewrite* of
+  // the query string on the page one is already on, and `/plan` does exactly
+  // that at mount when it restores a route from the cache. Keyed on the full
+  // URL, the next back press (closing a panel) re-read the location, saw a
+  // new key, and remounted the planner from its draft with the computed
+  // results gone. No link in the app goes from one query string to another
+  // under the same path, so the path is a sufficient key.
+  const key = path;
 
-  if (path === "/plan") return <PlanPage key={key} />;
-  if (path === "/methodologie")
-    return <LazyPageBoundary key={key} load={loadMethodologie} fallback={docFallback} />;
-  if (path === "/config") return <ConfigPage key={key} />;
-  if (path === "/confidentialite")
-    return <LazyPageBoundary key={key} load={loadConfidentialite} fallback={docFallback} />;
-  return <App key={key} />;
+  switch (matchRoute(path)) {
+    case "plan":
+      return <PlanPage key={key} />;
+    case "config":
+      return <ConfigPage key={key} />;
+    case "methodologie":
+      return <LazyPageBoundary key={key} load={loadMethodologie} fallback={docFallback} />;
+    case "confidentialite":
+      return <LazyPageBoundary key={key} load={loadConfidentialite} fallback={docFallback} />;
+    case "not-found":
+      return <NotFoundPage key={key} />;
+    case "explore":
+      return <App key={key} />;
+  }
 }

--- a/packages/web/src/navigation.ts
+++ b/packages/web/src/navigation.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The address bar, as one store the whole app writes through.
+ *
+ * `history.pushState` and `history.replaceState` are silent: the browser fires
+ * no event for them, only for a back or forward press. Any code that wrote to
+ * the address bar directly therefore left the router holding the URL from
+ * before the write, and the router only found out at the next `popstate`.
+ *
+ * That is a real bug, not a tidiness point. On `/plan` opened without a query
+ * string, the mount rewrote the URL with the restored route; the router kept
+ * `search: ""`. The first back press (closing the boat selector, which pushes
+ * an entry of its own) re-read the location, the page key changed from
+ * `/plan` to `/plan?wpts=…`, and `PlanPage` remounted from the draft, results
+ * gone. The reader saw their computed passage vanish on a gesture that was
+ * only meant to close a panel.
+ *
+ * So every internal write goes through `navigate`, which writes and then
+ * notifies. No listener can be missed, and there is one place to look when
+ * asking what changes the URL.
+ *
+ * Kept apart from `router.tsx` so it stays free of React and of the service
+ * worker: the plan session persists its URL from a layout effect, and must be
+ * able to import this without dragging either in.
+ */
+
+export interface AppLocation {
+  /** Pathname, trailing slash removed. */
+  path: string;
+  /** Query string including its leading "?", or "". */
+  search: string;
+}
+
+/** GitHub Pages appended trailing slashes when a matching directory existed
+    under public/. Strip it so route matching stays a plain comparison. */
+export function normalisePath(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+function readLocation(): AppLocation {
+  return {
+    path: normalisePath(window.location.pathname),
+    search: window.location.search,
+  };
+}
+
+let snapshot: AppLocation = readLocation();
+const listeners = new Set<() => void>();
+
+/**
+ * The current location.
+ *
+ * The returned object keeps its identity while the URL does not change, which
+ * is what `useSyncExternalStore` requires. It is re-read on every call rather
+ * than trusted from the last `navigate`, so a write from outside this module
+ * (a browser extension, a test, code we have not written yet) is picked up at
+ * the next render instead of being ignored forever.
+ */
+export function getLocation(): AppLocation {
+  const next = readLocation();
+  if (next.path !== snapshot.path || next.search !== snapshot.search) {
+    snapshot = next;
+  }
+  return snapshot;
+}
+
+/** Subscribe to location changes. The first subscriber wires `popstate`. */
+export function subscribe(listener: () => void): () => void {
+  if (listeners.size === 0) {
+    window.addEventListener("popstate", notify);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      window.removeEventListener("popstate", notify);
+    }
+  };
+}
+
+/** Tell every subscriber to re-read the location. */
+export function notify(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+export interface NavigateOptions {
+  /**
+   * Replace the current history entry instead of stacking a new one. Used for
+   * a URL that *describes* the page rather than being a place the reader
+   * chose to go: the plan URL rewritten after a computation, or a navigation
+   * away from a page whose open panel had pushed an entry of its own.
+   */
+  replace?: boolean;
+}
+
+/**
+ * Change the address bar, and tell the router.
+ *
+ * `replaceState(null, …)` also resets `history.state`, which is the signal
+ * `BackStack.close` reads to leave behind an entry it no longer owns. That
+ * behaviour is unchanged and load-bearing; see `hooks/useBackDismiss.ts`.
+ */
+export function navigate(url: string, options: NavigateOptions = {}): void {
+  if (options.replace) {
+    window.history.replaceState(null, "", url);
+  } else {
+    window.history.pushState(null, "", url);
+  }
+  notify();
+}

--- a/packages/web/src/plan/session/persist.ts
+++ b/packages/web/src/plan/session/persist.ts
@@ -25,6 +25,7 @@ import {
 } from "../lastSimulation";
 import { savePlanDraft, clearPlanDraft } from "../draft";
 import type { CacheWrite, PersistCommand, PlanState } from "./reducer";
+import { navigate } from "../../navigation";
 
 /**
  * Merge a committed result into the persisted simulation.
@@ -94,10 +95,13 @@ export function applyCacheWrite(write: CacheWrite): void {
  * `BackStack.close` reads to leave an entry it no longer owns alone. Called
  * from a layout effect for that reason, while the rest waits for the passive
  * pass.
+ *
+ * Goes through `navigate` rather than `history` directly so the router is told
+ * about the rewrite; see `navigation.ts` for what silence cost.
  */
 export function applyUrlWrite(command: PersistCommand): void {
   if (command.url !== undefined) {
-    window.history.replaceState(null, "", command.url);
+    navigate(command.url, { replace: true });
   }
 }
 

--- a/packages/web/src/routeTable.test.ts
+++ b/packages/web/src/routeTable.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it } from "vitest";
+import { matchRoute } from "./routeTable";
+
+describe("matchRoute", () => {
+  it("resolves every page the app publishes", () => {
+    expect(matchRoute("/")).toBe("explore");
+    expect(matchRoute("/plan")).toBe("plan");
+    expect(matchRoute("/config")).toBe("config");
+    expect(matchRoute("/methodologie")).toBe("methodologie");
+    expect(matchRoute("/confidentialite")).toBe("confidentialite");
+  });
+
+  it("answers not-found for an unknown path", () => {
+    // Was the explore map, under an address that does not exist.
+    expect(matchRoute("/plans")).toBe("not-found");
+    expect(matchRoute("/PLAN")).toBe("not-found");
+    expect(matchRoute("/plan/leg/2")).toBe("not-found");
+    expect(matchRoute("/wp-admin")).toBe("not-found");
+  });
+
+  it("does not answer from the prototype chain", () => {
+    // A path is untrusted input. With an object literal these would still be
+    // safe thanks to the leading slash; the Map makes it true without the
+    // reasoning.
+    expect(matchRoute("/constructor")).toBe("not-found");
+    expect(matchRoute("constructor")).toBe("not-found");
+    expect(matchRoute("__proto__")).toBe("not-found");
+  });
+});

--- a/packages/web/src/routeTable.ts
+++ b/packages/web/src/routeTable.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Which page a path resolves to.
+ *
+ * A plain function rather than a table inside `Routes.tsx`, so the routing
+ * rules can be read and tested without mounting an application that pulls in
+ * Leaflet and MapLibre. It is also where "no route matched" became a case of
+ * its own: until now the explore page was the fallback, so a typo in a URL, a
+ * stale bookmark or a crawler on `/plans` got the map under the wrong address,
+ * with nothing saying so.
+ */
+
+export type RouteName =
+  | "explore"
+  | "plan"
+  | "config"
+  | "methodologie"
+  | "confidentialite"
+  | "not-found";
+
+// A Map rather than an object literal: a path is untrusted input, and an
+// object lookup answers "/constructor" with a function from the prototype
+// chain. The leading slash makes that unreachable in practice, which is
+// exactly the kind of reasoning a Map spares the next reader.
+const ROUTES = new Map<string, RouteName>([
+  ["/", "explore"],
+  ["/plan", "plan"],
+  ["/config", "config"],
+  ["/methodologie", "methodologie"],
+  ["/confidentialite", "confidentialite"],
+]);
+
+/** `path` is expected already normalised (see `navigation.normalisePath`). */
+export function matchRoute(path: string): RouteName {
+  return ROUTES.get(path) ?? "not-found";
+}

--- a/packages/web/src/router.test.tsx
+++ b/packages/web/src/router.test.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useRouter } from "./router";
+import { getLocation, navigate, normalisePath } from "./navigation";
+
+// The router calls into the service worker on every navigation. That module
+// registers a worker and imports a virtual one, neither of which belongs in a
+// routing test.
+vi.mock("./sw", () => ({
+  checkForAppUpdate: vi.fn(),
+  flushPendingUpdate: vi.fn(),
+}));
+
+function Probe() {
+  const { path, search } = useRouter();
+  return (
+    <div>
+      <span data-testid="path">{path}</span>
+      <span data-testid="search">{search}</span>
+      <a href="/plan">planifier</a>
+      <a href="/config">réglages</a>
+      <a href="https://example.org/ailleurs">dehors</a>
+      <a href="/exemple.csv" download="exemple.csv">
+        télécharger
+      </a>
+    </div>
+  );
+}
+
+/** jsdom starts every file at the same URL; reset to "/" between cases. */
+beforeEach(() => {
+  window.history.replaceState(null, "", "/");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("normalisePath", () => {
+  it("strips a trailing slash, except on the root", () => {
+    expect(normalisePath("/plan/")).toBe("/plan");
+    expect(normalisePath("/plan")).toBe("/plan");
+    expect(normalisePath("/")).toBe("/");
+  });
+});
+
+describe("getLocation", () => {
+  it("keeps its identity while the URL does not change", () => {
+    // useSyncExternalStore loops forever on a snapshot rebuilt every call.
+    const first = getLocation();
+    expect(getLocation()).toBe(first);
+  });
+
+  it("returns a new snapshot once the URL changes", () => {
+    const first = getLocation();
+    window.history.replaceState(null, "", "/config");
+    const second = getLocation();
+    expect(second).not.toBe(first);
+    expect(second.path).toBe("/config");
+  });
+});
+
+describe("useRouter", () => {
+  it("reports the location at mount", () => {
+    window.history.replaceState(null, "", "/plan?wpts=1,2");
+    const { getByTestId } = render(<Probe />);
+    expect(getByTestId("path").textContent).toBe("/plan");
+    expect(getByTestId("search").textContent).toBe("?wpts=1,2");
+  });
+
+  it("follows a push", () => {
+    const { getByTestId } = render(<Probe />);
+    act(() => {
+      navigate("/config");
+    });
+    expect(getByTestId("path").textContent).toBe("/config");
+    expect(window.location.pathname).toBe("/config");
+  });
+
+  it("follows a replace, which is the case the bug was about", () => {
+    // On /plan without a query string, the mount rewrites the URL with the
+    // restored route. Written straight to `history`, the router kept
+    // `search: ""` and the page remounted at the next back press, dropping
+    // the computed results.
+    window.history.replaceState(null, "", "/plan");
+    const { getByTestId } = render(<Probe />);
+    expect(getByTestId("search").textContent).toBe("");
+    act(() => {
+      navigate("/plan?wpts=43.29,5.37", { replace: true });
+    });
+    expect(getByTestId("search").textContent).toBe("?wpts=43.29,5.37");
+  });
+
+  it("stacks a push and replaces on a replace", () => {
+    const before = window.history.length;
+    act(() => {
+      navigate("/config");
+    });
+    expect(window.history.length).toBe(before + 1);
+    act(() => {
+      navigate("/config?tab=polar", { replace: true });
+    });
+    expect(window.history.length).toBe(before + 1);
+  });
+
+  it("follows a back press", () => {
+    const { getByTestId } = render(<Probe />);
+    act(() => {
+      navigate("/config");
+    });
+    expect(getByTestId("path").textContent).toBe("/config");
+    // The back press itself is the browser's job, and jsdom traverses its
+    // history on a queue we would have to race. What is ours is the listener:
+    // the URL moves, `popstate` fires, and the router has to re-read.
+    act(() => {
+      window.history.replaceState(null, "", "/");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(getByTestId("path").textContent).toBe("/");
+  });
+
+  it("picks up a back press that only closes a panel, without losing the query", () => {
+    // The exact sequence of the bug: /plan mounts, rewrites its own URL, then
+    // a panel is opened and closed. The location the router reports after the
+    // back press must be the rewritten one, unchanged since the rewrite.
+    window.history.replaceState(null, "", "/plan");
+    const { getByTestId } = render(<Probe />);
+    act(() => {
+      navigate("/plan?wpts=43.29,5.37", { replace: true });
+    });
+    act(() => {
+      // A layer pushes an entry with no URL change, then pops it.
+      window.history.pushState({ "ohmywind:layer": 1 }, "");
+      window.history.replaceState(null, "", "/plan?wpts=43.29,5.37");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(getByTestId("path").textContent).toBe("/plan");
+    expect(getByTestId("search").textContent).toBe("?wpts=43.29,5.37");
+  });
+
+  it("intercepts a same-origin link instead of leaving it to the browser", () => {
+    const { getByText, getByTestId } = render(<Probe />);
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 });
+    act(() => {
+      getByText("planifier").dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+    expect(getByTestId("path").textContent).toBe("/plan");
+  });
+
+  it("leaves an external link, a modified click and a download alone", () => {
+    const { getByText, getByTestId } = render(<Probe />);
+    const cases = [
+      [getByText("dehors"), new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })],
+      [getByText("télécharger"), new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })],
+      [
+        getByText("réglages"),
+        new MouseEvent("click", { bubbles: true, cancelable: true, button: 0, metaKey: true }),
+      ],
+      [
+        getByText("réglages"),
+        new MouseEvent("click", { bubbles: true, cancelable: true, button: 1 }),
+      ],
+    ] as const;
+    for (const [el, event] of cases) {
+      act(() => {
+        el.dispatchEvent(event);
+      });
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(getByTestId("path").textContent).toBe("/");
+  });
+
+  it("ignores a click on the URL already displayed", () => {
+    window.history.replaceState(null, "", "/plan");
+    const { getByText } = render(<Probe />);
+    const before = window.history.length;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 });
+    act(() => {
+      getByText("planifier").dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.history.length).toBe(before);
+  });
+
+  it("stops listening once unmounted", () => {
+    const { getByTestId, unmount } = render(<Probe />);
+    const rendered = getByTestId("path");
+    unmount();
+    act(() => {
+      navigate("/config");
+    });
+    // The detached node keeps the last value it was given, and no update was
+    // attempted on an unmounted tree (React would warn).
+    expect(rendered.textContent).toBe("/");
+  });
+});

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { checkForAppUpdate, flushPendingUpdate } from "./sw";
 import { backStack, isLayerEntry } from "./hooks/useBackDismiss";
+import { getLocation, navigate, subscribe, type AppLocation } from "./navigation";
 
 /**
  * Minimal client-side routing, no dependency.
@@ -17,17 +18,10 @@ import { backStack, isLayerEntry } from "./hooks/useBackDismiss";
  * Links are intercepted at the document level rather than replaced by a
  * `<Link>` component. Ordinary `<a href="/plan">` markup keeps working, stays
  * middle-clickable and copyable, and still resolves if the script fails.
+ *
+ * The location itself lives in `navigation.ts`, which every write goes
+ * through. This module is the React face of it, plus the click interception.
  */
-
-/** GitHub Pages appended trailing slashes when a matching directory existed
-    under public/. Strip it so route matching stays a plain comparison. */
-function normalisePath(pathname: string): string {
-  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-}
-
-function currentLocation(): { path: string; search: string } {
-  return { path: normalisePath(window.location.pathname), search: window.location.search };
-}
 
 /** Whether this click should be handled in-app rather than by the browser. */
 function isInAppNavigation(e: MouseEvent, anchor: HTMLAnchorElement): boolean {
@@ -43,18 +37,13 @@ function isInAppNavigation(e: MouseEvent, anchor: HTMLAnchorElement): boolean {
   return !!href && href.startsWith("/") && !href.startsWith("//");
 }
 
-export function useRouter(): { path: string; search: string } {
-  const [location, setLocation] = useState(currentLocation);
+export function useRouter(): AppLocation {
+  const location = useSyncExternalStore(subscribe, getLocation);
 
   useEffect(() => {
-    const sync = () => {
-      setLocation(currentLocation());
-      // Navigations no longer hit the network, so this is now the only
-      // regular occasion to notice a deploy. Throttled and best-effort.
-      checkForAppUpdate();
-    };
-
-    const onPopState = () => sync();
+    // Navigations no longer hit the network, so a click is now the only
+    // regular occasion to notice a deploy. Throttled and best-effort.
+    const onPopState = () => checkForAppUpdate();
 
     const onClick = (e: MouseEvent) => {
       const target = e.target;
@@ -69,18 +58,14 @@ export function useRouter(): { path: string; search: string } {
       // transient state of the page being left, so the navigation takes its
       // place rather than stacking on top of it. Otherwise a back press would
       // land on an entry whose panel is long gone and appear to do nothing.
-      if (isLayerEntry(window.history.state)) {
-        window.history.replaceState(null, "", href);
-      } else {
-        window.history.pushState(null, "", href);
-      }
+      navigate(href, { replace: isLayerEntry(window.history.state) });
       backStack.detachAll();
       window.scrollTo(0, 0);
-      sync();
+      checkForAppUpdate();
       // Safest occasion to apply an update already found and held back: the
       // reader asked to change view, so a reload here reads as that
-      // navigation. Deliberately not in `sync`, which also runs on `popstate`
-      // — a back press that only dismisses a panel must not reload the page.
+      // navigation. Deliberately not on `popstate`: a back press that only
+      // dismisses a panel must not reload the page.
       flushPendingUpdate();
     };
 
@@ -97,4 +82,4 @@ export function useRouter(): { path: string; search: string } {
   return location;
 }
 
-export { normalisePath };
+export { navigate };

--- a/packages/web/src/routes/NotFoundPage.tsx
+++ b/packages/web/src/routes/NotFoundPage.tsx
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * No route matched.
+ *
+ * The explore map used to be the fallback for every unknown path, so a typo,
+ * a stale bookmark or a crawler landed on the app under an address that does
+ * not exist, with nothing to say so and no way back except editing the URL.
+ */
+export function NotFoundPage() {
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center gap-4 px-6 text-center"
+      style={{ background: "var(--ow-bg-0)", color: "var(--ow-fg-1)" }}
+    >
+      <p
+        className="text-5xl font-bold tabular-nums"
+        style={{ color: "var(--ow-accent)", fontFamily: "var(--ow-font-mono)" }}
+      >
+        404
+      </p>
+      <h1 className="text-lg font-semibold" style={{ color: "var(--ow-fg-0)" }}>
+        Cette page n'existe pas
+      </h1>
+      <p className="max-w-sm text-sm">
+        Le lien est peut-être incomplet, ou la page a changé d'adresse.
+      </p>
+      <a
+        href="/"
+        className="mt-2 min-h-[44px] px-5 py-2.5 rounded-lg text-sm font-semibold inline-flex items-center transition-all active:scale-[0.98]"
+        style={{ background: "var(--ow-accent)", color: "var(--ow-bg-0)" }}
+      >
+        Retour à la carte
+      </a>
+    </div>
+  );
+}

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -28,6 +28,7 @@ import { useBackDismiss } from "../hooks/useBackDismiss";
 import { useMapView } from "../hooks/useMapView";
 import { LG_MEDIA_QUERY, useMediaQuery } from "../hooks/useMediaQuery";
 import { parseMapView, mapViewQuery } from "../utils/mapViewParams";
+import { navigate } from "../navigation";
 
 // ── local helpers (mobile components) ────────────────────────────────────────
 
@@ -452,10 +453,13 @@ export function PlanPage() {
   // and computing when nothing usable could be restored.
   useEffect(() => {
     if (initial.mount.rewriteUrl) {
-      window.history.replaceState(
-        null,
-        "",
+      // Through the router, not through `history` directly: this rewrite
+      // happens on the page the reader is already on, and a router left
+      // holding the previous URL remounted the planner at the next back
+      // press, results and all.
+      navigate(
         buildPlanUrl(initial.waypoints, initial.departure, initial.archetype),
+        { replace: true },
       );
     }
     if (initial.mount.fetch) actions.compute();


### PR DESCRIPTION
Lot 4, PR 4.6. Le bug préexistant relevé par l'agent du lot 1 et consigné en fin de section « Lot 1 » de `plan/audit-2026-09/02-suivi-lot0.md`, plus la 404 de l'annexe B (Mo1).

## Le défaut

`pushState` et `replaceState` sont silencieux : le navigateur n'émet aucun événement pour eux, seulement pour un retour ou une avance. Tout code qui écrivait dans la barre d'adresse laissait donc `useRouter()` sur l'URL d'avant, jusqu'au prochain `popstate`.

Ce n'est pas un point de propreté. La séquence :

1. `/plan` ouvert sans query string. `useRouter()` retient `{ path: "/plan", search: "" }`, `Routes` en fait la clé `"/plan"`.
2. `PlanPage` monte, restaure la route depuis le cache et réécrit l'URL en `/plan?wpts=…` avec un `replaceState` direct. Le routeur n'en sait rien.
3. Le lecteur ouvre le sélecteur de bateau : `useBackDismiss` pousse une entrée d'historique à lui, sans changer l'URL.
4. Il le referme d'un retour. `popstate` arrive, le routeur relit enfin la localisation, la clé passe de `"/plan"` à `"/plan?wpts=…"`, et **`PlanPage` remonte**.

Au remontage, `resolveInitialSession` repart des trois médias, et le brouillon de `sessionStorage` l'emporte par construction sur l'URL et sur le cache. Si le lecteur avait touché à sa route depuis le dernier calcul, c'est le brouillon qui revient : les résultats calculés disparaissent sur un geste censé seulement fermer un panneau.

## Le correctif

- **`src/navigation.ts`** : la localisation devient un store unique, avec `navigate(url, { replace })` qui écrit *puis* prévient. Aucun écouteur ne peut plus être manqué, et il y a un seul endroit où chercher ce qui change l'URL. Le module est tenu hors de React et hors du service worker, parce que la session de plan persiste son URL depuis un effet de layout et doit pouvoir l'importer sans traîner ni l'un ni l'autre.
  `getLocation()` relit `window.location` à chaque appel mais ne renvoie un nouvel objet que si l'URL a bougé : c'est ce que `useSyncExternalStore` exige, et une écriture venue d'ailleurs est quand même rattrapée au rendu suivant plutôt qu'ignorée pour toujours.
- **`src/router.tsx`** : `useRouter` passe sur `useSyncExternalStore`, l'interception des clics est inchangée. Les deux `replaceState` restants (le montage de `PlanPage`, `persist.applyUrlWrite`) passent par `navigate`. Le `replaceState(null, …)` continue de remettre `history.state` à `null`, signal que `BackStack.close` lit : ce comportement est porté par `navigate` et reste documenté aux deux endroits.
- **`Routes.tsx` est clé sur le chemin seul.** Une navigation remonte toujours la page, ce que les pages attendent (chacune lit sa query string une fois, au montage) ; une *réécriture* de query string sur la page où l'on est déjà ne le fait plus. Vérifié : aucun lien de l'application ne va d'une query string à une autre sous le même chemin, les deux liens qui portent une query (`/plan?center=…` depuis l'explorateur, `/?center=…` depuis le planificateur) changent aussi de chemin.
- **`src/routeTable.ts`** : `matchRoute(path)` sort la table de `Routes.tsx`, testable sans monter une application qui tire Leaflet et MapLibre. Une `Map` plutôt qu'un objet littéral, parce qu'un chemin est une entrée non fiable et qu'un littéral répond à `"constructor"` par une fonction du prototype.
- **`src/routes/NotFoundPage.tsx`** : une 404 en français, avec un retour vers la carte. Jusqu'ici l'explorateur était le repli de tout chemin inconnu : une faute de frappe, un favori périmé ou un robot obtenaient la carte sous une adresse qui n'existe pas, sans rien pour le dire.

## Tests

Tests 634 → 651. `src/router.test.tsx` (jsdom) : localisation au montage, `navigate` en push et en replace, longueur de l'historique, `popstate`, la séquence exacte du bug (réécriture puis retour qui ne ferme qu'un panneau), clic intercepté, clic externe ou modifié ou `download` laissé au navigateur, clic sur l'URL déjà affichée, démontage. `src/routeTable.test.ts` : chaque page, les chemins inconnus, le prototype.

## Vérifications live, et ce qu'elles ne montrent pas

Aperçu de production (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`) :

- `/plans` affiche la 404, avec le bouton « Retour à la carte ».
- `/plan` sans query string : le montage restaure la route et réécrit l'URL ; une entrée de panneau poussée puis dépilée laisse l'URL et les résultats intacts (38,1 nm, 15h17 avant et après).
- Navigation ordinaire : clic sur l'engrenage vers `/config` puis retour, la carte revient avec son plan.

**Ce que je n'ai pas reproduit en live** : la perte visible des résultats. Elle demande un brouillon de `sessionStorage` divergent de l'URL, donc une édition de route entre deux calculs, que je n'ai pas mise en scène ; sans brouillon divergent, le remontage relit la même URL et le même cache et réaffiche la même chose. Le mécanisme, lui, est couvert de façon déterministe par le test du routeur. À rejouer à la main sur `dev` avec le parcours J5 (tracer, calculer, déplacer un waypoint, ouvrir puis fermer le sélecteur de bateau).

Ce correctif touche aussi l'issue **#300** (bouton retour Android) par la bande : le premier retour ne remonte plus la page. À re-tester sur l'app TWA dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
