### PR TITLE
feat(web): une zone par force sur la moyenne, toujours, plus large et plus soutenue

### DIFF
--- a/packages/web/src/plan/ConditionsCompass.tsx
+++ b/packages/web/src/plan/ConditionsCompass.tsx
@@ -36,9 +36,10 @@ const COMPASS_R = 104;
 const ARROW_TAIL_R = 100;
 const ARROW_TIP_R = 58;
 // Rings of the average variant: wind band outside, current band inside,
-// the hull (34 units long) clear of both.
-const WIND_BAND = { inner: 90, outer: COMPASS_R };
-const CURRENT_BAND = { inner: 40, outer: 54 };
+// the hull (34 units long) clear of both. Wide enough to read as zones at
+// 140 px, where a 14-unit ring against the dashed dial went unnoticed.
+const WIND_BAND = { inner: 84, outer: COMPASS_R };
+const CURRENT_BAND = { inner: 38, outer: 58 };
 const NEEDLE_R = { tail: 30, tip: 62 };
 
 // 0° = up (12 o'clock), increasing clockwise. Returns [x, y] in dial units.
@@ -260,9 +261,9 @@ function SpreadBand({ arc, band, color, m }: { arc: [number, number]; band: Band
     <path
       d={d}
       fill={color}
-      fillOpacity="0.18"
+      fillOpacity="0.24"
       stroke={color}
-      strokeOpacity="0.7"
+      strokeOpacity="0.8"
       strokeWidth={1 * m.px}
       strokeDasharray={`${2 * m.px} ${3 * m.px}`}
       strokeLinejoin="round"

--- a/packages/web/src/plan/aggregateLegs.test.ts
+++ b/packages/web/src/plan/aggregateLegs.test.ts
@@ -276,9 +276,15 @@ describe("legSpread", () => {
     expect(to).toBeCloseTo(20, 0);
   });
 
-  it("draws nothing when the steps agree", () => {
-    expect(legSpread(stepsAt([300, 304, 302])).twd_arc).toBeNull();
-    expect(legSpread(stepsAt([300])).twd_arc).toBeNull();
+  it("keeps a narrow zone around the mean when the steps agree", () => {
+    // Mean 302: a 12° zone, 296 to 308, rather than no zone at all.
+    const [from, to] = legSpread(stepsAt([300, 304, 302])).twd_arc as [number, number];
+    expect(from).toBeCloseTo(296, 0);
+    expect(to).toBeCloseTo(308, 0);
+    const [f1, t1] = legSpread(stepsAt([300])).twd_arc as [number, number];
+    expect(f1).toBeCloseTo(294, 0);
+    expect(t1).toBeCloseTo(306, 0);
+    expect(legSpread([]).twd_arc).toBeNull();
   });
 
   it("ignores currents too weak to be reported when arcing the set", () => {
@@ -304,6 +310,8 @@ describe("legSpread", () => {
     expect(legSpread(stepsAt([300, 300], { hs_m: 0.4 })).hs_range).toEqual([0.4, 0.4]);
     expect(legSpread(stepsAt([300, 300], { hs_m: null })).hs_range).toBeNull();
     expect(legSpread(stepsAt([300, 300], { hs_m: null })).current_speed_range).toBeNull();
+    // No reportable current on any step: no zone for it.
+    expect(legSpread(stepsAt([300, 300], { current_direction_to_deg: 90, current_speed_kn: 0.1 })).current_arc).toBeNull();
   });
 });
 

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -373,16 +373,19 @@ export function aggregateSteps(
 // below are what the diagram shades around the mean so the reader can see
 // the disagreement instead of trusting a single needle.
 
-/** Under this angular width the steps agree: no arc is drawn. */
-const SPREAD_MIN_DEG = 10;
+/** Narrowest zone drawn: when the steps agree, the force still gets a zone
+    this wide around its mean, so every force has one and a steady wind reads
+    as a thin wedge rather than as nothing. */
+const ARC_MIN_DEG = 12;
 
 export interface LegSpread {
   step_count: number;
   /** Clockwise arc `[from, to]` in true degrees covering every step's wind
-      direction, null when they agree within `SPREAD_MIN_DEG`. */
+      direction, at least `ARC_MIN_DEG` wide around the mean. Null only
+      without steps. */
   twd_arc: [number, number] | null;
   /** Same for the set of the current, counting only steps whose current is
-      strong enough to be reported at all. */
+      strong enough to be reported at all; null when none is. */
   current_arc: [number, number] | null;
   /** Min and max of the per-step mean wave height, null without sea data. */
   hs_range: [number, number] | null;
@@ -391,14 +394,19 @@ export interface LegSpread {
 }
 
 /** Smallest clockwise arc around the circular mean that contains every
-    angle, or null when it is narrower than `SPREAD_MIN_DEG`. */
+    angle, widened to `ARC_MIN_DEG` around the mean when the angles agree.
+    Null without angles. */
 function arcAround(angles: number[]): [number, number] | null {
-  if (angles.length < 2) return null;
+  if (angles.length === 0) return null;
   const mean = circularMeanDeg(angles);
   const deltas = angles.map((a) => ((a - mean + 540) % 360) - 180);
-  const lo = Math.min(...deltas);
-  const hi = Math.max(...deltas);
-  if (hi - lo < SPREAD_MIN_DEG) return null;
+  let lo = Math.min(...deltas);
+  let hi = Math.max(...deltas);
+  if (hi - lo < ARC_MIN_DEG) {
+    const centre = (lo + hi) / 2;
+    lo = centre - ARC_MIN_DEG / 2;
+    hi = centre + ARC_MIN_DEG / 2;
+  }
   const norm = (d: number) => ((d % 360) + 360) % 360;
   return [norm(mean + lo), norm(mean + hi)];
 }


### PR DESCRIPTION
Retour sur #363 : la répartition du vent ne se voyait pas sur la moyenne.

- La zone du vent n'apparaissait que si les pas divergeaient d'au moins 10°, et à 140 px un anneau de 14 unités en gris pâle contre le cadran pointillé passait inaperçu.
- **Chaque force a maintenant sa zone dès qu'elle a des données** : au moins 12° autour de la moyenne quand les pas sont d'accord, un vent stable se lit comme un coin étroit plutôt que comme rien. Même règle pour le courant, dès qu'un pas porte un courant au-dessus du seuil.
- Anneaux élargis (20 unités au lieu de 14) et remplissage un peu plus soutenu.

Tests (762, dont les attentes de `legSpread` mises à jour) et typecheck verts, lint 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
