### PR TITLE
perf(web): le corps du POST de passage part en gzip

### DIFF
--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -2,8 +2,55 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ApiError, formatRetryDelay, friendlyError } from "./passage";
+import { ApiError, fetchPassage, formatRetryDelay, friendlyError } from "./passage";
 import { ApiShapeError } from "./parse";
+import { resetBodyEncoding } from "./postJson";
+
+// Les trois POST passent par postJson, qui decide de la compression. Ce test
+// verifie le cablage, pas la negociation : celle-ci a son propre fichier.
+describe("cablage de la compression", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetBodyEncoding();
+  });
+
+  it("envoie le forecast_cache en gzip", async () => {
+    let sentBody: ArrayBuffer | null = null;
+    let sentEncoding: string | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        sentEncoding = new Headers(init.headers).get("Content-Encoding");
+        sentBody = init.body as ArrayBuffer;
+        return new Response("{}", { status: 200 });
+      }),
+    );
+    const forecastCache = {
+      points: Array.from({ length: 15 }, (_, i) => ({
+        lat: 43.3 - i * 0.02,
+        lon: 5.35 + i * 0.06,
+        models: [{ model: "arome", wind_kn: Array.from({ length: 48 }, (_, h) => 8 + (h % 7)) }],
+      })),
+    } as never;
+    // La reponse vide echoue au parsing : c'est la requete qui nous interesse.
+    await expect(
+      fetchPassage({
+        waypoints: [
+          [43.3, 5.35],
+          [43.0, 6.2],
+        ],
+        departure: "2026-09-03T09:00",
+        archetype: "cruiser_30ft",
+        forecastCache,
+      }),
+    ).rejects.toBeInstanceOf(ApiShapeError);
+    expect(sentEncoding).toBe("gzip");
+    const stream = new Blob([sentBody!]).stream().pipeThrough(new DecompressionStream("gzip"));
+    const back = JSON.parse(await new Response(stream).text());
+    expect(back.forecast_cache.points).toHaveLength(15);
+    expect(back.archetype).toBe("cruiser_30ft");
+  });
+});
 
 // Regression guard for the dev incident of 2026-08-01: the rate-limit copy
 // hard-coded "une minute" while the server ran a 300 s window, so the user

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -6,6 +6,7 @@ import type { ModelName } from "../config/modelConfig";
 import type { PolarData } from "../config/polarConfig";
 import { COEFF_DEFAULT } from "../config/polarConfig";
 import { API_BASE } from "./config";
+import { postJson } from "./postJson";
 import type { ForecastCache } from "./forecastCache";
 import {
   ApiShapeError,
@@ -282,12 +283,7 @@ export async function fetchPassage(params: {
   if (params.overrides?.models?.length) body["models"] = params.overrides.models;
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
   if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
-  const res = await fetch(`${API_BASE}/api/v1/passage`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: params.signal,
-  });
+  const res = await postJson(`${API_BASE}/api/v1/passage`, body, params.signal);
   if (!res.ok) throw await toError(res);
   return parsePassageResponse(await res.json());
 }
@@ -318,12 +314,7 @@ export async function fetchPassageWindows(params: {
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
   if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
 
-  const res = await fetch(`${API_BASE}/api/v1/passage`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: params.signal,
-  });
+  const res = await postJson(`${API_BASE}/api/v1/passage`, body, params.signal);
   if (!res.ok) throw await toError(res);
   return parseMultiWindowResponse(await res.json());
 }
@@ -348,12 +339,7 @@ export async function fetchPassageByEta(params: {
   if (params.overrides?.polar) body["polar"] = params.overrides.polar;
   if (params.forecastCache) body["forecast_cache"] = params.forecastCache;
 
-  const res = await fetch(`${API_BASE}/api/v1/passage-by-eta`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: params.signal,
-  });
+  const res = await postJson(`${API_BASE}/api/v1/passage-by-eta`, body, params.signal);
   if (!res.ok) throw await toError(res);
   return parsePassageByEtaResponse(await res.json());
 }

--- a/packages/web/src/api/postJson.test.ts
+++ b/packages/web/src/api/postJson.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bodyEncoding, postJson, resetBodyEncoding } from "./postJson";
+
+/** Le pendant de la compression, par la meme API web : le paquet n'a pas de
+    @types/node, et DecompressionStream prouve la meme chose que zlib. */
+async function gunzip(buffer: ArrayBuffer): Promise<string> {
+  const stream = new Blob([buffer]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return await new Response(stream).text();
+}
+
+const URL_ = "https://example.test/api/v1/passage";
+
+/** Over MIN_GZIP_BYTES, and compressible like a real corridor. */
+const bigBody = () => ({
+  waypoints: [
+    [43.3, 5.35],
+    [43.0, 6.2],
+  ],
+  forecast_cache: {
+    points: Array.from({ length: 15 }, (_, i) => ({
+      lat: 43.3 - i * 0.02,
+      lon: 5.35 + i * 0.06,
+      wind_kn: Array.from({ length: 48 }, (_, h) => 8 + (h % 7)),
+    })),
+  },
+});
+
+const smallBody = () => ({ waypoints: [[43.3, 5.35]], archetype: "cruiser_30ft" });
+
+function ok(): Response {
+  return new Response('{"ok":true}', { status: 200 });
+}
+
+interface Sent {
+  encoding: string | null;
+  contentType: string | null;
+  body: ArrayBuffer | string;
+}
+
+/** Records what each call was handed, then answers as told. */
+function stubFetch(...answers: (Response | Error)[]) {
+  const sent: Sent[] = [];
+  const fake = vi.fn(async (_url: string, init: RequestInit) => {
+    const headers = new Headers(init.headers);
+    const raw = init.body;
+    sent.push({
+      encoding: headers.get("Content-Encoding"),
+      contentType: headers.get("Content-Type"),
+      body: typeof raw === "string" ? raw : (raw as ArrayBuffer),
+    });
+    const answer = answers[sent.length - 1] ?? answers[answers.length - 1];
+    if (answer instanceof Error) throw answer;
+    return answer;
+  });
+  vi.stubGlobal("fetch", fake);
+  return sent;
+}
+
+function transportFailure(): TypeError {
+  return new TypeError("Failed to fetch");
+}
+
+beforeEach(() => resetBodyEncoding());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("postJson: compression", () => {
+  it("sends gzip and declares it", async () => {
+    const sent = stubFetch(ok());
+    const body = bigBody();
+    await postJson(URL_, body);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].encoding).toBe("gzip");
+    expect(sent[0].contentType).toBe("application/json");
+    // Le corps est bien un gzip valide, et il redonne le JSON d'origine.
+    expect(JSON.parse(await gunzip(sent[0].body as ArrayBuffer))).toEqual(body);
+    expect(bodyEncoding()).toBe("gzip");
+  });
+
+  it("gagne des octets sur un corridor realiste", async () => {
+    const sent = stubFetch(ok());
+    const body = bigBody();
+    await postJson(URL_, body);
+    const clear = JSON.stringify(body).length;
+    const compressed = (sent[0].body as ArrayBuffer).byteLength;
+    expect(compressed).toBeLessThan(clear / 3);
+  });
+
+  it("laisse les petits corps en clair, ou gzip couterait plus qu'il ne rend", async () => {
+    const sent = stubFetch(ok());
+    await postJson(URL_, smallBody());
+    expect(sent[0].encoding).toBeNull();
+    expect(sent[0].body).toBe(JSON.stringify(smallBody()));
+    // Rien n'a ete appris : la negociation attend un vrai corps.
+    expect(bodyEncoding()).toBe("unknown");
+  });
+
+  it("part en clair quand le navigateur n'a pas CompressionStream", async () => {
+    const sent = stubFetch(ok());
+    vi.stubGlobal("CompressionStream", undefined);
+    await postJson(URL_, bigBody());
+    expect(sent[0].encoding).toBeNull();
+  });
+
+  it("passe le signal d'abandon aux deux tentatives", async () => {
+    const seen: (AbortSignal | null | undefined)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_u: string, init: RequestInit) => {
+        seen.push(init.signal);
+        return seen.length === 1 ? new Response("", { status: 415 }) : ok();
+      }),
+    );
+    const controller = new AbortController();
+    await postJson(URL_, bigBody(), controller.signal);
+    expect(seen).toEqual([controller.signal, controller.signal]);
+  });
+});
+
+describe("postJson: repli", () => {
+  it("rejoue une fois en clair sur un 415, puis ne compresse plus", async () => {
+    const sent = stubFetch(new Response("", { status: 415 }), ok(), ok());
+    const res = await postJson(URL_, bigBody());
+    expect(res.status).toBe(200);
+    expect(sent.map((s) => s.encoding)).toEqual(["gzip", null]);
+    expect(bodyEncoding()).toBe("identity");
+
+    // Le corps suivant part directement en clair : une seule requete.
+    await postJson(URL_, bigBody());
+    expect(sent).toHaveLength(3);
+    expect(sent[2].encoding).toBeNull();
+  });
+
+  it("ne rejoue pas deux fois: un 415 sur la reprise en clair remonte tel quel", async () => {
+    const sent = stubFetch(
+      new Response("", { status: 415 }),
+      new Response("", { status: 415 }),
+    );
+    const res = await postJson(URL_, bigBody());
+    expect(res.status).toBe(415);
+    expect(sent).toHaveLength(2);
+  });
+
+  it("ne rejoue pas sur une erreur du serveur qui n'est pas 415", async () => {
+    const sent = stubFetch(new Response("", { status: 429 }));
+    const res = await postJson(URL_, bigBody());
+    expect(res.status).toBe(429);
+    expect(sent).toHaveLength(1);
+    // Le serveur a lu le corps compresse : l'encodage est acquis.
+    expect(bodyEncoding()).toBe("gzip");
+  });
+
+  it("rejoue en clair quand le prevol refuse l'en-tete, une seule fois", async () => {
+    const sent = stubFetch(transportFailure(), ok());
+    const res = await postJson(URL_, bigBody());
+    expect(res.status).toBe(200);
+    expect(sent.map((s) => s.encoding)).toEqual(["gzip", null]);
+    expect(bodyEncoding()).toBe("identity");
+  });
+
+  it("remonte la panne quand la reprise en clair echoue aussi", async () => {
+    stubFetch(transportFailure(), transportFailure());
+    await expect(postJson(URL_, bigBody())).rejects.toThrow(/failed to fetch/i);
+  });
+
+  it("ne sonde plus une fois l'encodage acquis: une panne reste une panne", async () => {
+    const sent = stubFetch(ok(), transportFailure());
+    await postJson(URL_, bigBody());
+    expect(bodyEncoding()).toBe("gzip");
+    await expect(postJson(URL_, bigBody())).rejects.toThrow(/failed to fetch/i);
+    // Deux requetes en tout, pas trois : aucune reprise sur la seconde.
+    expect(sent).toHaveLength(2);
+  });
+
+  it.each([
+    ["AbortError", "AbortError"],
+    ["TimeoutError", "TimeoutError"],
+  ])("laisse passer un abandon (%s) sans le lire comme un refus", async (_label, name) => {
+    const abort = new Error("aborted");
+    abort.name = name;
+    const sent = stubFetch(abort);
+    await expect(postJson(URL_, bigBody())).rejects.toThrow("aborted");
+    expect(sent).toHaveLength(1);
+    expect(bodyEncoding()).toBe("unknown");
+  });
+});

--- a/packages/web/src/api/postJson.ts
+++ b/packages/web/src/api/postJson.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+/**
+ * The one place a JSON body leaves the browser, and the one place it is gzipped.
+ *
+ * A passage request without `forecast_cache` is a few hundred bytes. One with
+ * it, measured live on a 63 NM Mediterranean route, is 44 KB: the corridor
+ * carries a week of hourly wind for four models at fifteen points, and that is
+ * exactly the payload the mobile reader uploads on a slow link before anything
+ * appears. Gzipped it is 9.6 KB. The response has been compressed since #317;
+ * this is the other direction, which nobody had asked the browser to do.
+ *
+ * ## Negotiation, without a round trip to ask
+ *
+ * There is no capability endpoint, so the module tries and remembers. Three
+ * states, per page load:
+ *
+ * | state | what it means | what the next POST does |
+ * |---|---|---|
+ * | `unknown` | nothing tried yet | compress, and watch |
+ * | `gzip` | a compressed body was accepted | compress |
+ * | `identity` | a compressed body was refused | never compress again |
+ *
+ * Two refusals are recognised, because a server that does not decompress can
+ * fail in two very different ways:
+ *
+ * - **415.** The request reached the server, which understood the header and
+ *   said no. Unambiguous.
+ * - **A transport failure on a body we have never seen accepted.** The
+ *   `Content-Encoding` request header is not CORS-safelisted, so it has to be
+ *   in the preflight's `Access-Control-Allow-Headers`. A server that
+ *   decompresses but forgot to allow the header makes the browser refuse to
+ *   send the request at all, and `fetch` rejects with a `TypeError` that looks
+ *   exactly like an outage. Retrying once uncompressed costs one request per
+ *   page load and tells the two apart: if the plain retry fails too, its error
+ *   is the one that reaches the caller, so a real outage is still reported as
+ *   an outage.
+ *
+ * An abort is never a refusal: `AbortError` and `TimeoutError` propagate
+ * untouched, or a newer computation cancelling an older one would be read as
+ * a server that hates gzip.
+ *
+ * ## What is not compressed
+ *
+ * Bodies under `MIN_GZIP_BYTES`. Below a kilobyte the gzip header and the
+ * CPU cost more than the bytes saved, and the small bodies are exactly the
+ * ones that were never a problem. A page that only ever sends small bodies
+ * therefore stays in `unknown` and never spends the probing retry.
+ */
+
+/** Below this, compressing is a loss. See the module doc. */
+const MIN_GZIP_BYTES = 1024;
+
+type BodyEncoding = "unknown" | "gzip" | "identity";
+
+let state: BodyEncoding = "unknown";
+
+/** Test seam: the state is a page-load fact, and tests need several. */
+export function resetBodyEncoding(): void {
+  state = "unknown";
+}
+
+/** What the last POST decided. Exported for the tests and for debugging. */
+export function bodyEncoding(): BodyEncoding {
+  return state;
+}
+
+function canCompress(): boolean {
+  return typeof CompressionStream !== "undefined";
+}
+
+async function gzip(text: string): Promise<ArrayBuffer> {
+  const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"));
+  return await new Response(stream).arrayBuffer();
+}
+
+/** An abort or a timeout, which must never be mistaken for a server verdict. */
+function isAbort(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  );
+}
+
+/**
+ * POST a JSON body, gzipped when that is worth it and the server takes it.
+ *
+ * Returns the `Response` untouched, error statuses included: reading the error
+ * contract stays the caller's business (`toError` in `passage.ts`).
+ */
+export async function postJson(
+  url: string,
+  body: unknown,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const json = JSON.stringify(body);
+  const plain = () =>
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: json,
+      signal,
+    });
+
+  const worthIt = json.length >= MIN_GZIP_BYTES;
+  if (state === "identity" || !worthIt || !canCompress()) return plain();
+
+  const probing = state === "unknown";
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Encoding": "gzip" },
+      body: await gzip(json),
+      signal,
+    });
+  } catch (error) {
+    // A preflight that refused `Content-Encoding` lands here, and so does a
+    // genuine outage. Probe once; after that the encoding is settled and the
+    // error is the caller's.
+    if (isAbort(error) || !probing) throw error;
+    state = "identity";
+    return plain();
+  }
+
+  if (res.status === 415) {
+    state = "identity";
+    return plain();
+  }
+  state = "gzip";
+  return res;
+}


### PR DESCRIPTION
Quick win resté ouvert après le lot 0 : « corps du POST toujours 43,7 Ko non compressés ». #324 avait pris les 321 octets d'arrondi de coordonnées et conclu que la vraie marge était la compression du corps. La réponse est compressée depuis #317 ; le sens montant, lui, ne l'était pas.

Le corps mesuré en live sur une route méditerranéenne de 63 NM : 43,7 Ko, dont 42,9 pour `forecast_cache`, une semaine de vent horaire sur quatre modèles en quinze points du corridor. C'est ce que le lecteur mobile téléverse avant que quoi que ce soit s'affiche.

## Ce que fait la PR

`api/postJson.ts` devient le seul endroit d'où un corps JSON sort du navigateur, et les trois POST (`/passage` simple, `/passage` en balayage, `/passage-by-eta`) y passent. Il compresse quand `CompressionStream` existe et que le corps dépasse 1 Ko, sous quoi l'en-tête gzip et le temps CPU coûtent plus que les octets gagnés. `AbortSignal` est transmis, aux deux tentatives quand il y en a deux.

## La négociation, sans endpoint de capacité

Trois états, pour la durée du chargement de page :

| état | ce qu'il dit | ce que fait le POST suivant |
|---|---|---|
| `unknown` | rien d'essayé | compresse, et regarde |
| `gzip` | un corps compressé a été accepté | compresse |
| `identity` | un corps compressé a été refusé | ne compresse plus |

Deux refus sont reconnus, parce qu'un serveur qui ne décompresse pas peut échouer de deux façons très différentes :

- **415.** La requête a atteint le serveur, qui a compris l'en-tête et a dit non. Sans ambiguïté.
- **Une panne de transport sur un corps jamais accepté jusque-là.** `Content-Encoding` n'est pas sur la liste sûre CORS : il doit figurer dans l'`Access-Control-Allow-Headers` du prévol. Un serveur qui décompresse mais oublie d'autoriser l'en-tête fait échouer la requête **avant son envoi**, avec un `TypeError` qui ressemble exactement à une coupure réseau. Une reprise en clair, une seule par chargement de page, distingue les deux : si elle échoue aussi, c'est son erreur qui remonte à l'appelant, donc une vraie panne reste rapportée comme une panne.

Un abandon (`AbortError`, `TimeoutError`) n'est jamais lu comme un refus : sinon un calcul plus récent qui annule le précédent condamnerait la compression pour toute la session.

## Mesures

Sur le corridor de 15 points des tests de #324 (route de 63 NM, sous-segments de 10 NM), quatre modèles et la couche marine, corps complet du POST :

| Horizon | Séries lisses, clair → gzip | Séries aléatoires (pire cas), clair → gzip |
|---|---|---|
| 24 h | 28 683 → 1 429 o (20x) | 29 709 → 10 431 o (2,8x) |
| 48 h | 51 489 → 2 081 o | 53 282 → 19 322 o |
| 169 h | 165 233 → 4 612 o | 171 515 → 62 111 o |

La vraie météo est entre les deux bornes : le relevé live de l'audit donne 43,7 Ko en clair pour 9,6 Ko compressés, soit 4,6x.

## Tests

Treize cas dans `postJson.test.ts` avec un `fetch` doublé : en-tête posé, corps réellement gzip et redonnant le JSON d'origine après décompression, petits corps laissés en clair, absence de `CompressionStream`, repli 415 avec mémoire de session, absence de double reprise, 429 qui ne déclenche pas de repli, repli sur refus de prévol, panne qui reste une panne une fois l'encodage acquis, abandons laissés passer. Plus un test de câblage dans `passage.test.ts` : `fetchPassage` avec un `forecast_cache` de 15 points part bien en gzip et le serveur y retrouve ses quinze points.

La décompression se fait par `DecompressionStream` et non par `zlib` : le paquet web n'a pas `@types/node`, et l'API web prouve la même chose.

`npm run typecheck`, `npm run lint:budget` (0 erreur), `npm run test` (53 fichiers, 709 tests, +14), `npm run build` : verts.

## Côté serveur

La décompression est livrée en parallèle par l'agent backend (`Content-Encoding: gzip` accepté sur `POST /api/v1/*`, taille décompressée plafonnée à 4 Mo, 415 pour les autres encodages). Deux choses à vérifier au déploiement : que `Content-Encoding` figure bien dans l'`Access-Control-Allow-Headers` du prévol, et que le Worker de bord relaie le corps compressé tel quel. Tant que rien n'est déployé, la première requête d'une page coûte un aller-retour de plus, puis plus rien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
