### PR TITLE
fix(web): retours du forum et alertes de console

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -47,12 +47,11 @@
          emplacement de connexion. -->
     <link rel="preconnect" href="https://tiles.openfreemap.org" crossorigin>
 
-    <!-- Inter est une police variable : un seul fichier porte toutes les
-         graisses du premier ecran (400 du texte courant, 600 des intertitres,
-         800 du logo), donc un seul preload les couvre. Le sous-ensemble
-         latin-ext n'est tire que si un caractere le reclame, et JetBrains Mono
-         ne sert que dans la vue plan : ni l'un ni l'autre n'est preloade. -->
-    <link rel="preload" href="/src/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <!-- Pas de preload des polices, volontairement. Inter latin en avait un ;
+         Firefox signalait a chaque chargement une ressource prechargee mais
+         jamais utilisee, parce que le service worker sert la police depuis son
+         precache et que Firefox n'apparie pas cette reponse au preload. Le
+         gain ne valait que la toute premiere visite, avant le precache. -->
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/packages/web/src/components/BoatAdvanced.test.tsx
+++ b/packages/web/src/components/BoatAdvanced.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { BoatAdvanced } from "./BoatAdvanced";
+import { defaultPolarConfig, type PolarConfig } from "../config/polarConfig";
+
+function Harness({ onChange }: { onChange: (next: PolarConfig) => void }) {
+  const [cfg, setCfg] = useState<PolarConfig>(() => defaultPolarConfig());
+  return (
+    <BoatAdvanced
+      config={cfg}
+      onChange={(next) => {
+        onChange(next);
+        setCfg(next);
+      }}
+    />
+  );
+}
+
+function lastConfig(spy: ReturnType<typeof vi.fn>): PolarConfig | undefined {
+  return spy.mock.calls.at(-1)?.[0] as PolarConfig | undefined;
+}
+
+describe("BoatAdvanced, angle de près minimal", () => {
+  it("garde 50 quand on tape 50 (forum : 50 devenait 70)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+    const input = screen.getByPlaceholderText(/^auto/) as HTMLInputElement;
+    await user.type(input, "50");
+    expect(input.value).toBe("50");
+    expect(lastConfig(onChange)?.minUpwindDeg).toBe(50);
+    await user.tab();
+    expect(input.value).toBe("50");
+    expect(lastConfig(onChange)?.minUpwindDeg).toBe(50);
+  });
+
+  it("n'applique le plancher qu'en quittant le champ", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+    const input = screen.getByPlaceholderText(/^auto/) as HTMLInputElement;
+    await user.type(input, "5");
+    expect(input.value).toBe("5");
+    expect(lastConfig(onChange)?.minUpwindDeg).toBeUndefined();
+    await user.tab();
+    expect(input.value).toBe("25");
+    expect(lastConfig(onChange)?.minUpwindDeg).toBe(25);
+  });
+});

--- a/packages/web/src/components/BoatAdvanced.tsx
+++ b/packages/web/src/components/BoatAdvanced.tsx
@@ -9,11 +9,13 @@ import {
   MIN_UPWIND_MIN,
   SPI_MAX_TWS_MAX,
   SPI_MAX_TWS_MIN,
+  commitMinUpwindDraft,
   commitSpiMaxTwsDraft,
   effectiveMinUpwind,
   effectivePolar,
   hasOverrides,
   isImportedActive,
+  parseMinUpwindDraft,
   parseSpiMaxTwsDraft,
   type PolarConfig,
   type PolarSource,
@@ -42,6 +44,7 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
   const [tuningOpen, setTuningOpen] = useState(false);
   const [selectedTwsIdx, setSelectedTwsIdx] = useState(0);
   const [spiMaxTwsDraft, setSpiMaxTwsDraft] = useState<string | null>(null);
+  const [minUpwindDraft, setMinUpwindDraft] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importedActive = isImportedActive(config);
 
@@ -105,18 +108,29 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
     setSelectedTwsIdx(0);
   }
 
+  // Same draft rule as the spinnaker threshold below: the field shows what
+  // was typed, the config only takes values already inside the range, and
+  // the floor applies on blur. Without it "5" became 25 and "50" became 70.
   function setMinUpwind(raw: string) {
-    const val = raw.trim();
-    if (val === "") {
+    setMinUpwindDraft(raw);
+    if (raw.trim() === "") {
       onChange({ ...config, minUpwindDeg: undefined });
       return;
     }
-    const num = Number(val);
-    if (!Number.isFinite(num)) return;
-    onChange({
-      ...config,
-      minUpwindDeg: Math.round(Math.min(MIN_UPWIND_MAX, Math.max(MIN_UPWIND_MIN, num))),
-    });
+    const next = parseMinUpwindDraft(raw);
+    if (next !== null && next >= MIN_UPWIND_MIN && next !== config.minUpwindDeg) {
+      onChange({ ...config, minUpwindDeg: next });
+    }
+  }
+
+  function commitMinUpwind() {
+    const draft = minUpwindDraft;
+    setMinUpwindDraft(null);
+    if (draft === null || draft.trim() === "") return;
+    const next = commitMinUpwindDraft(draft);
+    if (next !== null && next !== config.minUpwindDeg) {
+      onChange({ ...config, minUpwindDeg: next });
+    }
   }
 
   function setSpi(spi: SpiKind) {
@@ -265,8 +279,9 @@ export function BoatAdvanced({ config, onChange }: BoatAdvancedProps) {
             min={MIN_UPWIND_MIN}
             max={MIN_UPWIND_MAX}
             placeholder={t("config.boat.advanced.minUpwindPlaceholder", { deg: autoMinUpwind })}
-            value={config.minUpwindDeg ?? ""}
+            value={minUpwindDraft ?? (config.minUpwindDeg ?? "")}
             onChange={(e) => setMinUpwind(e.target.value)}
+            onBlur={commitMinUpwind}
             className="polar-motor-input w-28"
           />
           {config.minUpwindDeg !== undefined && (

--- a/packages/web/src/components/MarineTable.tsx
+++ b/packages/web/src/components/MarineTable.tsx
@@ -409,9 +409,10 @@ export function MarineTable({
   const selectHour = useCallback((t: string) => onSelectHour(t), [onSelectHour]);
 
   return (
-    <div className="animate-fade-in min-h-0 flex flex-col">
-      <div className={`scroll-container flex-1 min-h-0 ${scrolledEnd ? "scrolled-end" : ""}`}>
-        <div ref={scrollRef} className="h-full overflow-auto wind-table-scroll">
+    // Flex column down to the scroller, no percentage height: see WindTable.
+    <div className="animate-fade-in flex-1 min-h-0 flex flex-col">
+      <div className={`scroll-container flex-1 min-h-0 flex flex-col ${scrolledEnd ? "scrolled-end" : ""}`}>
+        <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto wind-table-scroll">
           <table className="border-collapse" role="table">
             <thead className="sticky top-0 z-20">
               <TimelineHeader

--- a/packages/web/src/components/TideChart.tsx
+++ b/packages/web/src/components/TideChart.tsx
@@ -115,9 +115,10 @@ export function TideChart({
   const selectedIdx = selectedHour ? masterTimeline.indexOf(selectedHour) : -1;
 
   return (
-    <div className="animate-fade-in h-full">
-      <div className={`scroll-container h-full ${scrolledEnd ? "scrolled-end" : ""}`}>
-        <div ref={scrollRef} className="h-full overflow-auto wind-table-scroll">
+    // Flex column down to the scroller, no percentage height: see WindTable.
+    <div className="animate-fade-in flex-1 min-h-0 flex flex-col">
+      <div className={`scroll-container flex-1 min-h-0 flex flex-col ${scrolledEnd ? "scrolled-end" : ""}`}>
+        <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto wind-table-scroll">
           <table className="border-collapse" role="table">
             <colgroup>
               <col style={{ width: STICKY_W }} />

--- a/packages/web/src/components/WindTable.tsx
+++ b/packages/web/src/components/WindTable.tsx
@@ -135,12 +135,15 @@ export function WindTable({
   }
 
   return (
-    // Same shape as MarineTable: a column whose scroller takes the space the
-    // note leaves, so the note sits on the bottom edge instead of scrolling
-    // away with the cells.
-    <div className="animate-fade-in min-h-0 flex flex-col">
-      <div className={`scroll-container flex-1 min-h-0 ${scrolledEnd ? "scrolled-end" : ""}`}>
-        <div ref={scrollRef} className="h-full overflow-auto wind-table-scroll">
+    // Same shape as MarineTable and TideChart: a flex column all the way down
+    // to the scroller, and no percentage height anywhere. The scroller used
+    // to be `h-full` inside a flex item: Chrome resolves that against the
+    // flexed size, Firefox does not (the item's height is indefinite), so the
+    // scroller grew to the whole table and the panel clipped the last rows
+    // with no way to scroll (Firefox on Mac, forum, 2026-09).
+    <div className="animate-fade-in flex-1 min-h-0 flex flex-col">
+      <div className={`scroll-container flex-1 min-h-0 flex flex-col ${scrolledEnd ? "scrolled-end" : ""}`}>
+        <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto wind-table-scroll">
           <table className="border-collapse" role="table">
             <thead className="sticky top-0 z-20">
               <TimelineHeader

--- a/packages/web/src/config/polarConfig.test.ts
+++ b/packages/web/src/config/polarConfig.test.ts
@@ -11,6 +11,7 @@ import {
   SPI_MAX_TWS_DEFAULT,
   SPI_MAX_TWS_MAX,
   SPI_MAX_TWS_MIN,
+  commitMinUpwindDraft,
   commitSpiMaxTwsDraft,
   defaultPolarConfig,
   derivedMinUpwind,
@@ -21,6 +22,7 @@ import {
   isPersoActive,
   isPolarCustomized,
   loadPolarConfig,
+  parseMinUpwindDraft,
   parseSpiMaxTwsDraft,
   planEfficiency,
   planMinUpwind,
@@ -551,5 +553,25 @@ describe("polarFingerprint", () => {
     expect(polarFingerprint(withImported({ persoActive: false }))).not.toBe(
       polarFingerprint(withImported()),
     );
+  });
+});
+
+describe("minimum upwind angle draft", () => {
+  it("keeps a digit on its way to a value in range, and floors it only on commit", () => {
+    expect(parseMinUpwindDraft("5")).toBe(5);
+    expect(commitMinUpwindDraft("5")).toBe(25);
+  });
+
+  it("takes 50 as 50, not 70 (forum, 2026-09)", () => {
+    expect(parseMinUpwindDraft("50")).toBe(50);
+    expect(commitMinUpwindDraft("50")).toBe(50);
+  });
+
+  it("caps at the ceiling while typing and refuses junk", () => {
+    expect(parseMinUpwindDraft("250")).toBe(70);
+    expect(parseMinUpwindDraft("")).toBeNull();
+    expect(parseMinUpwindDraft("abc")).toBeNull();
+    expect(parseMinUpwindDraft("-3")).toBeNull();
+    expect(commitMinUpwindDraft("  ")).toBeNull();
   });
 });

--- a/packages/web/src/config/polarConfig.ts
+++ b/packages/web/src/config/polarConfig.ts
@@ -377,6 +377,24 @@ export function commitSpiMaxTwsDraft(raw: string): number | null {
   return parsed === null ? null : Math.max(SPI_MAX_TWS_MIN, parsed);
 }
 
+// The minimum upwind angle had the bug #270 fixed for the spinnaker: clamped
+// on every keystroke, "5" on its way to "50" became the 25° floor, and the
+// next digit made "250", clamped to the 70° ceiling. A reader who typed 50
+// saw 70 (forum, 2026-09). Same cure: only the ceiling while typing, the
+// floor once the field is left.
+export function parseMinUpwindDraft(raw: string): number | null {
+  const val = raw.trim();
+  if (val === "") return null;
+  const num = Number(val);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return Math.round(Math.min(MIN_UPWIND_MAX, num));
+}
+
+export function commitMinUpwindDraft(raw: string): number | null {
+  const parsed = parseMinUpwindDraft(raw);
+  return parsed === null ? null : Math.max(MIN_UPWIND_MIN, parsed);
+}
+
 function sanitizeOverrides(raw: unknown, base: PolarData): Record<string, number> {
   if (raw == null || typeof raw !== "object") return {};
   const out: Record<string, number> = {};

--- a/packages/web/src/hooks/useTimelineScroll.test.tsx
+++ b/packages/web/src/hooks/useTimelineScroll.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { act, render } from "@testing-library/react";
 import { useTimelineScroll } from "./useTimelineScroll";
 
@@ -118,5 +118,49 @@ describe("useTimelineScroll", () => {
     // Back on the anchored column, and this time without the 60 px offset,
     // which would otherwise drift the table a little on every switch.
     expect(el.scrollLeft).toBe(30 * CELL_W);
+  });
+
+  it("pans with a mouse drag and swallows the click that ends it", () => {
+    const onCell = vi.fn();
+    function DragHarness() {
+      const { scrollRef } = useTimelineScroll(hours(48), CELL_W, "2026-09-02T00");
+      return (
+        <div data-testid="scroller" ref={scrollRef}>
+          <button type="button" data-testid="cell" onClick={onCell}>
+            cell
+          </button>
+        </div>
+      );
+    }
+    const { getByTestId } = render(<DragHarness />);
+    const el = getByTestId("scroller");
+    sizeScroller(el);
+    el.scrollLeft = 200;
+    const pointer = (type: string, x: number, pointerType = "mouse") => {
+      const ev = new MouseEvent(type, { bubbles: true, clientX: x, clientY: 10, button: 0 });
+      Object.defineProperty(ev, "pointerType", { value: pointerType });
+      Object.defineProperty(ev, "pointerId", { value: 1 });
+      el.dispatchEvent(ev);
+    };
+
+    pointer("pointerdown", 100);
+    pointer("pointermove", 102); // under the threshold: still a click
+    expect(el.scrollLeft).toBe(200);
+    expect(el.classList.contains("is-dragging")).toBe(false);
+
+    pointer("pointermove", 150); // dragged 50 px to the right: content follows
+    expect(el.scrollLeft).toBe(150);
+    expect(el.classList.contains("is-dragging")).toBe(true);
+    pointer("pointerup", 150);
+    expect(el.classList.contains("is-dragging")).toBe(false);
+
+    getByTestId("cell").click(); // the click closing the drag selects nothing
+    expect(onCell).not.toHaveBeenCalled();
+    getByTestId("cell").click(); // a plain click still does
+    expect(onCell).toHaveBeenCalledTimes(1);
+
+    pointer("pointerdown", 100, "touch"); // touch pans natively: not ours
+    pointer("pointermove", 300, "touch");
+    expect(el.scrollLeft).toBe(150);
   });
 });

--- a/packages/web/src/hooks/useTimelineScroll.ts
+++ b/packages/web/src/hooks/useTimelineScroll.ts
@@ -18,6 +18,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
  * - **The day being read.** The leftmost visible column drives the sticky day
  *   label above the table.
  * - **End of scroll.** Whether the fade-out on the right edge should show.
+ * - **Mouse drag.** A press-and-drag with a mouse pans the table, as a thumb
+ *   does on a phone; on a desktop the only other way across the week was the
+ *   scrollbar under the last row.
  * - **Anchor restoration.** The leftmost hour is remembered across timeline
  *   changes, so switching spots comes back to the same "+3 days" window rather
  *   than jumping to now. On the very first render of a session there is no
@@ -104,6 +107,73 @@ export function useTimelineScroll(
     el.addEventListener("scroll", checkScrollEnd, { passive: true });
     return () => el.removeEventListener("scroll", checkScrollEnd);
   }, [checkScrollEnd]);
+
+  // Drag-to-scroll, mouse only: touch already pans natively. A press that
+  // travels less than the threshold is still a click on a cell; past it the
+  // click that closes the gesture is swallowed, so a drag never also selects
+  // an hour. While dragging, `is-dragging` turns the smooth scrolling and the
+  // snapping off (index.css): both fight a hand moving the scroll position
+  // sixty times a second.
+  useEffect(() => {
+    const el = scrollRef.current;
+    // No timeline, no table: the ref points at nothing worth listening to.
+    if (!el || masterTimeline.length === 0) return;
+    const DRAG_PX = 4;
+    let pressed = false;
+    let dragged = false;
+    let startX = 0;
+    let startY = 0;
+    let startLeft = 0;
+    let startTop = 0;
+    const onDown = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse" || e.button !== 0) return;
+      pressed = true;
+      dragged = false;
+      startX = e.clientX;
+      startY = e.clientY;
+      startLeft = el.scrollLeft;
+      startTop = el.scrollTop;
+    };
+    const onMove = (e: PointerEvent) => {
+      if (!pressed) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      if (!dragged && Math.abs(dx) < DRAG_PX && Math.abs(dy) < DRAG_PX) return;
+      if (!dragged) {
+        dragged = true;
+        el.classList.add("is-dragging");
+        el.setPointerCapture?.(e.pointerId);
+      }
+      el.scrollLeft = startLeft - dx;
+      el.scrollTop = startTop - dy;
+      e.preventDefault();
+    };
+    const onUp = () => {
+      pressed = false;
+      el.classList.remove("is-dragging");
+    };
+    const onClick = (e: MouseEvent) => {
+      if (!dragged) return;
+      dragged = false;
+      e.stopPropagation();
+      e.preventDefault();
+    };
+    el.addEventListener("pointerdown", onDown);
+    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointerup", onUp);
+    el.addEventListener("pointercancel", onUp);
+    el.addEventListener("click", onClick, true);
+    return () => {
+      el.removeEventListener("pointerdown", onDown);
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", onUp);
+      el.removeEventListener("pointercancel", onUp);
+      el.removeEventListener("click", onClick, true);
+    };
+    // Re-attached when the timeline changes, like the scroll listener above:
+    // while a spot loads the table is a skeleton and the ref points nowhere,
+    // so an effect run once at mount would never meet the real scroller.
+  }, [masterTimeline]);
 
   return { scrollRef, scrolledEnd, visibleDay, dayStarts };
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -220,6 +220,15 @@ select,
 .wind-table-scroll th {
   scroll-snap-align: start;
 }
+/* While a mouse drags the table (useTimelineScroll): the scroll position is
+   set by hand on every move, so neither the smooth scrolling nor the snap
+   must intervene, and the text under the pointer must not get selected. */
+.wind-table-scroll.is-dragging {
+  scroll-behavior: auto;
+  scroll-snap-type: none;
+  user-select: none;
+  cursor: grabbing;
+}
 
 
 /* Scroll fade indicator */

--- a/packages/web/src/utils/basemapLayer.ts
+++ b/packages/web/src/utils/basemapLayer.ts
@@ -140,6 +140,15 @@ export function addBasemap(map: L.Map, theme: BasemapTheme): Basemap {
   // the explore map is unaffected.
   map.whenReady(() => {
     glMap = L.maplibreGL({ style: STYLE_URLS[current] }).addTo(map).getMaplibreMap();
+    // OpenFreeMap's dark style asks for a "circle-11" icon under towns and
+    // cities below zoom 9, and its sprite does not ship one (checked on
+    // sprites/ofm_f384, 2026-09-04): MapLibre warned on every request. A
+    // blank pixel registered under that name keeps the console quiet and
+    // draws nothing, which is what the style managed to draw anyway.
+    glMap.on("styleimagemissing", (e) => {
+      if (!glMap || glMap.hasImage(e.id)) return;
+      glMap.addImage(e.id, { width: 1, height: 1, data: new Uint8Array(4) });
+    });
     // Re-applied on every style load rather than once: switching theme swaps
     // the whole style document, which drops any paint property set on the
     // one before it.


### PR DESCRIPTION
## Retours du forum

- **Légende sous les tables** (f_blc) : déjà retirée par #367.
- **Angle de près : « je tape 50, ça affiche 70 »** (f_blc) : la saisie était bornée à chaque frappe, « 5 » devenait 25 puis « 250 » devenait 70. Même remède que le seuil de spi (#270) : brouillon pendant la frappe, plancher appliqué en quittant le champ. Test de composant qui tape « 50 ».
- **Frise du temps à la souris** (f_blc) : un clic maintenu déplace maintenant la frise comme le pouce sur mobile. Seuil de 4 px avant de considérer un glisser, clic de fin avalé pour ne pas sélectionner une heure, lissage et aimantation coupés pendant le geste.
- **Firefox Mac, table coupée en bas** (Seter) : le défileur avait une hauteur en pourcentage dans une colonne flex, que Firefox ne résout pas contrairement à Chrome, donc la table débordait sans barre verticale. Colonne flex jusqu'au défileur dans les trois tables. Vérifié dans Chrome sur une fenêtre de 520 px : panneau borné, défilement vertical présent. À confirmer sous Firefox.
- **Flèches vent, courant, mer sur la carte du plan** (f_blc) : non traité, c'est une évolution à dessiner (une flèche par pas au milieu du segment), pas un correctif.

## Alertes de console

- **`Image "circle-11" could not be loaded`** : le style sombre d'OpenFreeMap demande cette icône sous les villes en dessous du zoom 9, et son sprite ne la contient pas (vérifié sur `sprites/ofm_f384`). Un pixel transparent enregistré sous ce nom via `styleimagemissing` fait taire MapLibre sans rien changer à l'écran.
- **Police Inter préchargée mais inutilisée** (Firefox) : le service worker sert la police depuis son précache et Firefox n'apparie pas cette réponse au preload. Preload retiré ; le gain ne valait que la toute première visite.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 58 fichiers / 785 tests, build de prod vérifié dans Chrome (défileur borné, glisser à la souris).

🤖 Generated with [Claude Code](https://claude.com/claude-code)