### PR TITLE
perf(web): un seul appel MARC pour tout le corridor

### DIFF
--- a/packages/web/src/api/marine.test.ts
+++ b/packages/web/src/api/marine.test.ts
@@ -12,6 +12,7 @@ import {
   marcMayCover,
   mergeMarcOverlay,
   parseMarcCoverage,
+  resetMarcBatchSupport,
   type MarcAtlasBox,
   type MarcOverlay,
 } from "./marine";
@@ -356,14 +357,28 @@ describe("fetchMarineCorridor", () => {
 
   interface Calls {
     marine: string[];
+    /** Per-point GET /marine/marc, the path the batch route replaces. */
     marc: string[];
+    /** One entry per POST /marine/marc/batch: the points it carried. */
+    batch: [number, number][][];
     coverage: number;
   }
 
+  interface StubOpts {
+    /** Status of the batch route. 404 is a Space that predates it. */
+    batchStatus?: number;
+    /** Body of a 200 batch answer. Defaults to one uncovered overlay per point. */
+    batchBody?: (points: [number, number][]) => unknown;
+  }
+
   /** Stubs fetch and records what was asked of whom. */
-  function stubFetch(coverage: { status: number; body?: unknown }, points: number): Calls {
-    const calls: Calls = { marine: [], marc: [], coverage: 0 };
-    vi.stubGlobal("fetch", async (input: string) => {
+  function stubFetch(
+    coverage: { status: number; body?: unknown },
+    points: number,
+    opts: StubOpts = {},
+  ): Calls {
+    const calls: Calls = { marine: [], marc: [], batch: [], coverage: 0 };
+    vi.stubGlobal("fetch", async (input: string, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/marine/marc/coverage")) {
         calls.coverage += 1;
@@ -371,6 +386,21 @@ describe("fetchMarineCorridor", () => {
           ok: coverage.status === 200,
           status: coverage.status,
           json: async () => coverage.body,
+        };
+      }
+      if (url.includes("/marine/marc/batch")) {
+        const sent = JSON.parse(String(init?.body ?? "{}")) as {
+          points: [number, number][];
+        };
+        calls.batch.push(sent.points);
+        const status = opts.batchStatus ?? 200;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () =>
+            opts.batchBody
+              ? opts.batchBody(sent.points)
+              : { overlays: sent.points.map(() => ({ covered: false })) },
         };
       }
       if (url.includes("/marine/marc")) {
@@ -397,6 +427,7 @@ describe("fetchMarineCorridor", () => {
   beforeEach(() => {
     clearMarineCache();
     clearMarcCoverageCache();
+    resetMarcBatchSupport();
     vi.stubGlobal("localStorage", {
       getItem: () => null,
       setItem: () => {},
@@ -438,27 +469,36 @@ describe("fetchMarineCorridor", () => {
     expect(calls.coverage).toBe(1);
   });
 
-  it("still asks MARC inside an atlas", async () => {
+  it("asks MARC once for the whole corridor inside an atlas", async () => {
     const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 2);
     await fetchMarineCorridor([
       { lat: 48.3, lon: -4.5 },
       { lat: 48.4, lon: -4.6 },
     ]);
-    expect(calls.marc).toHaveLength(2);
-    expect(calls.marc[0]).toContain("lat=48.3");
+    expect(calls.batch).toEqual([
+      [
+        [48.3, -4.5],
+        [48.4, -4.6],
+      ],
+    ]);
+    expect(calls.marc).toEqual([]);
   });
 
-  it("falls back to asking every point when the endpoint is missing", async () => {
-    // A Space deployed before the coverage route exists answers 404.
+  it("asks every point when the coverage endpoint is missing, but in one batch", async () => {
+    // A Space deployed before the coverage route exists answers 404, so every
+    // point is a candidate again. That is one batch, not one call per point.
     const calls = stubFetch({ status: 404 }, 4);
     await fetchMarineCorridor(MED_CORRIDOR);
-    expect(calls.marc).toHaveLength(4);
+    expect(calls.batch).toHaveLength(1);
+    expect(calls.batch[0]).toHaveLength(4);
+    expect(calls.marc).toEqual([]);
   });
 
-  it("falls back the same way on a malformed body", async () => {
+  it("does the same on a malformed coverage body", async () => {
     const calls = stubFetch({ status: 200, body: { oops: true } }, 4);
     await fetchMarineCorridor(MED_CORRIDOR);
-    expect(calls.marc).toHaveLength(4);
+    expect(calls.batch).toHaveLength(1);
+    expect(calls.batch[0]).toHaveLength(4);
   });
 
   it("asks the coverage endpoint once per session, not once per point", async () => {
@@ -521,7 +561,131 @@ describe("fetchMarineCorridor", () => {
       4,
     );
     await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.batch).toHaveLength(1);
+    expect(calls.batch[0]).toHaveLength(4);
+  });
+
+  it("porte la fenetre et le pas dans le corps du lot", async () => {
+    let body: Record<string, unknown> = {};
+    vi.stubGlobal("fetch", async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/coverage")) {
+        return { ok: false, status: 404, json: async () => ({}) };
+      }
+      if (url.includes("/marine/marc/batch")) {
+        body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            overlays: (body.points as unknown[]).map(() => ({ covered: false })),
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => [omPoint(0.5)] };
+    });
+    await fetchMarineCorridor(MED_CORRIDOR.slice(0, 1));
+    expect(body.step_minutes).toBe(60);
+    expect(String(body.start)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(Date.parse(String(body.end)) - Date.parse(String(body.start))).toBe(
+      7 * 24 * 3600 * 1000,
+    );
+  });
+
+  it("fusionne chaque reponse du lot dans le point qui lui correspond", async () => {
+    // Deux points couverts, un seul rendu couvert par le serveur : la maree
+    // MARC doit atterrir sur le second et pas sur le premier.
+    const calls = stubFetch({ status: 404 }, 2, {
+      batchBody: (points) => ({
+        overlays: points.map((_, k) =>
+          k === 1
+            ? {
+                covered: true,
+                z0_hydro_m: -3.74,
+                // omPoint parle en heure de Paris : le 8 mai a 00:00 CEST,
+                // c'est 22:00Z la veille.
+                times: [
+                  "2026-05-07T22:00:00+00:00",
+                  "2026-05-07T23:00:00+00:00",
+                  "2026-05-08T00:00:00+00:00",
+                ],
+                tide_height_m: [3.1, 3.2, 3.3],
+                current_speed_kn: [0.4, 0.5, 0.6],
+                current_direction_to_deg: [90, 90, 90],
+              }
+            : { covered: false },
+        ),
+      }),
+    });
+    const out = await fetchMarineCorridor([
+      { lat: 48.3, lon: -4.5 },
+      { lat: 48.4, lon: -4.6 },
+    ]);
+    expect(calls.batch).toHaveLength(1);
+    expect(out[0]!.tide_height_zh_m).toBeUndefined();
+    expect(out[0]!.current_speed_kn[0]).toBeCloseTo(1); // SMOC, intact
+    expect(out[1]!.tide_height_zh_m![0]).toBeCloseTo(3.1 + 3.74);
+    expect(out[1]!.current_speed_kn[0]).toBeCloseTo(0.4);
+  });
+
+  it("remplit le cache par point depuis la reponse du lot", async () => {
+    const calls = stubFetch({ status: 404 }, 2);
+    const route = [
+      { lat: 48.3, lon: -4.5 },
+      { lat: 48.4, lon: -4.6 },
+    ];
+    await fetchMarineCorridor(route);
+    await fetchMarineCorridor(route);
+    // Le second calcul ne redemande rien, ni la meteo marine ni MARC.
+    expect(calls.marine).toHaveLength(1);
+    expect(calls.batch).toHaveLength(1);
+  });
+
+  it("revient au point par point quand la route de lot n'existe pas, une seule fois", async () => {
+    const calls = stubFetch({ status: 404 }, 4, { batchStatus: 404 });
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.batch).toHaveLength(1);
     expect(calls.marc).toHaveLength(4);
+
+    // Le verdict est retenu : le corridor suivant part directement en GET.
+    clearMarineCache();
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.batch).toHaveLength(1);
+    expect(calls.marc).toHaveLength(8);
+  });
+
+  it("fait de meme sur un 405", async () => {
+    const calls = stubFetch({ status: 404 }, 4, { batchStatus: 405 });
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toHaveLength(4);
+  });
+
+  it("garde les donnees Open-Meteo quand le lot echoue autrement", async () => {
+    // 500 n'est pas un verdict sur la route : pas de repli, pas de recouvrement
+    // MARC, mais le corridor garde ses vagues et ses courants SMOC.
+    const calls = stubFetch({ status: 404 }, 4, { batchStatus: 500 });
+    const out = await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toEqual([]);
+    expect(out.every((m) => m !== null)).toBe(true);
+    expect(out[0]!.wave_height_m[0]).toBe(0.5);
+  });
+
+  it("rejette un lot dont la longueur ne correspond pas aux points envoyes", async () => {
+    // Un decalage collerait la maree d'un point sur la position d'un autre.
+    const calls = stubFetch({ status: 404 }, 4, {
+      batchBody: () => ({ overlays: [{ covered: true }] }),
+    });
+    const out = await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.marc).toEqual([]);
+    expect(out.every((m) => m !== null)).toBe(true);
+    expect(out[0]!.tide_height_zh_m).toBeUndefined();
+  });
+
+  it("ne demande rien du tout quand aucun point n'est couvert", async () => {
+    const calls = stubFetch({ status: 200, body: { atlases: [MED_BOX] } }, 4);
+    await fetchMarineCorridor(MED_CORRIDOR);
+    expect(calls.batch).toEqual([]);
+    expect(calls.marc).toEqual([]);
   });
 
   it("returns an empty result for an empty corridor without asking anything", async () => {

--- a/packages/web/src/api/marine.ts
+++ b/packages/web/src/api/marine.ts
@@ -267,6 +267,134 @@ function fetchMarcOverlayIfCovered(
   return fetchMarcOverlay(lat, lon, startUtcIso, endUtcIso);
 }
 
+// ── MARC overlays for a whole corridor ───────────────────────────────────────
+//
+// Coverage (#322) removed the calls that could never have carried data. What
+// remains is an Atlantic route, where every corridor point *is* covered and
+// each one was still a round trip of its own: fifteen requests, fifteen
+// harmonic evaluations, fifteen rate-limit hits, for one route. The Space now
+// takes the whole corridor in one POST and answers in the same order, one
+// element per point, each element exactly the per-point GET's body. Same
+// rate-limit bucket, one hit.
+//
+// Availability is discovered rather than configured: a deployment that
+// predates the route answers 404 or 405, and the client falls back to the
+// per-point path and remembers for the page load. Every other failure is
+// treated as "no overlay", which is what a failed per-point GET already did:
+// the corridor keeps its Open-Meteo SMOC values rather than losing its marine
+// data altogether.
+
+const MARC_BATCH_URL = `${MARC_URL}/batch`;
+
+/** Server cap. A corridor is far under it; chunking is belt and braces. */
+const MARC_BATCH_MAX_POINTS = 120;
+
+/** `null` while nothing is known, then the verdict for this page load. */
+let marcBatchAvailable: boolean | null = null;
+
+/** Test seam: the verdict is a page-load fact, and tests need several. */
+export function resetMarcBatchSupport(): void {
+  marcBatchAvailable = null;
+}
+
+/**
+ * One POST for up to `MARC_BATCH_MAX_POINTS` points.
+ *
+ * Returns `null` when the route is absent, so the caller can fall back;
+ * returns an array of nulls when the route is there but the call failed, which
+ * is the per-point behaviour on a failed GET.
+ */
+async function fetchMarcOverlayBatch(
+  points: { lat: number; lon: number }[],
+  startUtcIso: string,
+  endUtcIso: string,
+): Promise<(MarcOverlay | null)[] | null> {
+  let resp: Response;
+  try {
+    resp = await fetch(MARC_BATCH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        points: points.map((p) => [p.lat, p.lon]),
+        start: startUtcIso,
+        end: endUtcIso,
+        step_minutes: 60,
+      }),
+    });
+  } catch {
+    // Transport failure. Not a verdict on the route: the next corridor may
+    // well succeed, so the availability flag is left alone.
+    return points.map(() => null);
+  }
+  if (resp.status === 404 || resp.status === 405) return null;
+  if (!resp.ok) return points.map(() => null);
+  let body: unknown;
+  try {
+    body = await resp.json();
+  } catch {
+    return points.map(() => null);
+  }
+  const overlays = (body as { overlays?: unknown })?.overlays;
+  // A length mismatch would silently attach one point's tide to another's
+  // position, so it is rejected whole.
+  if (!Array.isArray(overlays) || overlays.length !== points.length) {
+    return points.map(() => null);
+  }
+  return overlays.map((o) =>
+    o && typeof o === "object" ? (o as MarcOverlay) : null,
+  );
+}
+
+/**
+ * Overlays for a corridor, aligned with `points`, `null` where none applies.
+ *
+ * Points the atlases cannot cover never leave the browser. When none is
+ * covered, nothing is requested at all.
+ */
+async function fetchMarcOverlays(
+  points: { lat: number; lon: number }[],
+  startUtcIso: string,
+  endUtcIso: string,
+  atlases: MarcAtlasBox[] | null,
+): Promise<(MarcOverlay | null)[]> {
+  const out: (MarcOverlay | null)[] = points.map(() => null);
+  const covered: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    if (marcMayCover(points[i].lat, points[i].lon, atlases)) covered.push(i);
+  }
+  if (covered.length === 0) return out;
+
+  if (marcBatchAvailable !== false) {
+    const chunks: number[][] = [];
+    for (let i = 0; i < covered.length; i += MARC_BATCH_MAX_POINTS) {
+      chunks.push(covered.slice(i, i + MARC_BATCH_MAX_POINTS));
+    }
+    const answers = await Promise.all(
+      chunks.map((chunk) =>
+        fetchMarcOverlayBatch(chunk.map((i) => points[i]), startUtcIso, endUtcIso),
+      ),
+    );
+    if (answers.every((a) => a !== null)) {
+      marcBatchAvailable = true;
+      chunks.forEach((chunk, c) => {
+        chunk.forEach((i, k) => {
+          out[i] = answers[c]![k];
+        });
+      });
+      return out;
+    }
+    marcBatchAvailable = false;
+  }
+
+  const perPoint = await Promise.all(
+    covered.map((i) => fetchMarcOverlay(points[i].lat, points[i].lon, startUtcIso, endUtcIso)),
+  );
+  covered.forEach((i, k) => {
+    out[i] = perPoint[k];
+  });
+  return out;
+}
+
 // Merge MARC overlay into the OM-shaped MarineHourly, index-by-index. Tide
 // and current arrays from MARC override SMOC on matching hours; uncovered or
 // non-matching hours keep SMOC. Always populates ``tide_height_zh_m`` when
@@ -413,8 +541,9 @@ export async function fetchMarine(lat: number, lon: number): Promise<MarineHourl
  * point: 14 of them measured on a 63 NM Mediterranean leg, each a round trip
  * of its own on a browser that opens six connections at a time.
  *
- * The MARC overlay stays per point, because it is per location by nature, but
- * it is now only requested where an atlas could answer.
+ * The MARC overlay is per location by nature, but it no longer costs a request
+ * per location: it is asked only where an atlas could answer, and those points
+ * travel together in one POST (see `fetchMarcOverlays`).
  *
  * Results land in the same 30-minute per-point cache `fetchMarine` uses, so a
  * spot already looked at costs nothing here, and a corridor point looked at
@@ -470,10 +599,11 @@ export async function fetchMarineCorridor(
 
   const [startIso, endIso] = marcWindow();
   const atlases = await coveragePromise;
-  const overlays = await Promise.all(
-    missing.map((i) =>
-      fetchMarcOverlayIfCovered(coords[i].lat, coords[i].lon, startIso, endIso, atlases),
-    ),
+  const overlays = await fetchMarcOverlays(
+    missing.map((i) => coords[i]),
+    startIso,
+    endIso,
+    atlases,
   );
 
   const fetchedAt = Date.now();


### PR DESCRIPTION
Suite de #321 et #322, qui avaient supprimé les appels MARC ne pouvant rien rapporter : en Méditerranée, 14 réponses « covered: false » sur 14. Ce qui reste, c'est une route atlantique, où chaque point du corridor **est** couvert et coûtait encore un aller-retour à lui seul. Quinze requêtes, quinze évaluations harmoniques, quinze coups de seau de limitation, pour une route.

## Ce que fait la PR

`fetchMarineCorridor` envoie les points retenus par `marcMayCover` en un seul `POST /api/v1/marine/marc/batch`, corps `{"points": [[lat, lon], ...], "start", "end", "step_minutes": 60}`, et n'envoie rien du tout quand aucun n'est retenu. La réponse `{"overlays": [...]}` est lue dans l'ordre, un élément par point, chacun ayant exactement la forme du GET par point, et alimente le même cache par point qu'avant : deux plans sur la même route ne redemandent rien.

Les points sont découpés par 120, le plafond du serveur, ce qui ne se produira pas sur un corridor mais évite d'avoir à s'en souvenir.

| Corridor atlantique de 15 points | Avant | Après |
|---|---|---|
| Requêtes MARC | 15 | 1 |
| Coups de seau de limitation | 15 | 1 |

Le chemin point par point (`fetchMarine`, un spot) n'est pas touché.

## Découverte, pas configuration

Un déploiement qui précède la route répond 404 ou 405 : on revient au point par point et on retient le verdict pour le chargement de page, donc le corridor suivant part directement en GET sans re-sonder.

Toute autre défaillance vaut « pas de recouvrement », ce que faisait déjà un GET en échec : le corridor garde ses valeurs Open-Meteo SMOC plutôt que de perdre ses données marines. Une réponse dont la longueur ne correspond pas aux points envoyés est rejetée en entier, parce qu'un décalage collerait la marée d'un point sur la position d'un autre.

## Tests

Onze cas ajoutés à `marine.test.ts` avec un `fetch` doublé qui distingue la route de lot du GET par point : un lot pour N points couverts, aucun appel quand aucun n'est couvert, fenêtre de 7 jours et pas de 60 min dans le corps, fusion de la marée MARC sur le bon point et pas sur son voisin, cache par point rempli depuis la réponse du lot, repli 404 puis 405 retenu pour la session, 500 sans repli, longueur incohérente rejetée. Les quatre tests existants qui comptaient un GET par point comptent maintenant un lot. Suite passée sous quatre fuseaux (UTC, New York, Auckland, Paris).

`npm run typecheck`, `npm run lint:budget` (0 erreur), `npm run test` (52 fichiers, 703 tests, +8), `npm run build` : verts.

## À savoir avant de merger

La route `POST /api/v1/marine/marc/batch` est livrée en parallèle par l'agent backend et **n'est peut-être pas encore déployée sur dev**. Le repli est justement là pour ça : tant qu'elle répond 404, le comportement est celui d'aujourd'hui, au prix d'une requête de sondage par chargement de page. La vérification live est à faire une fois le Space dev reconstruit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
