### PR TITLE
fix(web): un brouillon s'efface devant une autre route dans l'URL

### DIFF
--- a/packages/web/src/plan/PlanSidebar.test.tsx
+++ b/packages/web/src/plan/PlanSidebar.test.tsx
@@ -95,6 +95,7 @@ const ARCHETYPES: Archetype[] = [
 
 const baseSession: InitialSession = {
   waypoints: [MARSEILLE, PORQUEROLLES],
+  originWaypoints: [MARSEILLE, PORQUEROLLES],
   archetype: "cruiser_30ft",
   departure: "2026-09-10T08:00",
   timeAnchor: "departure",

--- a/packages/web/src/plan/draft.test.ts
+++ b/packages/web/src/plan/draft.test.ts
@@ -39,6 +39,10 @@ const draft: Omit<PlanDraft, "savedAt"> = {
     [43.2, 5.36],
     [43.01, 6.2],
   ],
+  originWaypoints: [
+    [43.2, 5.36],
+    [43.0, 6.19],
+  ],
   departure: "2026-09-03T09:00",
   timeAnchor: "departure",
   archetype: "cruiser_30ft",
@@ -94,6 +98,43 @@ describe("plan draft round-trip", () => {
     expect(loadPlanDraft()).toBeNull();
     expect(hasPlanDraft()).toBe(false);
     expect(() => clearPlanDraft()).not.toThrow();
+  });
+});
+
+describe("originWaypoints", () => {
+  const now = 1_800_000_000_000;
+  const withoutOrigin = (over: Record<string, unknown> = {}) => {
+    const rest: Record<string, unknown> = { ...draft, savedAt: now, ...over };
+    if (!("originWaypoints" in over)) delete rest.originWaypoints;
+    return JSON.stringify(rest);
+  };
+
+  it("fait l'aller-retour, distinct de la route courante", () => {
+    installStorage();
+    savePlanDraft(draft);
+    const back = loadPlanDraft()!;
+    expect(back.originWaypoints).toEqual(draft.originWaypoints);
+    expect(back.originWaypoints).not.toEqual(back.waypoints);
+  });
+
+  it("garde une origine vide, qui dit un dessin parti de zero", () => {
+    installStorage();
+    savePlanDraft({ ...draft, originWaypoints: [] });
+    expect(loadPlanDraft()!.originWaypoints).toEqual([]);
+  });
+
+  // Le champ est arrive apres la cle : un brouillon v1 ouvert au moment d'un
+  // deploiement reste lisible, avec une origine inconnue.
+  it.each([
+    ["absent", withoutOrigin()],
+    ["null", withoutOrigin({ originWaypoints: null })],
+    ["pas un tableau", withoutOrigin({ originWaypoints: "43.2,5.36" })],
+    ["paires invalides", withoutOrigin({ originWaypoints: [[91, 5.36]] })],
+  ])("lit une origine %s comme inconnue sans jeter le brouillon", (_label, raw) => {
+    const parsed = parsePlanDraft(raw, now);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.originWaypoints).toBeNull();
+    expect(parsed!.waypoints).toEqual(draft.waypoints);
   });
 });
 

--- a/packages/web/src/plan/draft.ts
+++ b/packages/web/src/plan/draft.ts
@@ -13,9 +13,14 @@
  *
  * This module is that missing tier: the tab's uncommitted state, in
  * `sessionStorage` (per tab, gone when the tab closes, never shared with the
- * next visit — a draft is not a plan). It wins over the URL and over the
- * cached simulation at mount, because by construction it is more recent
- * than both.
+ * next visit; a draft is not a plan). It wins over the cached simulation at
+ * mount, because by construction it is more recent.
+ *
+ * Against the URL it wins only over the route it was started from, which is
+ * what `originWaypoints` records. Opening a `/plan?wpts=...` link in a tab
+ * that already held a draft used to show the draft's route and the draft's
+ * boat instead of the link's: the reader followed a link and landed on
+ * somebody else's plan. See `session/initial.ts` for the resulting table.
  */
 
 import { SESSION_STORAGE_KEYS } from "../storage/keys";
@@ -34,6 +39,17 @@ export interface PlanDraft {
   /** Route under construction. May hold a single point, or none at all when
       only the departure was touched. */
   waypoints: [number, number][];
+  /** The route this draft is an edit *of*: what `/plan` was showing when the
+      first uncommitted change landed, and what the last computation left
+      behind afterwards. Empty when the draft was started from a blank page.
+
+      `null` means a draft written before this field existed. The key is not
+      versioned for it on purpose: the field is optional, its absence has a
+      defined meaning (origin unknown, so the URL wins), and bumping the key
+      would throw away the half-drawn route of every reader with `/plan` open
+      at the moment of a deploy, which is the one thing this module exists to
+      prevent. */
+  originWaypoints: [number, number][] | null;
   /** Naive local "YYYY-MM-DDTHH:MM". In ETA mode this is the target arrival,
       as on the slider itself. */
   departure: string;
@@ -74,6 +90,12 @@ export function parsePlanDraft(raw: string, now: number): PlanDraft | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const d = parsed as Record<string, unknown>;
   if (!Array.isArray(d.waypoints) || !d.waypoints.every(isCoordPair)) return null;
+  // Absent or malformed reads as "origin unknown" rather than rejecting the
+  // draft: a v1 payload is still a route worth keeping.
+  const origin =
+    Array.isArray(d.originWaypoints) && d.originWaypoints.every(isCoordPair)
+      ? (d.originWaypoints as [number, number][])
+      : null;
   if (typeof d.departure !== "string" || d.departure === "") return null;
   if (typeof d.archetype !== "string" || d.archetype === "") return null;
   if (d.mode !== "single" && d.mode !== "compare") return null;
@@ -86,6 +108,7 @@ export function parsePlanDraft(raw: string, now: number): PlanDraft | null {
   if (now - d.savedAt > MAX_AGE_MS) return null;
   return {
     waypoints: d.waypoints as [number, number][],
+    originWaypoints: origin,
     departure: d.departure,
     timeAnchor: d.timeAnchor,
     archetype: d.archetype,

--- a/packages/web/src/plan/session/initial.test.ts
+++ b/packages/web/src/plan/session/initial.test.ts
@@ -92,6 +92,9 @@ const compareBlock = (over: Partial<NonNullable<LastSimulation["compare"]>> = {}
 
 const draft = (over: Partial<PlanDraft> = {}): PlanDraft => ({
   waypoints: [TOULON, PORQUEROLLES],
+  // Par defaut le brouillon est parti de la meme route que celle qu'il porte :
+  // les tests d'avant la precedence n'avaient pas d'URL concurrente.
+  originWaypoints: over.waypoints ?? [TOULON, PORQUEROLLES],
   departure: FUTURE,
   timeAnchor: "departure",
   archetype: "racer_35ft",
@@ -121,8 +124,12 @@ function resolve(over: Partial<InitialSessionInput> = {}, polar?: PolarConfig) {
 describe("resolveInitialSession: route precedence", () => {
   it.each([
     [
-      "draft over URL and cache",
-      { draft: draft(), url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}`), cache: cache() },
+      "draft over URL and cache, quand l'URL porte la route d'origine du brouillon",
+      {
+        draft: draft({ originWaypoints: [MARSEILLE, PORQUEROLLES] }),
+        url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}`),
+        cache: cache(),
+      },
       "draft",
       [TOULON, PORQUEROLLES],
     ],
@@ -158,6 +165,72 @@ describe("resolveInitialSession: route precedence", () => {
   });
 });
 
+describe("resolveInitialSession: brouillon contre URL", () => {
+  const urlRoute = parsePlanUrl(
+    `?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft&departure=${FUTURE}`,
+  );
+
+  // Le brouillon parle pour la route dont il est parti et pour aucune autre.
+  // Chaque ligne : origine du brouillon, URL, qui seme la session.
+  it.each([
+    ["URL muette, origine quelconque", [TOULON, MARSEILLE] as [number, number][], parsePlanUrl(""), "draft"],
+    ["URL muette, origine inconnue", null, parsePlanUrl(""), "draft"],
+    ["URL egale a l'origine", [MARSEILLE, PORQUEROLLES] as [number, number][], urlRoute, "draft"],
+    ["URL differente de l'origine", [TOULON, MARSEILLE] as [number, number][], urlRoute, "url"],
+    ["origine vide, dessin parti de zero", [] as [number, number][], urlRoute, "url"],
+    ["origine inconnue, brouillon d'avant le champ", null, urlRoute, "url"],
+  ])("%s => %s", (_label, origin, url, expected) => {
+    const s = resolve({ draft: draft({ originWaypoints: origin }), url });
+    expect(s.sources.route).toBe(expected);
+  });
+
+  it("laisse tomber le brouillon en entier, pas seulement sa route", () => {
+    const s = resolve({
+      draft: draft({ originWaypoints: [TOULON, MARSEILLE] }),
+      url: urlRoute,
+    });
+    expect(s.sources.route).toBe("url");
+    // Bateau, depart, mode, plage de balayage : rien du brouillon ne subsiste.
+    expect(s.archetype).toBe("cata_38ft");
+    expect(s.sources.boat).toBe("url");
+    expect(s.departure).toBe(FUTURE);
+    expect(s.sources.departure).toBe("url");
+    expect(s.mode).toBe("single");
+    expect(s.sweepIntervalHours).toBe(3);
+    // Et la page n'ouvre pas en etat perime : elle calcule ce que le lien demande.
+    expect(s.isStale).toBe(false);
+    expect(s.mount.fetch).toBe(true);
+  });
+
+  it("restaure le resultat en cache quand l'URL gagne contre le brouillon", () => {
+    const s = resolve({
+      draft: draft({ originWaypoints: [TOULON, MARSEILLE] }),
+      url: parsePlanUrl(
+        `?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&departure=${FUTURE}`,
+      ),
+      cache: cache(),
+    });
+    expect(s.sources.route).toBe("url");
+    expect(s.passage).not.toBeNull();
+    expect(s.mount.fetch).toBe(false);
+  });
+
+  it("garde l'origine du brouillon restaure, et non sa route courante", () => {
+    const origin: [number, number][] = [MARSEILLE, PORQUEROLLES];
+    const s = resolve({ draft: draft({ originWaypoints: origin }), url: urlRoute });
+    expect(s.waypoints).toEqual([TOULON, PORQUEROLLES]);
+    expect(s.originWaypoints).toEqual(origin);
+  });
+
+  it("fait de la route semee l'origine quand il n'y a pas de brouillon", () => {
+    const fromUrl = resolve({ url: urlRoute });
+    expect(fromUrl.originWaypoints).toEqual(fromUrl.waypoints);
+    const fromCache = resolve({ cache: cache() });
+    expect(fromCache.originWaypoints).toEqual(fromCache.waypoints);
+    expect(resolve().originWaypoints).toEqual([]);
+  });
+});
+
 describe("resolveInitialSession: boat precedence", () => {
   const customized: PolarConfig = { ...defaultPolarConfig(), base: "racer_40ft", spi: "asymmetric" };
 
@@ -170,14 +243,24 @@ describe("resolveInitialSession: boat precedence", () => {
       "polar",
     ],
     [
-      "the draft over the URL",
+      "the draft over the URL, sur la route dont il est parti",
       undefined,
       {
-        draft: draft(),
+        draft: draft({ originWaypoints: [MARSEILLE, PORQUEROLLES] }),
         url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft`),
       },
       "racer_35ft",
       "draft",
+    ],
+    [
+      "the URL over a draft parti d'une autre route",
+      undefined,
+      {
+        draft: draft({ originWaypoints: [TOULON, MARSEILLE] }),
+        url: parsePlanUrl(`?wpts=${wptsParam([MARSEILLE, PORQUEROLLES])}&archetype=cata_38ft`),
+      },
+      "cata_38ft",
+      "url",
     ],
     [
       "the URL over the cache",

--- a/packages/web/src/plan/session/initial.ts
+++ b/packages/web/src/plan/session/initial.ts
@@ -31,7 +31,7 @@
  * | mode | draft > cache > single |
  * | sweep range and step | draft > cache > derived from the departure |
  *
- * Two rules cut across the table:
+ * Three rules cut across the table:
  *
  * - **Freshness.** A departure already behind us is never seeded, whatever
  *   supplied it: a draft left overnight or a bookmarked link from last week
@@ -40,6 +40,23 @@
  *   so a link is authoritative over what this browser last computed; the cache
  *   is then read only to *restore results* for that same route, never to seed
  *   the route itself.
+ * - **A draft only outranks the URL on its own route.** The draft is read at
+ *   all only when the URL carries no waypoints, or when the URL's waypoints
+ *   are the ones the draft was started from (`draft.originWaypoints`). A URL
+ *   naming another route is a different plan, and following a link has to land
+ *   on that link. Everything the draft holds is dropped together in that case,
+ *   boat and departure included: half a draft would be neither plan.
+ *
+ *   A draft written before `originWaypoints` existed has an unknown origin and
+ *   therefore loses to any URL that carries a route.
+ *
+ * | URL waypoints | Draft origin | Who seeds the session |
+ * |---|---|---|
+ * | none | anything | the draft |
+ * | A, B | A, B | the draft |
+ * | A, B | C, D | the URL |
+ * | A, B | empty (drawn from scratch) | the URL |
+ * | A, B | unknown (pre-`originWaypoints`) | the URL |
  *
  * ## Restoring results
  *
@@ -89,6 +106,9 @@ export interface InitialSessionInput {
 
 export interface InitialSession {
   waypoints: [number, number][];
+  /** The route the next draft will say it is an edit of: the restored draft's
+      own origin, or the route this session was seeded with. */
+  originWaypoints: [number, number][];
   archetype: string;
   /** Naive local "YYYY-MM-DDTHH:MM". In arrival mode this is a target ETA. */
   departure: string;
@@ -158,6 +178,14 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
   const urlWaypoints = urlOk ? url.waypoints : [];
   const urlHasWaypoints = urlWaypoints.length >= 2;
 
+  // A draft speaks for the route it was started from and for no other. An
+  // unknown origin (a draft written before the field existed, or one drawn on
+  // a blank page) loses to any URL that carries a route.
+  const draftOwnsUrlRoute =
+    !urlHasWaypoints ||
+    (draft?.originWaypoints != null && waypointsEqual(draft.originWaypoints, urlWaypoints));
+  const seedDraft = draftOwnsUrlRoute ? draft : null;
+
   // The cache seeds nothing while the URL carries a route: a shared link wins
   // over what this browser happens to have computed last.
   const seedCache = urlHasWaypoints ? null : cache;
@@ -166,8 +194,8 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
   // ── route ──────────────────────────────────────────────────────────────────
   let waypoints: [number, number][] = [];
   let routeSource: RouteSource = "none";
-  if (draft) {
-    waypoints = draft.waypoints;
+  if (seedDraft) {
+    waypoints = seedDraft.waypoints;
     routeSource = "draft";
   } else if (urlHasWaypoints) {
     waypoints = urlWaypoints;
@@ -181,13 +209,13 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
   // A customized polar pins the boat to cfg.base, the hull the tuning was built
   // on and the one the selector displays, so a stale URL or cache slug from an
   // earlier session cannot silently re-board the plan on another boat (#220).
-  const draftOrUrlSlug = draft?.archetype ?? (urlOk ? url.archetype : null);
+  const draftOrUrlSlug = seedDraft?.archetype ?? (urlOk ? url.archetype : null);
   const cachedSlug = useCachedRoute ? seedCache.archetype : null;
   const archetype = initialPlanBoat(polarConfig, draftOrUrlSlug, cachedSlug);
   const boatSource: BoatSource = isPersoActive(polarConfig)
     ? "polar"
     : draftOrUrlSlug
-      ? draft?.archetype
+      ? seedDraft?.archetype
         ? "draft"
         : "url"
       : cachedSlug
@@ -200,8 +228,8 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
   const cachedDeparture = seedCache?.single?.departure ?? seedCache?.compare?.sweepEarliest;
   let departure: string;
   let departureSource: DepartureSource;
-  if (isFuture(draft?.departure, now)) {
-    departure = draft.departure;
+  if (isFuture(seedDraft?.departure, now)) {
+    departure = seedDraft.departure;
     departureSource = "draft";
   } else if (urlOk && isFuture(url.departure, now)) {
     departure = url.departure;
@@ -215,17 +243,20 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
   }
 
   // ── mode, anchor, sweep ────────────────────────────────────────────────────
-  const timeAnchor: TimeAnchor = draft?.timeAnchor ?? "departure";
-  const mode: PlanMode = draft?.mode ?? seedCache?.mode ?? "single";
+  const timeAnchor: TimeAnchor = seedDraft?.timeAnchor ?? "departure";
+  const mode: PlanMode = seedDraft?.mode ?? seedCache?.mode ?? "single";
   const sweepEarliest =
-    draft?.sweepEarliest ?? seedCache?.compare?.sweepEarliest ?? departure;
+    seedDraft?.sweepEarliest ?? seedCache?.compare?.sweepEarliest ?? departure;
   const sweepLatest =
-    draft?.sweepLatest ?? seedCache?.compare?.sweepLatest ?? defaultSweepLatest(departure);
+    seedDraft?.sweepLatest ?? seedCache?.compare?.sweepLatest ?? defaultSweepLatest(departure);
   const sweepIntervalHours =
-    draft?.sweepIntervalHours ?? seedCache?.compare?.sweepIntervalHours ?? 3;
+    seedDraft?.sweepIntervalHours ?? seedCache?.compare?.sweepIntervalHours ?? 3;
 
   const base = {
     waypoints,
+    // A restored draft keeps pointing at the route it was started from; a
+    // session seeded from the URL or the cache makes that route its own origin.
+    originWaypoints: seedDraft ? (seedDraft.originWaypoints ?? []) : waypoints,
     archetype,
     departure,
     timeAnchor,
@@ -238,8 +269,9 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
     windows: null,
     metaWarnings: [] as string[],
     forecastUpdatedAt: null,
-    isStale: draft != null,
-    actionTaken: urlHasWaypoints || useCachedRoute || (draft?.waypoints.length ?? 0) >= 2,
+    isStale: seedDraft != null,
+    actionTaken:
+      urlHasWaypoints || useCachedRoute || (seedDraft?.waypoints.length ?? 0) >= 2,
     center: urlOk ? url.center : null,
     urlError: urlOk ? null : url.error,
     mount: { rewriteUrl: false, fetch: false },
@@ -248,11 +280,12 @@ export function resolveInitialSession(input: InitialSessionInput): InitialSessio
 
   // ── results ────────────────────────────────────────────────────────────────
 
-  // Path 0, a draft was restored. It is this tab's most recent state, and by
-  // definition it has no results yet. Hydrating the URL's or the cache's
+  // Path 0, a draft was restored, meaning it also owns the route the URL asks
+  // for. It is this tab's most recent state, and by definition it has no
+  // results yet. Hydrating the URL's or the cache's
   // results on top would show a passage that does not match the route on
   // screen, and computing would spend a request the user did not ask for.
-  if (draft) return base;
+  if (seedDraft) return base;
 
   // Path A, the URL carries a route. Respect it, restore from cache when the
   // cache is about the same route + boat + preferences, otherwise compute. The

--- a/packages/web/src/plan/session/persist.ts
+++ b/packages/web/src/plan/session/persist.ts
@@ -127,6 +127,7 @@ export function syncDraft(state: PlanState): void {
   }
   savePlanDraft({
     waypoints: state.waypoints,
+    originWaypoints: state.originWaypoints,
     departure: state.departure,
     timeAnchor: state.timeAnchor,
     archetype: state.archetype,

--- a/packages/web/src/plan/session/reducer.test.ts
+++ b/packages/web/src/plan/session/reducer.test.ts
@@ -72,6 +72,7 @@ const aWindow = (over: Partial<PassageWindow> = {}): PassageWindow => ({
 
 const session = (over: Partial<InitialSession> = {}): InitialSession => ({
   waypoints: [MARSEILLE, PORQUEROLLES],
+  originWaypoints: over.waypoints ?? [MARSEILLE, PORQUEROLLES],
   archetype: "cruiser_30ft",
   departure: "2026-09-10T08:00",
   timeAnchor: "departure",
@@ -260,6 +261,57 @@ describe("computing", () => {
     // The panel is on the single view, so it does not blank for a sweep.
     expect(isLoadingForMode(s)).toBe(false);
     expect(isLoadingForMode({ ...s, mode: "compare" })).toBe(true);
+  });
+});
+
+describe("l'origine du brouillon", () => {
+  // originWaypoints dit de quelle route les edits en cours sont des edits.
+  // C'est ce que le brouillon compare a l'URL au montage (plan/draft.ts).
+  it("suit la route calculee, pas la route en cours d'edition", () => {
+    let s = start({ waypoints: [MARSEILLE, PORQUEROLLES] });
+    expect(s.originWaypoints).toEqual([MARSEILLE, PORQUEROLLES]);
+
+    s = run(s, { type: "WAYPOINT_APPENDED", lat: 43.1, lon: 5.93 });
+    // Un point de plus ne deplace pas l'origine : c'est encore un edit de la
+    // route d'avant.
+    expect(s.waypoints).toHaveLength(3);
+    expect(s.originWaypoints).toEqual([MARSEILLE, PORQUEROLLES]);
+
+    s = run(s, { type: "FETCH_STARTED", requestId: 1, kind: "single" }, succeedSingle(1));
+    // Le calcul valide la route : elle devient l'origine des edits suivants.
+    expect(s.originWaypoints).toEqual(s.waypoints);
+  });
+
+  it("suit aussi un balayage et le choix d'une fenetre", () => {
+    let s = start({ waypoints: [MARSEILLE, PORQUEROLLES], mode: "compare" });
+    s = run(s, { type: "WAYPOINT_APPENDED", lat: 43.1, lon: 5.93 });
+    const edited = s.waypoints;
+    s = run(
+      s,
+      { type: "FETCH_STARTED", requestId: 1, kind: "sweep" },
+      {
+        type: "FETCH_SUCCEEDED",
+        requestId: 1,
+        kind: "sweep",
+        configFingerprint: "arome|cruiser_30ft",
+        windows: [aWindow()],
+        metaWarnings: [],
+        forecastUpdatedAt: "2026-09-09T06:00:00Z",
+      },
+    );
+    expect(s.originWaypoints).toEqual(edited);
+  });
+
+  it("repart de rien apres un nouveau plan", () => {
+    let s = start({ waypoints: [MARSEILLE, PORQUEROLLES] });
+    s = run(s, {
+      type: "RESET",
+      archetype: "cruiser_30ft",
+      departure: "2026-09-11T08:00",
+      sweepLatest: "2026-09-13T08:00",
+    });
+    expect(s.waypoints).toEqual([]);
+    expect(s.originWaypoints).toEqual([]);
   });
 });
 

--- a/packages/web/src/plan/session/reducer.ts
+++ b/packages/web/src/plan/session/reducer.ts
@@ -86,6 +86,10 @@ export type CacheWrite =
 export interface PlanState {
   // ── inputs ────────────────────────────────────────────────────────────────
   waypoints: [number, number][];
+  /** The route the current edits are edits *of*: the seed at mount, then the
+      route of every computation that lands. Only the draft reads it, to say
+      which URL it may outrank (`plan/draft.ts`). */
+  originWaypoints: [number, number][];
   archetype: string;
   /** Naive local "YYYY-MM-DDTHH:MM". A target arrival in `arrival` anchor. */
   departure: string;
@@ -174,6 +178,7 @@ export type PlanAction =
 export function createInitialState(initial: InitialSession): PlanState {
   return {
     waypoints: initial.waypoints,
+    originWaypoints: initial.originWaypoints,
     archetype: initial.archetype,
     departure: initial.departure,
     timeAnchor: initial.timeAnchor,
@@ -324,6 +329,8 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
             pending: null,
             isStale: false,
             selectedLegIdx: null,
+            // A computed route is the one the next edits will be edits of.
+            originWaypoints: state.waypoints,
             passage: action.passage,
             complexity: action.complexity,
             forecastUpdatedAt: action.forecastUpdatedAt,
@@ -350,6 +357,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
           ...state,
           pending: null,
           isStale: false,
+          originWaypoints: state.waypoints,
           windows: action.windows,
           metaWarnings: action.metaWarnings,
           forecastUpdatedAt: action.forecastUpdatedAt,
@@ -402,6 +410,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
           pending: null,
           isStale: false,
           selectedLegIdx: null,
+          originWaypoints: state.waypoints,
           passage: action.window.passage,
           complexity: action.window.complexity_full,
         },
@@ -427,6 +436,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
         {
           ...state,
           waypoints: [],
+          originWaypoints: [],
           archetype: action.archetype,
           departure: action.departure,
           timeAnchor: "departure",

--- a/packages/web/src/plan/session/usePlanSession.test.tsx
+++ b/packages/web/src/plan/session/usePlanSession.test.tsx
@@ -94,6 +94,7 @@ const aWindow = (over: Partial<PassageWindow> = {}): PassageWindow => ({
 
 const session = (over: Partial<InitialSession> = {}): InitialSession => ({
   waypoints: [MARSEILLE, PORQUEROLLES],
+  originWaypoints: over.waypoints ?? [MARSEILLE, PORQUEROLLES],
   archetype: "cruiser_30ft",
   departure: "2026-09-10T08:00",
   timeAnchor: "departure",


### PR DESCRIPTION
Décision produit prise sur le constat de la QA du lot 1 : « un brouillon périmé de l'onglet l'emporte sur une URL `/plan?wpts=...` différente ouverte ensuite dans le même onglet ». Le lecteur suivait un lien MCP ou partagé et atterrissait sur le plan de quelqu'un d'autre, avec le bateau du brouillon en prime.

## La règle

Le brouillon garde la priorité, mais seulement sur la route dont il est parti. Il enregistre donc cette route, `originWaypoints` : ce que `/plan` affichait quand la première édition non calculée a atterri, et ce que chaque calcul y laisse ensuite.

| Waypoints de l'URL | Origine du brouillon | Qui sème la session |
|---|---|---|
| aucun | n'importe laquelle | le brouillon |
| A, B | A, B | le brouillon |
| A, B | C, D | l'URL |
| A, B | vide (tracé de zéro) | l'URL |
| A, B | inconnue (brouillon d'avant le champ) | l'URL |

Quand l'URL gagne, le brouillon est ignoré **en entier** : bateau, départ, mode et plage de balayage compris. Une moitié de brouillon ne serait ni l'un ni l'autre plan. La page ouvre alors non périmée, restaure le cache si le cache parle de cette route, et calcule sinon ; le brouillon périmé est effacé au montage par `syncDraft`, qui suit `isStale`.

## La clé n'est pas versionnée

Le champ est optionnel et son absence a un sens défini, « origine inconnue », qui perd devant toute URL portant une route. Bumper `ow_plan_draft_v1` jetterait la route à moitié tracée de tout lecteur ayant `/plan` ouvert au moment d'un déploiement, ce que ce module existe précisément pour éviter. Une origine absente, `null`, non tabulaire ou faite de paires invalides est lue comme inconnue sans jeter le reste du brouillon.

## Câblage

`originWaypoints` descend dans `PlanState` : semé au montage depuis `InitialSession`, remis à `state.waypoints` par chaque succès (simple, balayage, choix de fenêtre), vidé par `RESET`. `syncDraft` l'écrit. Un brouillon restauré garde sa propre origine et non sa route courante, sinon la deuxième sauvegarde perdrait l'information.

## Changement de comportement, vérifié en live

Deux builds de prod servies en parallèle (`dev` d'un côté, la branche de l'autre), même brouillon injecté avant le boot, même URL.

Brouillon : Toulon vers Porquerolles, `cata_38ft`, départ le 5 septembre, origine Toulon vers Porquerolles. URL : `/plan?wpts=43.29000,5.37000;43.00000,6.20000&departure=2026-09-03T09:00&archetype=cruiser_30ft`.

| | `dev` | Cette branche |
|---|---|---|
| Route affichée | celle du brouillon, 13 nm | celle de l'URL |
| Bateau | `cata_38ft` | Croiseur 30 pieds |
| Départ | Samedi 5 septembre 09:00 | Jeudi 3 septembre 09:00 |
| Résultats | aucun, page périmée | restaurés du cache, 40,3 nm et 13h55 |
| POST vers l'API | 0 | 0 |
| Brouillon après montage | conservé | effacé |

Et le cas où le brouillon doit gagner, même URL, brouillon dont l'origine est Marseille vers Porquerolles : la branche affiche bien les 13 nm du brouillon, `cata_38ft`, départ du 5 septembre, page en état périmé avec « Calculer le passage ». Le brouillon reste en `sessionStorage`.

## Tests

Tables de cas dans `initial.test.ts` (six lignes de la table de précédence, plus le rejet complet du brouillon, la restauration du cache quand l'URL gagne, et la propagation de l'origine) et dans `draft.test.ts` (aller-retour, origine vide, et quatre formes d'origine illisible lues comme inconnues). `reducer.test.ts` couvre le suivi de l'origine par les trois succès et par le nouveau plan.

`npm run typecheck`, `npm run lint:budget` (0 erreur), `npm run test` (52 fichiers, 715 tests, +20), `npm run build` : verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
