### PR TITLE
fix(web): barre d'état iOS opaque et colorée par le thème, la page commence dessous

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -20,7 +20,14 @@
          sienne. Les deux disent la meme chose, garder les deux ne coute rien. -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- Barre d'etat opaque, pas translucide : en translucide, iOS pose la
+         barre par-dessus la page et c'est a la page de reserver la place via
+         env(safe-area-inset-top), ce qui n'a pas suffi sur un iPhone en mode
+         ecran d'accueil (champ de recherche sous la camera, 2026-09-06). En
+         "default", la page commence sous la barre, quoi qu'il arrive, et iOS
+         peint la barre de la couleur de theme-color, que le theme tient a
+         jour (design/initialTheme.ts). -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="OhMyWind" />
 
     <meta name="description" content="OhMyWind, sailing planner for the French Atlantic and Mediterranean coasts. Wind forecasts, passage estimates, complexity scores and high-precision tidal currents (SHOM Atlas C2D + MARC PREVIMER), powered by AROME 1.3 km models.">

--- a/packages/web/src/design/initialTheme.ts
+++ b/packages/web/src/design/initialTheme.ts
@@ -42,6 +42,25 @@ export function getInitialMode(): ThemeMode {
  * `var()`) would read the fallback palette and keep it until some unrelated
  * redraw. Idempotent, and the provider still owns every later change.
  */
+/**
+ * What the system bars take as the page colour: the theme-color meta, read by
+ * Android for the status bar of an installed app and by iOS for the status
+ * bar of a home-screen web app (index.html asks for an opaque one). Same
+ * values as --ow-bg-0 in tokens.css; the manifest pins the dark one, which
+ * is the colour at launch, before any script runs.
+ */
+export const THEME_COLOR: Record<ThemeMode, string> = {
+  dark: "#030712",
+  light: "#f4f6fb",
+};
+
+/** Stamp the theme on the document: the attribute the tokens key on, and
+    the colour the system bars follow. */
+export function applyTheme(mode: ThemeMode): void {
+  document.documentElement.setAttribute("data-theme", mode);
+  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", THEME_COLOR[mode]);
+}
+
 export function applyInitialTheme(): void {
-  document.documentElement.setAttribute("data-theme", getInitialMode());
+  applyTheme(getInitialMode());
 }

--- a/packages/web/src/design/theme.tsx
+++ b/packages/web/src/design/theme.tsx
@@ -5,7 +5,7 @@ import { LOCAL_STORAGE_KEYS } from "../storage/keys";
 import { useEffect, useState } from 'react';
 
 import { useT } from '../i18n';
-import { getInitialMode } from './initialTheme';
+import { applyTheme, getInitialMode } from './initialTheme';
 import { ThemeCtx, useTheme, type ThemeMode } from './useTheme';
 
 const STORAGE_KEY = LOCAL_STORAGE_KEYS.theme;
@@ -17,14 +17,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // (applyInitialTheme, called from main.tsx, and setMode below) are there to
   // beat an ordering, not to replace this one.
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', mode);
+    applyTheme(mode);
   }, [mode]);
 
   function setMode(m: ThemeMode) {
     // Written before the re-render, for the same reason as the initial stamp:
     // the map effects that resolve a token from the DOM run before the
     // provider's own effect, and would otherwise read the outgoing palette.
-    document.documentElement.setAttribute('data-theme', m);
+    applyTheme(m);
     setModeState(m);
     try {
       localStorage.setItem(STORAGE_KEY, m);


### PR DESCRIPTION
## Quoi

Sur iPhone en mode « Sur l'écran d'accueil », le champ de recherche restait sous la caméra malgré #377 : avec une barre d'état translucide, iOS pose la barre par-dessus la page et compte sur `env(safe-area-inset-top)` pour que la page réserve la place, ce qui n'a pas suffi sur l'appareil de Quentin et ne se teste pas ici.

- `apple-mobile-web-app-status-bar-style` passe de `black-translucent` à `default` : la page commence sous la barre, quoi qu'il arrive.
- iOS peint alors la barre de la couleur de `theme-color` ; le thème la tient à jour au démarrage et à chaque bascule (sombre `#030712`, clair `#f4f6fb`, les `--ow-bg-0` des jetons). Le manifeste garde le sombre, couleur de lancement avant tout script.
- Les classes `.safe-*` de #377 restent pour l'indicateur d'accueil et les encoches latérales.

## À vérifier sur l'iPhone

Depuis dev.ohmywind.fr : supprimer le raccourci, rouvrir la page dans Safari, l'ajouter à l'écran d'accueil, ouvrir. Le champ de recherche doit être sous la barre d'état, et la barre de la couleur du fond, en sombre comme en clair.

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 796 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)