### PR TITLE
fix(web): les cinq langues tiennent sur une ligne, en trigrammes sur écran étroit

### DIFF
--- a/packages/web/src/i18n/index.ts
+++ b/packages/web/src/i18n/index.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Quentin Donnars
 
-export { AVAILABLE_LANGS, LANGS, LANG_NAMES, LOCALE_BY_LANG, isLang, type Lang } from "./types";
+export {
+  AVAILABLE_LANGS,
+  LANGS,
+  LANG_NAMES,
+  LANG_SHORT_NAMES,
+  LOCALE_BY_LANG,
+  isLang,
+  type Lang,
+} from "./types";
 export { getLang, getLocale, initI18n, setLang, t, tn, type Key, type PluralKey } from "./store";
 export { useLang, useT } from "./useT";
 export { rich, type RichTags } from "./rich";

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -33,6 +33,21 @@ export const LANG_NAMES: Record<Lang, string> = {
   es: "Español",
 };
 
+/**
+ * Three-letter form of the same endonyms, for the narrow screens where the
+ * five full names no longer fit on one line. Abbreviations of native names,
+ * so they are invariant across interface languages and stay out of the
+ * dictionaries. Picked for recognition by a native speaker rather than for
+ * ISO 639-2 conformity, hence ESP for Español and not SPA.
+ */
+export const LANG_SHORT_NAMES: Record<Lang, string> = {
+  fr: "FRA",
+  en: "ENG",
+  de: "DEU",
+  it: "ITA",
+  es: "ESP",
+};
+
 export function isLang(v: unknown): v is Lang {
   return typeof v === "string" && (LANGS as readonly string[]).includes(v);
 }

--- a/packages/web/src/routes/ConfigPage.test.tsx
+++ b/packages/web/src/routes/ConfigPage.test.tsx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Quentin Donnars
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LangPicker } from "./ConfigPage";
+import { AVAILABLE_LANGS, LANG_NAMES, LANG_SHORT_NAMES } from "../i18n";
+
+/**
+ * The picker keeps its five pills on one line at every width, so both labels
+ * ship in the markup and CSS decides which one shows. jsdom applies no
+ * stylesheet, hence no assertion here on which of the two is visible: what
+ * these tests pin is that shortening the label never shortens what a screen
+ * reader announces.
+ */
+describe("LangPicker", () => {
+  it("names every pill with the full endonym, never the trigram", () => {
+    render(<LangPicker />);
+    for (const l of AVAILABLE_LANGS) {
+      expect(screen.getByRole("radio", { name: LANG_NAMES[l] })).toBeDefined();
+      expect(screen.queryByRole("radio", { name: LANG_SHORT_NAMES[l] })).toBeNull();
+    }
+  });
+
+  it("renders both labels, full name and trigram, for every language", () => {
+    render(<LangPicker />);
+    for (const l of AVAILABLE_LANGS) {
+      expect(screen.getByText(LANG_NAMES[l])).toBeDefined();
+      expect(screen.getByText(LANG_SHORT_NAMES[l])).toBeDefined();
+    }
+  });
+
+  it("keeps the radiogroup and marks the active language", () => {
+    render(<LangPicker />);
+    const group = screen.getByRole("radiogroup", { name: "Langue" });
+    expect(group).toBeDefined();
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(AVAILABLE_LANGS.length);
+    const checked = radios.filter((r) => r.getAttribute("aria-checked") === "true");
+    expect(checked).toHaveLength(1);
+    expect(checked[0].getAttribute("aria-label")).toBe(LANG_NAMES["fr"]);
+  });
+});

--- a/packages/web/src/routes/ConfigPage.tsx
+++ b/packages/web/src/routes/ConfigPage.tsx
@@ -23,7 +23,14 @@ import { BoatEssentials } from "../components/BoatEssentials";
 import { BoatResult } from "../components/BoatResult";
 import { ConfigTile } from "../components/ConfigTile";
 import { useDragReorder } from "../hooks/useDragReorder";
-import { AVAILABLE_LANGS, LANG_NAMES, setLang, t as translate, useT } from "../i18n";
+import {
+  AVAILABLE_LANGS,
+  LANG_NAMES,
+  LANG_SHORT_NAMES,
+  setLang,
+  t as translate,
+  useT,
+} from "../i18n";
 import "./config.css";
 
 // Tab id "polar" predates the tab's rename to "Bateau"; kept to avoid churn
@@ -255,8 +262,20 @@ export function ConfigPage() {
  * translated names: a reader lost in the wrong language must recognise their
  * own. The choice persists at once, no save step, and the dictionary loads
  * before the switch lands (see i18n/store).
+ *
+ * The five pills stay on a single line at every width, by decision: no wrap,
+ * no inner scroll, no dropdown. Below the width where the full endonyms fit
+ * (the breakpoint and its measurement live in config.css) each pill falls
+ * back to its trigram, FRA / ENG / DEU / ITA / ESP, which is still the native
+ * name and still recognisable to the reader it is meant for. The full name
+ * comes back as soon as there is room for it.
+ *
+ * Both labels are rendered and CSS picks the one that shows, so nothing
+ * depends on measuring at runtime. The accessible name is pinned to the full
+ * endonym on the button itself: a screen reader announces "Deutsch", never
+ * "DEU", whichever label is on screen.
  */
-function LangPicker() {
+export function LangPicker() {
   const { t, lang } = useT();
   return (
     <section className="mb-6 flex items-center justify-between gap-3 flex-wrap">
@@ -268,11 +287,17 @@ function LangPicker() {
             type="button"
             role="radio"
             aria-checked={lang === l}
+            aria-label={LANG_NAMES[l]}
             lang={l}
             className={`config-segment-btn ${lang === l ? "is-active" : ""}`}
             onClick={() => void setLang(l)}
           >
-            {LANG_NAMES[l]}
+            <span className="config-segment-full" aria-hidden="true">
+              {LANG_NAMES[l]}
+            </span>
+            <span className="config-segment-short" aria-hidden="true">
+              {LANG_SHORT_NAMES[l]}
+            </span>
           </button>
         ))}
       </div>

--- a/packages/web/src/routes/config.css
+++ b/packages/web/src/routes/config.css
@@ -402,6 +402,7 @@
    under a name that says what it is rather than where it came from. */
 .config-segment {
   display: inline-flex;
+  flex-wrap: nowrap;
   gap: 2px;
   padding: 2px;
   border-radius: 10px;
@@ -413,6 +414,7 @@
   border-radius: 8px;
   font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
   color: var(--ow-fg-1);
   background: transparent;
   border: 0;
@@ -425,4 +427,33 @@
 .config-segment-btn.is-active {
   background: var(--ow-accent);
   color: #fff;
+}
+
+/*
+ * Full endonym or trigram, one line either way.
+ *
+ * The five full names (Français / English / Deutsch / Italiano / Español)
+ * measure 362.6 px on the built bundle. The picker sits in `main.px-6`, which
+ * takes 2 x 24 px off the viewport, so they need 410.6 px of viewport to fit,
+ * call it 411. Below that they used to run 13 px past the right edge on a
+ * 375 px screen, unreachable because the overflow does not scroll. The pills
+ * must stay on one line, so the labels shorten instead: the trigrams measure
+ * 249.5 px, need 297.5 px of viewport and so clear a 320 px screen with
+ * 22.5 px to spare.
+ *
+ * Breakpoint at 420 px rather than exactly 411 px: full names come back at
+ * 421 px, a 10 px cushion for the font fallbacks that render a shade wider
+ * than Inter, and it lands between the two device widths that matter (393 px
+ * for an iPhone 15, 430 px for its Pro Max).
+ */
+.config-segment-short {
+  display: none;
+}
+@media (max-width: 420px) {
+  .config-segment-full {
+    display: none;
+  }
+  .config-segment-short {
+    display: inline;
+  }
 }


### PR DESCRIPTION
## Le défaut

Sur `/config` à 375 px de large (iPhone SE, 8, 12/13 mini), le sélecteur de langue débordait de 13 px, mesuré sur `dev.ohmywind.fr` :

- `document.documentElement.clientWidth = 375`, `scrollWidth = 388`
- `.config-segment` mesurait 362,6 px dans un conteneur de 327 px (`main.px-6`, soit 375 moins 2 x 24 px), bord droit à 386,6 px
- la pastille « Español » allait de 313,5 à 383,6 px, donc environ 9 px hors écran, bord arrondi et padding droit rognés
- `scrollLeft` restait bloqué à 0 : le contenu rogné n'était pas atteignable

Cause : `.config-segment` est un `inline-flex` sans repli, avec cinq pastilles portant les noms de langue complets. Régression jamais partie en prod, `ohmywind.fr/config` n'a pas encore le sélecteur.

## La décision

Les cinq pastilles restent sur **une seule ligne, toujours**. Pas de retour à la ligne, pas de scroll horizontal interne, pas de menu déroulant. Quand la largeur ne suffit plus pour les noms complets, chaque pastille bascule sur son trigramme.

| langue | complet | trigramme |
|---|---|---|
| fr | Français | FRA |
| en | English | ENG |
| de | Deutsch | DEU |
| it | Italiano | ITA |
| es | Español | ESP |

Trigrammes choisis pour la reconnaissance par un locuteur natif plutôt que pour la conformité ISO 639-2, d'où `ESP` et non `SPA`. Ce sont des abréviations de noms natifs, invariantes selon la langue de l'interface : elles vivent à côté de `LANG_NAMES` dans `src/i18n/types.ts`, pas dans les dictionnaires.

L'intention d'origine du composant est préservée : les endonymes servent à ce qu'un lecteur perdu dans la mauvaise langue reconnaisse la sienne, et le nom complet revient dès qu'il y a la place.

## Le point de bascule

Mesuré sur le build de production, pas sur le serveur de dev :

- les cinq noms complets mesurent **362,6 px**, plus les 2 x 24 px de padding de `main.px-6` : il leur faut **410,6 px de viewport**, soit 411 px
- les cinq trigrammes mesurent **249,5 px**, soit **297,5 px de viewport** : ils passent à 320 px avec 22,5 px de marge

Bascule posée à `@media (max-width: 420px)`, donc noms complets à partir de 421 px. Les 10 px de marge au-dessus des 411 px théoriques couvrent les polices de repli, qui rendent un peu plus large qu'Inter, et le point tombe entre les deux largeurs d'appareil qui comptent : 393 px pour un iPhone 15, 430 px pour son Pro Max. Le chiffre et sa provenance sont écrits dans `config.css`.

## Mesures

Build de production servi par `vite preview`, Chrome DevTools MCP, page `/config` :

| viewport | `scrollWidth` - `clientWidth` | `.config-segment` | conteneur | 1re pastille | dernière pastille | lignes | libellé |
|---|---|---|---|---|---|---|---|
| 320 px | 0 | 249,5 px | 272 px | 27 à 74,6 | 223,7 à 270,5 | 1 | trigramme |
| 375 px | 0 | 249,5 px | 327 px | 104,5 à 152,1 | 301,2 à 348 | 1 | trigramme |
| 393 px | 0 | 249,5 px | 345 px | 122,5 à 170,1 | 319,2 à 366 | 1 | trigramme |
| 430 px | 0 | 362,6 px | 382 px | 27 à 100,4 | 313,5 à 383,6 | 1 | complet |
| 768 px | 0 | 362,6 px | 720 px | 384,4 à 457,8 | 670,8 à 741 | 1 | complet |

Écart `scrollWidth - clientWidth` nul partout. Les cinq boutons partagent le même `getBoundingClientRect().top` à chaque largeur, une seule ligne donc, et première comme dernière pastille sont entièrement dans le viewport. Contrôle du seuil : à 421 px, noms complets, bord droit à 386,6 px, aucun débordement.

## Vérifié

- `npm run typecheck` : sans erreur
- `npm run lint:budget` : 0 erreur, 1 avertissement (le `react-hooks/exhaustive-deps` documenté, préexistant)
- `npm run test` : 59 fichiers, 799 tests au vert, dont les 3 nouveaux de `src/routes/ConfigPage.test.tsx`
- `npm run build` puis `npm run preview`, mesures faites sur le bundle construit
- bascule de langue : un clic sur « DEU » passe l'interface en allemand, `aria-checked` suit, `ow_lang` vaut `de` et la préférence tient au rechargement ; retour sur « FRA » de même
- pas de régression ailleurs : `/` et `/plan` à 375 px, écart `scrollWidth - clientWidth` nul

## Accessibilité

Les deux libellés sont dans le DOM, le CSS choisit lequel s'affiche : rien ne dépend d'une mesure au runtime. Le nom accessible est épinglé sur le bouton via `aria-label={LANG_NAMES[l]}`, les deux `span` sont `aria-hidden`. Un lecteur d'écran annonce « Deutsch », jamais « DEU », quel que soit le libellé à l'écran. `role="radiogroup"`, `role="radio"` et `aria-checked` sont inchangés. Le test de composant vérifie que chaque bouton porte le nom complet comme nom accessible, qu'aucun n'est atteignable par son trigramme, et que les deux libellés sont bien rendus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
