### PR TITLE
fix(web): au moteur, l'addition de la vitesse montre le moteur, pas « polaire + mer »

### DIFF
--- a/packages/web/src/i18n/de/panel.ts
+++ b/packages/web/src/i18n/de/panel.ts
@@ -125,6 +125,7 @@ export const panel: Record<keyof typeof frPanel, string> = {
   "panel.legDetail.buildUpPolar": "{value} Polare",
   "panel.legDetail.buildUpSea": "{value} See",
   "panel.legDetail.buildUpCurrent": "{value} Strom",
+  "panel.legDetail.buildUpMotor": "{value} Motor",
   "panel.legDetail.headerAverage": "Mittel · {duration}",
   "panel.legDetail.headerHint": "einen Abschnitt antippen",
   "panel.legDetail.noteMotorOnStep": "unter Motor auf diesem Abschnitt",

--- a/packages/web/src/i18n/en/panel.ts
+++ b/packages/web/src/i18n/en/panel.ts
@@ -123,6 +123,7 @@ export const panel: Record<keyof typeof frPanel, string> = {
   "panel.legDetail.buildUpPolar": "{value} polar",
   "panel.legDetail.buildUpSea": "{value} sea",
   "panel.legDetail.buildUpCurrent": "{value} current",
+  "panel.legDetail.buildUpMotor": "{value} motor",
   "panel.legDetail.headerAverage": "Average · {duration}",
   "panel.legDetail.headerHint": "tap a step",
   "panel.legDetail.noteMotorOnStep": "under engine on this step",

--- a/packages/web/src/i18n/fr/panel.ts
+++ b/packages/web/src/i18n/fr/panel.ts
@@ -124,6 +124,7 @@ export const panel = {
   "panel.legDetail.buildUpPolar": "{value} polaire",
   "panel.legDetail.buildUpSea": "{value} mer",
   "panel.legDetail.buildUpCurrent": "{value} courant",
+  "panel.legDetail.buildUpMotor": "{value} moteur",
   "panel.legDetail.headerAverage": "Moyenne · {duration}",
   "panel.legDetail.headerHint": "touchez un pas",
   "panel.legDetail.noteMotorOnStep": "au moteur sur ce pas",

--- a/packages/web/src/i18n/it/panel.ts
+++ b/packages/web/src/i18n/it/panel.ts
@@ -124,6 +124,7 @@ export const panel: Record<keyof typeof frPanel, string> = {
   "panel.legDetail.buildUpPolar": "{value} polare",
   "panel.legDetail.buildUpSea": "{value} mare",
   "panel.legDetail.buildUpCurrent": "{value} corrente",
+  "panel.legDetail.buildUpMotor": "{value} motore",
   "panel.legDetail.headerAverage": "Media · {duration}",
   "panel.legDetail.headerHint": "toccare una tappa",
   "panel.legDetail.noteMotorOnStep": "a motore su questa tappa",

--- a/packages/web/src/plan/LegDetailCard.tsx
+++ b/packages/web/src/plan/LegDetailCard.tsx
@@ -283,13 +283,28 @@ export function LegDetailCard({
           </div>
           {!spread && (
             <div className="mt-1 text-[10px] flex flex-wrap gap-x-1.5" style={{ paddingLeft: LABEL_PX + 8 }}>
-              <span style={{ color: FORCE_COLORS.wind }}>
-                {t("panel.legDetail.buildUpPolar", { value: num1(view.polar_after_eff_kn) })}
-              </span>
-              {hasWaves && Math.abs(view.wave_delta_kn) > 0.05 && (
-                <span style={{ color: FORCE_COLORS.waves }}>
-                  {t("panel.legDetail.buildUpSea", { value: fmtSigned1(view.wave_delta_kn) })}
+              {view.motor_used ? (
+                // Under engine neither the polar nor the sea apply: the boat
+                // does the motoring speed and only the current moves the
+                // figure. Spelling it out as "polar + sea" showed the sea
+                // adding speed, which was the residual of a formula that is
+                // not in force on this step (2,3 polaire +1,8 mer at 4 kn).
+                <span style={{ color: "var(--ow-fg-1)" }}>
+                  {t("panel.legDetail.buildUpMotor", {
+                    value: num1(view.polar_after_eff_kn + view.wave_delta_kn),
+                  })}
                 </span>
+              ) : (
+                <>
+                  <span style={{ color: FORCE_COLORS.wind }}>
+                    {t("panel.legDetail.buildUpPolar", { value: num1(view.polar_after_eff_kn) })}
+                  </span>
+                  {hasWaves && Math.abs(view.wave_delta_kn) > 0.05 && (
+                    <span style={{ color: FORCE_COLORS.waves }}>
+                      {t("panel.legDetail.buildUpSea", { value: fmtSigned1(view.wave_delta_kn) })}
+                    </span>
+                  )}
+                </>
               )}
               {currentDelta && (
                 <span style={{ color: FORCE_COLORS.current }}>

--- a/packages/web/src/plan/aggregateLegs.ts
+++ b/packages/web/src/plan/aggregateLegs.ts
@@ -27,7 +27,8 @@ export interface AggregatedLeg {
   // build-up adds up exactly: polar_after_eff_kn + wave_delta_kn (≤ 0)
   // ≈ boat_speed_kn, and boat_speed_kn + current_delta_kn = target_speed_kn.
   polar_after_eff_kn: number; // polar lookup × passage efficiency (no waves, no current)
-  wave_delta_kn: number; // ≤ 0 — loss from wave_derate
+  wave_delta_kn: number; // ≤ 0, loss from wave_derate; > 0 only under engine,
+  // where boat_speed_kn is the motoring speed and the card shows one motor term
   current_delta_kn: number | null; // signed — gain when along, loss when against; null without current data
   boat_speed_kn: number; // STW (polar × efficiency × derate)
   target_speed_kn: number; // SOG when current modelled, else STW — used for duration


### PR DESCRIPTION
## Quoi

Sur un pas au moteur, la carte de détail affichait « 2,3 polaire +1,8 mer −0,2 courant » pour 3,8 kn : la mer semblait ajouter de la vitesse. Le +1,8 n'était que le résidu de `boat_speed − polaire`, une formule qui ne s'applique plus quand le moteur tourne (vitesse à l'eau = vitesse moteur, sans efficacité ni réduction par les vagues, cf. Méthodologie étape 5).

La carte affiche désormais « 4,0 moteur −0,2 courant ». Le calcul était juste : polaire 2,3 kn sous le seuil de 3 kn, moteur à 4 kn, courant contraire −0,2, SOG 3,8.

Clé `panel.legDetail.buildUpMotor` dans les quatre langues.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 779 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)