### PR TITLE
feat(android): retire la clé de signature archivée et passe en 1.1.0

### DIFF
--- a/packages/android-dev/twa-manifest.json
+++ b/packages/android-dev/twa-manifest.json
@@ -21,7 +21,7 @@
     "path": "../android/android.keystore",
     "alias": "android"
   },
-  "appVersionCode": 4,
+  "appVersionCode": 5,
   "shortcuts": [
     {
       "name": "Planifier une route",
@@ -56,14 +56,11 @@
   "fingerprints": [
     {
       "value": "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
-    },
-    {
-      "value": "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
     }
   ],
   "additionalTrustedOrigins": [],
   "retainedBundles": [],
   "displayOverride": [],
-  "appVersion": "1.0.4",
-  "appVersionName": "1.0.4"
+  "appVersion": "1.1.0",
+  "appVersionName": "1.1.0"
 }

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -46,6 +46,8 @@ Il en faut deux pour `fr.ohmywind.app`, parce que les deux canaux de distributio
 - la **clé d'upload** (`android.keystore` local), pour les APK installés en direct via `bubblewrap install` / `adb install`;
 - la **clé Play App Signing**, celle avec laquelle Google re-signe le build qu'il distribue. Play Console la publie sous Test et publication → Intégrité de l'app → Clé de signature de l'app.
 
+Une troisième empreinte y a longtemps figuré, celle d'une clé locale créée le 2026-08-01 et remplacée le 2026-08-16 par la clé d'upload officielle. Elle n'a jamais été enregistrée chez Google et ne signe plus rien: retirée en 1.1.0. Un APK sideloadé avec elle entre ces deux dates s'ouvrira désormais avec la barre Chrome; le remède est de le réinstaller depuis un build courant. Le test `packages/web/src/manifest.test.ts` vérifie que les empreintes des `twa-manifest.json` et celles d'`assetlinks.json` restent le même jeu, flavor par flavor: c'est le seul garde-fou contre l'oubli d'un des deux fichiers.
+
 Ne jamais faire confiance à une empreinte recopiée à la main: la vérité terrain, c'est le certificat de l'APK réellement installé. Pour la mesurer:
 
 ```bash

--- a/packages/android/twa-manifest.json
+++ b/packages/android/twa-manifest.json
@@ -21,8 +21,8 @@
     "path": "./android.keystore",
     "alias": "android"
   },
-  "appVersionName": "1.0.4",
-  "appVersionCode": 7,
+  "appVersionName": "1.1.0",
+  "appVersionCode": 8,
   "shortcuts": [
     {
       "name": "Planifier une route",
@@ -60,13 +60,10 @@
     },
     {
       "value": "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
-    },
-    {
-      "value": "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
     }
   ],
   "additionalTrustedOrigins": [],
   "retainedBundles": [],
   "displayOverride": [],
-  "appVersion": "1.0.4"
+  "appVersion": "1.1.0"
 }

--- a/packages/web/public/.well-known/assetlinks.json
+++ b/packages/web/public/.well-known/assetlinks.json
@@ -6,8 +6,7 @@
       "package_name": "fr.ohmywind.app",
       "sha256_cert_fingerprints": [
         "DF:C9:D2:19:37:69:24:65:19:47:96:EF:D7:A2:61:D3:6C:C6:3A:D6:06:6B:1C:C5:28:3A:35:CF:2D:E2:05:90",
-        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82",
-        "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
+        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
       ]
     }
   },
@@ -17,8 +16,7 @@
       "namespace": "android_app",
       "package_name": "fr.ohmywind.app.dev",
       "sha256_cert_fingerprints": [
-        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82",
-        "32:45:AD:CB:65:03:07:FA:9B:60:A7:AD:8D:98:B4:02:B5:98:E8:A9:6C:DB:4E:09:EC:45:A4:B7:E0:C0:3C:7D"
+        "6B:F4:67:EB:7E:EA:C5:F0:54:0A:67:E6:5A:86:2D:1D:67:66:C4:9A:B3:35:03:5C:A8:79:AA:81:2F:54:36:82"
       ]
     }
   }

--- a/packages/web/src/manifest.test.ts
+++ b/packages/web/src/manifest.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 import webManifestRaw from "../public/manifest.json?raw";
 import twaProdRaw from "../../android/twa-manifest.json?raw";
 import twaDevRaw from "../../android-dev/twa-manifest.json?raw";
+import assetlinksRaw from "../public/.well-known/assetlinks.json?raw";
 // Imported for their side effect on this test: resolution fails if the file
 // is not in public/, which is exactly the breakage we are guarding against.
 import planIconUrl from "../public/shortcut-plan-192.png?url";
@@ -79,14 +80,22 @@ describe("web manifest shortcuts", () => {
   });
 });
 
+/** Every certificate allowed to sign an app that speaks for the site, by
+    package. A fingerprint missing here opens the app with the Chrome address
+    bar instead of full screen, which is only ever noticed on a device. */
+const assetlinks = JSON.parse(assetlinksRaw) as {
+  target: { package_name: string; sha256_cert_fingerprints: string[] };
+}[];
+
 describe.each([
-  ["prod", twaProdRaw, "ohmywind.fr"],
-  ["dev", twaDevRaw, "dev.ohmywind.fr"],
-])("%s TWA manifest", (_flavour, raw, host) => {
+  ["prod", twaProdRaw, "ohmywind.fr", "fr.ohmywind.app"],
+  ["dev", twaDevRaw, "dev.ohmywind.fr", "fr.ohmywind.app.dev"],
+])("%s TWA manifest", (_flavour, raw, host, packageId) => {
   const twa = JSON.parse(raw) as {
     shortcuts: TwaShortcut[];
     appVersion: string;
     appVersionName: string;
+    fingerprints: { value: string }[];
   };
 
   it("mirrors the web manifest onto its own host", () => {
@@ -96,6 +105,18 @@ describe.each([
     );
     expect(twa.shortcuts.map((s) => s.chosenIconUrl)).toEqual(
       shortcuts.map((s) => `https://${host}${s.icons[0].src}`),
+    );
+  });
+
+  it("declares exactly the certificates the site trusts", () => {
+    // The two files are edited by hand, one under packages/android and one
+    // under packages/web/public: adding a key to one and forgetting the other
+    // is the whole failure mode. Retiring one (the local key replaced on
+    // 2026-08-16) has to happen in both too.
+    const declared = assetlinks.find((entry) => entry.target.package_name === packageId);
+    expect(declared).toBeDefined();
+    expect(new Set(twa.fingerprints.map((f) => f.value))).toEqual(
+      new Set(declared!.target.sha256_cert_fingerprints),
     );
   });
 


### PR DESCRIPTION
Contenu de la **1.1.0** (code 8 en prod, code 5 en dev), troisième et dernière montée de version du plan.

## Ce que ça change

L'empreinte `32:45` déclarée dans `assetlinks.json` était celle d'une clé locale créée le 2026-08-01 et remplacée le 2026-08-16 par la clé d'upload officielle. Elle n'a jamais été enregistrée chez Google et ne signe plus aucun build, mais tant qu'elle reste déclarée, **une app signée avec elle peut parler au nom du domaine en plein écran**. Elle est retirée des deux paquets et des deux `twa-manifest.json`.

Conséquence assumée: un APK sideloadé avec cette clé entre ces deux dates s'ouvrira désormais avec la barre Chrome, et devra être réinstallé depuis un build courant. Les installs du Play Store (signées par la clé Google `DF:C9`) et les installs directs actuels (clé d'upload `6B:F4`) ne sont pas touchés.

## Le garde-fou

Les empreintes vivent dans deux fichiers édités à la main, `packages/android*/twa-manifest.json` et `packages/web/public/.well-known/assetlinks.json`. En ajouter une d'un côté et l'oublier de l'autre est le mode de panne classique, et il ne se voit que sur un appareil, au lancement. Le test de contrat vérifie désormais que les deux jeux sont identiques, flavor par flavor.

## Ce qui était prévu au lot qualité et se trouve déjà livré

- Manifeste web enrichi: `id`, `lang`, `dir`, `categories`, `screenshots`, `scope` sont en place.
- Pinch-zoom: jamais bloqué, le viewport ne pose ni `maximum-scale` ni `user-scalable=no`.
- CLI Bubblewrap: déjà en 1.25.0, la dernière publiée.

## Vérifications

- Test de contrat des manifestes et des empreintes: 13 assertions, vertes.
- Le reste de la suite n'est pas touché par ce diff (3 JSON, un README, un test); le `node_modules` de ce worktree précède les tests de composants de septembre, donc la validation complète est laissée à la CI de cette PR plutôt qu'à une réinstallation locale.