### PR TITLE
refacto(web): le thème Tailwind est adossé aux jetons de design (lot 4.5)

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -65,7 +65,7 @@
       }
     </script>
   </head>
-  <body class="bg-gray-950 text-white">
+  <body class="bg-surface-0 text-ink-0">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -294,7 +294,7 @@ function App() {
           ref={fabRef}
           href={`/plan${mapViewQuery(mapView)}`}
           className="absolute top-3 left-3 z-[400] w-[58px] h-[58px] sm:w-20 sm:h-20 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95"
-          style={{ background: "var(--ow-accent)", color: "#fff" }}
+          style={{ background: "var(--ow-accent)", color: "var(--ow-on-accent)" }}
           title="Planifier un passage"
         >
           <img src="/compass.png" alt="" className="select-none w-[64px] h-[64px] sm:w-[88px] sm:h-[88px]" draggable={false} />

--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -31,7 +31,9 @@ const loadConfidentialite = () =>
 
 // Les deux pages imposent un fond "papier blanc" quel que soit le theme.
 // L'attente reprend ce fond pour eviter un clignotement sombre puis clair
-// pendant le telechargement du chunk.
+// pendant le telechargement du chunk. Les deux valeurs sont ecrites en dur
+// exprès : elles appartiennent a la palette papier de routes/*.css, qui ne
+// suit deliberement aucun theme, et non aux jetons --ow-*.
 const docFallback = (
   <div className="min-h-screen" style={{ background: "#ffffff", color: "#6b7280" }}>
     <p className="max-w-3xl mx-auto px-6 py-10 text-sm">Chargement…</p>

--- a/packages/web/src/components/InfoPanel.tsx
+++ b/packages/web/src/components/InfoPanel.tsx
@@ -247,7 +247,7 @@ export function InfoPanel() {
           className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold transition-transform hover:scale-105 active:scale-95"
           style={{
             background: "var(--ow-accent)",
-            color: "#fff",
+            color: "var(--ow-on-accent)",
           }}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -96,9 +96,9 @@ function MarineCellImpl({
   isDayStart,
   onSelect,
 }: MarineCellProps) {
-  const nowBorder = isNow ? "border-l-2 border-l-teal-400" : "";
+  const nowBorder = isNow ? "border-l-2 border-l-accent" : "";
   const daySepClass = !isNow && isDayStart ? "ow-day-sep" : "";
-  const selectedStyle = selected ? "ring-2 ring-teal-400/70 ring-inset bg-teal-400/10" : "";
+  const selectedStyle = selected ? "ring-2 ring-accent/70 ring-inset bg-accent/10" : "";
   const select = () => onSelect(time);
 
   if (timeIdx == null) {

--- a/packages/web/src/components/PolarDiagram.tsx
+++ b/packages/web/src/components/PolarDiagram.tsx
@@ -396,10 +396,10 @@ export function PolarDiagram({
           touch-action: none;
         }
         .polar-handle:hover {
-          fill: #fff;
+          fill: var(--ow-on-accent);
         }
         .polar-handle.is-overridden {
-          fill: #fbbf24;
+          fill: var(--ow-warn);
         }
         .polar-handle.is-readonly {
           cursor: default;

--- a/packages/web/src/components/SeamarkButton.tsx
+++ b/packages/web/src/components/SeamarkButton.tsx
@@ -30,7 +30,7 @@ export function SeamarkButton({ enabled, onToggle, className = "" }: SeamarkButt
         background: enabled ? "var(--ow-accent)" : "var(--ow-surface-glass)",
         backdropFilter: "blur(8px)",
         border: enabled ? "1px solid var(--ow-accent)" : "1px solid var(--ow-line-2)",
-        color: enabled ? "#fff" : "var(--ow-fg-1)",
+        color: enabled ? "var(--ow-on-accent)" : "var(--ow-fg-1)",
       }}
     >
       {/* East cardinal beacon: two cones base to base on a staff, standing

--- a/packages/web/src/components/SpotDialogs.tsx
+++ b/packages/web/src/components/SpotDialogs.tsx
@@ -72,7 +72,7 @@ export function SpotEditDialog({
           Renommer
         </button>
         <button
-          className="w-full min-h-[44px] py-2.5 rounded-lg bg-red-700/80 text-white text-sm font-medium hover:bg-red-600 active:bg-red-500 active:scale-[0.98] transition-all"
+          className="w-full min-h-[44px] py-2.5 rounded-lg bg-danger text-on-danger text-sm font-medium hover:bg-danger-hover active:bg-danger-active active:scale-[0.98] transition-all"
           onClick={onDelete}
         >
           Supprimer
@@ -124,7 +124,7 @@ export function SpotNameDialog({
           Annuler
         </button>
         <button
-          className="flex-1 min-h-[44px] py-2.5 rounded-lg bg-teal-600 text-white text-sm font-semibold hover:bg-teal-500 active:scale-[0.98] transition-all"
+          className="flex-1 min-h-[44px] py-2.5 rounded-lg bg-accent-strong text-on-accent text-sm font-semibold hover:bg-accent-strong-hover active:scale-[0.98] transition-all"
           onClick={onConfirm}
         >
           {renaming ? "Renommer" : "Créer"}

--- a/packages/web/src/components/SpotMap.tsx
+++ b/packages/web/src/components/SpotMap.tsx
@@ -6,6 +6,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { Spot, ModelForecast, MarineHourly, MetricView } from "../types";
 import { useTheme } from "../design/useTheme";
+import { readToken } from "../design/tokens";
 import { reverseGeocode } from "../api/reverseGeocode";
 import { useLongPress, type LongPressDetail } from "../hooks/useLongPress";
 import { SpotEditDialog, SpotNameDialog, type PendingSpot } from "./SpotDialogs";
@@ -172,7 +173,10 @@ export function SpotMap({
   useEffect(() => {
     if (!mapRef.current) return;
     syncPreviewMarker(mapRef.current, previewLayerRef, current, customSpots);
-  }, [current, customSpots]);
+    // resolvedTheme is a dependency because the marker colours are read from
+    // the theme now, and Leaflet keeps a resolved string: without it, toggling
+    // the theme would leave the markers painted in the previous palette.
+  }, [current, customSpots, resolvedTheme]);
 
   // Draw the "you are here" dot whenever a fix is known.
   useEffect(() => {
@@ -312,7 +316,9 @@ export function SpotMap({
     } else {
       clearAutoCenter();
     }
-  }, [current, customSpots, syncMarkers, autoCenter, clearAutoCenter]);
+    // resolvedTheme: see the preview marker above. The marker colours are
+    // read from the theme, and Leaflet keeps the resolved string.
+  }, [current, customSpots, syncMarkers, autoCenter, clearAutoCenter, resolvedTheme]);
 
   // Fly to the user only when the page asks for it (first visit with no
   // saved spot, or an explicit tap on the locate button). Keying on the
@@ -345,8 +351,12 @@ export function SpotMap({
       metric,
       forecasts,
       marine,
-      color: resolvedTheme === "light" ? "#64748b" : "#ffffff",
+      color: readToken("--ow-map-arrow"),
     });
+    // resolvedTheme is not read in the body: it is the trigger. The arrow
+    // colour is resolved from the DOM because it is handed to an element as a
+    // string, so a theme switch has to redraw the layer to pick up the new
+    // value.
   }, [selectedHour, forecasts, marine, metric, current, resolvedTheme]);
 
   return (

--- a/packages/web/src/components/TimelineHeader.tsx
+++ b/packages/web/src/components/TimelineHeader.tsx
@@ -225,9 +225,9 @@ export function TimelineHeader({
               scope="col"
               className={`text-[10px] lg:text-xs font-semibold py-1 cursor-pointer transition-colors relative border-b ${col.isDayStart ? 'ow-day-sep' : ''} ${
                 col.time === selectedHour
-                  ? "text-white bg-teal-600"
+                  ? "text-on-accent bg-accent-strong"
                   : isNow
-                  ? "text-teal-100 bg-teal-700/70 font-bold"
+                  ? "text-on-accent-muted bg-accent-deep/70 font-bold"
                   : "ow-hour-cell"
               }`}
               style={{
@@ -237,7 +237,7 @@ export function TimelineHeader({
             >
               {col.hourLabel}
               {isNow && (
-                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-teal-400" />
+                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-accent" />
               )}
             </th>
           );

--- a/packages/web/src/components/WindCell.tsx
+++ b/packages/web/src/components/WindCell.tsx
@@ -21,9 +21,9 @@ interface WindCellProps {
 
 function WindCellImpl({ time, speed, gusts, direction, selected, isNow, isDayStart, onSelect }: WindCellProps) {
   // `isNow` border takes precedence over the day separator (the now marker is more salient).
-  const nowBorder = isNow ? "border-l-2 border-l-teal-400" : "";
+  const nowBorder = isNow ? "border-l-2 border-l-accent" : "";
   const daySepClass = !isNow && isDayStart ? "ow-day-sep" : "";
-  const selectedStyle = selected ? "ring-2 ring-teal-400/70 ring-inset bg-teal-400/10" : "";
+  const selectedStyle = selected ? "ring-2 ring-accent/70 ring-inset bg-accent/10" : "";
 
   if (speed == null) {
     return (

--- a/packages/web/src/design/initialTheme.ts
+++ b/packages/web/src/design/initialTheme.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+// Which theme to start in, and stamping it on <html>. Apart from theme.tsx for
+// the same reason as useTheme.ts: that file exports components and nothing
+// else, or Fast Refresh reloads the whole app on a theme edit.
+
+import { LOCAL_STORAGE_KEYS } from "../storage/keys";
+import type { ThemeMode } from "./useTheme";
+
+const STORAGE_KEY = LOCAL_STORAGE_KEYS.theme;
+
+// Every access below is guarded because both APIs throw outright, rather than
+// returning null, when the browser blocks site data: Safari in private mode
+// for localStorage, and any embedder that denies matchMedia. A theme is a
+// preference, so failing to read one falls back to the default instead of
+// taking the app down.
+export function getInitialMode(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // Storage denied: fall through to the system preference.
+  }
+  // No stored preference: follow the system.
+  try {
+    return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+  } catch {
+    // matchMedia denied: fall through to the default below.
+  }
+  return "dark";
+}
+
+/**
+ * Stamp `data-theme` before React renders anything.
+ *
+ * Called from `main.tsx` rather than left to the provider's effect, because
+ * effects run children first: on the very first mount, every component below
+ * the provider runs its effects while `<html>` still carries no theme at all.
+ * A component that resolves a token from the live DOM there (the two maps,
+ * which hand Leaflet and the arrow layer a colour string rather than a
+ * `var()`) would read the fallback palette and keep it until some unrelated
+ * redraw. Idempotent, and the provider still owns every later change.
+ */
+export function applyInitialTheme(): void {
+  document.documentElement.setAttribute("data-theme", getInitialMode());
+}

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -4,39 +4,26 @@
 import { LOCAL_STORAGE_KEYS } from "../storage/keys";
 import { useEffect, useState } from 'react';
 
+import { getInitialMode } from './initialTheme';
 import { ThemeCtx, useTheme, type ThemeMode } from './useTheme';
 
 const STORAGE_KEY = LOCAL_STORAGE_KEYS.theme;
 
-// Every access below is guarded because both APIs throw outright, rather than
-// returning null, when the browser blocks site data: Safari in private mode
-// for localStorage, and any embedder that denies matchMedia. A theme is a
-// preference, so failing to read one falls back to the default instead of
-// taking the app down.
-function getInitialMode(): ThemeMode {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
-    if (stored === 'light' || stored === 'dark') return stored;
-  } catch {
-    // Storage denied: fall through to the system preference.
-  }
-  // No stored preference — follow system
-  try {
-    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-  } catch {
-    // matchMedia denied: fall through to the default below.
-  }
-  return 'dark';
-}
-
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [mode, setModeState] = useState<ThemeMode>(getInitialMode);
 
+  // Keeps the attribute in step with the state. The two other writers
+  // (applyInitialTheme, called from main.tsx, and setMode below) are there to
+  // beat an ordering, not to replace this one.
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', mode);
   }, [mode]);
 
   function setMode(m: ThemeMode) {
+    // Written before the re-render, for the same reason as the initial stamp:
+    // the map effects that resolve a token from the DOM run before the
+    // provider's own effect, and would otherwise read the outgoing palette.
+    document.documentElement.setAttribute('data-theme', m);
     setModeState(m);
     try {
       localStorage.setItem(STORAGE_KEY, m);

--- a/packages/web/src/design/tokens.css
+++ b/packages/web/src/design/tokens.css
@@ -4,8 +4,16 @@
    Dark theme is the default; light theme overrides are listed
    after. Both selectors are applied to <html data-theme="...">
    via ThemeProvider in theme.tsx.
+
+   The dark block also matches :root, so the tokens exist before
+   ThemeProvider has set data-theme, which it only does from an
+   effect. Anything painted before hydration (the body background
+   in index.html) would otherwise be styled with an undefined
+   variable and flash white. Same specificity as the light block,
+   which comes later in the file and therefore still wins.
    ============================================================= */
 
+:root,
 [data-theme="dark"] {
   /* Backgrounds */
   --ow-bg-0: #030712;        /* deepest bg (gray-950) */
@@ -23,6 +31,33 @@
   --ow-accent: #2dd4bf;
   --ow-accent-soft: rgba(45, 212, 191, 0.12);
   --ow-accent-line: rgba(45, 212, 191, 0.25);
+  /* Filled accent control (a selected column header, a primary button): the
+     accent itself is a *text and stroke* colour, too bright here to carry
+     white type. This pair is the one that may. */
+  --ow-accent-strong: #0d9488;
+  --ow-accent-strong-hover: #14b8a6;
+  /* One step deeper: a second filled band that has to read *below* the
+     selected one without leaving the accent family (the current hour, under
+     the hour the reader picked). */
+  --ow-accent-deep: #0f766e;
+  --ow-on-accent: #ffffff;
+  /* Ink on that second band. A tinted white rather than white: it is what
+     keeps the current hour reading as secondary to the picked one. */
+  --ow-on-accent-muted: #ccfbf1;
+
+  /* Destructive action. Same values in both themes so far, named here so a
+     future light-theme adjustment has somewhere to land. */
+  --ow-danger: rgba(185, 28, 28, 0.8);
+  --ow-danger-hover: #dc2626;
+  --ow-danger-active: #ef4444;
+  --ow-on-danger: #ffffff;
+
+  /* Compare mode. A second accent, on purpose: the two planner modes have to
+     read as two different things and not as two states of one, so "comparer
+     les fenetres" owns the amber the way "simuler ma route" owns the teal.
+     Amber is bright enough that its ink is a near-black, not white. */
+  --ow-compare: #F4C25C;
+  --ow-on-compare: #3a2a08;
 
   /* Lines */
   --ow-line: rgba(255, 255, 255, 0.08);
@@ -57,7 +92,8 @@
   --ow-w-6: #e84118;         /* fort — rouge-orange */
   --ow-w-7: #c41408;         /* très fort — rouge */
   --ow-w-8: #8b1460;         /* tempête — magenta foncé */
-  --ow-cell-ink: #0B1D14;    /* texte sur cellules claires */
+  --ow-cell-ink: #0B1D14;    /* encre sombre sur tout aplat clair : cellules,
+                                pastilles de complexite, cartes de mode */
 
   /* Text colors per Beaufort level */
   --ow-cell-text-0: #e8eaf0;
@@ -89,7 +125,27 @@
   --ow-ok-line: rgba(52, 211, 153, 0.25);
   --ow-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
 
+  /* Current on the leg dial. A following current is the "ok" green; these two
+     are the cases that must not be mistaken for it, nor for the wave amber.
+     The blue is deliberate: grey washes out on the light theme. */
+  --ow-current-against: #fb923c;
+  --ow-current-abeam: #3b82f6;
+
+  /* The B end of the route in the empty-state sketch. Softer than the map's
+     own end marker, which it deliberately does not share. */
+  --ow-sketch-end: #FF7A59;
+
   /* Map */
+  /* Markers drawn by Leaflet, which takes a resolved colour and not a var().
+     Read through design/tokens.ts. Named by role rather than by position so
+     the two maps (explore, plan) can share them. */
+  --ow-marker-active: #2dd4bf;    /* the spot being read, the first waypoint */
+  --ow-marker-idle: #6b7280;      /* a saved spot that is not the active one */
+  --ow-marker-stroke: #ffffff;    /* ring around the active marker */
+  --ow-marker-stroke-idle: #9ca3af;
+  --ow-marker-end: #e84118;       /* the last waypoint of a route */
+  --ow-map-arrow: #ffffff;        /* wind, wave and current arrows over the map */
+
   --ow-map-sea-0: #0B1A2E;
   --ow-map-sea-1: #060B17;
   --ow-map-land-0: #0F1A2A;
@@ -111,6 +167,19 @@
   --ow-accent: #0f766e;
   --ow-accent-soft: rgba(15, 118, 110, 0.12);
   --ow-accent-line: rgba(15, 118, 110, 0.25);
+  --ow-accent-strong: #0f766e;
+  --ow-accent-strong-hover: #0d9488;
+  --ow-accent-deep: #115e59;
+  --ow-on-accent: #ffffff;
+  --ow-on-accent-muted: #ccfbf1;
+
+  --ow-danger: rgba(185, 28, 28, 0.8);
+  --ow-danger-hover: #dc2626;
+  --ow-danger-active: #ef4444;
+  --ow-on-danger: #ffffff;
+
+  --ow-compare: #F4C25C;
+  --ow-on-compare: #3a2a08;
 
   --ow-line: rgba(0, 0, 0, 0.08);
   --ow-line-2: rgba(0, 0, 0, 0.14);
@@ -121,6 +190,19 @@
   --ow-shadow-1: 0 1px 4px rgba(0, 0, 0, 0.12);
   --ow-shadow-2: 0 4px 16px rgba(0, 0, 0, 0.14);
   --ow-shadow-pop: 0 8px 32px rgba(0, 0, 0, 0.16);
+
+  /* Markers are the same colour in both themes today, which is why they were
+     writable as four hex values in the first place. They are listed again
+     here because that is a design decision, not a fact: the dark teal has
+     1.7:1 on a pale sea, and the day someone wants to fix that, this is the
+     line to change and nothing else. The arrows are the one map colour that
+     already differed. */
+  --ow-marker-active: #2dd4bf;
+  --ow-marker-idle: #6b7280;
+  --ow-marker-stroke: #ffffff;
+  --ow-marker-stroke-idle: #9ca3af;
+  --ow-marker-end: #e84118;
+  --ow-map-arrow: #64748b;
 
   --ow-map-sea-0: #c8ddf0;
   --ow-map-sea-1: #b0cee8;
@@ -177,4 +259,9 @@
   --ow-ok-soft: rgba(14, 159, 143, 0.12);
   --ow-ok-line: rgba(14, 159, 143, 0.40);
   --ow-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08);
+
+  --ow-current-against: #fb923c;
+  --ow-current-abeam: #3b82f6;
+
+  --ow-sketch-end: #FF7A59;
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1,6 +1,63 @@
 @import "tailwindcss";
 @import './design/tokens.css';
 
+/* Le pont entre Tailwind et les jetons de design.
+
+   Il manquait, et l'audit de septembre 2026 (annexe B, Mo3) a compte quatre
+   systemes de couleur vivant cote a cote : les classes Tailwind, les jetons
+   ecrits a la main en style={{ var() }}, cette feuille, et des blocs <style>
+   dans le JSX. Le probleme n'est pas l'inelegance : une classe de la palette
+   Tailwind par defaut, bg-teal-600 par exemple, ne connait pas
+   [data-theme] et garde donc la meme valeur dans les deux themes, la ou le
+   jeton correspondant change expres.
+
+   @theme declare les jetons a Tailwind, qui en tire des utilitaires. Les
+   valeurs sont des var(--ow-*), donc l'utilitaire genere pointe vers la
+   variable et non vers une couleur figee : bg-surface-1 suit le theme comme
+   le fait style={{ background: 'var(--ow-bg-1)' }}, sans quitter les classes.
+
+   Nommage : ce sont les roles, pas les teintes. surface-* pour les fonds,
+   ink-* pour le texte, line* pour les traits. Une couleur nommee par sa
+   teinte est une couleur qu'on ne peut plus changer. */
+@theme {
+  --color-surface-0: var(--ow-bg-0);
+  --color-surface-1: var(--ow-bg-1);
+  --color-surface-2: var(--ow-bg-2);
+  --color-surface-3: var(--ow-bg-3);
+
+  --color-ink-0: var(--ow-fg-0);
+  --color-ink-1: var(--ow-fg-1);
+  --color-ink-2: var(--ow-fg-2);
+  --color-ink-3: var(--ow-fg-3);
+
+  --color-accent: var(--ow-accent);
+  --color-accent-soft: var(--ow-accent-soft);
+  --color-accent-line: var(--ow-accent-line);
+  --color-accent-strong: var(--ow-accent-strong);
+  --color-accent-strong-hover: var(--ow-accent-strong-hover);
+  --color-accent-deep: var(--ow-accent-deep);
+  --color-on-accent: var(--ow-on-accent);
+  --color-on-accent-muted: var(--ow-on-accent-muted);
+
+  --color-compare: var(--ow-compare);
+  --color-on-compare: var(--ow-on-compare);
+
+  --color-danger: var(--ow-danger);
+  --color-danger-hover: var(--ow-danger-hover);
+  --color-danger-active: var(--ow-danger-active);
+  --color-on-danger: var(--ow-on-danger);
+
+  --color-line: var(--ow-line);
+  --color-line-2: var(--ow-line-2);
+
+  --font-ui: var(--ow-font-ui);
+  --font-mono: var(--ow-font-mono);
+
+  --radius-ow-sm: var(--ow-r-sm);
+  --radius-ow-md: var(--ow-r-md);
+  --radius-ow-lg: var(--ow-r-lg);
+}
+
 /* Polices auto-hebergees.
 
    Elles venaient de deux @import vers fonts.googleapis.com. Chacun

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -6,7 +6,12 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { Routes } from "./Routes";
 import { ThemeProvider } from "./design/theme";
+import { applyInitialTheme } from "./design/initialTheme";
 import { registerServiceWorker } from "./sw";
+
+// Before the first render, so the tokens the maps read from the DOM are
+// already those of the reader's theme. See applyInitialTheme.
+applyInitialTheme();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -22,8 +22,8 @@ const COLORS = {
   wind: "var(--ow-fg-0)",
   waves: "var(--ow-warn)",
   currentPortant: "var(--ow-ok)",
-  currentContraire: "#fb923c",  // distinct from waves' amber
-  currentTravers: "#3b82f6",    // blue-500 — clearly visible in both themes (grey washed out in light)
+  currentContraire: "var(--ow-current-against)",
+  currentTravers: "var(--ow-current-abeam)",
 };
 
 // 0° = up (12 o'clock), increasing clockwise. Returns [x, y] in SVG coords.

--- a/packages/web/src/plan/ModeToggle.tsx
+++ b/packages/web/src/plan/ModeToggle.tsx
@@ -8,11 +8,11 @@ export type PlanMode = "single" | "compare";
 // (server.estimate_passage_for_arrival via /api/v1/passage-by-eta).
 export type TimeAnchor = "departure" | "arrival";
 
-// Per-mode accent palette — picked up by tab icons so the two modes feel
-// distinct at a glance (cyan = simulate, amber = compare windows).
+// Per-mode accent, picked up by tab icons so the two modes feel distinct at
+// a glance (teal = simulate, amber = compare windows).
 const MODE_ACCENT: Record<PlanMode, string> = {
   single: "var(--ow-accent)",
-  compare: "#F4C25C",
+  compare: "var(--ow-compare)",
 };
 
 const MODE_META: Record<PlanMode, { title: string; sub: string; icon: "route" | "clock" }> = {

--- a/packages/web/src/plan/PlanMap.tsx
+++ b/packages/web/src/plan/PlanMap.tsx
@@ -307,7 +307,9 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       const isLast = i === waypoints.length - 1 && waypoints.length > 1;
       // Number every waypoint 1..N so labels match the sidebar legs; last gets a flag.
       const label = isLast ? flagSvg : String(i + 1);
-      const bg = isFirst ? "#2dd4bf" : isLast ? "#e84118" : "#6b7280";
+      const bg = readToken(
+        isFirst ? "--ow-marker-active" : isLast ? "--ow-marker-end" : "--ow-marker-idle",
+      );
       const marker = L.marker([lat, lon], {
         icon: waypointIcon(label, bg, !!onWptDelete),
         draggable: true,
@@ -345,7 +347,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
         const lls = positions.map(([la, lo]) => L.latLng(la, lo));
         if (!dragLineRef.current) {
           dragLineRef.current = L.polyline(lls, {
-            color: "#6b7280",
+            color: readToken("--ow-marker-idle"),
             weight: 3,
             dashArray: "6 4",
             opacity: 0.85,
@@ -368,8 +370,10 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
 
       markersRef.current.push(marker);
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [waypoints]);
+    // resolvedTheme: the waypoint colours are read from the theme, and
+    // Leaflet keeps the resolved string in the icon markup.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [waypoints, resolvedTheme]);
 
   // Fill the sounding slot of each waypoint icon.
   //
@@ -409,7 +413,7 @@ export const PlanMap = forwardRef<PlanMapHandle, PlanMapProps>(function PlanMap(
       // A fresh route without per-segment colors (e.g. compare mode) draws as
       // a solid neutral line so it doesn't read as "not computed yet".
       const line = L.polyline(waypoints.map(([lat, lon]) => L.latLng(lat, lon)), {
-        color: "#6b7280",
+        color: readToken("--ow-marker-idle"),
         weight: 5,
         dashArray: isStale ? "6 4" : undefined,
         opacity: isStale ? 0.7 : 0.85,

--- a/packages/web/src/plan/PlanStates.tsx
+++ b/packages/web/src/plan/PlanStates.tsx
@@ -30,7 +30,7 @@ export function RouteSketch() {
         strokeDasharray="4 4"
       />
       <circle cx="30" cy="70" r="6" fill="var(--ow-accent)" stroke="var(--ow-bg-1)" strokeWidth="2" />
-      <circle cx="250" cy="30" r="6" fill="#FF7A59" stroke="var(--ow-bg-1)" strokeWidth="2" />
+      <circle cx="250" cy="30" r="6" fill="var(--ow-sketch-end)" stroke="var(--ow-bg-1)" strokeWidth="2" />
       <text x="30" y="88" fontSize="9" fill="var(--ow-fg-2)" fontFamily="var(--ow-font-mono)" textAnchor="middle">A</text>
       <text x="250" y="14" fontSize="9" fill="var(--ow-fg-2)" fontFamily="var(--ow-font-mono)" textAnchor="middle">B</text>
     </svg>
@@ -106,9 +106,9 @@ function BigCard({
       <div className="flex items-center gap-2 mb-1.5">
         <span
           className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
-          style={{ background: accent, color: "#0B1A14" }}
+          style={{ background: accent, color: "var(--ow-cell-ink)" }}
         >
-          <PickerIcon name={icon} color="#0B1A14" />
+          <PickerIcon name={icon} color="var(--ow-cell-ink)" />
         </span>
         <div
           className="text-sm font-semibold"
@@ -155,7 +155,7 @@ export function ModePicker({
       />
       <BigCard
         icon="clock"
-        accent="#F4C25C"
+        accent="var(--ow-compare)"
         title="Comparer les fenêtres"
         body="Vous savez où aller. OhMyWind teste plusieurs heures de départ et classe les créneaux par confort."
         example="Ex. : « Quel est le meilleur départ entre samedi et lundi ? »"

--- a/packages/web/src/plan/sidebar/CompareResults.tsx
+++ b/packages/web/src/plan/sidebar/CompareResults.tsx
@@ -36,8 +36,8 @@ export function CompareResults({
         onClick={computeWindows}
         disabled={!canCalculate}
         style={{
-          background: canCalculate ? "#F4C25C" : "var(--ow-bg-2)",
-          color: canCalculate ? "#3a2a08" : "var(--ow-fg-3)",
+          background: canCalculate ? "var(--ow-compare)" : "var(--ow-bg-2)",
+          color: canCalculate ? "var(--ow-on-compare)" : "var(--ow-fg-3)",
           border: `1px solid ${canCalculate ? "transparent" : "var(--ow-line)"}`,
         }}
       />

--- a/packages/web/src/plan/sidebar/LegList.tsx
+++ b/packages/web/src/plan/sidebar/LegList.tsx
@@ -44,10 +44,10 @@ function KpiBlock({
       className="rounded-md border px-2 py-1"
       style={{
         background: tone === "warn"
-          ? "color-mix(in srgb, var(--ow-warn, #fbbf24) 14%, transparent)"
+          ? "color-mix(in srgb, var(--ow-warn) 14%, transparent)"
           : "var(--ow-bg-1)",
         borderColor: tone === "warn"
-          ? "color-mix(in srgb, var(--ow-warn, #fbbf24) 38%, transparent)"
+          ? "color-mix(in srgb, var(--ow-warn) 38%, transparent)"
           : "var(--ow-line)",
       }}
     >
@@ -142,7 +142,7 @@ function LegRow({
           <div className="flex flex-col items-start gap-0.5">
             <span
               className="inline-flex h-6 px-1.5 rounded-md items-center justify-center text-[10px] font-bold tabular-nums whitespace-nowrap"
-              style={{ background: cxLevelVar(cx), color: "#0B1D14", fontFamily: "var(--ow-font-mono)" }}
+              style={{ background: cxLevelVar(cx), color: "var(--ow-cell-ink)", fontFamily: "var(--ow-font-mono)" }}
             >
               {index + 1}→{index + 2}
             </span>

--- a/packages/web/src/plan/sidebar/PlanForm.tsx
+++ b/packages/web/src/plan/sidebar/PlanForm.tsx
@@ -13,8 +13,8 @@ import { RefreshIcon } from "./parts";
 export function PlanForm({ canCalculate }: { canCalculate: boolean }) {
   const { state, actions, compute, computeWindows } = usePlan();
   const { mode, timeAnchor, waypoints } = state;
-  const accent = mode === "compare" ? "#F4C25C" : "var(--ow-accent)";
-  const ctaInk = mode === "compare" ? "#3a2a08" : "#fff";
+  const accent = mode === "compare" ? "var(--ow-compare)" : "var(--ow-accent)";
+  const ctaInk = mode === "compare" ? "var(--ow-on-compare)" : "var(--ow-on-accent)";
 
   return (
     <div className="p-4 space-y-3 animate-fade-in">

--- a/packages/web/src/plan/sidebar/SingleResults.tsx
+++ b/packages/web/src/plan/sidebar/SingleResults.tsx
@@ -43,7 +43,7 @@ export function SingleResults({
         onClick={compute}
         style={{
           background: isStale ? "var(--ow-accent)" : "var(--ow-bg-2)",
-          color: isStale ? "#fff" : "var(--ow-fg-1)",
+          color: isStale ? "var(--ow-on-accent)" : "var(--ow-fg-1)",
           border: `1px solid ${isStale ? "transparent" : "var(--ow-line)"}`,
         }}
       />

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -491,7 +491,7 @@ export function PlanPage() {
           <a
             href={`/${mapViewQuery(mapView)}`}
             className="inline-block mt-4 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
-            style={{ background: "var(--ow-accent)", color: "#fff" }}
+            style={{ background: "var(--ow-accent)", color: "var(--ow-on-accent)" }}
           >
             ← Explorer la météo
           </a>
@@ -549,7 +549,7 @@ export function PlanPage() {
           <a
             href={`/${mapViewQuery(mapView)}`}
             className="absolute top-3 left-3 z-[400] w-[58px] h-[58px] sm:w-20 sm:h-20 rounded-full flex items-center justify-center shadow-lg transition-transform hover:scale-105 active:scale-95"
-            style={{ background: "var(--ow-accent)", color: "#fff" }}
+            style={{ background: "var(--ow-accent)", color: "var(--ow-on-accent)" }}
             title="Retour à l'exploration"
           >
             <img src="/wind-icon.png" alt="" className="select-none w-[64px] h-[64px] sm:w-[88px] sm:h-[88px]" draggable={false} />

--- a/packages/web/src/utils/spotMarkerLayer.ts
+++ b/packages/web/src/utils/spotMarkerLayer.ts
@@ -16,6 +16,7 @@
 
 import L from "leaflet";
 import type { Spot } from "../types";
+import { readToken } from "../design/tokens";
 
 // Leaflet renders a CircleMarker into an SVG node it keeps to itself: there is
 // no public accessor, only the internal ``_path``. Hit-testing needs that node
@@ -33,12 +34,14 @@ function isAt(spot: Spot, at: Spot | null): boolean {
   return at != null && spot.latitude === at.latitude && spot.longitude === at.longitude;
 }
 
-/** Bigger, brighter and ringed when the spot is the one being read. */
+/** Bigger, brighter and ringed when the spot is the one being read. Colours
+    come from the theme rather than from four hex values written here: Leaflet
+    wants a resolved string, so they are read at draw time. */
 function styleFor(active: boolean) {
   return {
     radius: active ? 10 : 7,
-    color: active ? "#ffffff" : "#9ca3af",
-    fillColor: active ? "#2dd4bf" : "#6b7280",
+    color: readToken(active ? "--ow-marker-stroke" : "--ow-marker-stroke-idle"),
+    fillColor: readToken(active ? "--ow-marker-active" : "--ow-marker-idle"),
     fillOpacity: active ? 0.9 : 0.6,
     weight: active ? 2.5 : 1,
   };
@@ -122,12 +125,13 @@ export function syncPreviewMarker(
   layerRef.current = null;
   if (!current) return;
   if (savedSpots.some((s) => isAt(s, current))) return;
+  const accent = readToken("--ow-marker-active");
   layerRef.current = L.circleMarker([current.latitude, current.longitude], {
     radius: 9,
-    color: "#2dd4bf",
+    color: accent,
     weight: 2.5,
     dashArray: "4 3",
-    fillColor: "#2dd4bf",
+    fillColor: accent,
     fillOpacity: 0.25,
     interactive: false,
   }).addTo(map);


### PR DESCRIPTION
Lot 4.5 du plan de rework, repris depuis la branche `refacto/tailwind-theme-tokens` (empilée sur #342, non mergée) et rejoué sur `dev` par cherry-pick, sans conflit.

## Le problème

Quatre systèmes de couleur cohabitaient : les classes de la palette Tailwind, les jetons écrits à la main en `style={{ var() }}`, `index.css`, et des blocs `<style>` dans le JSX. `bg-teal-600` ne connaît pas `[data-theme]` et garde la même valeur dans les deux thèmes, là où le jeton correspondant change exprès. Le thème clair montrait donc, à ces endroits, le turquoise du thème sombre.

## Ce que fait la PR

Un bloc `@theme` dans `index.css` déclare les jetons à Tailwind, qui en tire des utilitaires. Les valeurs sont des `var(--ow-*)`, donc l'utilitaire généré pointe vers la variable et non vers une couleur figée : `bg-surface-1` suit le thème comme le fait `style={{ background: 'var(--ow-bg-1)' }}`. Nommage par rôle et non par teinte : `surface-*`, `ink-*`, `accent*`, `danger*`, `compare`.

Jetons ajoutés dans `tokens.css` (les deux thèmes) : `accent-strong`, `accent-strong-hover`, `accent-deep`, `on-accent`, `on-accent-muted`, `danger*`, `compare` et `on-compare`, `current-against`, `current-abeam`, `marker-*`, `map-arrow`, `sketch-end`.

`data-theme` est désormais posé avant le premier rendu (`design/initialTheme.ts`, appelé par `main.tsx`). Les effets s'exécutent des enfants vers le parent : au premier montage, les cartes lisaient leurs couleurs dans un `<html>` qui ne portait encore aucun thème. Elles les lisent dans le DOM parce que Leaflet et la couche de flèches veulent une chaîne résolue, pas un `var()`.

## Chiffres

| Mesure sur `packages/web/src` | Avant | Après |
|---|---|---|
| Classes de palette non thémées dans les `.tsx` (hors `QuickSpots.tsx`) | 17 | 1 |
| Valeurs hexadécimales dans les `.tsx` | 32 | 2 |

Ce qui reste est volontaire : `bg-black/50` (un voile de modale n'a pas de thème) et les deux hex du repli des pages de doc dans `Routes.tsx`, qui appartiennent à la palette papier de `routes/*.css` et à aucun thème. Les 18 classes de palette de `QuickSpots.tsx` ne sont pas comptées ni touchées : le fichier est mort et #342 le supprime.

## Vérification : aucun changement visuel non voulu

Deux builds de prod (`VITE_API_BASE=https://mcp-dev.ohmywind.fr`) servies en parallèle, `dev` sur un port et la branche sur l'autre, même `localStorage`, même spot. Pour chaque page et chaque thème, relevé des styles calculés (fond, texte, bordure, ombre, `fill`, `stroke`) de tous les éléments du DOM hors carte, puis comparaison élément par élément.

| Page / thème | Éléments comparés | Éléments qui changent |
|---|---|---|
| Explorateur, sombre | 5045 | 7 |
| Explorateur, clair | 5044 | 7 |
| /plan, sombre | 167 | 1 |
| /plan, clair | 166 | 1 |

Les sept sont les mêmes dans les deux thèmes :

- la racine, qui passe de `text-white` au jeton d'encre (`#e8eaf0` en sombre, `#0d1117` en clair). Aucun descendant n'en hérite : tous les autres éléments gardent exactement la même couleur calculée.
- l'en-tête de l'heure sélectionnée et son liseré (le `TH` et les quatre `TD` de la colonne). En sombre, ils passent du teal de la palette Tailwind 4 (`oklch(0.6 0.118 184.704)`) au teal du jeton `#0d9488`, quelques unités par canal. En clair, ils passent de ce même teal clair au `#0f766e` du thème : c'est exactement le défaut que la PR corrige.

Captures avant/après dans le scratchpad de session (`shots/61-{before,after}-{home,plan}-{light,dark}.png`).

## Un défaut trouvé en vérifiant, et corrigé par la même ligne

`data-theme` posé avant le premier rendu n'est pas un détail d'hygiène. Les effets React s'exécutent des enfants vers le parent : au premier montage, la couche Leaflet lit ses couleurs dans un `<html>` qui ne porte encore aucun thème, et `getComputedStyle` lui rend une chaîne vide. Le tracé prend alors `stroke=""` et reste invisible pour la vie de la carte, une bascule de thème ne le rattrape pas.

Reproduit sur la build de `dev`, en 390x844, sur un plan restauré depuis `ow_last_simulation_v1` (le cas où les waypoints existent dès le premier rendu, sans attendre une réponse réseau) : les deux marqueurs sont là, la route entre eux ne l'est pas, et `path.leaflet-interactive` porte `stroke=""` sur les cinq segments.

Sur cette branche, même scénario, même stockage : `stroke="#2dc97a"` sur les cinq segments, route visible, toujours zéro POST.

## Contrôles

`npm run typecheck`, `npm run lint:budget` (0 erreur, budget tenu), `npm run test` (52 fichiers, 695 tests), `npm run build` : verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
