### PR TITLE
feat(pwa): cache runtime borné du fond de carte et état hors ligne (lot 5.1)

### DIFF
--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -150,6 +150,11 @@ describe("error contract: code first, English text as fallback", () => {
       expect: /trop de temps à répondre/,
     },
     {
+      code: "upstream_unavailable",
+      text: "backend temporarily unavailable",
+      expect: /momentanément injoignable/,
+    },
+    {
       code: "upstream_rate_limited",
       text: "upstream weather service rate limit reached",
       expect: /pas lié à votre usage/,
@@ -291,5 +296,72 @@ describe("panne de transport", () => {
     // Un serveur qui a repondu a toujours raison sur la cause.
     const answered = new ApiError("rate limit exceeded", "rate_limited", 60);
     expect(friendlyError(answered)).toContain("Trop de calculs");
+  });
+});
+
+// Le proxy de bord (PR #350) repond 503
+// {"error":"backend temporarily unavailable","code":"upstream_unavailable",
+//  "retry_after":30} quand le Space ne repond pas, le plus souvent parce
+// qu'il dort et se reveille. Sans copie dediee, c'est l'anglais brut qui
+// s'affichait.
+describe("backend injoignable vu du proxy de bord", () => {
+  /** Meme doublure minimale que `toError` ci-dessus. */
+  function edgeResponse(): Response {
+    const headers: Record<string, string> = { "Retry-After": "30" };
+    return {
+      ok: false,
+      status: 503,
+      headers: { get: (k: string) => headers[k] ?? null },
+      json: async () => ({
+        error: "backend temporarily unavailable",
+        code: "upstream_unavailable",
+        retry_after: 30,
+      }),
+    } as unknown as Response;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("lit le code et relaie le delai que le bord a annonce", async () => {
+    vi.stubGlobal("fetch", async () => edgeResponse());
+    const { fetchPassage } = await import("./passage");
+    let error: ApiError | null = null;
+    try {
+      await fetchPassage({
+        waypoints: [[43, 5], [43.1, 5.1]],
+        departure: "2026-09-04T08:00:00+02:00",
+        archetype: "cruiser_30ft",
+      });
+    } catch (e) {
+      error = e as ApiError;
+    }
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("upstream_unavailable");
+    expect(error!.retryAfter).toBe(30);
+    const msg = friendlyError(error!);
+    expect(msg).toContain("momentanément injoignable");
+    // Le delai vient du bord, jamais d'une constante d'ici : c'est la lecon
+    // de l'incident de copie sur la limitation de debit.
+    expect(msg).toContain("30 secondes");
+    expect(msg).not.toContain("backend temporarily unavailable");
+  });
+
+  it("reste vague quand le bord n'annonce aucun delai", () => {
+    const msg = friendlyError(new ApiError("backend down", "upstream_unavailable", null));
+    expect(msg).toContain("momentanément injoignable");
+    expect(msg).toContain("quelques minutes");
+    expect(msg).not.toMatch(/\d/);
+  });
+
+  it("ne se confond pas avec l'indisponibilite du service meteo amont", () => {
+    // `upstream_timeout` et `upstream_rate_limited` parlent d'Open-Meteo ;
+    // `upstream_unavailable` parle de notre propre backend. Deux phrases
+    // distinctes, sinon le lecteur cherche la panne du mauvais cote.
+    const ours = friendlyError(new ApiError("x", "upstream_unavailable", null));
+    const theirs = friendlyError(new ApiError("x", "upstream_timeout", null));
+    expect(ours).not.toBe(theirs);
+    expect(theirs).toContain("service météo");
   });
 });

--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -251,3 +251,45 @@ describe("toError", () => {
     expect(friendlyError(error)).toMatch(/indisponible/);
   });
 });
+
+// Une requete qui n'atteint jamais de serveur n'a pas de corps a lire : elle
+// rejette avec l'erreur du moteur du navigateur, en anglais, et c'est ce
+// texte brut qui s'affichait ("Failed to fetch"). C'est pourtant le cas le
+// plus frequent en mer, ou le reseau tombe pour de bon.
+describe("panne de transport", () => {
+  const sentence = "Impossible de joindre le serveur. Vérifiez votre connexion puis réessayez.";
+
+  it("reconnait le rejet de fetch de chaque moteur", () => {
+    // Chrome, Firefox, Safari, undici (Node) : meme panne, quatre libelles.
+    for (const message of [
+      "Failed to fetch",
+      "NetworkError when attempting to fetch resource.",
+      "Load failed",
+      "fetch failed",
+    ]) {
+      expect(friendlyError(new TypeError(message))).toBe(sentence);
+    }
+  });
+
+  it("reconnait un delai depasse et un abandon", () => {
+    const timeout = new Error("signal timed out");
+    timeout.name = "TimeoutError";
+    const aborted = new Error("aborted");
+    aborted.name = "AbortError";
+    expect(friendlyError(timeout)).toBe(sentence);
+    expect(friendlyError(aborted)).toBe(sentence);
+  });
+
+  it("laisse passer un TypeError qui n'a rien a voir avec le reseau", () => {
+    // Un bug a nous ne doit pas se deguiser en probleme de connexion : le
+    // message d'origine reste lisible pour qui debogue.
+    const bug = new TypeError("x.map is not a function");
+    expect(friendlyError(bug)).toBe("x.map is not a function");
+  });
+
+  it("laisse la priorite au contrat d'erreur du serveur", () => {
+    // Un serveur qui a repondu a toujours raison sur la cause.
+    const answered = new ApiError("rate limit exceeded", "rate_limited", 60);
+    expect(friendlyError(answered)).toContain("Trop de calculs");
+  });
+});

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -60,6 +60,7 @@ export function formatRetryDelay(seconds: number | null): string {
  * | `sweep_too_large` | the sweep would produce too many windows |
  * | `upstream_timeout` | the weather service did not answer in time |
  * | `upstream_rate_limited` | the weather service is throttling *us* |
+ * | `upstream_unavailable` | the edge proxy could not reach our own backend |
  * | `body_too_large` | request body over the cap |
  * | `invalid_forecast_cache` | the attached corridor did not check out |
  *
@@ -191,6 +192,14 @@ const ERROR_COPY: Record<string, (retryAfter: number | null) => string> = {
   // is our own limiter and IS about the caller's pace.
   upstream_rate_limited: () =>
     "Le service météo limite temporairement nos requêtes. Ce n'est pas lié à votre usage, réessayez dans quelques minutes.",
+  // Emis par le proxy de bord (Worker Cloudflare), pas par le Space : le
+  // backend n'a pas repondu du tout. A ne pas confondre avec les deux
+  // `upstream_*` ci-dessus, ou le service amont est Open-Meteo ; ici l'amont
+  // vu du bord, c'est nous. Cause la plus frequente : le Space dort et se
+  // reveille, ce qui prend une trentaine de secondes, d'ou le delai que le
+  // bord envoie et que l'on relaie plutot que d'en inventer un.
+  upstream_unavailable: (retryAfter) =>
+    `Le serveur est momentanément injoignable, il redémarre peut-être. ${formatRetryDelay(retryAfter)}`,
   body_too_large: () =>
     "La route est trop détaillée pour être envoyée. Retirez quelques waypoints ou raccourcissez la période.",
   invalid_forecast_cache: () =>
@@ -238,6 +247,12 @@ function matchErrorText(raw: string): string {
   }
   if (/upstream weather service rate limit/i.test(raw)) {
     return ERROR_COPY.upstream_rate_limited(null);
+  }
+  if (/backend temporarily unavailable/i.test(raw)) {
+    // Meme forme que la regle de limitation : le delai est ajoute par
+    // `toError` en suffixe, pas par le bord dans sa phrase.
+    const retryIn = /retry in (\d+)s/i.exec(raw);
+    return ERROR_COPY.upstream_unavailable(retryIn ? Number(retryIn[1]) : null);
   }
   if (/Erreur serveur 5\d\d/.test(raw) || /HTTP 5\d\d/.test(raw)) {
     return ERROR_COPY.server_unavailable(null);

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -124,7 +124,33 @@ export function friendlyError(raw: string | Error): string {
     return ERROR_COPY[raw.code](raw.retryAfter);
   }
   if (raw instanceof ApiShapeError) return ERROR_COPY.invalid_response(null);
+  // Avant la lecture du texte : une requete qui n'a jamais atteint de serveur
+  // n'a pas de contrat d'erreur a lire, et son message est celui du moteur du
+  // navigateur, en anglais.
+  if (isNetworkFailure(raw)) return ERROR_COPY.network_unreachable(null);
   return matchErrorText(raw.message);
+}
+
+/**
+ * Une panne de transport, par opposition a une reponse du serveur.
+ *
+ * `fetch` rejette avec un `TypeError` quand la requete n'est jamais partie ou
+ * n'est jamais revenue : coupure reseau, DNS, TLS, origine injoignable. Le
+ * libelle differe d'un moteur a l'autre (« Failed to fetch » sur Chrome,
+ * « NetworkError when attempting to fetch resource. » sur Firefox, « Load
+ * failed » sur Safari), d'ou la liste. Le nom de l'erreur est teste en plus
+ * du type parce qu'un `DOMException` d'abandon n'est pas un `TypeError` :
+ * `AbortSignal.timeout` rejette en `TimeoutError`, un abandon explicite en
+ * `AbortError`. Les abandons volontaires (un calcul plus recent remplace
+ * celui en vol) ne passent jamais par ici : `usePlanSession` les ecarte avant
+ * d'appeler cette fonction.
+ */
+function isNetworkFailure(error: Error): boolean {
+  if (error.name === "AbortError" || error.name === "TimeoutError") return true;
+  if (!(error instanceof TypeError)) return false;
+  return /failed to fetch|network\s?error|load failed|network request failed|fetch failed/i.test(
+    error.message,
+  );
 }
 
 /** French copy per stable code. `retryAfter` is only read by `rate_limited`. */
@@ -171,6 +197,11 @@ const ERROR_COPY: Record<string, (retryAfter: number | null) => string> = {
     "Les données météo préparées par le navigateur ont été refusées. Réessayez : le calcul repartira des données du serveur.",
   server_unavailable: () =>
     "Le serveur météo est indisponible. Réessayez dans quelques instants.",
+  // Pas un code du serveur : la requete n'a jamais abouti (reseau coupe,
+  // portail captif, delai depasse). Rien a dire sur la meteo, tout a dire sur
+  // le lien. Voir `isNetworkFailure`.
+  network_unreachable: () =>
+    "Impossible de joindre le serveur. Vérifiez votre connexion puis réessayez.",
   // Not a server code: a 200 whose body is not the contract (see parse.ts).
   invalid_response: () =>
     "Le serveur a renvoyé une réponse inattendue. Réessayez dans quelques instants.",

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { SpotSearch } from "./SpotSearch";
 import { ThemeToggle } from "../design/theme";
 import { InfoButton } from "./InfoButton";
 import { rememberReturnPath } from "../config/returnPath";
+import { OfflineBanner } from "./OfflineBanner";
 
 
 interface HeaderProps {
@@ -77,6 +78,11 @@ export function Header({ onSelectSpot, nearLat, nearLon, savedSpots }: HeaderPro
         <SettingsButton />
         <ThemeToggle />
       </div>
+      {/* Sous la barre plutot qu'au-dessus : la ligne du logo et de la
+          recherche ne bouge pas quand le reseau tombe. Rendu ici parce que
+          l'explorateur et le planificateur montent tous deux ce header, donc
+          une seule instance couvre les deux ecrans. */}
+      <OfflineBanner />
     </header>
   );
 }

--- a/packages/web/src/components/OfflineBanner.test.tsx
+++ b/packages/web/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { OfflineBanner } from "./OfflineBanner";
+
+function setOnLine(value: boolean) {
+  Object.defineProperty(window.navigator, "onLine", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  setOnLine(true);
+});
+
+describe("OfflineBanner", () => {
+  it("ne montre rien tant que le navigateur a du reseau", () => {
+    render(<OfflineBanner />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("apparait a la coupure et disparait au retour", () => {
+    render(<OfflineBanner />);
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    const banner = screen.getByRole("status");
+    expect(banner.textContent).toContain("Hors connexion");
+    expect(banner.textContent).toContain("prévisions");
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("n'ecrit aucune couleur en dur", () => {
+    setOnLine(false);
+    render(<OfflineBanner />);
+    // Les couleurs viennent des jetons : un hex ici casserait le theme clair.
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("style")).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(banner.getAttribute("style")).toContain("--ow-warn");
+  });
+});

--- a/packages/web/src/components/OfflineBanner.tsx
+++ b/packages/web/src/components/OfflineBanner.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { useOnline } from "../hooks/useOnline";
+
+/**
+ * One line under the header, only while the browser reports no network.
+ *
+ * Placed in the `Header`, which the explorer and the planner both mount, so
+ * there is a single instance and a single wording. Discreet on purpose: the
+ * shell, the map already loaded and a plan already computed all keep working
+ * offline. What stops is the refresh of the forecasts, and that is what the
+ * sentence says, rather than a blanket "no connection" that would suggest the
+ * page is broken.
+ *
+ * `role="status"` and not `alert`: losing the network is worth announcing to
+ * a screen reader once it is idle, not worth interrupting whatever it is
+ * reading. Every colour comes from the warning tokens, so the banner follows
+ * the light and dark themes without a hard-coded value.
+ */
+export function OfflineBanner() {
+  const online = useOnline();
+  if (online) return null;
+  return (
+    <div
+      role="status"
+      className="max-w-screen-2xl mx-auto mt-2 px-2.5 py-1.5 rounded-md text-[12px] font-medium flex items-center gap-2"
+      style={{
+        background: "var(--ow-warn-soft)",
+        border: "1px solid var(--ow-warn-line)",
+        color: "var(--ow-warn)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ background: "var(--ow-warn)" }}
+      />
+      Hors connexion : les prévisions ne peuvent pas être actualisées.
+    </div>
+  );
+}

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -8,6 +8,7 @@ import { WindCell } from "./WindCell";
 import { useTimezone } from "../hooks/useTimezone";
 import { nowParisHourPrefix } from "../domain/datetime";
 import { useTimelineScroll } from "../hooks/useTimelineScroll";
+import { useOnline } from "../hooks/useOnline";
 import { MODEL_META, type ModelName } from "../config/modelConfig";
 
 function modelStep(name: string): number {
@@ -79,6 +80,25 @@ function SkeletonTable() {
   );
 }
 
+/**
+ * Aucun modele n'a repondu pour ce point.
+ *
+ * `fetchAllModels` avale les echecs reseau et rend une liste vide, exactement
+ * comme un point hors de toutes les grilles : le tableau ne peut donc pas
+ * distinguer les deux cas tout seul. Le navigateur, lui, le sait. Hors ligne,
+ * on nomme la cause au lieu de laisser croire que la mer n'a pas de meteo.
+ */
+function EmptyForecast() {
+  const online = useOnline();
+  return (
+    <div className="text-center py-8 px-4 text-sm" style={{ color: 'var(--ow-fg-2)' }}>
+      {online
+        ? "Aucune donnée disponible pour ce point."
+        : "Hors connexion : impossible de récupérer les prévisions. Reconnectez-vous puis touchez à nouveau ce point."}
+    </div>
+  );
+}
+
 export function WindTable({
   forecasts,
   isLoading,
@@ -110,11 +130,7 @@ export function WindTable({
   }
 
   if (forecasts.length === 0) {
-    return (
-      <div className="text-center py-8 text-sm" style={{ color: 'var(--ow-fg-2)' }}>
-        No data available
-      </div>
-    );
+    return <EmptyForecast />;
   }
 
   return (

--- a/packages/web/src/hooks/useOnline.test.tsx
+++ b/packages/web/src/hooks/useOnline.test.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { onlineStore, useOnline, type OnlineEventTargetLike, type OnlineSourceLike } from "./useOnline";
+
+function fakeTarget() {
+  const listeners = new Map<string, Set<() => void>>();
+  const target: OnlineEventTargetLike & { fire: (type: string) => void; count: number } = {
+    addEventListener: (type, listener) => {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener: (type, listener) => void listeners.get(type)?.delete(listener),
+    fire: (type) => listeners.get(type)?.forEach((l) => l()),
+    get count() {
+      let n = 0;
+      listeners.forEach((set) => (n += set.size));
+      return n;
+    },
+  };
+  return target;
+}
+
+describe("onlineStore", () => {
+  it("reads the browser's current answer", () => {
+    expect(onlineStore({ onLine: true }, null).getSnapshot()).toBe(true);
+    expect(onlineStore({ onLine: false }, null).getSnapshot()).toBe(false);
+  });
+
+  it("re-reads the source rather than caching the first answer", () => {
+    const source: OnlineSourceLike & { onLine: boolean } = { onLine: true };
+    const store = onlineStore(source, null);
+    source.onLine = false;
+    expect(store.getSnapshot()).toBe(false);
+  });
+
+  it("subscribes to both events and detaches on unsubscribe", () => {
+    const target = fakeTarget();
+    const store = onlineStore({ onLine: true }, target);
+    let notified = 0;
+    const unsubscribe = store.subscribe(() => (notified += 1));
+    expect(target.count).toBe(2);
+    target.fire("offline");
+    target.fire("online");
+    expect(notified).toBe(2);
+    unsubscribe();
+    expect(target.count).toBe(0);
+    target.fire("offline");
+    expect(notified).toBe(2);
+  });
+
+  it("reads as online without a DOM, and unsubscribing is safe", () => {
+    // No `navigator`, no `window`: a browser too old for the API, or any
+    // non-DOM render path. Neither may be accused of being offline.
+    const store = onlineStore(null, null);
+    expect(store.getSnapshot()).toBe(true);
+    expect(() => store.subscribe(() => {})()).not.toThrow();
+  });
+});
+
+function Probe() {
+  return <span>{useOnline() ? "en ligne" : "hors ligne"}</span>;
+}
+
+// jsdom's `navigator.onLine` is a getter on the prototype and always true.
+// Overriding the own property is how a lost signal is simulated; each test
+// puts it back so the next one starts from a connected browser.
+function setOnLine(value: boolean) {
+  Object.defineProperty(window.navigator, "onLine", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  setOnLine(true);
+});
+
+describe("useOnline", () => {
+  it("starts from what the browser reports at mount", () => {
+    setOnLine(false);
+    render(<Probe />);
+    expect(screen.getByText("hors ligne")).toBeTruthy();
+  });
+
+  it("follows the offline and online events", () => {
+    render(<Probe />);
+    expect(screen.getByText("en ligne")).toBeTruthy();
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(screen.getByText("hors ligne")).toBeTruthy();
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(screen.getByText("en ligne")).toBeTruthy();
+  });
+});

--- a/packages/web/src/hooks/useOnline.ts
+++ b/packages/web/src/hooks/useOnline.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { useMemo, useSyncExternalStore } from "react";
+
+/**
+ * What the store reads: the browser's own idea of whether it has a network.
+ *
+ * Split from the event target so a test can move `onLine` under a live
+ * subscription, which is exactly what a phone losing its signal does.
+ */
+export interface OnlineSourceLike {
+  readonly onLine: boolean;
+}
+
+/** The slice of `window` the store subscribes to. */
+export interface OnlineEventTargetLike {
+  addEventListener(type: "online" | "offline", listener: () => void): void;
+  removeEventListener(type: "online" | "offline", listener: () => void): void;
+}
+
+/**
+ * Pure: turns `navigator` plus `window` into the `subscribe`/`getSnapshot`
+ * pair `useSyncExternalStore` wants.
+ *
+ * Either half may be `null` (no DOM at all): the store then reads as online
+ * and subscribes to nothing. Reading as online is the deliberate default,
+ * see `useOnline` below.
+ */
+export function onlineStore(
+  source: OnlineSourceLike | null,
+  target: OnlineEventTargetLike | null,
+): {
+  subscribe: (onChange: () => void) => () => void;
+  getSnapshot: () => boolean;
+} {
+  return {
+    subscribe(onChange) {
+      if (!target) return () => {};
+      target.addEventListener("online", onChange);
+      target.addEventListener("offline", onChange);
+      return () => {
+        target.removeEventListener("online", onChange);
+        target.removeEventListener("offline", onChange);
+      };
+    },
+    getSnapshot: () => source?.onLine ?? true,
+  };
+}
+
+/**
+ * Whether the browser believes it has a network, kept in sync with the
+ * `online` and `offline` events.
+ *
+ * ## What this value proves, and what it does not
+ *
+ * The two directions are not symmetric, and the copy keyed on this hook
+ * depends on knowing which is which:
+ *
+ * - `false` is trustworthy. The browser reports no link at all (airplane
+ *   mode, no interface up), and no request can succeed. That is the case
+ *   worth telling the sailor about, because a forecast that cannot be
+ *   refreshed is the one thing this app must never let pass silently.
+ * - `true` proves nothing. A captive portal, a marina wifi with no route
+ *   out, or an origin that is down all read as online. So `true` is never
+ *   used to promise anything, only to hide the warning.
+ *
+ * That asymmetry is why the fallbacks read as online: a browser without the
+ * API, and any non-DOM render path, must not be accused of being offline.
+ * The request itself remains the source of truth for failure, and
+ * `friendlyError` in `api/passage.ts` handles the network error on its own.
+ *
+ * `useSyncExternalStore` rather than state plus an effect: the value is read
+ * from the browser during render, so there is no frame where the banner and
+ * the actual connectivity disagree.
+ */
+export function useOnline(): boolean {
+  const store = useMemo(
+    () =>
+      onlineStore(
+        typeof navigator !== "undefined" ? navigator : null,
+        typeof window !== "undefined" ? window : null,
+      ),
+    [],
+  );
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, () => true);
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -105,9 +105,74 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         // SPA fallback so deep links (/plan, /config, ...) resolve offline.
         navigateFallback: '/index.html',
-        // No runtimeCaching on purpose: Leaflet map tiles and the Open-Meteo /
-        // MCP APIs must always hit the network (fresh marine data, avoid a fat
-        // opaque cache). Only the static app shell is cached for offline res.
+        // Doctrine du cache runtime : le fond de carte, et rien d'autre.
+        //
+        // Ce qui entre au cache : les octets statiques d'OpenFreeMap. Les
+        // tuiles vectorielles, les glyphes, les sprites et les fonds Natural
+        // Earth sont versionnes dans leur URL et servis avec un
+        // `Cache-Control` de dix ans ; ils ne changent jamais sous une URL
+        // donnee. Sans eux, un rechargement hors ligne affiche la coque de
+        // l'application au-dessus d'un carre vide, alors que ce sont les
+        // seules donnees de la page qui ne perimeront pas.
+        //
+        // Ce qui n'y entre jamais : les donnees marines. Open-Meteo
+        // (`api.open-meteo.com`, `marine-api.open-meteo.com`), notre propre
+        // API (`mcp.ohmywind.fr`, `mcp-dev.ohmywind.fr`, les Spaces
+        // `*.hf.space`), EMODnet et les geocodeurs restent toujours reseau :
+        // une prevision servie depuis un cache est une prevision fausse, et
+        // c'est sur elle que se decide une sortie en mer. Elles n'ont donc
+        // aucune regle ici, et l'absence de regle est la garantie : Workbox
+        // ne touche pas a ce qu'il ne reconnait pas.
+        //
+        // OpenSeaMap est exclu pour une autre raison : ses tuiles sont
+        // chargees par Leaflet en balise <img> sans `crossOrigin`, donc la
+        // reponse est opaque. Une entree opaque compte pour plusieurs Mo dans
+        // le quota d'origine quelle que soit sa taille reelle, et son statut
+        // (0) empeche de distinguer une tuile d'une erreur. Le jour ou la
+        // couche marine passera en `crossOrigin`, la question pourra se
+        // reposer.
+        runtimeCaching: [
+          {
+            // Contenus versionnes d'OpenFreeMap. `CacheFirst` parce que
+            // l'URL porte la version du planet : le contenu ne bouge pas,
+            // revalider serait un aller-retour pour rien.
+            urlPattern: /^https:\/\/tiles\.openfreemap\.org\/(planet|fonts|sprites|natural_earth)\//,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "ow-basemap-v1",
+              expiration: {
+                // 600 entrees couvrent la vue initiale (25 requetes) et
+                // plusieurs zones parcourues, sans devenir un depot sans fond.
+                maxEntries: 600,
+                maxAgeSeconds: 7 * 24 * 60 * 60,
+                // Si le navigateur refuse une ecriture faute de place, le
+                // cache se purge au lieu de rester coince en echec.
+                purgeOnQuotaError: true,
+              },
+              // 200 seulement, jamais 0 : OpenFreeMap repond en CORS `*` et
+              // MapLibre le lit en `fetch`, donc les reponses utiles sont des
+              // 200 lisibles. Admettre le statut 0 ferait entrer des reponses
+              // opaques, impossibles a distinguer d'une erreur et comptees au
+              // quota a leur taille rembourree.
+              cacheableResponse: { statuses: [200] },
+            },
+          },
+          {
+            // Les documents qui pointent vers ces contenus : la feuille de
+            // style et le TileJSON. Eux changent (nouvelle version du planet,
+            // retouche de style) et sont servis en `max-age` d'un jour.
+            // `StaleWhileRevalidate` rend la carte immediate et ramene la
+            // nouvelle version en arriere-plan ; hors ligne, la derniere
+            // connue suffit a afficher les tuiles deja en cache.
+            urlPattern: /^https:\/\/tiles\.openfreemap\.org\/(styles\/|planet$|natural_earth$)/,
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "ow-basemap-style-v1",
+              expiration: { maxEntries: 16, maxAgeSeconds: 24 * 60 * 60 },
+              cacheableResponse: { statuses: [200] },
+            },
+          },
+        ],
       },
       devOptions: {
         // Keep `npm run dev` free of the service worker.


### PR DESCRIPTION
Lot 5.1 du plan de rework, sous **[GO 5]**. Change une doctrine : jusqu'ici le service worker ne cachait rien au-delà de la coque précachée.

## Le problème

Annexe D, constat 3 et annexe E, problème 3 : aucun état hors ligne nulle part, et le fond de carte n'était jamais mis en cache. Concrètement :

- rechargement sans réseau : la coque s'affiche (précache), la carte est un carré vide ;
- 1,76 Mo d'OpenFreeMap retéléchargés à chaque session froide (25 requêtes avant la moindre interaction) ;
- l'explorateur avalait les échecs réseau et affichait `No data available`, en anglais, sans dire pourquoi ;
- le planificateur affichait le message brut du moteur, `Failed to fetch`.

## La doctrine retenue

Le fond de carte statique entre au cache, borné. Les données marines n'y entrent jamais.

Les octets d'OpenFreeMap portent la version du planet dans leur URL et sont servis en `Cache-Control` de dix ans : sous une URL donnée, ils ne changent pas. Une prévision, elle, change ; servie depuis un cache, c'est une prévision fausse, et c'est sur elle que se décide une sortie en mer.

| Origine | Règle |
|---|---|
| `tiles.openfreemap.org/(planet\|fonts\|sprites\|natural_earth)/` | `CacheFirst`, `ow-basemap-v1`, 600 entrées, 7 jours, `purgeOnQuotaError` |
| `tiles.openfreemap.org/styles/…` et le TileJSON `/planet` | `StaleWhileRevalidate` 24 h, `ow-basemap-style-v1`, 16 entrées |
| `api.open-meteo.com`, `marine-api.open-meteo.com`, `mcp*.ohmywind.fr`, `*.hf.space`, EMODnet, Nominatim, Photon | aucune règle, donc toujours réseau |
| `tiles.openseamap.org` | aucune règle : tuiles chargées en `<img>` sans `crossOrigin`, donc réponses opaques |

Deux points qui ne sont pas dans le plan et qui ont été tranchés à la mesure :

- **`statuses: [200]`, pas `[0, 200]`.** OpenFreeMap répond en CORS `*` et MapLibre lit en `fetch` : les réponses utiles sont des 200 lisibles. Admettre le statut 0 ferait entrer des réponses opaques, impossibles à distinguer d'une erreur et comptées au quota à leur taille rembourrée. Vérifié en préversion : **0 entrée opaque** sur 145.
- **Le TileJSON est à `https://tiles.openfreemap.org/planet`, sans slash final.** Il échappait donc au motif `CacheFirst` (qui exige un slash) comme au motif `/styles/`. Sans lui, la carte reste noire hors ligne malgré des tuiles en cache. Il rejoint la règle `StaleWhileRevalidate`, à côté de la feuille de style : ce sont les deux documents mutables qui pointent vers les octets immuables.

## État hors ligne

- `useOnline()` (`useSyncExternalStore` sur `navigator.onLine` + `online`/`offline`), avec la dissymétrie documentée dans le fichier : `false` prouve la coupure, `true` ne prouve rien (portail captif, wifi de port sans route). D'où le fait que `true` ne sert jamais à promettre quoi que ce soit, seulement à masquer l'avertissement.
- Bandeau discret sous le header, donc monté une seule fois pour l'explorateur et pour le planificateur : « Hors connexion : les prévisions ne peuvent pas être actualisées. » Volontairement précis : la coque, la carte déjà chargée et un plan déjà calculé continuent de fonctionner ; ce qui s'arrête, c'est le rafraîchissement. Couleurs prises aux jetons d'avertissement, aucun hex en dur (un test le vérifie).
- `friendlyError` reconnaît une panne de transport et répond « Impossible de joindre le serveur. Vérifiez votre connexion puis réessayez. » Les quatre libellés des moteurs sont couverts (`Failed to fetch`, `NetworkError…`, `Load failed`, `fetch failed`), plus `TimeoutError` et `AbortError`. Le contrat d'erreur du serveur garde la priorité, et un `TypeError` sans rapport avec le réseau reste lisible tel quel : un bug à nous ne doit pas se déguiser en problème de connexion.
- L'explorateur nomme la cause quand aucun modèle ne répond hors ligne, au lieu du `No data available` anglais.

## Vérification sur le build de prod

`VITE_API_BASE=https://mcp-dev.ohmywind.fr npm run build && vite preview`, profil isolé, Chrome DevTools.

**Ce qui entre au cache** (première visite, fenêtre desktop) :

| Cache | Entrées | Octets décodés |
|---|---|---|
| `workbox-precache-v2` | 21 | 2 370 Kio |
| `ow-basemap-v1` | 64 puis 145 après navigation | 11,6 Mo à 64 entrées |
| `ow-basemap-style-v1` | 2 (`/styles/positron`, `/planet`) | 44 407 o |

`storage.estimate()` : 15,7 Mo utilisés pour 3,2 Go de quota après la première visite. Entrées opaques : **0**. Hôtes présents dans les trois caches : `localhost` (précache) et `tiles.openfreemap.org`, **rien d'autre**. Une requête Open-Meteo lancée depuis la page revient en 200 et n'ajoute aucune entrée à aucun cache.

**Le fond de carte hors ligne.** Précision méthodologique : l'émulation `Offline` de CDP s'applique à la pile réseau de la page, pas aux `fetch` du service worker. La preuve ne repose donc pas sur elle mais sur une propriété de `CacheFirst`, qui ne touche au réseau que sur un manque : rechargement à chaud de `/`, cache du fond de carte **avant 145 entrées, après 145 entrées, 0 ajoutée**. Aucune requête du fond de carte n'est donc allée au réseau, et les 6 entrées de `resource timing` visibles depuis le fil principal ont toutes `transferSize: 0`. Côté page, l'émulation fonctionne et le seul échec du journal est la sonde Open-Meteo (`ERR_INTERNET_DISCONNECTED`), ce qui confirme que le worker ne s'interpose pas sur les données marines.

**Parcours hors ligne** (émulation CDP + `navigator.onLine` forcé à `false` avec l'événement `offline`, ce que fait un vrai terminal) :

1. rechargement : la coque s'affiche, la carte se peint entièrement depuis le cache, le bandeau apparaît. Capture : carte d'Europe complète, labels compris, alors qu'avant cette PR c'était un carré vide.
2. clic sur la carte dans l'explorateur : « Hors connexion : impossible de récupérer les prévisions. Reconnectez-vous puis touchez à nouveau ce point. » Aucun plantage.
3. `/plan`, deux waypoints, « Calculer le passage » : « Impossible de joindre le serveur. Vérifiez votre connexion puis réessayez. » Plus aucun texte anglais à l'écran.
4. retour en ligne : le bandeau disparaît au premier événement `online`.

Console : deux avertissements WebGL logiciel propres à l'environnement headless, plus les échecs réseau attendus pendant la phase hors ligne. Aucune erreur applicative.

Captures dans le scratchpad de la session : `51-offline-map-from-cache.png`, `51-offline-banner-and-message.png`, `51-plan-offline-error.png`.

## Tests

`npm run typecheck`, `npm run lint:budget` (0 erreur, budget tenu), `npm run test` : **688 tests, 52 fichiers, tous verts**. 15 tests ajoutés : `onlineStore` et `useOnline` en jsdom (montage, coupure, retour, absence de DOM), `OfflineBanner` (apparition, disparition, aucune couleur en dur), et la panne de transport dans `passage.test.ts` (quatre moteurs, délai dépassé, abandon, non-régression du `TypeError` étranger et de la priorité du contrat serveur).

`knip` n'est pas configuré sur cette branche (il arrive avec #342).

## Reste à faire

- Le style du fond de carte reste à alléger (18 plages de glyphes sur trois graisses, dont des plages inutiles côté français). Hors périmètre ici : cette PR met en cache ce qui est chargé, elle ne réduit pas ce qui est chargé.
- Vérification sur dev après merge, et sur un vrai terminal en mode avion (la seule façon de voir `navigator.onLine` basculer pour de bon).

## Ajout : le 503 du proxy de bord

Second commit, même fichier que la traduction des pannes de transport. Le Worker edge de #350 répond maintenant `{"error":"backend temporarily unavailable","code":"upstream_unavailable","retry_after":30}` avec `Retry-After: 30` quand le Space ne répond pas, ce qui arrive surtout quand il dort et se réveille. `friendlyError` n'avait pas d'entrée pour ce code, donc l'anglais brut s'affichait, juste après le travail de cette PR pour l'éliminer.

`upstream_unavailable` rejoint `ERROR_COPY` : « Le serveur est momentanément injoignable, il redémarre peut-être. » suivie du délai que le bord annonce, relayé par `formatRetryDelay` et jamais inventé ici (c'est la leçon de l'incident de copie sur la limitation de débit). Le repli sur le texte anglais est ajouté pour un bord déployé sans `code`, comme pour les autres.

Le code est volontairement distinct de `upstream_timeout` et `upstream_rate_limited`, qui parlent d'Open-Meteo : ici l'amont vu du bord, c'est nous. Un test verrouille le fait que les deux phrases ne se confondent pas, sinon le lecteur cherche la panne du mauvais côté.

Quatre tests ajoutés (parité code / texte, lecture du 503 de bout en bout avec son délai, absence de délai inventé, non-confusion avec l'amont météo). Suite : **692 tests**, verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
