### PR TITLE
fix(web): marges de sécurité iPhone, la barre de recherche ne passe plus sous la caméra

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -10,6 +10,8 @@
          longtemps. viewport-fit=cover laisse la page passer sous les encoches
          et la barre de geste, comme l'attend le mode standalone. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- ... et c'est aux barres et panneaux de bord de rendre cette place :
+         classes .safe-top / .safe-x / .safe-bottom dans index.css. -->
     <title>OhMyWind</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#030712" />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -310,7 +310,7 @@ function App() {
             ``thead.sticky top-0`` collides with the same container that
             scrolls (otherwise the hour row drifts away when the user scrolls
             down through GFS/ECMWF rows). */}
-        <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col">
+        <div className="absolute left-0 right-0 bottom-0 max-h-[44vh] md:max-h-[46vh] z-[400] flex flex-col safe-bottom">
           {/* Locate FAB — anchored to the overlay rather than to the map, so
               it rides up and down as the data panel grows and shrinks
               instead of ending up buried under it. The 16 px offset is

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -57,7 +57,7 @@ function SettingsButton() {
 export function Header({ onSelectSpot, nearLat, nearLon, savedSpots }: HeaderProps) {
   return (
     <header
-      className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6"
+      className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6 safe-top safe-x"
       style={{ background: 'var(--ow-surface-glass)', borderBottom: '1px solid var(--ow-accent-line)' }}
     >
       <div className="flex items-center gap-3 max-w-screen-2xl mx-auto">

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -231,6 +231,21 @@ select,
 }
 
 
+/* iPhone. index.html asks for viewport-fit=cover (#352), so the page runs
+   under the notch and the home indicator, and it is up to us to give the
+   space back where a bar or a panel meets an edge: the header went under the
+   camera and the search field with it. Zero on every other device. */
+.safe-top {
+  padding-top: env(safe-area-inset-top, 0px);
+}
+.safe-x {
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
+}
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 /* Scroll fade indicator */
 .scroll-container {
   position: relative;

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -240,7 +240,7 @@ const ResizableMobileDrawer = forwardRef<DrawerHandle, {
   return (
     <div
       ref={outerRef}
-      className="shrink-0 overflow-y-auto border-t flex flex-col"
+      className="shrink-0 overflow-y-auto border-t flex flex-col safe-bottom"
       style={{
         height: `${vh}vh`,
         background: "var(--ow-bg-1)",

--- a/packages/web/src/routes/confidentialite.css
+++ b/packages/web/src/routes/confidentialite.css
@@ -15,6 +15,8 @@
   color: #1f2937;
 }
 .conf-header {
+  /* iPhone: the status bar area, see .safe-top in index.css. */
+  padding-top: env(safe-area-inset-top, 0px);
   background: rgba(255, 255, 255, 0.85);
   border-color: rgba(15, 23, 42, 0.10);
 }

--- a/packages/web/src/routes/config.css
+++ b/packages/web/src/routes/config.css
@@ -228,6 +228,8 @@
   border-left-color: var(--ow-fg-2, #94a3b8);
 }
 .config-header {
+  /* iPhone: the status bar area, see .safe-top in index.css. */
+  padding-top: env(safe-area-inset-top, 0px);
   background: color-mix(in srgb, var(--ow-bg-0, #0b1220) 75%, transparent);
   border-color: var(--ow-line-2, rgba(255,255,255,0.08));
 }

--- a/packages/web/src/routes/methodologie.css
+++ b/packages/web/src/routes/methodologie.css
@@ -15,6 +15,8 @@
   color: #1f2937;
 }
 .methodo-header {
+  /* iPhone: the status bar area, see .safe-top in index.css. */
+  padding-top: env(safe-area-inset-top, 0px);
   background: rgba(255, 255, 255, 0.85);
   border-color: rgba(15, 23, 42, 0.10);
 }


### PR DESCRIPTION
## Quoi

Depuis #352 (2 septembre) le viewport demande `viewport-fit=cover` : la page passe sous l'encoche et l'indicateur d'accueil, et rien ne rendait cette place. Sur iPhone en mode « écran d'accueil », l'en-tête et son champ de recherche se retrouvaient sous la caméra.

- `.safe-top`, `.safe-x`, `.safe-bottom` dans `index.css`, sur `env(safe-area-inset-*)` avec repli à zéro.
- Posées sur l'en-tête commun (`Header`, pages classique et plan), les en-têtes collants de /config, /methodologie et /confidentialite, le panneau bas de la page classique et le tiroir mobile du plan.
- Aucun effet sur les autres appareils (insets à zéro).

## À vérifier

Sur l'iPhone, depuis dev.ohmywind.fr en mode écran d'accueil : le champ de recherche sous la barre d'état, plus sous la caméra ; en bas, la dernière ligne du tableau au-dessus de l'indicateur d'accueil.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 796 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)