### PR TITLE
feat(web): la convention des flèches est dite aussi sur l'onglet Vent

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -327,7 +327,13 @@ function App() {
                   showCurrents={showCurrents}
                 />
               </div>
-              <div ref={dataPanelRef} className="flex-1 min-h-0 overflow-hidden">
+              {/* Colonne flex, pour que la table qui depasse se comprime au
+                  lieu d'etre rognee. La hauteur du panneau est bornee par un
+                  max-h en vh : une hauteur en pourcentage ne s'y resout pas,
+                  donc h-full sur l'enfant ne bornait rien et la note de
+                  convention sortait par le bas quand la table du vent
+                  affichait quatre modeles. */}
+              <div ref={dataPanelRef} className="flex-1 min-h-0 overflow-hidden flex flex-col">
                 {effectiveView === "wind" || !marine ? (
                   <WindTable
                     forecasts={forecasts}

--- a/packages/web/src/components/ArrowConventionNote.test.tsx
+++ b/packages/web/src/components/ArrowConventionNote.test.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { MetricView } from "../types";
+import { ArrowConventionNote } from "./ArrowConventionNote";
+
+afterEach(cleanup);
+
+const METRICS: MetricView[] = ["wind", "waves", "tides", "currents"];
+
+function noteFor(metric: MetricView): string {
+  const { container } = render(<ArrowConventionNote metric={metric} />);
+  return container.querySelector("p")?.textContent ?? "";
+}
+
+describe("ArrowConventionNote", () => {
+  it.each(METRICS)("dit quelque chose pour l'onglet %s", (metric) => {
+    expect(noteFor(metric).length).toBeGreaterThan(20);
+  });
+
+  it("donne au vent et a la houle la meme lecture", () => {
+    // WindCell et la cellule wave_dir tournent le meme glyphe de dir + 180 :
+    // la fleche pointe la ou ca va, le chiffre dit d'ou ca vient.
+    for (const metric of ["wind", "waves"] as const) {
+      const text = noteFor(metric);
+      expect(text).toMatch(/suivent le déplacement/);
+      expect(text).toMatch(/d'où (il|elle) vient/);
+      cleanup();
+    }
+  });
+
+  it("garde au courant sa convention inverse", () => {
+    expect(noteFor("currents")).toMatch(/vers laquelle le courant porte/);
+  });
+
+  it("ne parle pas de fleche pour la maree, qui n'en a pas", () => {
+    expect(noteFor("tides")).not.toMatch(/flèche/i);
+  });
+});

--- a/packages/web/src/components/ArrowConventionNote.tsx
+++ b/packages/web/src/components/ArrowConventionNote.tsx
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import type { MetricView } from "../types";
+
+/**
+ * Which way the arrows read, said out loud (issue #269).
+ *
+ * The rows do not share a convention, and nothing on screen said so. The arrow
+ * always follows the movement, but the degrees follow the convention of the
+ * source: a wind and a wave direction are where they come FROM, a current
+ * direction is where the water sets TO. A reader comparing two numbers without
+ * that key concludes the figures contradict each other.
+ *
+ * The note lived inside MarineTable and so covered every tab but the one the
+ * app opens on. Wind is where the convention is least obvious, because the
+ * arrow and the degrees disagree there too: `WindCell` rotates its glyph by
+ * `direction + 180`, so it points where the wind blows while the figure says
+ * where it comes from.
+ */
+export function ArrowConventionNote({ metric }: { metric: MetricView }) {
+  const text = NOTES[metric];
+  return (
+    <p
+      className="shrink-0 px-3 py-1.5 text-[10px] leading-snug border-t"
+      style={{
+        color: "var(--ow-fg-2)",
+        borderColor: "var(--ow-line-2)",
+        background: "var(--ow-bg-1)",
+      }}
+    >
+      {text}
+    </p>
+  );
+}
+
+const NOTES: Record<MetricView, string> = {
+  wind: "Les flèches suivent le déplacement du vent. Les degrés donnent la direction d'où il vient, convention TWD.",
+  waves:
+    "Les flèches suivent le déplacement de la houle. Les degrés donnent la direction d'où elle vient, comme le vent.",
+  currents:
+    "La flèche et les degrés donnent tous deux la direction vers laquelle le courant porte, à l'inverse du vent et des vagues qui se lisent d'où ils viennent.",
+  tides: "Hauteurs d'eau au-dessus du niveau de référence indiqué.",
+};

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -8,6 +8,7 @@ import { useTimezone } from "../hooks/useTimezone";
 import { nowParisHourPrefix } from "../domain/datetime";
 import { currentsLevel, tidesLevel, wavesLevel, windLevelVar } from "../domain/thresholds";
 import { useTimelineScroll } from "../hooks/useTimelineScroll";
+import { ArrowConventionNote } from "./ArrowConventionNote";
 
 type MarineMetric = Exclude<MetricView, "wind">;
 
@@ -334,36 +335,6 @@ function MarineCellImpl({
  */
 const MarineCell = memo(MarineCellImpl);
 
-/**
- * Which way the arrows read, said out loud (issue #269).
- *
- * The two rows do not share a convention, and nothing on screen said so. The
- * arrow always follows the movement, but the degrees follow the convention of
- * the source: a wave direction is where the swell comes FROM, a current
- * direction is where the water sets TO. A reader comparing the two numbers
- * without that key concludes the figures contradict each other.
- */
-function ArrowConventionNote({ metric }: { metric: MarineMetric }) {
-  const text =
-    metric === "waves"
-      ? "Les flèches suivent le déplacement de la houle. Les degrés donnent la direction d'où elle vient, comme le vent."
-      : metric === "currents"
-        ? "La flèche et les degrés donnent tous deux la direction vers laquelle le courant porte, à l'inverse du vent et des vagues qui se lisent d'où ils viennent."
-        : "Hauteurs d'eau au-dessus du niveau de référence indiqué.";
-  return (
-    <p
-      className="shrink-0 px-3 py-1.5 text-[10px] leading-snug border-t"
-      style={{
-        color: "var(--ow-fg-2)",
-        borderColor: "var(--ow-line-2)",
-        background: "var(--ow-bg-1)",
-      }}
-    >
-      {text}
-    </p>
-  );
-}
-
 interface MarineTableProps {
   metric: MarineMetric;
   marine: MarineHourly;
@@ -412,7 +383,7 @@ export function MarineTable({
   const selectHour = useCallback((t: string) => onSelectHour(t), [onSelectHour]);
 
   return (
-    <div className="animate-fade-in h-full flex flex-col">
+    <div className="animate-fade-in min-h-0 flex flex-col">
       <div className={`scroll-container flex-1 min-h-0 ${scrolledEnd ? "scrolled-end" : ""}`}>
         <div ref={scrollRef} className="h-full overflow-auto wind-table-scroll">
           <table className="border-collapse" role="table">

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -10,6 +10,7 @@ import { nowParisHourPrefix } from "../domain/datetime";
 import { useTimelineScroll } from "../hooks/useTimelineScroll";
 import { useOnline } from "../hooks/useOnline";
 import { MODEL_META, type ModelName } from "../config/modelConfig";
+import { ArrowConventionNote } from "./ArrowConventionNote";
 
 function modelStep(name: string): number {
   const meta = MODEL_META[name as ModelName];
@@ -134,8 +135,11 @@ export function WindTable({
   }
 
   return (
-    <div className="animate-fade-in h-full">
-      <div className={`scroll-container h-full ${scrolledEnd ? "scrolled-end" : ""}`}>
+    // Same shape as MarineTable: a column whose scroller takes the space the
+    // note leaves, so the note sits on the bottom edge instead of scrolling
+    // away with the cells.
+    <div className="animate-fade-in min-h-0 flex flex-col">
+      <div className={`scroll-container flex-1 min-h-0 ${scrolledEnd ? "scrolled-end" : ""}`}>
         <div ref={scrollRef} className="h-full overflow-auto wind-table-scroll">
           <table className="border-collapse" role="table">
             <thead className="sticky top-0 z-20">
@@ -209,6 +213,7 @@ export function WindTable({
           </table>
         </div>
       </div>
+      <ArrowConventionNote metric="wind" />
     </div>
   );
 }


### PR DESCRIPTION
Refs #269. Suite de #340, qui avait posé la note de convention sur Vagues, Courants et Marées, c'est-à-dire sur tous les onglets sauf celui sur lequel l'application s'ouvre. La QA du lot 5 l'avait relevé.

## Pourquoi le vent en avait le plus besoin

`WindCell` fait tourner son glyphe de `direction + 180`. La flèche montre donc où le vent va, pendant que le chiffre à côté dit d'où il vient. C'est exactement la convention de la houle, et exactement l'inverse de celle du courant. Sans légende, les deux se contredisent à la lecture.

## Ce que fait la PR

`ArrowConventionNote` sort de `MarineTable.tsx` dans `components/ArrowConventionNote.tsx` et prend un `MetricView` au lieu d'un `Exclude<MetricView, "wind">`. Les trois textes existants ne bougent pas d'une lettre. Le quatrième reprend la formulation de la houle :

> Les flèches suivent le déplacement du vent. Les degrés donnent la direction d'où il vient, convention TWD.

Sept tests couvrent les quatre onglets, dont un qui vérifie que vent et houle se lisent pareil et un qui vérifie que le courant garde sa convention inverse.

## Un défaut de mise en page trouvé en posant la note

Le panneau de données est borné par `max-h-[44vh]`, donc sa hauteur n'est pas définie et un `height: 100%` sur l'enfant ne se résout pas. Le `h-full` des deux tables était inerte : elles se dimensionnaient sur leur contenu. Avec la note en plus, la table du vent à quatre modèles mesurait 329 px dans un panneau de 318 et la note sortait par le bas, rognée par l'`overflow-hidden`.

Le panneau devient une colonne flex et les deux tables passent de `h-full` à `min-h-0`, ce qui laisse le défilement absorber la différence. Mesuré au repos sur la build de prod (`vite preview`), en lisant les rectangles du DOM :

| Onglet | Note rognée avant | Après | Défilement horizontal |
|---|---|---|---|
| Vent (1280x800, 4 modèles) | 10 px | 0 px | conservé |
| Vagues | 0 px | 0 px | conservé |
| Courants | 0 px | 0 px | conservé |
| Vent (390x844, note sur 2 lignes) | non applicable, la note n'existait pas | 0 px | conservé |

Le pied de page garde sa forme : même `<p>`, mêmes classes, mêmes jetons de couleur.

Captures : `shots/63-wind-note-{desktop,mobile}.png` dans le scratchpad de session.

## Note de rebasage

Cette PR touche `src/App.tsx` (six lignes de commentaire et une classe) comme #356, qui y remplace des couleurs. Les deux blocs sont éloignés, git les fusionne sans conflit ; à surveiller si l'ordre de merge change.

## Contrôles

`npm run typecheck`, `npm run lint:budget` (0 erreur), `npm run test` (53 fichiers, 702 tests, +7), `npm run build` : verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
