### PR TITLE
feat(web): le calcul repart tout seul quand le serveur météo se réveille

### DIFF
--- a/packages/web/src/api/passage.test.ts
+++ b/packages/web/src/api/passage.test.ts
@@ -2,7 +2,14 @@
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ApiError, fetchPassage, formatRetryDelay, friendlyError } from "./passage";
+import {
+  ApiError,
+  COLD_START_DELAY_S,
+  coldStartDelay,
+  fetchPassage,
+  formatRetryDelay,
+  friendlyError,
+} from "./passage";
 import { ApiShapeError } from "./parse";
 import { resetBodyEncoding } from "./postJson";
 
@@ -410,5 +417,25 @@ describe("backend injoignable vu du proxy de bord", () => {
     const theirs = friendlyError(new ApiError("x", "upstream_timeout", null));
     expect(ours).not.toBe(theirs);
     expect(theirs).toContain("service météo");
+  });
+});
+
+describe("coldStartDelay", () => {
+  it("retries a sleeping backend with the server's delay, within a minute", () => {
+    expect(coldStartDelay(new ApiError("x", "upstream_unavailable", 30))).toBe(30);
+    expect(coldStartDelay(new ApiError("x", "upstream_unavailable", 600))).toBe(60);
+    expect(coldStartDelay(new ApiError("x", "server_unavailable", null))).toBe(COLD_START_DELAY_S);
+  });
+
+  it("reads the text when a deployment sends no code", () => {
+    expect(coldStartDelay(new Error("backend temporarily unavailable, retry in 12s"))).toBe(12);
+    expect(coldStartDelay("Erreur serveur 503")).toBe(COLD_START_DELAY_S);
+  });
+
+  it("leaves the other failures to the reader", () => {
+    expect(coldStartDelay(new ApiError("x", "rate_limited", 30))).toBeNull();
+    expect(coldStartDelay(new ApiError("x", "invalid_datetime", null))).toBeNull();
+    expect(coldStartDelay(new TypeError("Failed to fetch"))).toBeNull();
+    expect(coldStartDelay(new Error("sweep would produce 400 windows"))).toBeNull();
   });
 });

--- a/packages/web/src/api/passage.ts
+++ b/packages/web/src/api/passage.ts
@@ -123,6 +123,36 @@ async function toError(res: Response): Promise<ApiError> {
  *
  * Unknown failures return their own text, so nothing becomes undebuggable.
  */
+/** Wait applied when the backend says it is restarting but not for how long. */
+export const COLD_START_DELAY_S = 20;
+
+/**
+ * Seconds to wait before sending the same request again on its own, or null
+ * when the failure is not one that time alone will fix.
+ *
+ * Two failures qualify: the edge proxy could not reach our own backend (a
+ * Space asleep, woken by the first request, which takes it a minute or two)
+ * and a bare 5xx. A rate limit carries its own delay and the reader's own
+ * usage behind it, bad input never gets better, and a dead network is on this
+ * side of the wire. The text rules mirror `matchErrorText`, for a deployment
+ * predating error codes. The server's delay is honoured within one minute.
+ */
+export function coldStartDelay(raw: unknown): number | null {
+  const bounded = (s: number | null) => Math.min(60, Math.max(1, s ?? COLD_START_DELAY_S));
+  if (raw instanceof ApiError && raw.code !== null) {
+    return raw.code === "upstream_unavailable" || raw.code === "server_unavailable"
+      ? bounded(raw.retryAfter)
+      : null;
+  }
+  const text = raw instanceof Error ? raw.message : typeof raw === "string" ? raw : "";
+  if (/backend temporarily unavailable/i.test(text)) {
+    const m = /retry in (\d+)s/i.exec(text);
+    return bounded(m ? Number(m[1]) : null);
+  }
+  if (/Erreur serveur 5\d\d/.test(text) || /HTTP 5\d\d/.test(text)) return bounded(null);
+  return null;
+}
+
 export function friendlyError(raw: string | Error): string {
   if (typeof raw === "string") return matchErrorText(raw);
   if (raw instanceof ApiError && raw.code !== null && raw.code in ERROR_COPY) {

--- a/packages/web/src/i18n/de/plan.ts
+++ b/packages/web/src/i18n/de/plan.ts
@@ -39,6 +39,10 @@ export const plan: Record<keyof typeof frPlan, string> = {
   "plan.states.picker.compare.example":
     "Z. B.: „Welche ist die beste Abfahrt zwischen Samstag und Montag?“",
   "plan.states.error.title": "Fehler",
+  "plan.states.waking.title": "Der Wetterserver wacht auf",
+  "plan.states.waking.body":
+    "Er war im Ruhezustand: die Berechnung startet in {seconds} s von selbst neu (Versuch {attempt} von {max}).",
+  "plan.states.waking.retryNow": "Jetzt erneut versuchen",
   "plan.recap.edit": "Ändern",
 
   // ── Mode picker and time anchor ───────────────────────────────────────────

--- a/packages/web/src/i18n/en/plan.ts
+++ b/packages/web/src/i18n/en/plan.ts
@@ -39,6 +39,10 @@ export const plan: Record<keyof typeof frPlan, string> = {
   "plan.states.picker.compare.example":
     "E.g. “Which is the best departure between Saturday and Monday?”",
   "plan.states.error.title": "Error",
+  "plan.states.waking.title": "The weather server is waking up",
+  "plan.states.waking.body":
+    "It was asleep: the computation restarts by itself in {seconds} s (attempt {attempt} of {max}).",
+  "plan.states.waking.retryNow": "Retry now",
   "plan.recap.edit": "Edit",
 
   // ── Mode picker and time anchor ───────────────────────────────────────────

--- a/packages/web/src/i18n/es/plan.ts
+++ b/packages/web/src/i18n/es/plan.ts
@@ -38,6 +38,10 @@ export const plan: Record<keyof typeof frPlan, string> = {
   "plan.states.picker.compare.example":
     "Ej.: «¿Cuál es la mejor salida entre el sábado y el lunes?»",
   "plan.states.error.title": "Error",
+  "plan.states.waking.title": "El servidor meteorológico se está reactivando",
+  "plan.states.waking.body":
+    "Estaba en reposo: el cálculo se reanuda solo en {seconds} s (intento {attempt} de {max}).",
+  "plan.states.waking.retryNow": "Reintentar ahora",
   "plan.recap.edit": "Modificar",
 
   // ── Mode picker and time anchor ───────────────────────────────────────────

--- a/packages/web/src/i18n/fr/plan.ts
+++ b/packages/web/src/i18n/fr/plan.ts
@@ -42,6 +42,10 @@ export const plan = {
   "plan.states.picker.compare.example":
     "Ex. : « Quel est le meilleur départ entre samedi et lundi ? »",
   "plan.states.error.title": "Erreur",
+  "plan.states.waking.title": "Le serveur météo se réveille",
+  "plan.states.waking.body":
+    "Il était en veille : le calcul repart tout seul dans {seconds} s (essai {attempt} sur {max}).",
+  "plan.states.waking.retryNow": "Réessayer maintenant",
   "plan.recap.edit": "Modifier",
 
   // ── Selecteur de mode et ancrage horaire ──────────────────────────────────

--- a/packages/web/src/i18n/it/plan.ts
+++ b/packages/web/src/i18n/it/plan.ts
@@ -37,6 +37,10 @@ export const plan: Record<keyof typeof frPlan, string> = {
     "Sa dove andare. OhMyWind prova più orari di partenza e classifica le finestre per comfort.",
   "plan.states.picker.compare.example": "Es.: «Qual è la partenza migliore tra sabato e lunedì?»",
   "plan.states.error.title": "Errore",
+  "plan.states.waking.title": "Il server meteo si sta riavviando",
+  "plan.states.waking.body":
+    "Era in pausa: il calcolo riparte da solo tra {seconds} s (tentativo {attempt} di {max}).",
+  "plan.states.waking.retryNow": "Riprovare ora",
   "plan.recap.edit": "Modificare",
 
   // ── Mode picker and time anchor ───────────────────────────────────────────

--- a/packages/web/src/plan/PlanSidebar.tsx
+++ b/packages/web/src/plan/PlanSidebar.tsx
@@ -29,6 +29,7 @@ import { CompareResults } from "./sidebar/CompareResults";
 import { SingleResults } from "./sidebar/SingleResults";
 import { boatLabel } from "./sidebar/boatLabel";
 import { useT } from "../i18n";
+import { useEffect, useState } from "react";
 
 /** Placeholder while a computation runs, so the panel never shows half a plan. */
 function LoadingSkeleton() {
@@ -53,6 +54,7 @@ export function PlanSidebar() {
     complexity,
     windows,
     apiError,
+    retry,
     mode,
     sweepEarliest,
     sweepLatest,
@@ -71,6 +73,19 @@ export function PlanSidebar() {
 
   // 1. computing
   if (isLoading) return <LoadingSkeleton />;
+
+  // 2a. the backend is waking up: the request goes again on its own
+  if (retry) {
+    return (
+      <div className="p-4">
+        <PlanHeaderRow locked={waypoints.length < 2} />
+        <WakingNotice
+          retry={retry}
+          onRetryNow={mode === "compare" ? actions.computeWindows : actions.compute}
+        />
+      </div>
+    );
+  }
 
   // 2. failed
   if (apiError) {
@@ -120,4 +135,46 @@ export function PlanSidebar() {
     return <PlanForm canCalculate={canCalculate} />;
   }
   return <SingleResults passage={passage} complexity={complexity} boatLabel={label} />;
+}
+
+/**
+ * Shown instead of the error while the backend wakes up (usePlanSession
+ * retries by itself). A countdown so the wait is visibly finite, and a button
+ * for the reader who would rather not wait for it.
+ */
+function WakingNotice({
+  retry,
+  onRetryNow,
+}: {
+  retry: { at: number; attempt: number; max: number };
+  onRetryNow: () => void;
+}) {
+  const { t } = useT();
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const seconds = Math.max(0, Math.ceil((retry.at - now) / 1000));
+  return (
+    <div
+      className="mt-4 rounded-xl p-4 text-sm animate-fade-in"
+      style={{ background: "var(--ow-bg-1)", color: "var(--ow-fg-1)", border: "1px solid var(--ow-line-2)" }}
+    >
+      <p className="font-semibold mb-1" style={{ color: "var(--ow-fg-0)" }}>
+        {t("plan.states.waking.title")}
+      </p>
+      <p className="leading-relaxed">
+        {t("plan.states.waking.body", { seconds, attempt: retry.attempt, max: retry.max })}
+      </p>
+      <button
+        type="button"
+        onClick={onRetryNow}
+        className="mt-3 rounded-lg px-3 py-1.5 text-xs font-semibold"
+        style={{ background: "var(--ow-accent)", color: "var(--ow-on-accent)" }}
+      >
+        {t("plan.states.waking.retryNow")}
+      </button>
+    </div>
+  );
 }

--- a/packages/web/src/plan/session/reducer.test.ts
+++ b/packages/web/src/plan/session/reducer.test.ts
@@ -533,3 +533,33 @@ describe("persist commands", () => {
     expect(s.persist).toBeNull();
   });
 });
+
+describe("cold-start retry", () => {
+  const scheduled = { type: "FETCH_RETRY_SCHEDULED", requestId: 1, at: 1000, attempt: 1, max: 4 } as const;
+
+  it("records the wait and drops the pending request", () => {
+    const s = run(start(), { type: "FETCH_STARTED", requestId: 1, kind: "single" }, scheduled);
+    expect(s.pending).toBeNull();
+    expect(s.apiError).toBeNull();
+    expect(s.retry).toEqual({ at: 1000, attempt: 1, max: 4 });
+  });
+
+  it("ignores a wait for a superseded request", () => {
+    const s = run(start(), { type: "FETCH_STARTED", requestId: 2, kind: "single" }, scheduled);
+    expect(s.retry).toBeNull();
+    expect(s.pending?.id).toBe(2);
+  });
+
+  it("clears the wait when a request starts, fails or the mode changes", () => {
+    const waiting = run(start(), { type: "FETCH_STARTED", requestId: 1, kind: "single" }, scheduled);
+    expect(run(waiting, { type: "FETCH_STARTED", requestId: 2, kind: "single" }).retry).toBeNull();
+    expect(run(waiting, { type: "MODE_CHANGED", mode: "compare" }).retry).toBeNull();
+    const failed = run(
+      waiting,
+      { type: "FETCH_STARTED", requestId: 2, kind: "single" },
+      { type: "FETCH_FAILED", requestId: 2, error: "boom" },
+    );
+    expect(failed.retry).toBeNull();
+    expect(failed.apiError).toBe("boom");
+  });
+});

--- a/packages/web/src/plan/session/reducer.ts
+++ b/packages/web/src/plan/session/reducer.ts
@@ -118,6 +118,9 @@ export interface PlanState {
   /** Edits not yet computed. */
   isStale: boolean;
   apiError: string | null;
+  /** The backend was asleep: the same request goes again by itself at `at`
+      (epoch ms). Null outside that wait. usePlanSession owns the timer. */
+  retry: { at: number; attempt: number; max: number } | null;
 
   // ── in flight ─────────────────────────────────────────────────────────────
   pending: { id: number; kind: FetchKind; editSeq: number } | null;
@@ -164,6 +167,7 @@ export type PlanAction =
       forecastUpdatedAt: string;
     }
   | { type: "FETCH_FAILED"; requestId: number; error: string }
+  | { type: "FETCH_RETRY_SCHEDULED"; requestId: number; at: number; attempt: number; max: number }
   | {
       type: "WINDOW_SELECTED";
       window: PassageWindow;
@@ -200,7 +204,7 @@ export function createInitialState(initial: InitialSession): PlanState {
     selectedStepIdx: null,
     actionTaken: initial.actionTaken,
     isStale: initial.isStale,
-    apiError: null,
+    apiError: null, retry: null,
     pending: null,
     editSeq: 0,
     persist: null,
@@ -292,7 +296,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
       // Opposite-mode results are deliberately kept in memory so the user can
       // toggle back and forth without recomputing. The render branches gate on
       // `mode`, so nothing stale leaks visually.
-      return { ...confirmed, mode: action.mode, apiError: null };
+      return { ...confirmed, mode: action.mode, apiError: null, retry: null };
     }
 
     case "SWEEP_CHANGED":
@@ -317,7 +321,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
     case "FETCH_STARTED":
       return {
         ...state,
-        apiError: null,
+        apiError: null, retry: null,
         pending: { id: action.requestId, kind: action.kind, editSeq: state.editSeq },
       };
 
@@ -398,7 +402,22 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
       // Same rule as a success: an error about a plan the user has already
       // moved on from is noise, not information.
       if (applies === "outdated") return { ...state, pending: null };
-      return { ...state, pending: null, apiError: action.error };
+      return { ...state, pending: null, apiError: action.error, retry: null };
+    }
+
+    case "FETCH_RETRY_SCHEDULED": {
+      // Same gate as a failure: a wait about a plan the reader has moved on
+      // from is not worth showing. The hook still fires the retry, which
+      // computes the plan as it stands then.
+      const applies = verdict(state, action.requestId);
+      if (applies === "superseded") return state;
+      if (applies === "outdated") return { ...state, pending: null };
+      return {
+        ...state,
+        pending: null,
+        apiError: null,
+        retry: { at: action.at, attempt: action.attempt, max: action.max },
+      };
     }
 
     case "WINDOW_SELECTED": {
@@ -407,7 +426,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
         mode: "single",
         departure: action.departure,
         metaWarnings: [],
-        apiError: null,
+        apiError: null, retry: null,
       };
       if (!action.window.passage || !action.window.complexity_full) {
         // Older deployments answer the sweep without the per-window detail.
@@ -467,7 +486,7 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
           selectedStepIdx: null,
           actionTaken: false,
           isStale: false,
-          apiError: null,
+          apiError: null, retry: null,
           // Anything in flight stops counting: its reply will be dropped by
           // `isCurrent`, and the shell aborts it anyway.
           pending: null,

--- a/packages/web/src/plan/session/usePlanSession.test.tsx
+++ b/packages/web/src/plan/session/usePlanSession.test.tsx
@@ -17,18 +17,25 @@ import type { PassageReport, ComplexityScore, PassageWindow } from "../types";
 import type { InitialSession } from "./initial";
 import { toTzAware } from "../../domain/datetime";
 import { usePlanSession } from "./usePlanSession";
+import { ApiError } from "../../api/passage";
 
 const fetchPassage = vi.fn();
 const fetchPassageWindows = vi.fn();
 const fetchPassageByEta = vi.fn();
 
-vi.mock("../../api/passage", () => ({
-  fetchPassage: (...args: unknown[]) => fetchPassage(...args),
-  fetchPassageWindows: (...args: unknown[]) => fetchPassageWindows(...args),
-  fetchPassageByEta: (...args: unknown[]) => fetchPassageByEta(...args),
-  friendlyError: (raw: string | Error) =>
-    `traduit: ${typeof raw === "string" ? raw : raw.message}`,
-}));
+// The transport is faked; the rest of the module (ApiError, coldStartDelay)
+// is the real thing, so the retry path below runs on the real triage.
+vi.mock("../../api/passage", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/passage")>();
+  return {
+    ...actual,
+    fetchPassage: (...args: unknown[]) => fetchPassage(...args),
+    fetchPassageWindows: (...args: unknown[]) => fetchPassageWindows(...args),
+    fetchPassageByEta: (...args: unknown[]) => fetchPassageByEta(...args),
+    friendlyError: (raw: string | Error) =>
+      `traduit: ${typeof raw === "string" ? raw : raw.message}`,
+  };
+});
 
 // The corridor sampler talks to Open-Meteo; the plan under test does not care
 // what it returns, only that it resolves.
@@ -238,6 +245,51 @@ describe("usePlanSession", () => {
     act(() => result.current.actions.compute());
     await waitFor(() => expect(result.current.state.apiError).toBe("traduit: rate limit exceeded"));
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("retries by itself while the backend wakes up, then shows the result", async () => {
+    fetchPassage
+      .mockRejectedValueOnce(
+        new ApiError("backend temporarily unavailable, retry in 1s", "upstream_unavailable", 1),
+      )
+      .mockResolvedValueOnce({
+        passage: passage(),
+        complexity: complexity(),
+        forecast_updated_at: "2026-09-09T06:00:00Z",
+      });
+    const { result } = renderHook(() => usePlanSession(session()));
+
+    act(() => result.current.actions.compute());
+    await waitFor(() => expect(result.current.state.retry).not.toBeNull());
+    expect(result.current.state.retry?.attempt).toBe(1);
+    expect(result.current.state.retry?.max).toBe(4);
+    expect(result.current.state.apiError).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    await waitFor(() => expect(result.current.state.passage).not.toBeNull(), { timeout: 4000 });
+    expect(fetchPassage).toHaveBeenCalledTimes(2);
+    expect(result.current.state.retry).toBeNull();
+    expect(result.current.state.apiError).toBeNull();
+  });
+
+  it("gives up with the error once the automatic attempts are spent", async () => {
+    fetchPassage.mockRejectedValue(new ApiError("backend temporarily unavailable", "upstream_unavailable", 1));
+    const { result } = renderHook(() => usePlanSession(session()));
+
+    act(() => result.current.actions.compute());
+    await waitFor(() => expect(result.current.state.apiError).not.toBeNull(), { timeout: 9000 });
+    expect(fetchPassage).toHaveBeenCalledTimes(5); // the request, then four retries
+    expect(result.current.state.retry).toBeNull();
+  }, 12000);
+
+  it("does not retry a failure that waiting will not fix", async () => {
+    fetchPassage.mockRejectedValue(new ApiError("rate limit exceeded", "rate_limited", 30));
+    const { result } = renderHook(() => usePlanSession(session()));
+
+    act(() => result.current.actions.compute());
+    await waitFor(() => expect(result.current.state.apiError).not.toBeNull());
+    expect(result.current.state.retry).toBeNull();
+    expect(fetchPassage).toHaveBeenCalledTimes(1);
   });
 
   it("says nothing when the request was aborted", async () => {

--- a/packages/web/src/plan/session/usePlanSession.ts
+++ b/packages/web/src/plan/session/usePlanSession.ts
@@ -28,6 +28,7 @@ import {
   fetchPassage,
   fetchPassageByEta,
   fetchPassageWindows,
+  coldStartDelay,
   friendlyError,
   type PlanOverrides,
 } from "../../api/passage";
@@ -96,6 +97,9 @@ function resolveEfficiency(): number {
 // compare so the cache check is a one-liner. Read at the same moment as the
 // result lands, so the persisted simulation is paired with the config that
 // produced it.
+/** Automatic attempts after a cold-start failure, before the error shows. */
+const MAX_COLD_START_RETRIES = 4;
+
 export function currentConfigFingerprint(): string {
   return `${activeModels(loadModelConfig()).join(",")}|${polarFingerprint(loadPolarConfig())}`;
 }
@@ -152,8 +156,27 @@ export function usePlanSession(initial: InitialSession): PlanSession {
     stateRef.current = state;
   });
 
+  // Cold start. The backend answers "unavailable, retry in N s" while the
+  // Space wakes up, which takes it a minute or two. Rather than an error the
+  // reader has to read and relaunch by hand, the same request goes again by
+  // itself, a few times, with the panel saying so (PlanSidebar). The counter
+  // resets on a success and on a request the reader starts; the timer dies
+  // with any new request and with the page.
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryAttemptRef = useRef(0);
+  const lastKindRef = useRef<"single" | "sweep">("single");
+  const rerunRef = useRef<() => void>(() => {});
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
   /** Mint a request, cancelling whatever was in flight. */
   const startRequest = useCallback((kind: "single" | "sweep") => {
+    clearRetryTimer();
+    lastKindRef.current = kind;
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -161,7 +184,7 @@ export function usePlanSession(initial: InitialSession): PlanSession {
     requestIdRef.current = requestId;
     dispatch({ type: "FETCH_STARTED", requestId, kind });
     return { requestId, signal: controller.signal };
-  }, []);
+  }, [clearRetryTimer]);
 
   const onFailure = useCallback((requestId: number, error: unknown) => {
     // An abort is not a failure: the request was replaced or the page left.
@@ -169,6 +192,23 @@ export function usePlanSession(initial: InitialSession): PlanSession {
     // An ApiError carries the server's stable code; anything else only has
     // words, and `friendlyError` falls back to matching them.
     const reported = error instanceof Error ? error : String(error);
+    const delay = coldStartDelay(error);
+    if (delay !== null && retryAttemptRef.current < MAX_COLD_START_RETRIES) {
+      const attempt = retryAttemptRef.current + 1;
+      retryAttemptRef.current = attempt;
+      dispatch({
+        type: "FETCH_RETRY_SCHEDULED",
+        requestId,
+        at: Date.now() + delay * 1000,
+        attempt,
+        max: MAX_COLD_START_RETRIES,
+      });
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
+        rerunRef.current();
+      }, delay * 1000);
+      return;
+    }
     dispatch({ type: "FETCH_FAILED", requestId, error: friendlyError(reported) });
   }, []);
 
@@ -212,6 +252,7 @@ export function usePlanSession(initial: InitialSession): PlanSession {
               }),
         )
         .then((res) => {
+          retryAttemptRef.current = 0;
           dispatch({
             type: "FETCH_SUCCEEDED",
             requestId,
@@ -249,6 +290,7 @@ export function usePlanSession(initial: InitialSession): PlanSession {
         }),
       )
       .then((res) => {
+        retryAttemptRef.current = 0;
         dispatch({
           type: "FETCH_SUCCEEDED",
           requestId,
@@ -262,8 +304,26 @@ export function usePlanSession(initial: InitialSession): PlanSession {
       .catch((error: unknown) => onFailure(requestId, error));
   }, [startRequest, onFailure]);
 
-  // Leaving the page cancels whatever is in flight.
-  useEffect(() => () => abortRef.current?.abort(), []);
+  // The retry recomputes the plan as it stands when the timer fires, not as
+  // it was when the request failed: an edit in between is not lost, and a
+  // route shrunk below two points is not sent.
+  useEffect(() => {
+    rerunRef.current = () => {
+      const s = stateRef.current;
+      if (s.waypoints.length < 2) return;
+      if (lastKindRef.current === "sweep") runSweep();
+      else runSingle(s.waypoints, s.archetype, s.departure, s.timeAnchor);
+    };
+  }, [runSingle, runSweep]);
+
+  // Leaving the page cancels whatever is in flight, retry timer included.
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+      clearRetryTimer();
+    },
+    [clearRetryTimer],
+  );
 
   // ── the one place this page writes to the outside world ───────────────────
   // One subscription to the state, in two phases. The commands the reducer
@@ -330,10 +390,14 @@ export function usePlanSession(initial: InitialSession): PlanSession {
       selectLeg: (index) => dispatch({ type: "LEG_SELECTED", index }),
       selectStep: (index) => dispatch({ type: "STEP_SELECTED", index }),
       compute: () => {
+        retryAttemptRef.current = 0;
         const { waypoints, archetype, departure, timeAnchor } = stateRef.current;
         runSingle(waypoints, archetype, departure, timeAnchor);
       },
-      computeWindows: runSweep,
+      computeWindows: () => {
+        retryAttemptRef.current = 0;
+        runSweep();
+      },
       selectWindow: (window) => {
         const departure = toNaiveLocal(new Date(window.departure));
         dispatch({


### PR DESCRIPTION
## Quoi

Quand le Space est en veille, le proxy répond « backend temporarily unavailable, retry in N s » pendant la minute ou deux de son réveil. Le panneau du plan affichait l'erreur et il fallait relancer à la main.

Désormais le même calcul repart de lui-même, jusqu'à quatre fois, en respectant le délai du serveur (borné à une minute, 20 s par défaut). Le panneau montre « Le serveur météo se réveille », un compte à rebours et un bouton « Réessayer maintenant ». Une fois les essais épuisés, l'erreur habituelle s'affiche.

- Ne repartent seuls que le proxy qui ne joint pas le backend (`upstream_unavailable`) et un 5xx nu (`server_unavailable`), y compris par lecture du texte pour un déploiement sans codes. Limitation, entrée invalide, réseau coupé : erreur immédiate comme avant.
- Le compteur repart de zéro sur un succès ou sur un calcul lancé par le lecteur ; toute nouvelle requête et la sortie de la page annulent le minuteur ; la reprise calcule le plan tel qu'il est à ce moment-là (une édition entre-temps n'est pas perdue, une route réduite à un point n'est pas envoyée).
- Nouvel état `retry` dans le reducer, action `FETCH_RETRY_SCHEDULED` soumise au même verdict qu'un échec.
- Copy dans les cinq langues.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 58 fichiers / 796 tests : triage des erreurs, reducer, et le hook branché sur un faux backend qui refuse une fois puis répond (vrai délai d'une seconde), qui refuse toujours (l'erreur arrive après quatre essais), et une limitation (aucun nouvel essai).

🤖 Generated with [Claude Code](https://claude.com/claude-code)