### PR TITLE
fix(web): plus de marge sous le tableau ni sous le tiroir, l'indicateur d'accueil passe dessus

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -10,8 +10,9 @@
          longtemps. viewport-fit=cover laisse la page passer sous les encoches
          et la barre de geste, comme l'attend le mode standalone. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <!-- ... et c'est aux barres et panneaux de bord de rendre cette place :
-         classes .safe-top / .safe-x / .safe-bottom dans index.css. -->
+    <!-- ... l'en-tete ajoute les marges de securite a son propre padding
+         (.app-header dans index.css) ; le bas n'est volontairement pas
+         reserve, l'indicateur d'accueil passe sur la derniere ligne. -->
     <title>OhMyWind</title>
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#030712" />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -46,12 +46,7 @@ function previewSpot(lat: number, lon: number): Spot {
 function EmptyState() {
   const { t } = useT();
   return (
-    <div
-      className="flex items-end justify-center px-4"
-      // Its own padding plus the home-indicator inset; .safe-bottom would
-      // have replaced the padding (see index.css).
-      style={{ paddingBottom: "calc(1.5rem + env(safe-area-inset-bottom, 0px))" }}
-    >
+    <div className="flex items-end justify-center pb-6 px-4">
       <div
         className="inline-flex items-center gap-2 px-3.5 py-2 rounded-full shadow-lg"
         style={{
@@ -341,15 +336,7 @@ function App() {
                   donc h-full sur l'enfant ne bornait rien et la note de
                   convention sortait par le bas quand la table du vent
                   affichait quatre modeles. */}
-              {/* The bottom inset (home indicator) is paid by this panel, not
-                  by the transparent overlay: painted with the rows' own
-                  background, the table reads as running to the edge of the
-                  screen instead of stopping short above a hole of map. */}
-              <div
-                ref={dataPanelRef}
-                className="flex-1 min-h-0 overflow-hidden flex flex-col safe-bottom"
-                style={{ background: "var(--ow-bg-1)" }}
-              >
+              <div ref={dataPanelRef} className="flex-1 min-h-0 overflow-hidden flex flex-col">
                 {effectiveView === "wind" || !marine ? (
                   <WindTable
                     forecasts={forecasts}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -231,26 +231,14 @@ select,
 }
 
 
-/* iPhone. index.html asks for viewport-fit=cover (#352), so the page runs
-   under the notch and the home indicator, and it is up to us to give the
-   space back where a bar or a panel meets an edge: the header went under the
-   camera and the search field with it. Zero on every other device. */
-.safe-top {
-  padding-top: env(safe-area-inset-top, 0px);
-}
-.safe-x {
-  padding-left: env(safe-area-inset-left, 0px);
-  padding-right: env(safe-area-inset-right, 0px);
-}
-.safe-bottom {
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-/* These three REPLACE the padding of the element they sit on (they are
-   unlayered, so they beat Tailwind's utilities): only for elements that
-   carry no padding utility of their own. The app header does, so it pays
-   the insets on top of its own padding here. #377 had put .safe-top and
-   .safe-x on it, and the header lost its 8 px and 12 px on every device,
-   not only on iPhone: logo flush left, icons flush right. */
+/* iPhone. index.html asks for viewport-fit=cover (#352), so the page may run
+   under the notch in landscape and under the home indicator; the status bar
+   itself is opaque (index.html), so the top inset is zero there today. The
+   header adds the insets to its own padding rather than replacing it: #377
+   had swapped the padding for the inset and the header lost its 8 px and
+   12 px on every device, logo flush left, icons flush right. The bottom is
+   deliberately not inset: a band under the last row read as a hole, and the
+   home indicator overlaying the table is what every app does. */
 .app-header {
   padding-top: calc(0.5rem + env(safe-area-inset-top, 0px));
   padding-bottom: 0.5rem;

--- a/packages/web/src/routes/PlanPage.tsx
+++ b/packages/web/src/routes/PlanPage.tsx
@@ -240,7 +240,7 @@ const ResizableMobileDrawer = forwardRef<DrawerHandle, {
   return (
     <div
       ref={outerRef}
-      className="shrink-0 overflow-y-auto border-t flex flex-col safe-bottom"
+      className="shrink-0 overflow-y-auto border-t flex flex-col"
       style={{
         height: `${vh}vh`,
         background: "var(--ow-bg-1)",


### PR DESCRIPTION
## Quoi

La bande réservée à l'indicateur d'accueil iPhone (#377, repeinte par #380) se lisait comme un espace perdu sous la dernière ligne. Retirée, à la demande de Quentin : le tableau de la page classique et le tiroir mobile du plan filent jusqu'au bord de l'écran, l'indicateur passant sur la dernière ligne comme dans la plupart des apps. L'invite de la page vide retrouve son `pb-6`.

Les classes `.safe-top` / `.safe-x` / `.safe-bottom` n'ayant plus d'usage, elles disparaissent ; l'en-tête garde `.app-header` (padding propre plus insets latéraux, utiles en paysage).

## Vérifs

`tsc`, `lint:budget` 0 erreur, `vitest` 796 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)