### PR TITLE
docs(web): la politique de confidentialité nomme Libramer responsable du traitement

### DIFF
--- a/packages/web/src/content/confidentialite.de.md
+++ b/packages/web/src/content/confidentialite.de.md
@@ -3,11 +3,14 @@
 *Diese Seite ist eine Übersetzung. Maßgeblich ist im Fall von Abweichungen die
 französische Fassung ([/confidentialite](/confidentialite)).*
 
-*Letzte Aktualisierung: 2. September 2026*
+*Letzte Aktualisierung: 12. September 2026*
 
 OhMyWind ist ein quelloffener Planer für Segeltörns, verfügbar unter
-[ohmywind.fr](https://ohmywind.fr) und als Android-Anwendung. Herausgegeben wird er
-privat und nicht gewerblich von Tinqueen. Bei Fragen zu dieser Erklärung:
+[ohmywind.fr](https://ohmywind.fr) und als Android-Anwendung. Verantwortlicher für die
+Verarbeitung ist der Verein Libramer (Verein ohne Erwerbszweck nach dem französischen
+Vereinsgesetz von 1901, RNA W751285736) mit Sitz in 51 rue Fondary, 75015 Paris,
+Frankreich. Die Android-Anwendung wird von Quentin Donnars herausgegeben und über
+Google Play vertrieben. Bei Fragen zu dieser Erklärung:
 [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
 
 Der Grundsatz: **OhMyWind hat weder Benutzerkonten noch eine Datenbank noch ein
@@ -34,12 +37,13 @@ Einstellungen Ihres Browsers oder von Android widerrufbar.
 ### Törnpläne und Einstellungen
 
 Ihre Wegpunkte, Bootspolaren und Einstellungen werden **lokal auf Ihrem Gerät**
-gespeichert (lokaler Speicher des Browsers oder der Anwendung). Sie verlassen Ihr Gerät
-nur dann, wenn Sie eine Passageberechnung starten: Die Koordinaten der Wegpunkte werden
-dann an das OhMyWind-Backend (gehostet bei Hugging Face) gesendet, um die Berechnung
-durchzuführen, im Arbeitsspeicher verarbeitet und anschließend vergessen. Das Löschen
-der Website-Daten in Ihrem Browser (oder der Anwendungsdaten unter Android) entfernt
-alles.
+gespeichert (lokaler Speicher des Browsers oder der Anwendung). Nur die Koordinaten der
+Wegpunkte verlassen Ihr Gerät: Sobald ein Wegpunkt auf der Planerkarte gesetzt wird,
+werden sie an EMODnet gesendet, um die Wassertiefe anzuzeigen; wenn Sie eine
+Passageberechnung starten, werden sie an das OhMyWind-Backend (gehostet bei Hugging
+Face) gesendet, um die Berechnung durchzuführen, im Arbeitsspeicher verarbeitet und
+anschließend vergessen. Das Löschen der Website-Daten in Ihrem Browser (oder der
+Anwendungsdaten unter Android) entfernt alles.
 
 ## Drittdienste
 
@@ -54,6 +58,8 @@ nennt die darüber hinaus übermittelten Anwendungsdaten.
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Geografische Koordinaten | Umgekehrte Geokodierung (angezeigter Ortsname) |
 | [Photon (Komoot)](https://photon.komoot.io) | Text Ihrer Ortssuchen | Ortssuche |
 | [OpenFreeMap](https://openfreemap.org/privacy/) | Angezeigter Kartenausschnitt | Kartenhintergründe (Kacheln) |
+| [OpenSeaMap](https://www.openseamap.org/index.php?id=imprint) | Angezeigter Kartenausschnitt, wenn die Seezeichen-Ebene aktiv ist | Seezeichen-Overlay (Tonnen, Baken, Leuchttürme) |
+| [EMODnet Bathymetry](https://emodnet.ec.europa.eu/en/privacy-statement) | Koordinaten Ihrer Wegpunkte | Wassertiefe unter jedem Wegpunkt |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Nichts, außer wenn Sie bewusst auf den Unterstützungslink klicken | Spenden |
 
 Diese Dienste sind unabhängige technische Auftragsverarbeiter und unterliegen ihren

--- a/packages/web/src/content/confidentialite.en.md
+++ b/packages/web/src/content/confidentialite.en.md
@@ -3,12 +3,14 @@
 *This page is a translation. The French version ([/confidentialite](/confidentialite))
 is the reference in the event of any discrepancy.*
 
-*Last updated: 2 September 2026*
+*Last updated: 12 September 2026*
 
 OhMyWind is an open-source sailing passage planner, available at
-[ohmywind.fr](https://ohmywind.fr) and as an Android application. It is published on a
-personal, non-commercial basis by Tinqueen. For any question relating to this policy:
-[contact@ohmywind.fr](mailto:contact@ohmywind.fr).
+[ohmywind.fr](https://ohmywind.fr) and as an Android application. The data controller
+is the association Libramer (non-profit association under the French law of 1901, RNA
+W751285736), whose registered office is at 51 rue Fondary, 75015 Paris, France. The
+Android application is published and distributed on Google Play by Quentin Donnars. For
+any question relating to this policy: [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
 
 The general principle: **OhMyWind has no user accounts, no database and no audience
 measurement tool**. No personal data is kept on OhMyWind servers.
@@ -33,11 +35,12 @@ or of Android.
 ### Passage plans and settings
 
 Your waypoints, boat polars and preferences are stored **locally on your device**
-(local storage of the browser or of the application). They leave your device only when
-you start a passage estimate: the coordinates of the waypoints are then sent to the
-OhMyWind backend (hosted on Hugging Face) to perform the calculation, processed in
-memory, then forgotten. Clearing the site data in your browser (or the application data
-in Android) deletes everything.
+(local storage of the browser or of the application). Only the coordinates of the
+waypoints leave your device: as soon as a waypoint is placed on the planner map, they
+are sent to EMODnet to display the sounding; when you start a passage estimate, they
+are sent to the OhMyWind backend (hosted on Hugging Face) to perform the calculation,
+processed in memory, then forgotten. Clearing the site data in your browser (or the
+application data in Android) deletes everything.
 
 ## Third-party services
 
@@ -52,6 +55,8 @@ states the application data transmitted in addition.
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Geographic coordinates | Reverse geocoding (name of the place displayed) |
 | [Photon (Komoot)](https://photon.komoot.io) | Text of your place searches | Place search |
 | [OpenFreeMap](https://openfreemap.org/privacy/) | Map area displayed | Base maps (tiles) |
+| [OpenSeaMap](https://www.openseamap.org/index.php?id=imprint) | Map area displayed, when the sea-mark layer is on | Sea-mark overlay (buoys, beacons, lighthouses) |
+| [EMODnet Bathymetry](https://emodnet.ec.europa.eu/en/privacy-statement) | Coordinates of your waypoints | Sounding (depth) under each waypoint |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Nothing, unless you deliberately click the support link | Donations |
 
 These services are independent technical processors, governed by their own privacy

--- a/packages/web/src/content/confidentialite.es.md
+++ b/packages/web/src/content/confidentialite.es.md
@@ -3,12 +3,15 @@
 *Esta página es una traducción. En caso de discrepancia, la versión francesa
 ([/confidentialite](/confidentialite)) es la referencia.*
 
-*Última actualización: 2 de septiembre de 2026*
+*Última actualización: 12 de septiembre de 2026*
 
 OhMyWind es un planificador de navegación a vela de código abierto, disponible en
-[ohmywind.fr](https://ohmywind.fr) y en forma de aplicación Android. Está editado a
-título personal y no comercial por Tinqueen. Para cualquier pregunta relativa a esta
-política: [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
+[ohmywind.fr](https://ohmywind.fr) y en forma de aplicación Android. El responsable del
+tratamiento es la asociación Libramer (asociación sin ánimo de lucro de derecho
+francés, ley de 1901, RNA W751285736), con domicilio social en 51 rue Fondary, 75015
+París, Francia. La aplicación Android está editada y distribuida en Google Play por
+Quentin Donnars. Para cualquier pregunta relativa a esta política:
+[contact@ohmywind.fr](mailto:contact@ohmywind.fr).
 
 El principio general: **OhMyWind no tiene cuentas de usuario, ni base de datos, ni
 herramienta de medición de audiencia**. Ningún dato personal se conserva en servidores
@@ -34,11 +37,13 @@ cualquier momento en los ajustes de su navegador o de Android.
 ### Planes de navegación y ajustes
 
 Sus puntos de paso, polares de barco y preferencias se almacenan **localmente en su
-dispositivo** (almacenamiento local del navegador o de la aplicación). Solo salen de su
-dispositivo cuando usted inicia una estimación de travesía: las coordenadas de los
-puntos de paso se envían entonces al backend de OhMyWind (alojado en Hugging Face) para
-realizar el cálculo, se tratan en memoria y después se olvidan. Borrar los datos del
-sitio en su navegador (o los datos de la aplicación en Android) lo elimina todo.
+dispositivo** (almacenamiento local del navegador o de la aplicación). Solo las
+coordenadas de los puntos de paso salen de su dispositivo: en cuanto se coloca un punto
+en el mapa del planificador, se envían a EMODnet para mostrar la sonda; cuando usted
+inicia una estimación de travesía, se envían al backend de OhMyWind (alojado en Hugging
+Face) para realizar el cálculo, se tratan en memoria y después se olvidan. Borrar los
+datos del sitio en su navegador (o los datos de la aplicación en Android) lo elimina
+todo.
 
 ## Servicios de terceros
 
@@ -53,6 +58,8 @@ IP; la tabla indica los datos de aplicación que se transmiten además.
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Coordenadas geográficas | Geocodificación inversa (nombre del lugar mostrado) |
 | [Photon (Komoot)](https://photon.komoot.io) | Texto de sus búsquedas de lugares | Búsqueda de lugares |
 | [OpenFreeMap](https://openfreemap.org/privacy/) | Zona del mapa mostrada | Mapas base (teselas) |
+| [OpenSeaMap](https://www.openseamap.org/index.php?id=imprint) | Zona del mapa mostrada, cuando la capa de balizamiento está activa | Balizamiento superpuesto (boyas, balizas, faros) |
+| [EMODnet Bathymetry](https://emodnet.ec.europa.eu/en/privacy-statement) | Coordenadas de sus puntos de paso | Sonda (profundidad) bajo cada punto de paso |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Nada, salvo si usted hace clic voluntariamente en el enlace de apoyo | Donaciones |
 
 Estos servicios son encargados del tratamiento técnicos independientes, regidos por sus

--- a/packages/web/src/content/confidentialite.it.md
+++ b/packages/web/src/content/confidentialite.it.md
@@ -3,12 +3,15 @@
 *Questa pagina è una traduzione. In caso di discordanza fa fede la versione francese
 ([/confidentialite](/confidentialite)).*
 
-*Ultimo aggiornamento: 2 settembre 2026*
+*Ultimo aggiornamento: 12 settembre 2026*
 
 OhMyWind è un pianificatore di navigazione a vela open source, disponibile su
-[ohmywind.fr](https://ohmywind.fr) e sotto forma di applicazione Android. È pubblicato
-a titolo personale e non commerciale da Tinqueen. Per qualsiasi domanda relativa alla
-presente informativa: [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
+[ohmywind.fr](https://ohmywind.fr) e sotto forma di applicazione Android. Il titolare
+del trattamento è l'associazione Libramer (associazione senza scopo di lucro di diritto
+francese, legge del 1901, RNA W751285736), con sede legale in 51 rue Fondary, 75015
+Parigi, Francia. L'applicazione Android è pubblicata e distribuita su Google Play da
+Quentin Donnars. Per qualsiasi domanda relativa alla presente informativa:
+[contact@ohmywind.fr](mailto:contact@ohmywind.fr).
 
 Il principio generale: **OhMyWind non ha account utente, né banca dati, né strumenti di
 misurazione del pubblico**. Nessun dato personale è conservato su server OhMyWind.
@@ -35,10 +38,12 @@ impostazioni del browser o di Android.
 
 I punti di passaggio, le polari della barca e le preferenze sono memorizzati
 **localmente sul dispositivo** (archiviazione locale del browser o dell'applicazione).
-Escono dal dispositivo soltanto quando si avvia una stima di traversata: le coordinate
-dei punti di passaggio vengono allora inviate al backend OhMyWind (ospitato su Hugging
-Face) per eseguire il calcolo, trattate in memoria e poi dimenticate. Cancellare i dati
-del sito nel browser (o i dati dell'applicazione in Android) elimina tutto.
+Soltanto le coordinate dei punti di passaggio escono dal dispositivo: non appena un
+punto viene posato sulla mappa del pianificatore, vengono inviate a EMODnet per
+mostrare il fondale; quando si avvia una stima di traversata, vengono inviate al
+backend OhMyWind (ospitato su Hugging Face) per eseguire il calcolo, trattate in
+memoria e poi dimenticate. Cancellare i dati del sito nel browser (o i dati
+dell'applicazione in Android) elimina tutto.
 
 ## Servizi terzi
 
@@ -53,6 +58,8 @@ indica i dati applicativi trasmessi in aggiunta.
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Coordinate geografiche | Geocodifica inversa (nome del luogo visualizzato) |
 | [Photon (Komoot)](https://photon.komoot.io) | Testo delle ricerche di luoghi | Ricerca di luoghi |
 | [OpenFreeMap](https://openfreemap.org/privacy/) | Area di mappa visualizzata | Sfondi cartografici (tasselli) |
+| [OpenSeaMap](https://www.openseamap.org/index.php?id=imprint) | Area di mappa visualizzata, quando il livello dei segnalamenti è attivo | Segnalamenti marittimi in sovrapposizione (boe, mede, fari) |
+| [EMODnet Bathymetry](https://emodnet.ec.europa.eu/en/privacy-statement) | Coordinate dei punti di passaggio | Fondale (profondità) sotto ogni punto di passaggio |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Nulla, salvo che si scelga di cliccare sul link di sostegno | Donazioni |
 
 Questi servizi sono responsabili del trattamento tecnici e indipendenti, disciplinati

--- a/packages/web/src/content/confidentialite.md
+++ b/packages/web/src/content/confidentialite.md
@@ -1,11 +1,13 @@
 # Politique de confidentialité
 
-*Dernière mise à jour : 2 septembre 2026*
+*Dernière mise à jour : 12 septembre 2026*
 
 OhMyWind est un planificateur de navigation à la voile open-source, disponible sur
-[ohmywind.fr](https://ohmywind.fr) et sous forme d'application Android. Il est édité à
-titre personnel et non commercial par Tinqueen. Pour toute question relative à
-cette politique : [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
+[ohmywind.fr](https://ohmywind.fr) et sous forme d'application Android. Le responsable
+du traitement est l'association Libramer (association loi 1901, RNA W751285736), dont
+le siège social est situé 51 rue Fondary, 75015 Paris. L'application Android est
+éditée et distribuée sur Google Play par Quentin Donnars. Pour toute question relative
+à cette politique : [contact@ohmywind.fr](mailto:contact@ohmywind.fr).
 
 Le principe général : **OhMyWind ne possède ni compte utilisateur, ni base de données,
 ni outil de mesure d'audience**. Aucune donnée personnelle n'est conservée sur des
@@ -31,12 +33,13 @@ de votre navigateur ou d'Android.
 ### Plans de navigation et réglages
 
 Vos points de passage, polaires de bateau et préférences sont stockés **localement sur
-votre appareil** (stockage local du navigateur ou de l'application). Ils ne quittent
-votre appareil que lorsque vous lancez une estimation de passage : les coordonnées des
-points de passage sont alors envoyées au backend OhMyWind (hébergé sur Hugging Face)
-pour effectuer le calcul, traitées en mémoire, puis oubliées. Effacer les données du
-site dans votre navigateur (ou les données de l'application dans Android) supprime
-tout.
+votre appareil** (stockage local du navigateur ou de l'application). Seules les
+coordonnées des points de passage quittent votre appareil : dès qu'un point est posé
+sur la carte du planificateur, elles sont envoyées à EMODnet pour afficher la sonde ;
+lorsque vous lancez une estimation de passage, elles sont envoyées au backend OhMyWind
+(hébergé sur Hugging Face) pour effectuer le calcul, traitées en mémoire, puis
+oubliées. Effacer les données du site dans votre navigateur (ou les données de
+l'application dans Android) supprime tout.
 
 ## Services tiers
 
@@ -51,6 +54,8 @@ indique les données applicatives transmises en plus.
 | [Nominatim / OpenStreetMap](https://osmfoundation.org/wiki/Privacy_Policy) | Coordonnées géographiques | Géocodage inverse (nom du lieu affiché) |
 | [Photon (Komoot)](https://photon.komoot.io) | Texte de vos recherches de lieu | Recherche de lieux |
 | [OpenFreeMap](https://openfreemap.org/privacy/) | Zone de carte affichée | Fonds de carte (tuiles) |
+| [OpenSeaMap](https://www.openseamap.org/index.php?id=imprint) | Zone de carte affichée, lorsque la couche des amers est active | Amers en surcouche (bouées, balises, phares) |
+| [EMODnet Bathymetry](https://emodnet.ec.europa.eu/en/privacy-statement) | Coordonnées de vos points de passage | Sonde (profondeur) sous chaque point de passage |
 | [Ko-fi](https://more.ko-fi.com/privacy) | Rien, sauf si vous cliquez volontairement sur le lien de soutien | Dons |
 
 Ces services sont des sous-traitants techniques indépendants, régis par leurs propres


### PR DESCRIPTION
## Pourquoi

Avant mise en production, la politique de confidentialité doit désigner le bon responsable du traitement et refléter les services tiers réellement appelés par l'application.

## Quoi

Dans les cinq langues (FR, EN, DE, IT, ES) :

- **Responsable du traitement** : association Libramer (loi 1901, RNA W751285736, siège 51 rue Fondary, 75015 Paris). L'application Android reste éditée et distribuée sur Google Play par Quentin Donnars. La mention « à titre personnel et non commercial par Tinqueen » est retirée.
- **Tableau des tiers** : ajout d'OpenSeaMap (tuiles des amers, quand la couche est active) et d'EMODnet Bathymetry (sonde sous les points de passage).
- **Paragraphe « Plans de navigation »** : il affirmait que les points de passage ne quittaient l'appareil qu'au lancement d'une estimation. Depuis l'arrivée des sondes, ils partent vers EMODnet dès qu'un point est posé sur le planificateur (`useWaypointDepths`). Les deux cas sont maintenant décrits.
- **Date de mise à jour** : 12 septembre 2026.

Contact inchangé : contact@ohmywind.fr.

## Vérification

- Les cinq fichiers parsent identiquement avec remark-gfm : 8 lignes × 3 cellules dans le tableau, 14 liens chacun.
- `vite build` OK, aucune trace résiduelle de « Tinqueen », pas de tiret cadratin, pas de tutoiement.
- Liens des nouveaux tiers vérifiés en 200 : Impressum OpenSeaMap, Privacy Statement EMODnet.
