### PR TITLE
fix(web): l'en-tête garde son padding, les marges iPhone s'y ajoutent

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -46,7 +46,12 @@ function previewSpot(lat: number, lon: number): Spot {
 function EmptyState() {
   const { t } = useT();
   return (
-    <div className="flex items-end justify-center pb-6 px-4 safe-bottom">
+    <div
+      className="flex items-end justify-center px-4"
+      // Its own padding plus the home-indicator inset; .safe-bottom would
+      // have replaced the padding (see index.css).
+      style={{ paddingBottom: "calc(1.5rem + env(safe-area-inset-bottom, 0px))" }}
+    >
       <div
         className="inline-flex items-center gap-2 px-3.5 py-2 rounded-full shadow-lg"
         style={{

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -57,7 +57,7 @@ function SettingsButton() {
 export function Header({ onSelectSpot, nearLat, nearLon, savedSpots }: HeaderProps) {
   return (
     <header
-      className="sticky top-0 z-30 backdrop-blur-lg px-3 py-2 lg:px-6 safe-top safe-x"
+      className="sticky top-0 z-30 backdrop-blur-lg app-header"
       style={{ background: 'var(--ow-surface-glass)', borderBottom: '1px solid var(--ow-accent-line)' }}
     >
       <div className="flex items-center gap-3 max-w-screen-2xl mx-auto">

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -245,6 +245,24 @@ select,
 .safe-bottom {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
+/* These three REPLACE the padding of the element they sit on (they are
+   unlayered, so they beat Tailwind's utilities): only for elements that
+   carry no padding utility of their own. The app header does, so it pays
+   the insets on top of its own padding here. #377 had put .safe-top and
+   .safe-x on it, and the header lost its 8 px and 12 px on every device,
+   not only on iPhone: logo flush left, icons flush right. */
+.app-header {
+  padding-top: calc(0.5rem + env(safe-area-inset-top, 0px));
+  padding-bottom: 0.5rem;
+  padding-left: calc(0.75rem + env(safe-area-inset-left, 0px));
+  padding-right: calc(0.75rem + env(safe-area-inset-right, 0px));
+}
+@media (min-width: 64rem) {
+  .app-header {
+    padding-left: calc(1.5rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1.5rem + env(safe-area-inset-right, 0px));
+  }
+}
 
 /* Scroll fade indicator */
 .scroll-container {


### PR DESCRIPTION
## Quoi

Régression de #377 : les classes `.safe-top` et `.safe-x`, non stratifiées, remplaçaient le padding Tailwind de l'en-tête au lieu de s'y ajouter. Sans encoche, l'en-tête passait à 0 px en haut et sur les côtés au lieu de 8 et 12, sur tous les appareils : logo collé à gauche, icônes collées à droite, en-tête plus bas de 8 px.

- `.app-header` dans `index.css` : padding propre plus `env(safe-area-inset-*)`, y compris la variante `lg`.
- L'invite « touchez la carte » de la page vide additionne de même son padding et l'inset bas.
- `.safe-*` restent pour les éléments sans padding utilitaire (panneau des données, tiroir du plan, en-têtes des pages doc), avec le commentaire qui le dit.

## Vérifs

Mesuré dans Chrome à 393 px de large : padding 8 / 12 / 8 / 12 et positions du logo, du champ et des boutons identiques à la prod. `tsc`, `lint:budget` 0 erreur, `vitest` 796 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)