### PR TITLE
fix(web): les décimales de la table marine et de la courbe de marée suivent la langue

### DIFF
--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -9,6 +9,7 @@ import { nowParisHourPrefix } from "../domain/datetime";
 import { currentsLevel, tidesLevel, wavesLevel, windLevelVar } from "../domain/thresholds";
 import { useTimelineScroll } from "../hooks/useTimelineScroll";
 import { t, useLang, useT, type Key } from "../i18n";
+import { numFixed } from "../plan/format";
 
 type MarineMetric = Exclude<MetricView, "wind">;
 
@@ -144,7 +145,7 @@ function MarineCellImpl({
       secondary = marine.wave_direction_deg[timeIdx];
       if (value != null) {
         level = wavesLevel(value);
-        display = value.toFixed(1);
+        display = numFixed(value, 1);
         aria =
           secondary != null
             ? t("explore.marineTable.aria.hsFrom", {
@@ -201,8 +202,8 @@ function MarineCellImpl({
       if (value != null) {
         level = tidesLevel(Math.abs(value));
         display = useZh
-          ? value.toFixed(1)
-          : (value >= 0 ? "+" : "") + value.toFixed(1);
+          ? numFixed(value, 1)
+          : (value >= 0 ? "+" : "") + numFixed(value, 1);
         if (prevTide != null) {
           const delta = value - prevTide;
           if (delta > 0.01) trend = 1;
@@ -224,7 +225,7 @@ function MarineCellImpl({
       value = marine.current_speed_kn[timeIdx];
       if (value != null) {
         level = currentsLevel(value);
-        display = value.toFixed(1);
+        display = numFixed(value, 1);
         aria = t("explore.marineTable.aria.current", { value: display });
       }
       break;

--- a/packages/web/src/components/TideChart.tsx
+++ b/packages/web/src/components/TideChart.tsx
@@ -9,6 +9,7 @@ import { nowParisHourPrefix } from "../domain/datetime";
 import { formatHour } from "../utils/format";
 import { useTimelineScroll } from "../hooks/useTimelineScroll";
 import { useT } from "../i18n";
+import { numFixed } from "../plan/format";
 
 // Fixed cell width for the chart so the SVG aligns perfectly with the timeline
 // header. 36 px shows ~30 hours per viewport on a typical mobile (good for
@@ -278,8 +279,8 @@ export function TideChart({
                         const labelX = onRight ? sx + 9 : sx - 9;
                         const labelAnchor = onRight ? "start" : "end";
                         const labelText = useZh
-                          ? `${sh.toFixed(2)} m`
-                          : `${sh >= 0 ? "+" : ""}${sh.toFixed(2)} m`;
+                          ? `${numFixed(sh, 2)} m`
+                          : `${sh >= 0 ? "+" : ""}${numFixed(sh, 2)} m`;
                         return (
                           <>
                             <line
@@ -327,8 +328,8 @@ export function TideChart({
                       const y = yForTide(h);
                       const time = formatHour(masterTimeline[e.idx], timezoneMode);
                       const heightLabel = useZh
-                        ? `${h.toFixed(2)} m`
-                        : `${h >= 0 ? "+" : ""}${h.toFixed(2)} m`;
+                        ? `${numFixed(h, 2)} m`
+                        : `${h >= 0 ? "+" : ""}${numFixed(h, 2)} m`;
                       const labelY = e.type === "high" ? y - 10 : y + 18;
                       return (
                         <g key={`ext-${e.idx}`}>

--- a/packages/web/src/plan/format.ts
+++ b/packages/web/src/plan/format.ts
@@ -44,20 +44,27 @@ export function fmtDepthM(m: number): string {
   return `${Math.round(m)} m`;
 }
 
-const NUM1_BY_LOCALE = new Map<string, Intl.NumberFormat>();
+const NUM_BY_LOCALE = new Map<string, Intl.NumberFormat>();
 
-/** One decimal in the active language: 38.2 → "38,2" in French, "38.2" in
-    English. No grouping: nothing formatted here reaches four digits. */
-export function num1(n: number): string {
+/** `n` with exactly `digits` decimals in the active language: 0.3 → "0,3"
+    in French, "0.3" in English. No grouping: nothing formatted here reaches
+    four digits. One formatter per locale and precision, built on first use. */
+export function numFixed(n: number, digits: number): string {
   const locale = getLocale();
-  let f = NUM1_BY_LOCALE.get(locale);
+  const id = `${locale}:${digits}`;
+  let f = NUM_BY_LOCALE.get(id);
   if (!f) {
     f = new Intl.NumberFormat(locale, {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
       useGrouping: false,
     });
-    NUM1_BY_LOCALE.set(locale, f);
+    NUM_BY_LOCALE.set(id, f);
   }
   return f.format(n);
+}
+
+/** One decimal in the active language: 38.2 → "38,2" in French, "38.2" in English. */
+export function num1(n: number): string {
+  return numFixed(n, 1);
 }


### PR DESCRIPTION
## Quoi

Hs, courant et hauteur d'eau de la table marine, et les étiquettes de la courbe de marée, passaient par `toFixed` : « 0.3 » quelle que soit la langue, alors que le panneau du plan écrit « 0,3 » en français depuis le lot i18n. `numFixed(n, digits)` dans `plan/format.ts`, formateur Intl mis en cache par locale et précision ; `num1` en devient un cas particulier. La période (entier) ne change pas.

Relevé par la passe QA J11 avant la promotion #370.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 779 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)