### PR TITLE
feat(edge): 503 JSON lisible, cache de bord et observabilité sur le proxy (lot 5.2)

### DIFF
--- a/packages/edge-proxy/.gitignore
+++ b/packages/edge-proxy/.gitignore
@@ -1,0 +1,3 @@
+# Local state written by `wrangler dev`: cache, observability traces, cf.json.
+.wrangler/
+node_modules/

--- a/packages/edge-proxy/README.md
+++ b/packages/edge-proxy/README.md
@@ -38,6 +38,185 @@ npx wrangler deploy
 The routes in `wrangler.toml` are applied on deploy. `zone_name` must stay
 `ohmywind.fr`.
 
+## When the origin is unreachable
+
+`fetch` throws when the Space cannot be reached at all: asleep past the Worker's
+own timeout, rebuilding, DNS or TLS gone. Left uncaught, Cloudflare answers with
+an HTML 1101/52x page that carries no CORS header, so the browser reports a CORS
+failure and the web app never sees a status, a body or a reason.
+
+The Worker answers instead, with the same error contract as the API:
+
+```json
+{ "error": "backend temporarily unavailable", "code": "upstream_unavailable", "retry_after": 30 }
+```
+
+`503`, `Content-Type: application/json`, `Retry-After: 30`, `Cache-Control:
+no-store`, and the CORS headers the browser needs to let the page read it:
+`Access-Control-Allow-Origin` echoes the caller when it is one of
+`ohmywind.fr`, `www.ohmywind.fr`, `dev.ohmywind.fr`, `localhost:5173` or
+`localhost:4173`, and is `*` otherwise (the API is public and keyless, so the
+wildcard is a correct answer for anyone else, and a missing header is what makes
+a failure opaque).
+
+Two details that are easy to get wrong and are covered by the tests:
+
+- **A preflight is answered too.** The web app sends `Content-Type:
+  application/json` on `POST /api/v1/passage`, so every plan request is preceded
+  by an `OPTIONS`. If that preflight fails, the browser never sends the POST and
+  the caller gets "Failed to fetch" instead of the JSON above. During an outage
+  the Worker answers it itself with a `204`.
+- **A status the origin really sent is never rewritten on `/mcp`.** The MCP
+  transport has to see it in the shape it came in, so the translation below
+  applies to `/api/v1/` only. A throw is different: there is no status to
+  preserve, so every path, `/mcp` included, gets the JSON above rather than an
+  HTML page.
+
+An origin that answers with a platform error page (`502`, `503`, `504` whose
+body is not JSON) gets the same treatment, keeping its status. An error the app
+itself produced is left alone: the API answers some failures with `503` and a
+JSON body carrying `upstream_timeout` or `upstream_rate_limited`, which the web
+app maps to precise French copy. Content type is the discriminator.
+
+The web app has to learn `upstream_unavailable`: it is not in `ERROR_COPY` in
+`packages/web/src/api/passage.ts` yet, and the text fallback does not catch it
+either (it matches `Erreur serveur 5xx`, not this body), so today the reader
+would see the raw English sentence. One line to add there, in the shape the
+neighbouring entries use so the delay is never hard-coded twice:
+
+```ts
+upstream_unavailable: (retryAfter) =>
+  `Le serveur est momentanément injoignable, il redémarre peut-être. ${formatRetryDelay(retryAfter)}`,
+```
+
+## Edge cache
+
+Three GETs are worth keeping at the edge. All three are derived from data
+compiled into the image, so they only change when a build ships, and a build
+restarts the deployment:
+
+| Path | TTL from the origin |
+| --- | --- |
+| `/api/v1/archetypes` | `public, max-age=86400` |
+| `/api/v1/marine/marc/coverage` | `public, max-age=86400`, `300` when the answer is empty |
+| `/api/v1/marine/marc` (with query) | `public, max-age=86400` |
+
+The origin already said all of this, and none of it was happening: a Worker
+subrequest to an origin outside Cloudflare is not cached unless the Worker asks,
+so all three were measured `cf-cache-status: DYNAMIC` through the proxy on
+2026-09-01. The Worker now uses the Cache API explicitly: `caches.default.match`
+first, and on a miss `ctx.waitUntil(cache.put(...))` when the response is a
+`200` carrying `Cache-Control: public, max-age=N`. The TTL is not re-decided
+here: `cache.put` reads the origin's own header, so changing the number stays a
+one-line change in `packages/api`.
+
+Never cached: any POST, anything under `/mcp`, any non-200, anything without a
+public `max-age`.
+
+`caches.default` keys on the full URL, hostname included, so `mcp` and `mcp-dev`
+never share an entry, and the query string of `/marine/marc` is part of the key.
+
+`X-OhMyWind-Edge-Cache` reports the outcome, `HIT` for a body served by the
+edge, `MISS` for one that came from the origin:
+
+```sh
+curl -sSI https://mcp-dev.ohmywind.fr/api/v1/archetypes | grep -i 'x-ohmywind-edge-cache\|cache-control'
+# first call:  x-ohmywind-edge-cache: MISS
+# second call: x-ohmywind-edge-cache: HIT
+```
+
+A hit is per data centre, so the second call has to leave from the same place as
+the first. Testing from a phone on mobile data right after a laptop on wifi can
+legitimately show two misses.
+
+One subtlety worth keeping in mind before adding a path to the list: Hugging
+Face's edge rewrites the CORS headers on every response, echoing back the
+`Origin` we forwarded, and the Cache API keys on the URL alone (it does not
+honour `Vary: Origin`). Cached as received, the first caller's `Origin` would be
+served to everyone after them, and a `dev.ohmywind.fr` session would break on an
+entry warmed from `localhost`. So the stored copy carries no
+`Access-Control-Allow-Origin` and the Worker stamps one per request.
+
+## Observability
+
+`[observability] enabled = true` with `head_sampling_rate = 1` in
+`wrangler.toml`. Traffic here is a few requests a minute, so everything is
+sampled; lower the rate if that changes. The Worker logs one structured JSON
+line per unreachable origin and per outage page, and one per keep-alive ping if
+that is ever switched on. Logs are in the dashboard under the Worker's
+Observability tab, and are kept 7 days.
+
+## Keep-alive, delivered off
+
+A free Space sleeps after 48 h of inactivity. The `scheduled` handler in
+`src/index.js` would ping `/api/v1/archetypes` on both Spaces (a table compiled
+into the image: no upstream call, no atlas read) and keep them warm.
+
+It is wired but not enabled: the `[triggers]` block in `wrangler.toml` is
+commented out, because the April 2026 product decision was the opposite, no
+pre-warming, accept the cold start of a few seconds
+(`plan/02-decisions.md`, section 4). What has changed since is the size of that
+wait: a container that has slept for 48 h takes long enough to wake that the
+Worker's own fetch can give up, which is now a `503` rather than an opaque
+failure, but still a failure.
+
+To turn it on: uncomment the two lines and redeploy.
+
+```toml
+[triggers]
+crons = ["*/30 * * * *"]
+```
+
+To turn it off again later, set `crons = []` and redeploy. Commenting the key
+out does not remove a trigger already registered on a deployed Worker.
+
+Cost, for the decision: 48 invocations a day per Space, which is nothing against
+the free plan's 100 000 requests a day, and 2 requests every 30 minutes against
+the origin's rate limiter, keyed on Cloudflare's egress address.
+
+## Rate limiting at the edge
+
+Not code, and not in this repository: a Rate Limiting rule is a dashboard
+setting, under Security -> WAF -> Rate limiting rules on the `ohmywind.fr` zone.
+Suggested first rule, which fits in the single rule the free plan allows:
+
+- **Match**: `http.host eq "mcp.ohmywind.fr" and http.request.method eq "POST"
+  and starts_with(http.request.uri.path, "/api/v1/passage")`
+- **Counting**: 60 requests per 1 minute, per client IP
+- **Action**: block for 1 minute (or managed challenge, which is friendlier to a
+  shared NAT)
+
+The number is deliberately above the origin's own limiter (30 requests per
+60 s per bucket, in `packages/api/src/openwind_api/security.py`) rather than
+below it. The origin's limiter is the precise one: it keys on a normalised
+network (`/32` for IPv4, `/64` for IPv6) and answers a `429` with `Retry-After`
+and a `code` the web app turns into French copy. The edge rule is a coarse
+first line, there to shed a flood before it costs a Worker invocation and a
+request to a small free container. Set it under the origin's threshold and the
+edge would answer first, with a Cloudflare block page instead of our JSON.
+
+`/mcp` is deliberately left out: the MCP transport keeps a long-lived connection
+and its own request pattern, and it is not what a flood would target.
+
+## Tests
+
+No dependency, no wrangler, no login. From this directory:
+
+```sh
+node --test
+```
+
+The Worker only touches three globals (`fetch`, `caches`, and the `ctx` it is
+handed), so `tests/index.test.mjs` stubs them and asserts the parts that are
+hard to see by reading: the 503 shape and its CORS, the preflight during an
+outage, HIT and MISS, that `/mcp` never touches the cache, that a JSON error
+from the app is passed through, and that the header collapse and the edge secret
+the origin depends on still behave exactly as before.
+
+What this cannot cover is the runtime itself: that `caches.default` really
+honours `Cache-Control`, and that a subrequest really throws when the origin is
+unreachable. Those are verified with curl after a deploy.
+
 ## Coupled configuration
 
 Three Space variables have to match this proxy. Getting any of them wrong
@@ -130,6 +309,7 @@ count safe to hard-code.
 
 ## Not handled here
 
-Free Spaces sleep after 48 h of inactivity, so a first request after a long
-quiet spell wakes a cold container. The proxy cannot help with that; a scheduled
-ping keeps the Space warm instead.
+Cold starts. A free Space sleeps after 48 h of inactivity, and the first request
+after a long quiet spell wakes a cold container. The proxy makes that failure
+readable (a `503` with `Retry-After`) but it cannot make it fast. The keep-alive
+above is the fix, and it is off by decision, not by omission.

--- a/packages/edge-proxy/package.json
+++ b/packages/edge-proxy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@ohmywind/edge-proxy",
+  "version": "0.0.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "description": "Cloudflare Worker fronting the MCP Spaces on mcp.ohmywind.fr. Deliberately dependency-free: tests run on the Node test runner.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/packages/edge-proxy/src/index.js
+++ b/packages/edge-proxy/src/index.js
@@ -14,6 +14,17 @@
  * origin's own hostname upstream. That happens implicitly: the runtime derives
  * `Host` from the request URL, so rewriting the URL's hostname is enough. There
  * is no way to set `Host` directly in a Worker, and no need to.
+ *
+ * Beyond the rewrite, this Worker owns three things the origin cannot do for
+ * itself, because they all apply when the origin is not answering, or before
+ * the request ever reaches it:
+ *
+ *   1. an origin outage becomes a JSON error the browser is allowed to read,
+ *      instead of an HTML page from Cloudflare with no CORS headers on it;
+ *   2. the three long-lived GETs are kept in the edge cache, which a Worker
+ *      subrequest to a non-Cloudflare origin never populates on its own;
+ *   3. a `scheduled` handler can keep the free Spaces awake. It ships wired but
+ *      disabled: see the commented `[triggers]` block in `wrangler.toml`.
  */
 
 // Public hostname -> Space hostname. The only place the backend is named.
@@ -22,8 +33,44 @@ const ORIGINS = {
   "mcp-dev.ohmywind.fr": "qdonnars-openwind-mcp-dev.hf.space",
 };
 
+// Browser origins we name explicitly when we answer for ourselves.
+//
+// The API is public and keyless, so `*` is a correct answer for every caller;
+// echoing the known ones only keeps our responses the same shape as the
+// origin's, and leaves the door open for a credentialed endpoint one day (`*`
+// is illegal with credentials, an echo is not). Anything else, including a
+// request with no Origin at all (curl, an MCP client), gets `*` rather than
+// nothing: a missing header is what turns a readable error into an opaque one.
+const ALLOWED_BROWSER_ORIGINS = new Set([
+  "https://ohmywind.fr",
+  "https://www.ohmywind.fr",
+  "https://dev.ohmywind.fr",
+  "http://localhost:5173",
+  "http://localhost:4173",
+]);
+
+// GETs worth keeping at the edge. All three are derived from data compiled
+// into the image: they change when a build ships, and a build restarts the
+// deployment. The origin already says so with `Cache-Control: public,
+// max-age=86400` (300 s for an empty coverage answer), but that header alone
+// caches nothing here: a Worker subrequest to an origin outside Cloudflare is
+// not cached unless the Worker asks, which is why every one of these was
+// measured `cf-cache-status: DYNAMIC` through the proxy on 2026-09-01.
+//
+// Anything else is left alone. `/mcp` is a transport, and every other
+// `/api/v1/` route is either a POST or depends on the moment it is asked.
+const CACHEABLE_PATHS = new Set([
+  "/api/v1/archetypes",
+  "/api/v1/marine/marc",
+  "/api/v1/marine/marc/coverage",
+]);
+
+// Seconds we ask the caller to wait when the origin is unreachable. A cold
+// Hugging Face container takes a few seconds; a rebuild takes a minute or so.
+const UNAVAILABLE_RETRY_AFTER = 30;
+
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const incoming = new URL(request.url);
     const origin = ORIGINS[incoming.hostname];
     if (!origin) {
@@ -33,6 +80,15 @@ export default {
         status: 404,
         headers: { "content-type": "text/plain; charset=utf-8" },
       });
+    }
+
+    // Edge cache, read side. Only ever consulted for the handful of GETs
+    // listed above, so `/mcp` and every POST reach the origin as before.
+    const cacheable =
+      request.method === "GET" && CACHEABLE_PATHS.has(incoming.pathname);
+    if (cacheable) {
+      const hit = await caches.default.match(request);
+      if (hit) return finish(hit, request, "HIT");
     }
 
     const upstreamUrl = new URL(request.url);
@@ -82,7 +138,28 @@ export default {
 
     // `manual` keeps 3xx responses as data instead of chasing them ourselves,
     // which would drop the Host rewrite on the follow-up request.
-    const response = await fetch(upstream, { redirect: "manual" });
+    //
+    // The try/catch is the difference between a readable failure and an opaque
+    // one. `fetch` throws when the origin cannot be reached at all: Space
+    // asleep past the Worker's own timeout, Space rebuilding, DNS or TLS gone.
+    // Cloudflare then answers with an HTML 1101/52x page carrying no CORS
+    // header, so the browser reports a CORS failure and the web app never sees
+    // a status, a body, or a reason. Measured 2026-09-01, annex D finding 6.
+    let response;
+    try {
+      response = await fetch(upstream, { redirect: "manual" });
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          message: "upstream unreachable",
+          host: incoming.hostname,
+          origin,
+          path: incoming.pathname,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      return unavailable(request, 503);
+    }
 
     // A redirect whose Location still names the Space would hand the origin
     // hostname straight back to the client, undoing the whole point of this
@@ -97,6 +174,218 @@ export default {
       return rewritten;
     }
 
+    // An origin that answers, but with a platform error page rather than with
+    // its own JSON: same treatment as an unreachable one, so the web app has a
+    // single shape to handle.
+    if (isPlatformOutage(incoming, response)) {
+      console.error(
+        JSON.stringify({
+          message: "upstream outage page",
+          host: incoming.hostname,
+          path: incoming.pathname,
+          status: response.status,
+        }),
+      );
+      return unavailable(request, response.status);
+    }
+
+    if (cacheable) return store(request, response, ctx);
+
     return response;
   },
+
+  /**
+   * Keep-alive ping. **Disabled on purpose**: `wrangler.toml` ships with its
+   * `[triggers]` block commented out, so this handler never runs today.
+   *
+   * The April 2026 product decision (plan/02-decisions.md, section 4) was "no
+   * pre-warming, we accept the cold start of a few seconds". What has changed
+   * since is the size of that wait: a free Space sleeps after 48 h, and waking
+   * a sleeping container is not a few seconds, it is long enough for the fetch
+   * above to give up and answer a 503. Wiring the handler now, off, makes
+   * enabling it a one-line edit whenever that trade is worth revisiting, and
+   * keeps the decision next to its consequence.
+   */
+  async scheduled(controller, env, ctx) {
+    const targets = Object.values(ORIGINS).map(
+      (host) => `https://${host}/api/v1/archetypes`,
+    );
+    const results = await Promise.allSettled(
+      // The cheapest route that still touches the app: a table compiled into
+      // the image, no upstream call, no atlas read. Enough to reset the idle
+      // timer, and it goes straight to the Space, not through this Worker, so
+      // the edge cache never answers it.
+      targets.map((url) => fetch(url, { redirect: "manual" })),
+    );
+    results.forEach((result, index) => {
+      console.log(
+        JSON.stringify({
+          message: "keepalive ping",
+          cron: controller.cron,
+          url: targets[index],
+          ok: result.status === "fulfilled",
+          status: result.status === "fulfilled" ? result.value.status : null,
+          error: result.status === "rejected" ? String(result.reason) : undefined,
+        }),
+      );
+    });
+  },
 };
+
+/**
+ * Is this an error page from the platform, or an error from the app?
+ *
+ * The API answers some of its own failures with 503 and a JSON body carrying a
+ * stable `code` (`upstream_timeout`, `upstream_rate_limited`), which the web
+ * app already maps to French copy. Rewriting those would replace a precise
+ * message with a vague one, so the content type is the discriminator: JSON is
+ * the app talking, anything else is Hugging Face or Cloudflare talking.
+ *
+ * `/mcp` is deliberately out of scope. The MCP transport has to see the status
+ * the origin really returned, in the shape it really returned it.
+ */
+function isPlatformOutage(url, response) {
+  if (!url.pathname.startsWith("/api/v1/")) return false;
+  if (
+    response.status !== 502 &&
+    response.status !== 503 &&
+    response.status !== 504
+  ) {
+    return false;
+  }
+  const type = (response.headers.get("Content-Type") ?? "").toLowerCase();
+  return !type.includes("application/json");
+}
+
+/**
+ * The one failure answer this Worker writes itself.
+ *
+ * Shape matches the API's own error contract (`error`, `code`, `retry_after`),
+ * so the web app has a single path to follow. The status of a translated page
+ * is kept as the origin sent it; a thrown fetch, which has no status of its
+ * own, becomes a 503.
+ */
+function unavailable(request, status) {
+  const headers = new Headers({ "Cache-Control": "no-store" });
+  applyCors(headers, request);
+  headers.set("Retry-After", String(UNAVAILABLE_RETRY_AFTER));
+
+  // A preflight has to be answered even when the origin is down, otherwise the
+  // browser refuses to send the request it precedes and the caller never
+  // reaches the JSON below: they get "Failed to fetch" and no reason. The web
+  // app sends `Content-Type: application/json` on /api/v1/passage, which is
+  // not a safelisted value, so every plan request is preceded by one of these.
+  if (request.method === "OPTIONS") {
+    headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    headers.set(
+      "Access-Control-Allow-Headers",
+      request.headers.get("Access-Control-Request-Headers") ?? "Content-Type",
+    );
+    return new Response(null, { status: 204, headers });
+  }
+
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  return new Response(
+    JSON.stringify({
+      error: "backend temporarily unavailable",
+      code: "upstream_unavailable",
+      retry_after: UNAVAILABLE_RETRY_AFTER,
+    }),
+    { status, headers },
+  );
+}
+
+/**
+ * Store a cacheable response, then hand the caller its copy.
+ *
+ * `cache.put` honours the response's own `Cache-Control`, so the origin keeps
+ * ownership of the TTL: 86400 s on the archetype table and on a MARC answer,
+ * 300 s on an empty coverage answer. Nothing here re-decides it.
+ */
+function store(request, response, ctx) {
+  const maxAge = publicMaxAge(response);
+  if (response.status === 200 && maxAge !== null) {
+    // clone() first: handing `response.body` to another Response disturbs the
+    // stream, and a disturbed body can no longer be cloned.
+    const copy = response.clone();
+    const stored = new Response(copy.body, copy);
+
+    // The CORS headers are the one thing that must not be shared between
+    // callers. Hugging Face's edge rewrites them on every response, echoing
+    // the Origin we forwarded, and `caches.default` keys on the URL alone: it
+    // does not honour `Vary: Origin`. Cached as received, the first caller's
+    // Origin would be handed to everyone after them, and a dev.ohmywind.fr
+    // session would break on an entry warmed from localhost. So the stored
+    // copy carries none, and `finish` stamps them per request.
+    stored.headers.delete("Access-Control-Allow-Origin");
+    stored.headers.delete("Access-Control-Expose-Headers");
+
+    ctx.waitUntil(caches.default.put(request, stored));
+  }
+  return finish(response, request, "MISS");
+}
+
+/**
+ * Stamp the outgoing response: cache state, then CORS.
+ *
+ * HIT means the body came from the edge. MISS means it came from the origin,
+ * whether or not it was then worth storing.
+ */
+function finish(response, request, state) {
+  const out = new Response(response.body, response);
+  out.headers.set("X-OhMyWind-Edge-Cache", state);
+  applyCors(out.headers, request);
+  return out;
+}
+
+/** CORS for a response this Worker owns, cached or synthesised. */
+function applyCors(headers, request) {
+  const origin = request.headers.get("Origin");
+  headers.set(
+    "Access-Control-Allow-Origin",
+    origin && ALLOWED_BROWSER_ORIGINS.has(origin) ? origin : "*",
+  );
+  headers.set("Vary", withVary(headers.get("Vary"), "Origin"));
+  // Retry-After and X-Request-Id are the origin's own list; the cache state
+  // joins it so the header can be read from a page, not only from curl.
+  headers.set(
+    "Access-Control-Expose-Headers",
+    "Retry-After, X-Request-Id, X-OhMyWind-Edge-Cache",
+  );
+}
+
+function withVary(existing, field) {
+  if (!existing) return field;
+  const listed = existing
+    .split(",")
+    .some((entry) => entry.trim().toLowerCase() === field.toLowerCase());
+  return listed ? existing : `${existing}, ${field}`;
+}
+
+/**
+ * The response's max-age, if and only if it says a shared cache may keep it.
+ *
+ * A gate, not a TTL: the Cache API reads the header itself. Returning the
+ * number keeps the decision readable and testable, and `cache.put` answers 413
+ * rather than storing anything if we ever get this wrong.
+ */
+function publicMaxAge(response) {
+  const value = response.headers.get("Cache-Control");
+  if (!value) return null;
+  const directives = value
+    .toLowerCase()
+    .split(",")
+    .map((entry) => entry.trim());
+  if (!directives.includes("public")) return null;
+  if (
+    directives.includes("private") ||
+    directives.includes("no-store") ||
+    directives.includes("no-cache")
+  ) {
+    return null;
+  }
+  const maxAge = directives.find((entry) => entry.startsWith("max-age="));
+  if (!maxAge) return null;
+  const seconds = Number(maxAge.slice("max-age=".length));
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}

--- a/packages/edge-proxy/tests/index.test.mjs
+++ b/packages/edge-proxy/tests/index.test.mjs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * Worker tests, on the Node test runner and nothing else.
+ *
+ * `node --test tests/` from this directory. There is no dependency to install,
+ * no wrangler, no login: the Worker only touches three globals (`fetch`,
+ * `caches`, and the `ctx` it is handed), so stubbing them is enough to pin the
+ * behaviours that are impossible to check by reading, and awkward to check in
+ * production. What this cannot cover is the runtime itself: that `caches.default`
+ * really honours `Cache-Control`, and that a Worker subrequest really throws
+ * when the origin is unreachable. Those are verified with curl after a deploy.
+ */
+
+import assert from "node:assert/strict";
+import { beforeEach, describe, test } from "node:test";
+
+import worker from "../src/index.js";
+
+const DEV = "https://mcp-dev.ohmywind.fr";
+
+/** Records what the Worker asked the edge cache and the origin to do. */
+function harness({ upstream, cached = null } = {}) {
+  const calls = { upstream: [], match: [], put: [], waitUntil: [] };
+
+  globalThis.fetch = async (request) => {
+    calls.upstream.push(request);
+    if (typeof upstream === "function") return upstream(request);
+    return upstream;
+  };
+
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        calls.match.push(request);
+        return cached;
+      },
+      async put(request, response) {
+        calls.put.push({ request, response });
+      },
+    },
+  };
+
+  const ctx = {
+    waitUntil(promise) {
+      calls.waitUntil.push(promise);
+    },
+  };
+
+  return { calls, ctx };
+}
+
+/** Drain whatever the Worker deferred, so cache writes have happened. */
+async function settle(calls) {
+  await Promise.all(calls.waitUntil);
+}
+
+function json(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+beforeEach(() => {
+  delete globalThis.fetch;
+  delete globalThis.caches;
+});
+
+describe("unknown host", () => {
+  test("is refused instead of proxied somewhere unintended", async () => {
+    const { ctx } = harness({ upstream: json({}) });
+    const response = await worker.fetch(
+      new Request("https://example.invalid/api/v1/archetypes"),
+      {},
+      ctx,
+    );
+    assert.equal(response.status, 404);
+  });
+});
+
+describe("origin unreachable", () => {
+  test("answers JSON 503 with Retry-After and readable CORS", async () => {
+    const { ctx } = harness({
+      upstream: () => {
+        throw new TypeError("fetch failed");
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/passage`, {
+        method: "POST",
+        headers: { Origin: "https://dev.ohmywind.fr" },
+      }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal(
+      response.headers.get("Content-Type"),
+      "application/json; charset=utf-8",
+    );
+    assert.equal(response.headers.get("Retry-After"), "30");
+    assert.equal(response.headers.get("Cache-Control"), "no-store");
+    assert.equal(
+      response.headers.get("Access-Control-Allow-Origin"),
+      "https://dev.ohmywind.fr",
+    );
+    assert.match(response.headers.get("Vary") ?? "", /Origin/);
+    assert.deepEqual(await response.json(), {
+      error: "backend temporarily unavailable",
+      code: "upstream_unavailable",
+      retry_after: 30,
+    });
+  });
+
+  test("falls back to a wildcard for an unlisted or absent Origin", async () => {
+    const { ctx } = harness({
+      upstream: () => {
+        throw new Error("boom");
+      },
+    });
+
+    const wildcard = await worker.fetch(new Request(`${DEV}/mcp`), {}, ctx);
+    assert.equal(wildcard.headers.get("Access-Control-Allow-Origin"), "*");
+
+    const foreign = await worker.fetch(
+      new Request(`${DEV}/mcp`, { headers: { Origin: "https://evil.example" } }),
+      {},
+      ctx,
+    );
+    assert.equal(foreign.headers.get("Access-Control-Allow-Origin"), "*");
+  });
+
+  test("answers the preflight too, so the POST it gates is even attempted", async () => {
+    const { ctx } = harness({
+      upstream: () => {
+        throw new Error("boom");
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/passage`, {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://dev.ohmywind.fr",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "content-type",
+        },
+      }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.status, 204);
+    assert.equal(
+      response.headers.get("Access-Control-Allow-Origin"),
+      "https://dev.ohmywind.fr",
+    );
+    assert.match(
+      response.headers.get("Access-Control-Allow-Methods") ?? "",
+      /POST/,
+    );
+    assert.equal(
+      response.headers.get("Access-Control-Allow-Headers"),
+      "content-type",
+    );
+  });
+});
+
+describe("platform error pages", () => {
+  test("an HTML 502 on /api/v1/ becomes the same JSON as an outage", async () => {
+    const { ctx } = harness({
+      upstream: new Response("<html>Error 1101</html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      }),
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/passage`, { method: "POST" }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.status, 502);
+    const body = await response.json();
+    assert.equal(body.code, "upstream_unavailable");
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+  });
+
+  test("a JSON 503 from the app itself is passed through untouched", async () => {
+    const { ctx } = harness({
+      upstream: json(
+        { error: "upstream weather service did not respond in time", code: "upstream_timeout" },
+        { status: 503 },
+      ),
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/passage`, { method: "POST" }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal((await response.json()).code, "upstream_timeout");
+  });
+
+  test("/mcp keeps the raw status the transport needs to see", async () => {
+    const { calls, ctx } = harness({
+      upstream: new Response("<html>502</html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      }),
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/mcp`, { method: "POST" }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.status, 502);
+    assert.equal(await response.text(), "<html>502</html>");
+    assert.equal(calls.match.length, 0, "/mcp never consults the edge cache");
+    assert.equal(response.headers.get("X-OhMyWind-Edge-Cache"), null);
+  });
+});
+
+describe("edge cache", () => {
+  test("a miss goes upstream, is stored, and says MISS", async () => {
+    const { calls, ctx } = harness({
+      upstream: json([{ slug: "cruiser_30ft" }], {
+        headers: { "Cache-Control": "public, max-age=86400" },
+      }),
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/archetypes`),
+      {},
+      ctx,
+    );
+    await settle(calls);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("X-OhMyWind-Edge-Cache"), "MISS");
+    assert.equal(calls.upstream.length, 1);
+    assert.equal(calls.put.length, 1);
+    assert.equal(
+      calls.put[0].request.url,
+      `${DEV}/api/v1/archetypes`,
+      "the cache key is the public URL, so mcp and mcp-dev never share entries",
+    );
+    assert.deepEqual(await response.json(), [{ slug: "cruiser_30ft" }]);
+  });
+
+  test("the stored copy carries no per-caller CORS header", async () => {
+    const { calls, ctx } = harness({
+      upstream: json([], {
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          "Access-Control-Allow-Origin": "http://localhost:5173",
+        },
+      }),
+    });
+
+    await worker.fetch(
+      new Request(`${DEV}/api/v1/archetypes`, {
+        headers: { Origin: "http://localhost:5173" },
+      }),
+      {},
+      ctx,
+    );
+    await settle(calls);
+
+    assert.equal(
+      calls.put[0].response.headers.get("Access-Control-Allow-Origin"),
+      null,
+    );
+  });
+
+  test("a hit never reaches the origin and says HIT", async () => {
+    const { calls, ctx } = harness({
+      upstream: json([]),
+      cached: json([{ slug: "cruiser_30ft" }], {
+        headers: { "Cache-Control": "public, max-age=86400" },
+      }),
+    });
+
+    const response = await worker.fetch(
+      new Request(`${DEV}/api/v1/marine/marc/coverage`, {
+        headers: { Origin: "https://dev.ohmywind.fr" },
+      }),
+      {},
+      ctx,
+    );
+
+    assert.equal(response.headers.get("X-OhMyWind-Edge-Cache"), "HIT");
+    assert.equal(calls.upstream.length, 0);
+    assert.equal(
+      response.headers.get("Access-Control-Allow-Origin"),
+      "https://dev.ohmywind.fr",
+      "CORS is re-stamped per caller, never served from the stored copy",
+    );
+    assert.match(
+      response.headers.get("Access-Control-Expose-Headers") ?? "",
+      /X-OhMyWind-Edge-Cache/,
+    );
+  });
+
+  test("query strings are part of the key, so /marine/marc caches per window", async () => {
+    const { calls, ctx } = harness({
+      upstream: json({ steps: [] }, {
+        headers: { "Cache-Control": "public, max-age=86400" },
+      }),
+    });
+
+    await worker.fetch(
+      new Request(`${DEV}/api/v1/marine/marc?lat=48.02&lon=-4.55&n_steps=24`),
+      {},
+      ctx,
+    );
+    await settle(calls);
+
+    assert.match(calls.put[0].request.url, /n_steps=24/);
+  });
+
+  test("nothing is stored without a public max-age, nor on a non-200", async () => {
+    for (const upstream of [
+      json([], { headers: { "Cache-Control": "no-store" } }),
+      json([]),
+      json({ error: "nope" }, {
+        status: 500,
+        headers: { "Cache-Control": "public, max-age=86400" },
+      }),
+    ]) {
+      const { calls, ctx } = harness({ upstream });
+      const response = await worker.fetch(
+        new Request(`${DEV}/api/v1/archetypes`),
+        {},
+        ctx,
+      );
+      await settle(calls);
+      assert.equal(calls.put.length, 0);
+      assert.equal(response.headers.get("X-OhMyWind-Edge-Cache"), "MISS");
+    }
+  });
+
+  test("a POST is never cached, even on a cacheable path", async () => {
+    const { calls, ctx } = harness({
+      upstream: json([], { headers: { "Cache-Control": "public, max-age=86400" } }),
+    });
+
+    await worker.fetch(
+      new Request(`${DEV}/api/v1/archetypes`, { method: "POST" }),
+      {},
+      ctx,
+    );
+    await settle(calls);
+
+    assert.equal(calls.match.length, 0);
+    assert.equal(calls.put.length, 0);
+  });
+
+  test("an uncacheable path is not consulted either", async () => {
+    const { calls, ctx } = harness({ upstream: json({}) });
+    await worker.fetch(new Request(`${DEV}/api/v1/_client`), {}, ctx);
+    assert.equal(calls.match.length, 0);
+    assert.equal(calls.put.length, 0);
+  });
+});
+
+describe("what the origin depends on, unchanged", () => {
+  test("X-Forwarded-For is collapsed and the edge secret replaced", async () => {
+    const { calls, ctx } = harness({ upstream: json({}) });
+
+    await worker.fetch(
+      new Request(`${DEV}/api/v1/_client`, {
+        headers: {
+          "CF-Connecting-IP": "203.0.113.7",
+          "X-Forwarded-For": "1.1.1.1, 2.2.2.2",
+          "X-OhMyWind-Edge": "forged",
+        },
+      }),
+      { EDGE_SHARED_SECRET: "real-secret" },
+      ctx,
+    );
+
+    const sent = calls.upstream[0];
+    assert.equal(sent.url, "https://qdonnars-openwind-mcp-dev.hf.space/api/v1/_client");
+    assert.equal(sent.headers.get("X-Forwarded-For"), "203.0.113.7");
+    assert.equal(sent.headers.get("X-OhMyWind-Edge"), "real-secret");
+  });
+
+  test("a forged attestation is stripped when we have no secret to set", async () => {
+    const { calls, ctx } = harness({ upstream: json({}) });
+
+    await worker.fetch(
+      new Request(`${DEV}/api/v1/_client`, {
+        headers: { "X-OhMyWind-Edge": "forged", "X-Forwarded-For": "1.1.1.1" },
+      }),
+      {},
+      ctx,
+    );
+
+    assert.equal(calls.upstream[0].headers.get("X-OhMyWind-Edge"), null);
+    assert.equal(calls.upstream[0].headers.get("X-Forwarded-For"), null);
+  });
+
+  test("a redirect to the Space is rewritten back to the public hostname", async () => {
+    const { ctx } = harness({
+      upstream: new Response(null, {
+        status: 302,
+        headers: {
+          Location: "https://qdonnars-openwind-mcp-dev.hf.space/mcp",
+        },
+      }),
+    });
+
+    const response = await worker.fetch(new Request(`${DEV}/`), {}, ctx);
+    assert.equal(response.headers.get("Location"), `${DEV}/mcp`);
+  });
+});
+
+describe("keep-alive ping", () => {
+  test("wakes every Space, direct, when a cron eventually fires", async () => {
+    const { calls, ctx } = harness({ upstream: json([]) });
+
+    await worker.scheduled({ cron: "*/30 * * * *" }, {}, ctx);
+
+    assert.deepEqual(
+      calls.upstream.map((request) => request.url ?? request),
+      [
+        "https://qdonnars-openwind-mcp.hf.space/api/v1/archetypes",
+        "https://qdonnars-openwind-mcp-dev.hf.space/api/v1/archetypes",
+      ],
+    );
+  });
+});

--- a/packages/edge-proxy/wrangler.toml
+++ b/packages/edge-proxy/wrangler.toml
@@ -10,3 +10,29 @@ routes = [
   { pattern = "mcp.ohmywind.fr/*", zone_name = "ohmywind.fr" },
   { pattern = "mcp-dev.ohmywind.fr/*", zone_name = "ohmywind.fr" },
 ]
+
+# Without this, a Worker in production is a black box: an intermittent 503 or a
+# cache that never hits leaves no trace anywhere. Traffic here is a few requests
+# a minute, so everything is sampled; lower the rate if that ever changes.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+# Keep-alive, deliberately not enabled. Uncomment to turn it on.
+#
+# A free Hugging Face Space sleeps after 48 h of inactivity, and the first
+# request after that wakes a cold container: slow enough that the Worker's own
+# fetch can give up, which is now a 503 instead of an opaque failure. A ping
+# every 30 minutes on /api/v1/archetypes (a table compiled into the image, no
+# upstream call) would keep both Spaces warm.
+#
+# It ships off because the April 2026 product decision was the opposite: no
+# pre-warming, accept the cold start (plan/02-decisions.md, section 4). The
+# handler is written and tested so that revisiting the decision is one line
+# here, not a change of code.
+#
+# To disable it again later, set `crons = []` and redeploy. Commenting the key
+# out does NOT remove a trigger already registered on the deployed Worker.
+#
+# [triggers]
+# crons = ["*/30 * * * *"]


### PR DESCRIPTION
## Pourquoi

Constat 6 de l'annexe D (`plan/audit-2026-09/annexes/D-livraison-mobile.md`), mesuré le 2026-09-01 :

- `src/index.js:85` faisait un `fetch` sans `try/catch`. Origine injoignable (Space endormi au-delà du timeout du Worker, Space en reconstruction, DNS ou TLS) = page HTML 1101/52x de Cloudflare, **sans en-tête CORS**. Le navigateur signale une erreur CORS opaque : ni statut, ni corps, ni raison pour l'utilisateur.
- `/api/v1/archetypes` et `/api/v1/marine/marc` remontaient `cf-cache-status: DYNAMIC` à travers le Worker alors que l'origine pose `Cache-Control: public, max-age=86400`. Une sous-requête Worker vers une origine hors Cloudflare n'est pas mise en cache sans demande explicite.
- `wrangler.toml` sans `[observability]` : un Worker en production sans traces.
- Le README évoquait un ping planifié qui n'existait nulle part.

PR 5.2 du lot 5 (`plan/audit-2026-09/01-plan-rework.md`). Périmètre strict : `packages/edge-proxy/**`, rien d'autre.

## Ce qui change

**1. Origine injoignable = 503 JSON lisible.** Le `fetch` est encadré, et le Worker répond lui-même avec le contrat d'erreur de l'API (celui de la PR 1.5 / GO 3) :

```json
{ "error": "backend temporarily unavailable", "code": "upstream_unavailable", "retry_after": 30 }
```

`Content-Type: application/json`, `Retry-After: 30`, `Cache-Control: no-store`, `Access-Control-Allow-Origin` (l'Origin appelant s'il fait partie de ohmywind.fr / www / dev / localhost:5173 / localhost:4173, sinon `*` puisque l'API est publique et sans clé), `Vary: Origin`.

Deux points qui ne se lisent pas dans le diff :

- **Le préflight est traité aussi.** Le web envoie `Content-Type: application/json` sur `POST /api/v1/passage`, donc chaque calcul est précédé d'un `OPTIONS`. Sans réponse à ce préflight, le navigateur n'envoie jamais le POST et l'utilisateur voit « Failed to fetch » : le 503 JSON ne serait jamais atteint. Pendant une panne, le Worker répond `204` avec les en-têtes de préflight.
- **`retry_after` en plus des deux champs demandés**, pour coller exactement au contrat `{error, code, retry_after}` de `packages/api/src/openwind_api/errors.py`. C'est additif, et c'est ce qui permet à la copie web de dériver le délai au lieu de le coder en dur.

**2. Page d'erreur plateforme traduite, erreur applicative préservée.** Un `502/503/504` dont le corps n'est pas du JSON, sous `/api/v1/`, prend la même forme (statut conservé). En revanche l'API répond elle-même `503` + JSON sur `upstream_timeout` et `upstream_rate_limited`, que le web traduit déjà finement : le type de contenu sert de discriminant, ces réponses passent intactes. `/mcp` n'est jamais réécrit quand l'origine a répondu (le transport MCP doit voir le statut brut) ; en revanche un `fetch` qui lève n'a aucun statut à préserver, donc `/mcp` reçoit lui aussi le JSON plutôt qu'une page HTML.

**3. Cache de bord sur les trois GET stables** (`/api/v1/archetypes`, `/api/v1/marine/marc/coverage`, `/api/v1/marine/marc` avec query) : `caches.default.match` d'abord, puis sur miss `ctx.waitUntil(cache.put(...))` si la réponse est un 200 portant `Cache-Control: public, max-age=N`. Le TTL n'est pas redécidé ici, `cache.put` lit l'en-tête de l'origine : changer 86400 reste une ligne dans `packages/api`. Jamais de POST, jamais `/mcp`, jamais de non-200. `X-OhMyWind-Edge-Cache: HIT|MISS` rend l'état vérifiable au curl.

Un piège trouvé en écrivant la PR et corrigé : l'edge Hugging Face réécrit les en-têtes CORS de chaque réponse en renvoyant l'Origin qu'on lui a transmis, et `caches.default` ne clé que sur l'URL (il n'honore pas `Vary: Origin`). Stockée telle quelle, l'entrée aurait servi l'Origin du premier appelant à tous les suivants, et une session `dev.ohmywind.fr` serait tombée sur une entrée chauffée depuis `localhost`. La copie stockée est donc dépouillée de `Access-Control-Allow-Origin`, réapposé par requête. Vérifié en local, voir plus bas.

**4. `[observability] enabled = true`, `head_sampling_rate = 1`** (quelques requêtes par minute, on échantillonne tout). Une ligne JSON structurée par origine injoignable et par page d'erreur.

**5. Cron de réveil écrit, testé, et livré DÉSACTIVÉ.** Le handler `scheduled` pinge `/api/v1/archetypes` sur les deux Spaces (table compilée dans l'image : aucun appel amont, aucune lecture d'atlas). Le bloc `[triggers]` de `wrangler.toml` est en commentaire. **Décision à prendre, voir la section dédiée en bas.**

**6. README** : nouvelles sections (503, cache et sa vérification au curl, observabilité, cron désactivé et comment l'activer, rate limiting au bord, tests). Le paragraphe final qui affirmait qu'« un ping planifié garde le Space chaud » est corrigé : ce ping n'existait pas.

**7. Rate limiting au bord : réglage tableau de bord, pas du code.** Documenté dans le README, règle suggérée sur la zone `ohmywind.fr` : `http.host eq "mcp.ohmywind.fr" and http.request.method eq "POST" and starts_with(http.request.uri.path, "/api/v1/passage")`, **60 requêtes par minute par IP**, blocage 1 minute. Le seuil est volontairement **au-dessus** des 30/60 s par seau de l'origine : le limiteur applicatif est le précis (clé /32 ou /64, `429` avec `Retry-After` et un `code` que le web traduit), la règle de bord n'est qu'une première ligne grossière pour absorber un flood avant qu'il ne coûte une invocation et une requête au conteneur gratuit. Placée en dessous, elle répondrait la première avec une page de blocage Cloudflare au lieu de notre JSON. Elle tient dans la règle unique du plan gratuit.

## Vérifications

`node --test` depuis `packages/edge-proxy` : **18 tests, 18 passés**, aucune dépendance, aucun login. Les globales `fetch`, `caches` et `ctx` sont doublées. Couvre la forme du 503 et son CORS, le préflight pendant une panne, HIT/MISS, la copie stockée sans CORS, `/mcp` qui ne touche jamais le cache, l'erreur JSON applicative laissée intacte, et en garde-fou le collapse de `X-Forwarded-For` et le secret de bord (inchangés au caractère près, seules deux lignes du fichier d'origine ont bougé : la signature `fetch(request, env)` -> `(request, env, ctx)` et le `fetch` désormais encadré).

`npx wrangler dev --local` fonctionne **sans authentification** dans cet environnement, donc le runtime réel a été smoké (workerd, pas seulement des doublures) :

| Vérification | Résultat |
|---|---|
| `GET /api/v1/archetypes` x2 | `X-OhMyWind-Edge-Cache: MISS` puis `HIT` (+ `CF-Cache-Status: HIT` posé par le runtime), 428 o gzip |
| Le même, deux Origin différentes | entrée chauffée avec `Origin: https://dev.ohmywind.fr`, deuxième appel avec `Origin: http://localhost:5173` -> `Access-Control-Allow-Origin: http://localhost:5173`. C'est exactement le bug évité par le dépouillement de la copie stockée |
| `GET /api/v1/marine/marc/coverage` | 200, `Cache-Control: public, max-age=86400`, mis en cache |
| `POST /mcp` (`initialize`) | 200, réponse JSON-RPC normale, **aucun** `X-OhMyWind-Edge-Cache` : le chemin cache n'est pas emprunté |
| Origine injoignable (copie du Worker pointée sur `unreachable.invalid`), `POST /api/v1/passage` | `503`, corps JSON exact ci-dessus, `Retry-After: 30`, `Cache-Control: no-store`, `Access-Control-Allow-Origin: https://dev.ohmywind.fr`, `Vary: Origin` |
| Même origine injoignable, `OPTIONS /api/v1/passage` | `204`, `Access-Control-Allow-Methods: GET, POST, OPTIONS`, `Access-Control-Allow-Headers: content-type` |

Deux nuances honnêtes sur ce smoke local :

- `wrangler dev` construit l'URL de la requête à partir de la **première route** du `wrangler.toml` et ignore l'en-tête `Host` : les appels ci-dessus sont donc partis vers le Space **prod**, pas dev (visible au `Link: .../spaces/Qdonnars/openwind-mcp`). Ce sont deux `GET` en lecture sur des routes cachées, sans effet de bord. Le routage par hostname reste couvert par les tests unitaires et inchangé.
- La copie stockée garde l'encodage renvoyé à la sous-requête (`Content-Encoding: gzip` en local). L'origine pose `Vary: Accept-Encoding`, qui est justement le seul champ de `Vary` que le cache Cloudflare honore ; c'est `Origin` qu'il n'honore pas, d'où le dépouillement décrit plus haut. Les navigateurs annoncent tous gzip, donc le web n'est pas concerné.

Non vérifiable sans déploiement : que `caches.default` honore réellement le `max-age` de l'origine en production, que le HIT tienne d'un centre de données à l'autre, et que la règle de rate limiting se comporte comme prévu (elle n'existe pas encore).

## Ce que le web devra ajouter (aucun fichier web touché ici)

`friendlyError` / `ERROR_COPY` de `packages/web/src/api/passage.ts` ne connaissent pas `upstream_unavailable`, et le repli textuel ne l'attrape pas non plus (il matche `Erreur serveur 5xx`, pas ce corps) : aujourd'hui le lecteur verrait la phrase anglaise brute. Une ligne à ajouter, dans la forme des entrées voisines pour ne pas coder le délai deux fois :

```ts
upstream_unavailable: (retryAfter) =>
  `Le serveur est momentanément injoignable, il redémarre peut-être. ${formatRetryDelay(retryAfter)}`,
```

(`formatRetryDelay(30)` donne « Patientez 30 secondes avant de relancer. »)

## Déploiement (à faire par Quentin, le Worker n'est pas déployé par cette PR)

`wrangler deploy` demande les identifiants Cloudflare, donc rien n'a été expédié. Le Worker n'est pas redéployé par un push : il ne bouge que sur cette commande.

```sh
cd packages/edge-proxy
npx wrangler deploy
```

Ordre des opérations, dans la logique de la section « Order of operations » du README :

1. Merger cette PR dans `dev` (le Worker sert **les deux** hostnames, il n'y a qu'un script : le déploiement affecte prod et dev en même temps, c'est déjà le cas aujourd'hui).
2. `npx wrangler deploy` depuis `packages/edge-proxy`. Les routes du `wrangler.toml` sont réappliquées, `zone_name` reste `ohmywind.fr`. Rien à toucher côté Spaces : aucune variable couplée ne change, `EDGE_SHARED_SECRET` est conservé (il est déjà posé, un déploiement ne l'efface pas).
3. Vérifier au curl :

```sh
curl -sSI https://mcp-dev.ohmywind.fr/api/v1/archetypes | grep -i 'x-ohmywind-edge-cache'
curl -sSI https://mcp-dev.ohmywind.fr/api/v1/archetypes | grep -i 'x-ohmywind-edge-cache'   # HIT au second appel, depuis le même point de présence
curl -s https://mcp.ohmywind.fr/api/v1/_client                                              # via_edge true, hops_applied 2, seau inchangé
```

4. Optionnel, la règle de Rate Limiting : Security -> WAF -> Rate limiting rules sur la zone `ohmywind.fr`, expression et seuil ci-dessus.

Si quelque chose se passe mal, le rollback est un `npx wrangler rollback` (ou un redéploiement de la version précédente depuis le tableau de bord) : rien d'autre n'a changé de côté.

## La décision à prendre : keep-alive, oui ou non ?

La décision d'avril 2026 (`plan/02-decisions.md`, section 4) est explicite : **pas de préchauffage, on accepte le cold start de quelques secondes**. Elle est respectée : le cron est livré éteint.

Ce qui a changé depuis, c'est la taille de l'attente. Un Space gratuit s'endort après 48 h ; réveiller un conteneur endormi n'est pas « quelques secondes », c'est assez long pour que le `fetch` du Worker abandonne. Avec cette PR, l'utilisateur voit alors un 503 propre avec un délai à attendre au lieu d'une erreur opaque, mais il voit quand même un échec, et il doit réessayer.

- **Garder éteint** : conforme à la décision, zéro invocation supplémentaire, et le premier visiteur après un week-end creux essuie le réveil (avec, maintenant, un message clair).
- **Allumer** : décommenter deux lignes de `wrangler.toml` et redéployer. Coût : 48 invocations par jour (contre 100 000 requêtes/jour offertes) et 2 requêtes toutes les 30 minutes vers l'origine, comptées sur le seau de l'adresse de sortie Cloudflare. Bénéfice : plus jamais de réveil à froid subi par un utilisateur.

Pour désactiver plus tard une fois activé : `crons = []` puis redéploiement. Commenter la clé ne retire pas un déclencheur déjà enregistré sur le Worker déployé (documenté dans le README, c'est un piège de la plateforme).

Aucune ligne de code ne change dans un sens comme dans l'autre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
