### PR TITLE
feat(api): corps de requête gzippé sur /api/v1, plafond après décompression (lot 6.5a)

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -56,6 +56,37 @@ test asserts it by importing the package with the name `mcp` blocked.
 Serialising a passage is not here: that is `openwind_data.views`, shared with
 the MCP shell so the two describe the same sailing.
 
+## Compressed request bodies
+
+`POST /api/v1/*` accepts `Content-Encoding: gzip` (and `deflate`, in both the
+zlib and the raw shapes the name is used for). The web client's biggest
+legitimate body is 48 KB of `forecast_cache` that gzips to 1.5 KB, which on a
+marina 4G link is the difference between a plan that starts now and one that
+starts in a second.
+
+The 4 MiB body ceiling applies to the **decompressed** bytes, and it is
+enforced as they are produced rather than after the fact: `zlib` is never
+asked for more than what is left of the budget, so a body that expands past
+the ceiling is refused with the usual 413 `body_too_large` having allocated a
+few kilobytes. A compressed body is also still bounded on the wire by the same
+ceiling, by the middleware outside this one.
+
+| Situation | Status | `code` |
+| --- | --- | --- |
+| decompressed body over the ceiling | 413 | `body_too_large` |
+| `Content-Encoding` we do not implement (`br`, `zstd`, a list) | 415 | `unsupported_encoding` |
+| body that does not decode as it claims to | 422 | `invalid_body_encoding` |
+
+`/mcp` is untouched: it is outside the `/api/v1` prefix and frames its own
+bodies.
+
+Hugging Face's edge passes request bodies through untouched, headers included,
+so a gzipped POST reaches the container as it was sent. Nothing at the edge
+decompresses it on our behalf, and nothing there rejects the header. The
+Cloudflare Worker in `packages/edge-proxy` forwards the body unchanged too.
+Verify on the dev Space after a deploy with the plain and the gzipped body
+side by side: the two responses must be identical.
+
 ## Logs
 
 One line per request on the `openwind_api.access` logger, at INFO, in logfmt:
@@ -70,6 +101,9 @@ only CPU. `bucket` is `sha256(client address)[:8]`: enough to tell whether one
 caller is responsible for a burst, and not an address. **No address is ever
 logged**, in any field, in any shape, and a test greps the whole log to keep
 it that way.
+
+`enc` is appended only when the request declared a `Content-Encoding`, so a
+plain request logs the line it always logged.
 
 `X-Request-Id` is echoed when the caller sends a usable one (64 chars of
 `[A-Za-z0-9._:-]`) and generated otherwise, returned on every response and

--- a/packages/api/src/openwind_api/access.py
+++ b/packages/api/src/openwind_api/access.py
@@ -40,6 +40,12 @@ If a collector ever appears, this is the single place to change.
     it separates the requests that cost us an upstream fan-out from the ones
     that cost us only CPU.
 ``bucket`` the rate-limit bucket's fingerprint, ``sha256(ip)[:8]``.
+``enc`` the ``Content-Encoding`` the request declared, and only when it
+    declared one. Absent from the overwhelming majority of lines on purpose:
+    a plain request logs exactly what it logged before compressed bodies
+    existed, and ``enc=gzip`` reads as the exception it is. It is what tells
+    a 415 caused by ``br`` apart from one caused by anything else, without
+    the header itself ever being logged.
 
 ## Addresses
 
@@ -155,9 +161,11 @@ class AccessLogMiddleware:
         self, scope: Scope, request_id: str, status: int, started: float, body_bytes: int
     ) -> None:
         duration_ms = (time.perf_counter() - started) * 1000
-        cached = scope.get("state", {}).get("forecast_cache")
+        state = scope.get("state", {})
+        cached = state.get("forecast_cache")
+        encoding = state.get("request_encoding")
         _logger.info(
-            "id=%s method=%s path=%s status=%d dur_ms=%.1f bytes=%d cache=%s bucket=%s",
+            "id=%s method=%s path=%s status=%d dur_ms=%.1f bytes=%d cache=%s bucket=%s%s",
             _field(request_id),
             _field(scope.get("method", "-")),
             _field(scope.get("path", "-")),
@@ -166,4 +174,5 @@ class AccessLogMiddleware:
             body_bytes,
             "-" if cached is None else ("yes" if cached else "no"),
             _field(bucket_id(scope)),
+            "" if encoding is None else f" enc={_field(encoding)}",
         )

--- a/packages/api/src/openwind_api/app.py
+++ b/packages/api/src/openwind_api/app.py
@@ -34,6 +34,7 @@ from openwind_api.security import (
     ALLOWED_ORIGINS,
     BodySizeLimitMiddleware,
     RateLimitMiddleware,
+    RequestDecompressionMiddleware,
     SecurityHeadersMiddleware,
 )
 from openwind_api.services import Services
@@ -186,9 +187,15 @@ def create_app(
             Middleware(PathScopedGZipMiddleware),
             Middleware(SecurityHeadersMiddleware),
             Middleware(RateLimitMiddleware),
-            # Innermost: an over-sized body is refused after it has been
-            # counted against the caller's quota, never before.
+            # An over-sized body is refused after it has been counted
+            # against the caller's quota, never before.
             Middleware(BodySizeLimitMiddleware),
+            # Innermost, so it sees the bytes the ceiling above already
+            # accepted and applies the same ceiling again to what they expand
+            # to. The order is load-bearing: a compressed body's declared
+            # length says nothing about its decompressed size, so the outer
+            # check alone would let a 40 KB request become 4 GB of JSON.
+            Middleware(RequestDecompressionMiddleware),
         ],
         lifespan=_lifespan(services, mcp_app),
     )

--- a/packages/api/src/openwind_api/errors.py
+++ b/packages/api/src/openwind_api/errors.py
@@ -39,7 +39,10 @@ code                         status  meaning
 ``invalid_time_window``      422     start/end pair refused
 ``too_many_steps``           422     the series would be longer than allowed
 ``invalid_request``          422     anything else the domain refused
-``body_too_large``           413     the request body exceeds the ceiling
+``invalid_body_encoding``    422     the body does not decode as it claims to
+``body_too_large``           413     the request body exceeds the ceiling,
+                                     before or after decompression
+``unsupported_encoding``     415     ``Content-Encoding`` we cannot decode
 ``rate_limited``             429     our own limiter, with ``retry_after``
 ``upstream_timeout``         503     Open-Meteo did not answer in time
 ``upstream_rate_limited``    503     Open-Meteo is refusing us
@@ -48,6 +51,12 @@ code                         status  meaning
 A caller that does not recognise a code must fall back on the status: the list
 grows, and a client pinned to an exhaustive match would break on the next
 addition.
+
+The transport-level ones (``body_too_large``, ``unsupported_encoding``,
+``invalid_body_encoding``, ``rate_limited``) are raised in ``security.py``,
+which builds its own responses: it is deployment hardening and deliberately
+knows nothing about the domain. They are listed here because the table is the
+contract, and a caller does not care which module answered.
 """
 
 from __future__ import annotations

--- a/packages/api/src/openwind_api/security.py
+++ b/packages/api/src/openwind_api/security.py
@@ -23,6 +23,7 @@ import logging
 import math
 import os
 import time
+import zlib
 from collections import OrderedDict, deque
 from collections.abc import Iterable
 
@@ -456,6 +457,22 @@ MAX_BODY_BYTES = int(os.environ.get("OPENWIND_MAX_BODY_BYTES", str(4 * 1024 * 10
 DEFAULT_BODY_LIMITED_PREFIX = "/api/v1"
 
 
+def body_too_large_response(max_bytes: int) -> JSONResponse:
+    """The one 413 body, wherever the ceiling is enforced.
+
+    Shared with ``RequestDecompressionMiddleware`` below: a caller who blows
+    the ceiling with 4 MiB of JSON and one who blows it with 40 KB of gzip
+    that expands past it have hit the same rule, so they read the same
+    sentence and branch on the same code.
+    """
+    megabytes = max_bytes / (1024 * 1024)
+    rendered = f"{megabytes:.0f}" if megabytes >= 1 else f"{megabytes:.2f}"
+    return JSONResponse(
+        {"error": f"request body too large (max {rendered} MB)", "code": "body_too_large"},
+        status_code=413,
+    )
+
+
 class BodySizeLimitMiddleware:
     """Refuse an over-sized request body on the REST routes with a 413.
 
@@ -489,12 +506,7 @@ class BodySizeLimitMiddleware:
         self._prefix = prefix
 
     def _too_large_response(self) -> JSONResponse:
-        megabytes = self._max_bytes / (1024 * 1024)
-        rendered = f"{megabytes:.0f}" if megabytes >= 1 else f"{megabytes:.2f}"
-        return JSONResponse(
-            {"error": f"request body too large (max {rendered} MB)", "code": "body_too_large"},
-            status_code=413,
-        )
+        return body_too_large_response(self._max_bytes)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if (
@@ -552,6 +564,240 @@ def _content_length(scope: Scope) -> int | None:
             except ValueError:
                 return None
     return None
+
+
+# ------------------------------------------------ compressed request bodies
+
+# What a caller may say it compressed the body with. ``x-gzip`` is the
+# pre-RFC-2616 spelling and still turns up in older HTTP libraries; it names
+# the same format. Anything else, ``br`` and ``zstd`` included, is refused
+# rather than guessed at: a body we cannot read is not a body we should hand
+# a JSON parser.
+GZIP_ENCODINGS = frozenset({"gzip", "x-gzip"})
+DEFLATE_ENCODINGS = frozenset({"deflate"})
+SUPPORTED_REQUEST_ENCODINGS = GZIP_ENCODINGS | DEFLATE_ENCODINGS
+
+# ``identity`` is the explicit absence of compression, and so is a missing
+# header. Both go straight through.
+_NO_ENCODING = frozenset({"", "identity"})
+
+
+class _DecompressionError(Exception):
+    """Raised inside the read loop, turned into a response by the caller."""
+
+
+class _BodyTooLargeError(_DecompressionError):
+    pass
+
+
+class _BodyNotDecodableError(_DecompressionError):
+    pass
+
+
+def unsupported_encoding_response() -> JSONResponse:
+    """415 for a Content-Encoding we do not implement."""
+    return JSONResponse(
+        {"error": "unsupported content encoding", "code": "unsupported_encoding"},
+        status_code=415,
+        # RFC 9110 5.3.4: a 415 caused by the content coding may carry the
+        # codings that would have worked, which is the only machine-readable
+        # way to say "send it plain or send it gzipped".
+        headers={"Accept-Encoding": "gzip, deflate, identity"},
+    )
+
+
+def invalid_body_encoding_response(encoding: str) -> JSONResponse:
+    """422 for a body that claims an encoding it does not actually carry."""
+    named = "gzip" if encoding in GZIP_ENCODINGS else encoding
+    return JSONResponse(
+        {"error": f"invalid {named} body", "code": "invalid_body_encoding"},
+        status_code=422,
+    )
+
+
+def _deflate_window_bits(head: bytes) -> int:
+    """zlib-wrapped or raw deflate, decided by the first two bytes.
+
+    ``Content-Encoding: deflate`` is specified as the zlib format (RFC 1950)
+    and is sent as a bare deflate stream (RFC 1951) by a long tail of clients
+    that read the name literally. Both are unambiguous on the wire: a zlib
+    header is a byte whose low nibble is 8 followed by a byte that makes the
+    pair a multiple of 31, and no raw deflate block can start that way often
+    enough to matter. Sniffing costs two bytes; refusing half the callers over
+    a naming accident from 1996 costs more.
+    """
+    if len(head) >= 2:
+        cmf, flg = head[0], head[1]
+        if cmf & 0x0F == 8 and ((cmf << 8) | flg) % 31 == 0:
+            return zlib.MAX_WBITS
+    return -zlib.MAX_WBITS
+
+
+class RequestDecompressionMiddleware:
+    """Decompress a ``Content-Encoding: gzip`` request body, under the ceiling.
+
+    The web client posts a ``forecast_cache`` that measured 48 KB in clear
+    text and 1.5 KB gzipped, which is the difference between a plan that
+    starts immediately on a marina 4G link and one that spends a second
+    uploading. The responses have been compressed since PR 0.5; this is the
+    other direction.
+
+    Why this cannot simply be ``BodySizeLimitMiddleware`` with a decompressor
+    bolted on: that middleware's whole job is to decide from
+    ``Content-Length``, and the declared length of a compressed body says
+    nothing about what it expands to. gzip's maximum ratio is about 1030:1, so
+    a 4 MiB body the ceiling happily accepts can carry 4 GiB of zeroes. **The
+    ceiling that matters here is on the decompressed bytes**, and it is
+    enforced as they are produced: ``decompress(max_length=...)`` never
+    materialises more than what is left of the budget, so a bomb is refused
+    having allocated a few kilobytes, not a few gigabytes.
+
+    Placed innermost, inside ``BodySizeLimitMiddleware``, which therefore
+    still bounds the *compressed* bytes we agree to read at all, and inside
+    the rate limiter, so a caller shovelling bombs still burns quota.
+
+    ``/mcp`` never reaches here: the prefix is the REST surface, and the MCP
+    transport owns its own framing.
+    """
+
+    _BODYLESS_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "DELETE"})
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        max_bytes: int = MAX_BODY_BYTES,
+        prefix: str = DEFAULT_BODY_LIMITED_PREFIX,
+    ) -> None:
+        self.app = app
+        self._max_bytes = max_bytes
+        self._prefix = prefix
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope["type"] != "http"
+            or scope.get("method", "").upper() in self._BODYLESS_METHODS
+            or not scope.get("path", "").startswith(self._prefix)
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        encoding = _content_encoding(scope)
+        if encoding in _NO_ENCODING:
+            await self.app(scope, receive, send)
+            return
+
+        # Recorded before the support check, so the access log can say what a
+        # 415 was refused for without the header having to be logged.
+        scope.setdefault("state", {})["request_encoding"] = encoding
+
+        if encoding not in SUPPORTED_REQUEST_ENCODINGS:
+            await unsupported_encoding_response()(scope, receive, send)
+            return
+
+        try:
+            chunks, total = await self._read_decompressed(receive, encoding)
+        except _BodyTooLargeError:
+            await body_too_large_response(self._max_bytes)(scope, receive, send)
+            return
+        except _BodyNotDecodableError:
+            await invalid_body_encoding_response(encoding)(scope, receive, send)
+            return
+
+        # The app downstream must see the body it is about to read: the
+        # encoding is gone, and the length is the decompressed one. Leaving
+        # the compressed Content-Length in place would misinform anything that
+        # trusts it, starting with a future middleware of our own.
+        scope["headers"] = [
+            (name, value)
+            for name, value in scope.get("headers", ())
+            if name not in (b"content-encoding", b"content-length")
+        ] + [(b"content-length", str(total).encode("latin-1"))]
+
+        queued = list(chunks) or [b""]
+
+        async def replay() -> Message:
+            if queued:
+                body = queued.pop(0)
+                return {"type": "http.request", "body": body, "more_body": bool(queued)}
+            return await receive()
+
+        await self.app(scope, replay, send)
+
+    async def _read_decompressed(self, receive: Receive, encoding: str) -> tuple[list[bytes], int]:
+        """Drain the compressed stream into decompressed chunks, or refuse.
+
+        Never holds more than ``max_bytes`` of output, and never asks zlib for
+        more than the budget still allows in a single call.
+        """
+        decompressor: zlib._Decompress | None = None
+        chunks: list[bytes] = []
+        total = 0
+        more = True
+        while more:
+            message = await receive()
+            if message["type"] != "http.request":
+                # A disconnect mid-upload. Stop reading; the eof check below
+                # will call the truncated body what it is, and the response
+                # goes nowhere because the client has gone.
+                break
+            data = message.get("body", b"")
+            more = message.get("more_body", False)
+            if not data:
+                continue
+            if decompressor is None:
+                window = (
+                    zlib.MAX_WBITS | 16
+                    if encoding in GZIP_ENCODINGS
+                    else _deflate_window_bits(data)
+                )
+                decompressor = zlib.decompressobj(window)
+            while data:
+                budget = self._max_bytes - total
+                try:
+                    # ``max_length=budget + 1`` is the bomb guard: one byte
+                    # over the ceiling is all that is ever allocated, and it
+                    # is enough to know the body is over it.
+                    produced = decompressor.decompress(data, max_length=budget + 1)
+                except zlib.error as exc:
+                    raise _BodyNotDecodableError(str(exc)) from exc
+                total += len(produced)
+                if total > self._max_bytes:
+                    raise _BodyTooLargeError()
+                if produced:
+                    chunks.append(produced)
+                # Non-empty only when ``max_length`` cut the call short, so
+                # the budget strictly shrinks each time round and this ends.
+                data = decompressor.unconsumed_tail
+
+        if decompressor is None:
+            # ``Content-Encoding: gzip`` and nothing to decode: an empty
+            # stream is not a valid member of either format.
+            raise _BodyNotDecodableError("empty body")
+        if not decompressor.eof:
+            # zlib does not raise on a stream that simply stops early, so a
+            # truncated upload would otherwise reach the handler as a
+            # half-parsed body and be reported as invalid JSON.
+            raise _BodyNotDecodableError("truncated stream")
+        if decompressor.unused_data:
+            # Bytes after the end of the stream. Concatenated gzip members are
+            # legal in the format and are not something any client of this API
+            # produces; silently dropping them would truncate the body.
+            raise _BodyNotDecodableError("trailing data after the compressed stream")
+        return chunks, total
+
+
+def _content_encoding(scope: Scope) -> str:
+    """Declared body encoding, lowercased and trimmed, ``""`` when absent.
+
+    A list of codings (``gzip, gzip``) is refused rather than unwrapped: it
+    does not occur outside a test suite, and layered decompression is a second
+    place for a bomb to hide.
+    """
+    for name, value in scope.get("headers", ()):
+        if name == b"content-encoding":
+            return value.decode("latin-1").strip().lower()
+    return ""
 
 
 # ---------------------------------------------------------- security headers

--- a/packages/api/tests/test_request_decompression.py
+++ b/packages/api/tests/test_request_decompression.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+"""Compressed request bodies on ``POST /api/v1/*``.
+
+The web client's ``forecast_cache`` is the reason this exists: 48 KB of clear
+JSON that gzips to 1.5 KB, uploaded from a phone on a marina 4G link before a
+single byte of planning can start. Responses have been compressed since PR
+0.5; this is the other direction, and it is the one with teeth, because a
+request body is chosen by the caller.
+
+Three properties, in order of how much they matter:
+
+1. **The same bytes come back.** A gzipped body and its plain twin produce
+   responses that are equal byte for byte, checked against the recorded
+   golden so a divergence shows up as a contract diff rather than a nuance.
+2. **The ceiling holds on what the body expands to**, not on what it declares.
+   ``test_a_compression_bomb_is_refused`` posts 4 GiB of zeroes as 4 MB of
+   gzip and asserts the same 413 as a plain over-sized body.
+3. **A body we cannot read is refused, not guessed at.** 415 for an encoding
+   we do not implement, 422 for one we do and that turns out to be corrupt.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import re
+import zlib
+from datetime import UTC, datetime
+
+import pytest
+from starlette.testclient import TestClient
+
+from openwind_api import security
+from openwind_api.app import create_app
+from openwind_api.settings import Settings
+
+DEPARTURE = datetime(2026, 5, 1, 6, 0, tzinfo=UTC)
+MARSEILLE = [43.29, 5.37]
+PORQUEROLLES = [43.00, 6.20]
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app(Settings()))
+
+
+def _body(**extra) -> dict:
+    body = {
+        "waypoints": [MARSEILLE, PORQUEROLLES],
+        "departure": DEPARTURE.isoformat(),
+        "archetype": "cruiser_30ft",
+        "efficiency": 0.75,
+    }
+    body.update(extra)
+    return body
+
+
+# 256 MiB of zeroes, 64 times the body ceiling, built a megabyte at a time so
+# the test process never holds what the middleware must refuse to hold either.
+# gzip tops out near 1030:1, so this is a quarter of what a body the ceiling
+# accepts could carry; it is sized for a fast test, not for the worst case.
+BOMB_PLAIN_BYTES = 256 * 1024 * 1024
+
+
+def _gzip_zeroes(size: int) -> bytes:
+    chunk = b"\0" * (1024 * 1024)
+    compressor = zlib.compressobj(wbits=zlib.MAX_WBITS | 16)
+    pieces = [compressor.compress(chunk) for _ in range(size // len(chunk))]
+    pieces.append(compressor.flush())
+    return b"".join(pieces)
+
+
+@pytest.fixture(scope="module")
+def bomb() -> bytes:
+    return _gzip_zeroes(BOMB_PLAIN_BYTES)
+
+
+def _post(client, payload: bytes, encoding: str, path: str = "/api/v1/passage"):
+    return client.post(
+        path,
+        content=payload,
+        headers={"Content-Type": "application/json", "Content-Encoding": encoding},
+    )
+
+
+class TestAcceptedBodies:
+    def test_a_gzipped_body_is_read_like_a_plain_one(self, client) -> None:
+        plain = json.dumps(_body(departure="tomorrow-ish")).encode()
+        assert (
+            _post(client, gzip.compress(plain), "gzip").content
+            == client.post(
+                "/api/v1/passage", content=plain, headers={"Content-Type": "application/json"}
+            ).content
+        )
+
+    def test_the_handler_sees_the_whole_payload(self, client) -> None:
+        # Not just "it parsed": a body truncated at the first chunk boundary
+        # would still be valid JSON prefix-wise and fail on a later field.
+        resp = _post(client, gzip.compress(json.dumps(_body(efficiency=4.0)).encode()), "gzip")
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "invalid_efficiency"
+
+    def test_a_body_split_across_chunks_is_reassembled(self, client) -> None:
+        """Chunked upload: the transport decides where the pieces fall.
+
+        The decompressor is fed message by message, so a stream cut in the
+        middle of a deflate block is the normal case, not the exotic one.
+        """
+        compressed = gzip.compress(json.dumps(_body(departure="tomorrow-ish")).encode())
+
+        def chunks():
+            for i in range(0, len(compressed), 7):
+                yield compressed[i : i + 7]
+
+        resp = client.post(
+            "/api/v1/passage",
+            content=chunks(),
+            headers={"Content-Type": "application/json", "Content-Encoding": "gzip"},
+        )
+        assert resp.status_code == 422
+        assert "invalid departure" in resp.json()["error"]
+
+    @pytest.mark.parametrize("encoding", ["gzip", "GZIP", " gzip ", "x-gzip"])
+    def test_the_header_is_matched_case_and_space_insensitively(self, client, encoding) -> None:
+        resp = _post(client, gzip.compress(b"{}"), encoding)
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "missing_fields"
+
+    @pytest.mark.parametrize(
+        "compress",
+        [
+            pytest.param(zlib.compress, id="zlib-wrapped"),
+            pytest.param(
+                lambda raw: (lambda c: c.compress(raw) + c.flush())(
+                    zlib.compressobj(wbits=-zlib.MAX_WBITS)
+                ),
+                id="raw",
+            ),
+        ],
+    )
+    def test_deflate_is_accepted_in_both_shapes_the_name_means(self, client, compress) -> None:
+        # RFC 1950 says zlib, a long tail of clients hears RFC 1951. Both are
+        # unambiguous on the wire, so both are read.
+        resp = _post(client, compress(json.dumps(_body(archetype="galleon")).encode()), "deflate")
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "unknown_archetype"
+
+    @pytest.mark.parametrize("encoding", ["identity", ""])
+    def test_an_explicit_absence_of_encoding_is_a_pass_through(self, client, encoding) -> None:
+        resp = _post(client, json.dumps(_body(efficiency=4.0)).encode(), encoding)
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "invalid_efficiency"
+
+    def test_the_by_eta_route_takes_it_too(self, client) -> None:
+        payload = {
+            "waypoints": [MARSEILLE, PORQUEROLLES],
+            "target_arrival": "not-a-date",
+            "archetype": "cruiser_30ft",
+        }
+        resp = _post(
+            client, gzip.compress(json.dumps(payload).encode()), "gzip", "/api/v1/passage-by-eta"
+        )
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "invalid_datetime"
+
+
+class TestCeiling:
+    """The ceiling is on what the body expands to, and it holds early."""
+
+    def test_a_compression_bomb_is_refused(self, client, bomb) -> None:
+        """256 MiB of zeroes in 255 KB of gzip: the reason this is streamed.
+
+        The declared length is a fraction of the body ceiling, so the outer
+        middleware waves it through and would be right to. What refuses it is
+        the budget handed to ``decompress(max_length=...)``, which never lets
+        zlib allocate more than one byte past the ceiling.
+        """
+        assert len(bomb) < security.MAX_BODY_BYTES
+        resp = _post(client, bomb, "gzip")
+        assert resp.status_code == 413
+        assert resp.json() == {
+            "error": "request body too large (max 4 MB)",
+            "code": "body_too_large",
+        }
+
+    def test_the_budget_handed_to_zlib_never_exceeds_the_ceiling(self, monkeypatch, bomb) -> None:
+        """The property behind the previous test, read off the call itself.
+
+        "Refused with a 413" would also be true of an implementation that
+        inflated the whole 256 MiB first and measured afterwards, which is the
+        failure this guards: what is asserted is that zlib is never allowed to
+        produce more than one byte past the budget in a single call.
+        """
+        budgets: list[int] = []
+        original = zlib.decompressobj
+
+        class _Watched:
+            """Everything the middleware reads, plus a note of every budget."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def decompress(self, data, max_length=0):
+                budgets.append(max_length)
+                return self._inner.decompress(data, max_length=max_length)
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        monkeypatch.setattr(zlib, "decompressobj", lambda *a, **k: _Watched(original(*a, **k)))
+        client = TestClient(create_app(Settings()))
+        resp = _post(client, bomb, "gzip")
+
+        assert resp.status_code == 413
+        assert budgets, "the decompressor was never exercised"
+        assert max(budgets) <= security.MAX_BODY_BYTES + 1
+
+    def test_a_body_that_expands_to_exactly_the_ceiling_is_accepted(self, monkeypatch) -> None:
+        # The boundary belongs to the caller: the ceiling is what a body may
+        # be, not what it must stay under.
+        monkeypatch.setattr(
+            security.RequestDecompressionMiddleware,
+            "__init__",
+            _init_with(max_bytes=512),
+        )
+        client = TestClient(create_app(Settings()))
+        filler = "a" * (512 - len('{"filler":""}'))
+        resp = _post(client, gzip.compress(f'{{"filler":"{filler}"}}'.encode()), "gzip")
+        assert resp.status_code == 422
+        assert resp.json()["code"] == "missing_fields"
+
+    def test_one_byte_past_the_ceiling_is_refused(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            security.RequestDecompressionMiddleware,
+            "__init__",
+            _init_with(max_bytes=512),
+        )
+        client = TestClient(create_app(Settings()))
+        filler = "a" * (513 - len('{"filler":""}'))
+        resp = _post(client, gzip.compress(f'{{"filler":"{filler}"}}'.encode()), "gzip")
+        assert resp.status_code == 413
+
+    def test_the_compressed_bytes_are_still_capped_by_the_outer_ceiling(self, client) -> None:
+        # Incompressible payload, so the compressed body itself is over the
+        # ceiling: the answer must come from BodySizeLimitMiddleware without
+        # a decompressor ever being built.
+        oversized = gzip.compress(b"x" * (security.MAX_BODY_BYTES + 1), compresslevel=0)
+        assert len(oversized) > security.MAX_BODY_BYTES
+        resp = _post(client, oversized, "gzip")
+        assert resp.status_code == 413
+
+
+class TestRefusedEncodings:
+    @pytest.mark.parametrize("encoding", ["br", "zstd", "compress", "gzip, gzip", "utf-8"])
+    def test_an_encoding_we_cannot_decode_is_a_415(self, client, encoding) -> None:
+        resp = _post(client, b"whatever", encoding)
+        assert resp.status_code == 415
+        assert resp.json() == {
+            "error": "unsupported content encoding",
+            "code": "unsupported_encoding",
+        }
+
+    def test_the_415_says_what_would_have_worked(self, client) -> None:
+        resp = _post(client, b"whatever", "br")
+        assert "gzip" in resp.headers["accept-encoding"]
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(b"not gzip at all", id="not-compressed"),
+            pytest.param(gzip.compress(b'{"a": 1}')[:20], id="truncated"),
+            pytest.param(gzip.compress(b'{"a": 1}')[:-1], id="missing-trailer"),
+            pytest.param(gzip.compress(b'{"a": 1}') + b"junk", id="trailing-junk"),
+            pytest.param(b"", id="empty"),
+        ],
+    )
+    def test_a_body_that_is_not_what_it_claims_is_a_422(self, client, payload) -> None:
+        resp = _post(client, payload, "gzip")
+        assert resp.status_code == 422
+        assert resp.json() == {"error": "invalid gzip body", "code": "invalid_body_encoding"}
+
+    def test_a_corrupt_deflate_body_names_deflate(self, client) -> None:
+        resp = _post(client, b"\x78\x9c" + b"\xff" * 40, "deflate")
+        assert resp.status_code == 422
+        assert resp.json() == {"error": "invalid deflate body", "code": "invalid_body_encoding"}
+
+    def test_a_refusal_still_counts_against_the_rate_limit(self, monkeypatch) -> None:
+        # Decompression is inside the limiter: shovelling bombs is not a way
+        # to spend our CPU for free.
+        original = security.RateLimitMiddleware.__init__
+
+        def _one(self, app, **kwargs):
+            original(self, app, **{**kwargs, "max_requests": 1})
+
+        monkeypatch.setattr(security.RateLimitMiddleware, "__init__", _one)
+        client = TestClient(create_app(Settings()))
+        assert _post(client, b"not gzip at all", "gzip").status_code == 422
+        assert _post(client, gzip.compress(b"{}"), "gzip").status_code == 429
+
+
+class TestScope:
+    def test_a_get_is_never_touched(self, client) -> None:
+        # No body to decode, and a Content-Encoding on a GET describes
+        # nothing. It must not turn a working request into a 415.
+        resp = client.get("/api/v1/archetypes", headers={"Content-Encoding": "br"})
+        assert resp.status_code == 200
+
+    def test_the_mcp_transport_is_left_alone(self) -> None:
+        """It frames its own bodies, and it is not under ``/api/v1``."""
+        seen: dict[str, object] = {}
+
+        async def _echo(scope, receive, send):
+            message = await receive()
+            seen["body"] = message.get("body", b"")
+            seen["headers"] = dict(scope["headers"])
+            from starlette.responses import PlainTextResponse
+
+            await PlainTextResponse("ok")(scope, receive, send)
+
+        client = TestClient(security.RequestDecompressionMiddleware(_echo))
+        payload = gzip.compress(b'{"a": 1}')
+        resp = client.post("/mcp", content=payload, headers={"Content-Encoding": "gzip"})
+        assert resp.status_code == 200
+        assert seen["body"] == payload
+
+    def test_the_handler_sees_the_decompressed_length(self) -> None:
+        """A stale, compressed Content-Length would misinform anything downstream."""
+        seen: dict[str, object] = {}
+
+        async def _echo(scope, receive, send):
+            body = b""
+            more = True
+            while more:
+                message = await receive()
+                body += message.get("body", b"")
+                more = message.get("more_body", False)
+            seen["body"] = body
+            seen["headers"] = {k.decode(): v.decode() for k, v in scope["headers"]}
+            from starlette.responses import PlainTextResponse
+
+            await PlainTextResponse("ok")(scope, receive, send)
+
+        client = TestClient(security.RequestDecompressionMiddleware(_echo))
+        plain = b'{"waypoints": []}'
+        client.post(
+            "/api/v1/passage",
+            content=gzip.compress(plain),
+            headers={"Content-Encoding": "gzip"},
+        )
+        assert seen["body"] == plain
+        headers = seen["headers"]
+        assert headers["content-length"] == str(len(plain))  # type: ignore[index]
+        assert "content-encoding" not in headers  # type: ignore[operator]
+
+
+class TestAccessLog:
+    def test_a_compressed_request_is_logged_as_one(self, client, caplog) -> None:
+        caplog.set_level(logging.INFO, logger="openwind_api.access")
+        _post(client, gzip.compress(b"{}"), "gzip")
+        line = [r.getMessage() for r in caplog.records if r.name == "openwind_api.access"][-1]
+        assert " enc=gzip" in line
+
+    def test_a_refused_encoding_is_logged_with_its_name(self, client, caplog) -> None:
+        caplog.set_level(logging.INFO, logger="openwind_api.access")
+        _post(client, b"whatever", "br")
+        line = [r.getMessage() for r in caplog.records if r.name == "openwind_api.access"][-1]
+        assert " enc=br" in line
+        assert " status=415 " in line
+
+    def test_a_plain_request_logs_the_line_it_always_logged(self, client, caplog) -> None:
+        # The field is absent, not "-": every existing line keeps its shape.
+        caplog.set_level(logging.INFO, logger="openwind_api.access")
+        client.get("/api/v1/archetypes")
+        line = [r.getMessage() for r in caplog.records if r.name == "openwind_api.access"][-1]
+        assert "enc=" not in line
+        assert re.search(r"bucket=[0-9a-f]{8}$", line)
+
+
+def _init_with(**overrides):
+    original = security.RequestDecompressionMiddleware.__init__
+
+    def _init(self, app, **kwargs):
+        kwargs.update(overrides)
+        original(self, app, **kwargs)
+
+    return _init

--- a/packages/api/tests/test_rest_goldens.py
+++ b/packages/api/tests/test_rest_goldens.py
@@ -25,6 +25,7 @@ below is produced without an MCP server in the process.
 
 from __future__ import annotations
 
+import gzip
 import json
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -154,6 +155,23 @@ class TestPassage:
         )
         assert resp.status_code == 200
         assert_golden("passage_single_forecast_cache.json", resp.content)
+
+    def test_a_gzipped_request_produces_the_very_same_bytes(self, client) -> None:
+        """The contract for compressed request bodies, stated as an equality.
+
+        The request that produced ``passage_single.json`` is posted again,
+        gzipped, and has to come back byte for byte identical. Anything the
+        decompression path does to the body other than decompress it, a lost
+        final chunk, a stray BOM, a re-encoded string, shows up here as a
+        golden diff rather than as a subtly different plan.
+        """
+        resp = client.post(
+            "/api/v1/passage",
+            content=gzip.compress(json.dumps(_passage_body()).encode()),
+            headers={"Content-Type": "application/json", "Content-Encoding": "gzip"},
+        )
+        assert resp.status_code == 200
+        assert_golden("passage_single.json", resp.content)
 
     def test_sweep_mode(self, client) -> None:
         resp = client.post(


### PR DESCRIPTION
Lot 6.5a. `POST /api/v1/*` accepte désormais un corps compressé. Le web client poste un `forecast_cache` de 48 Ko qui gzippe à 1,5 Ko : sur une 4G de port, c'est la différence entre un calcul qui démarre tout de suite et un qui passe une seconde à téléverser. Les réponses sont compressées depuis la PR 0.5, voici l'autre sens.

La PR web 6.5 consomme ce contrat en parallèle.

## Ce qui change

`RequestDecompressionMiddleware` (dans `security.py`, avec le reste du durcissement transport), placé **au plus profond de la pile**, à l'intérieur de `BodySizeLimitMiddleware` et du rate limiter.

| Situation | Statut | `code` |
|---|---|---|
| corps décompressé au-dessus du plafond | 413 | `body_too_large` (corps et formulation inchangés) |
| `Content-Encoding` non implémenté (`br`, `zstd`, une liste) | 415 | `unsupported_encoding` |
| corps qui ne décode pas comme il le prétend | 422 | `invalid_body_encoding` |

Codages acceptés : `gzip`, `x-gzip`, `deflate` (enveloppe zlib RFC 1950 **et** flux brut RFC 1951, départagés par les deux premiers octets), `identity` et l'absence d'en-tête en passe-plat.

## Le point qui compte : le plafond porte sur ce que le corps devient

La longueur déclarée d'un corps compressé ne dit rien de sa taille décompressée : gzip plafonne vers 1030:1, donc 4 Mio que le plafond actuel accepte volontiers peuvent porter 4 Gio de zéros. Le plafond est donc appliqué **pendant la production des octets** : `decompress(max_length=budget + 1)` ne laisse jamais zlib matérialiser plus d'un octet au-delà du budget restant. Une bombe est refusée en ayant alloué quelques kilo-octets.

Les octets compressés restent bornés par le même plafond de 4 Mio, par le middleware au-dessus : un corps gzip incompressible de plus de 4 Mio est refusé avant qu'un décompresseur existe.

`/mcp` n'est jamais concerné : il est hors du préfixe `/api/v1` et gère son propre cadrage.

## Journal d'accès

Un champ `enc` est ajouté, **seulement quand la requête a déclaré un `Content-Encoding`**. Une requête en clair journalise exactement la ligne qu'elle journalisait avant, et `enc=br` sur un 415 dit pourquoi sans que l'en-tête lui-même soit journalisé.

```
id=1270d141a362829c method=POST path=/api/v1/passage status=200 dur_ms=0.7 bytes=4267 cache=no bucket=aaf075b7 enc=gzip
id=b5013b810d90a546 method=POST path=/api/v1/passage status=415 dur_ms=0.1 bytes=70 cache=- bucket=aaf075b7 enc=br
id=70636cb48f3bd2ac method=POST path=/api/v1/passage status=413 dur_ms=10.1 bytes=69 cache=- bucket=aaf075b7 enc=gzip
```

## Tests

37 tests ajoutés (36 dans `tests/test_request_decompression.py`, 1 dans les goldens). Suite `api` 237 -> 274. `data-adapters` 385, `mcp-core` 70, `hf-space` 12, inchangées. ruff check + format propres, pyright basic 0 erreur sur `api` et `data-adapters`.

**Goldens : aucun octet modifié.** `test_a_gzipped_request_produces_the_very_same_bytes` reposte la requête qui a produit `passage_single.json`, gzippée, et compare au même golden : c'est le contrat énoncé comme une égalité.

Le test de bombe construit 256 Mio de zéros mégaoctet par mégaoctet (255 Ko de gzip) pour ne jamais tenir en mémoire ce que le middleware refuse justement de tenir, et `test_the_budget_handed_to_zlib_never_exceeds_the_ceiling` lit les `max_length` passés à zlib : « refusé avec un 413 » serait aussi vrai d'une implémentation qui gonfle tout d'abord et mesure ensuite.

## Smoke local (Space complet, vrais atlas MARC + SHOM)

Marseille (43.29, 5.37) -> Porquerolles (43.00, 6.20), demain 09:00+02:00, `cruiser_30ft`, en clair puis gzippé :

```
PLAIN  status=200 bytes=4267 time=0.364 s
GZIP   status=200 bytes=4267 time=0.002 s   (cache amont déjà chaud)
```

146 feuilles JSON comparées une à une : **une seule diffère**, `forecast_updated_at`, horodatage estampillé par requête. 40,31359497580557 nm, 14,912189032777777 h, `meteofrance_arome_france`, `max_sampling_drift_h` 6,25.

```
Content-Encoding: br      -> 415 {"error":"unsupported content encoding","code":"unsupported_encoding"}
gzip tronqué (40 octets)  -> 422 {"error":"invalid gzip body","code":"invalid_body_encoding"}
bombe 256 Mio / 255 Ko    -> 413 {"error":"request body too large (max 4 MB)","code":"body_too_large"} en 10,1 ms
POST /mcp + Content-Encoding: br -> 400 du transport MCP, pas notre 415 (il n'est pas passé par nous)
```

MCP : `initialize` OK (`ohmywind` 1.27.2), `tools/list` = `read_me`, `list_boat_archetypes`, `get_marine_forecast`, `plan_passage`.

## Vérification restant à faire côté Space dev

Documenté dans `packages/api/README.md` : le bord Hugging Face passe les corps de requête tels quels, en-têtes compris, et le Worker Cloudflare aussi. À confirmer après merge sur le Space dev en postant le corps en clair et le même corps gzippé côte à côte : les deux réponses doivent être identiques.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
